### PR TITLE
fixed function version to pre-patch until a solution is found for the…

### DIFF
--- a/Template/azuredeploy.json
+++ b/Template/azuredeploy.json
@@ -118,7 +118,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "beta"
+                            "value": "2.0.11961-alpha"
                         },
                         {
                             "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",


### PR DESCRIPTION
… host key

New Azure function runtime https://github.com/Azure/azure-functions-host/releases/tag/v2.0.12050-alpha, break the way the "deploy to Azure" template get the host key from the function. This is a temporary fix in order to have the template working. 
Function version will be stuck before the update, a better fix is expected in the next days.


