### PR TITLE
 Add typed configuration to network server

### DIFF
--- a/LoRaEngine/LoRaEngine.sln
+++ b/LoRaEngine/LoRaEngine.sln
@@ -17,6 +17,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Logger", "modules\LoRaWanNe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoRaWan.IntegrationTest", "test\LoRaWan.IntegrationTest\LoRaWan.IntegrationTest.csproj", "{26DF2637-43E0-4FFF-92BD-F4395C88DD50}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A3AF6806-947C-426F-8063-7229B71A4472}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoRaWanNetworkServer.Test", "test\LoRaWanNetworkServer.Test\LoRaWanNetworkServer.Test.csproj", "{D65BF8E2-DB42-4EA9-8A5E-CD7E671C4305}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -81,11 +85,24 @@ Global
 		{26DF2637-43E0-4FFF-92BD-F4395C88DD50}.Release|Any CPU.Build.0 = Release|Any CPU
 		{26DF2637-43E0-4FFF-92BD-F4395C88DD50}.Release|x86.ActiveCfg = Release|Any CPU
 		{26DF2637-43E0-4FFF-92BD-F4395C88DD50}.Release|x86.Build.0 = Release|Any CPU
+		{D65BF8E2-DB42-4EA9-8A5E-CD7E671C4305}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D65BF8E2-DB42-4EA9-8A5E-CD7E671C4305}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D65BF8E2-DB42-4EA9-8A5E-CD7E671C4305}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D65BF8E2-DB42-4EA9-8A5E-CD7E671C4305}.Debug|x86.Build.0 = Debug|Any CPU
+		{D65BF8E2-DB42-4EA9-8A5E-CD7E671C4305}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D65BF8E2-DB42-4EA9-8A5E-CD7E671C4305}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D65BF8E2-DB42-4EA9-8A5E-CD7E671C4305}.Release|x86.ActiveCfg = Release|Any CPU
+		{D65BF8E2-DB42-4EA9-8A5E-CD7E671C4305}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FD60E938-DB16-4486-8BEF-4F2CE460E71D}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{26DF2637-43E0-4FFF-92BD-F4395C88DD50} = {A3AF6806-947C-426F-8063-7229B71A4472}
+		{E96EDB52-7BCD-4418-BE7D-0C914EAA874D} = {A3AF6806-947C-426F-8063-7229B71A4472}
+		{D65BF8E2-DB42-4EA9-8A5E-CD7E671C4305} = {A3AF6806-947C-426F-8063-7229B71A4472}
 	EndGlobalSection
 EndGlobal

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/CaseInsensitiveEnvironmentVariables.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/CaseInsensitiveEnvironmentVariables.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace LoRaWan.NetworkServer
+{
+    public class CaseInsensitiveEnvironmentVariables
+    {
+        private readonly Dictionary<string, string> envVars;
+
+        public CaseInsensitiveEnvironmentVariables() : this(Environment.GetEnvironmentVariables())
+        {
+        }
+
+        public CaseInsensitiveEnvironmentVariables(IDictionary source)
+        {
+            this.envVars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (DictionaryEntry kv in source)
+            {
+                this.envVars[kv.Key.ToString()] = kv.Value.ToString();
+            }
+        }
+
+
+        public int GetEnvVar(string key, int defaultValue)
+        {
+            var value = defaultValue;
+            if (this.envVars.TryGetValue(key, out var envValue))
+            {
+                if (int.TryParse(envValue, out var parsedValue))
+                    value = parsedValue;
+            }
+            
+            return value;
+        }
+
+         public uint GetEnvVar(string key, uint defaultValue)
+        {
+            var value = defaultValue;
+            if (this.envVars.TryGetValue(key, out var envValue))
+            {
+                if (uint.TryParse(envValue, out var parsedValue))
+                    value = parsedValue;
+            }
+            
+            return value;
+        }
+
+        public double GetEnvVar(string key, double defaultValue)
+        {
+            var value = defaultValue;
+            if (this.envVars.TryGetValue(key, out var envValue))
+            {
+                if (double.TryParse(envValue, out var parsedValue))
+                    value = parsedValue;
+            }
+            
+            return value;
+        }
+
+        public bool GetEnvVar(string key, bool defaultValue)
+        {
+            var value = defaultValue;
+            if (this.envVars.TryGetValue(key, out var envValue))
+            {
+                if (bool.TryParse(envValue, out var parsedValue))
+                    value = parsedValue;
+            }
+            
+            return value;
+        }
+
+        public string GetEnvVar(string key, string defaultValue)
+        {
+            var value = defaultValue;
+            if (this.envVars.TryGetValue(key, out var envValue))
+                value = envValue;
+            return value;
+        }
+
+    }
+
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/IoTHubConnector.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/IoTHubConnector.cs
@@ -19,6 +19,7 @@ namespace LoRaWan.NetworkServer
         private string DevEUI;
 
         private string PrimaryKey;
+        private readonly NetworkServerConfiguration configuration;
 
         public async Task<Twin> GetTwinAsync()
         {
@@ -133,11 +134,11 @@ namespace LoRaWan.NetworkServer
             }
         }
 
-        public IoTHubConnector(string DevEUI, string PrimaryKey)
+        public IoTHubConnector(string DevEUI, string PrimaryKey, NetworkServerConfiguration configuration)
         {
             this.DevEUI = DevEUI;
             this.PrimaryKey = PrimaryKey;
-
+            this.configuration = configuration;
             CreateDeviceClient();
           
         }   
@@ -334,25 +335,19 @@ namespace LoRaWan.NetworkServer
 
         private string createIoTHubConnectionString()
         {
-            bool enableGateway = true;
             string connectionString = string.Empty;
 
-            string hostName = Environment.GetEnvironmentVariable("IOTEDGE_IOTHUBHOSTNAME");
-            string gatewayHostName = Environment.GetEnvironmentVariable("IOTEDGE_GATEWAYHOSTNAME");
 
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ENABLE_GATEWAY")))
-                enableGateway = bool.Parse(Environment.GetEnvironmentVariable("ENABLE_GATEWAY"));
-
-            if (string.IsNullOrEmpty(hostName))
+            if (string.IsNullOrEmpty(configuration.IoTHubHostName))
             {
-                Logger.Log("Environment variable IOTEDGE_IOTHUBHOSTNAME not found, creation of iothub connection not possible", Logger.LoggingLevel.Error);
+                Logger.Log("Configuration/Environment variable IOTEDGE_IOTHUBHOSTNAME not found, creation of iothub connection not possible", Logger.LoggingLevel.Error);
             }
 
-            connectionString += $"HostName={hostName};";
+            connectionString += $"HostName={configuration.IoTHubHostName};";
 
-            if (enableGateway)
+            if (configuration.EnableGateway)
             {
-                connectionString += $"GatewayHostName={gatewayHostName};";
+                connectionString += $"GatewayHostName={configuration.GatewayHostName};";
                 Logger.Log(DevEUI, $"using edgeHub local queue", Logger.LoggingLevel.Info);
             }
             else

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -1,0 +1,105 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+namespace LoRaWan.NetworkServer
+{
+    // Network server configuration
+    public class NetworkServerConfiguration
+    {
+        // Gets/sets if the server is running as an IoT Edge module
+        public bool RunningAsIoTEdgeModule { get; set; }
+
+        // Gets/sets the iot hub host name
+        public string IoTHubHostName { get; set; }
+
+        // Gets/sets the gateway host name
+        public string GatewayHostName { get; set; }
+
+        // Gets/sets if the gateway (edgeHub) is enabled     
+        public bool EnableGateway { get; set; } = true;
+
+        // Gets/sets the gateway identifier
+        public string GatewayID { get; set; }
+
+        // Gets/sets the Http proxy URL
+        public string HttpsProxy { get; set; }
+
+        // Gets/sets the 2nd receive windows data rate
+        // TODO: better documentation and property name
+        public string Rx2DataRate { get; set; }
+
+        // Gets/sets the 2nd receive windows data frequency
+        public double Rx2DataFrequency { get; set; }
+
+        // Gets/sets a IoT edge timeout, 0 keeps the default value
+        public uint IoTEdgeTimeout { get; set; }
+
+        // Gets/sets the Azure Facade Function URL
+        public string FacadeServerUrl { get; set; }
+
+        // Gets/sets the Azure Facade Function auth code
+        public string FacadeAuthCode { get; set; }
+
+        // Gets/sets if logging to console is enabled
+        // Default: true
+        public bool LogToConsole { get;  set; } = true;
+
+        // Gets/sets the logging level
+        // Default: 0 (Always logging)
+        public int LogLevel { get;  set; } = 0;
+
+        // Gets/sets if logging to IoT Hub is enabled
+        // Default: false
+        public bool LogToHub { get;  set; }
+
+        // Gets/sets if logging to udp is enabled (used for integration tests mainly)
+        // Default: false
+        public bool LogToUdp { get; set; }
+
+        // Gets/sets udp address to send log
+        public string LogToUdpAddress { get; set; }
+
+        // Gets/sets udp port to send logs
+        public int LogToUdpPort { get; set; } = 6000;
+
+        // Creates a new instance of NetworkServerConfiguration
+        public NetworkServerConfiguration()
+        {    
+        }
+
+        // Creates a new instance of NetworkServerConfiguration by reading values from environment variables
+        public static NetworkServerConfiguration CreateFromEnviromentVariables()
+        {
+            var config = new NetworkServerConfiguration();
+
+            // Create case insensitive dictionary from environment variables
+            var envVars = new CaseInsensitiveEnvironmentVariables(Environment.GetEnvironmentVariables());           
+
+            config.RunningAsIoTEdgeModule = !string.IsNullOrEmpty(envVars.GetEnvVar("IOTEDGE_APIVERSION", string.Empty));
+            config.IoTHubHostName = envVars.GetEnvVar("IOTEDGE_IOTHUBHOSTNAME", string.Empty);
+            config.GatewayHostName = envVars.GetEnvVar("IOTEDGE_GATEWAYHOSTNAME", string.Empty);
+            config.EnableGateway = envVars.GetEnvVar("ENABLE_GATEWAY", config.EnableGateway);
+            config.GatewayID = envVars.GetEnvVar("IOTEDGE_DEVICEID", string.Empty);
+            config.HttpsProxy = envVars.GetEnvVar("HTTPS_PROXY", string.Empty);          
+            config.Rx2DataRate = envVars.GetEnvVar("RX2_DATR", string.Empty);           
+            config.Rx2DataFrequency = envVars.GetEnvVar("RX2_FREQ", config.Rx2DataFrequency);
+            config.IoTEdgeTimeout = envVars.GetEnvVar("IOTEDGE_TIMEOUT", config.IoTEdgeTimeout);
+            config.FacadeServerUrl = envVars.GetEnvVar("FacadeServerUrl", string.Empty);
+            config.FacadeAuthCode = envVars.GetEnvVar("FacadeAuthCode", string.Empty);
+            config.LogToHub = envVars.GetEnvVar("LOG_TO_HUB", config.LogToHub);
+            config.LogLevel = envVars.GetEnvVar("LOG_LEVEL", config.LogLevel);
+            config.LogToConsole = envVars.GetEnvVar("LOG_TO_CONSOLE", config.LogToConsole);
+            config.LogToUdp = envVars.GetEnvVar("LOG_TO_UDP", config.LogToUdp);
+            config.LogToUdpAddress = envVars.GetEnvVar("LOG_TO_UDP_ADDRESS", string.Empty);
+            config.LogToUdpPort = envVars.GetEnvVar("LOG_TO_UDP_PORT", config.LogToUdpPort);
+
+            return config;
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule/Program.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule/Program.cs
@@ -50,7 +50,7 @@ namespace LoRaWanNetworkSrvModule
         {
            
                
-                udpServer = new UdpServer();
+                udpServer = UdpServer.Create();
                 await udpServer.RunServer();
            
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/LoggerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/LoggerConfiguration.cs
@@ -1,0 +1,34 @@
+using Microsoft.Azure.Devices.Client;
+
+namespace LoRaWan
+{
+    // Defines the logger configuration
+    public class LoggerConfiguration
+    {
+        // Gets/sets the module client
+         public ModuleClient ModuleClient { get; set; }
+
+        // Gets/sets if logging to console is enabled
+        // Default: true
+        public bool LogToConsole { get;  set; } = true;
+
+        // Gets/sets the logging level
+        // Default: 0 (Always logging)
+        public int LogLevel { get;  set; } = 0;
+
+        // Gets/sets if logging to IoT Hub is enabled
+        // Default: false
+        public bool LogToHub { get;  set; }
+
+        // Gets/sets if logging to udp is enabled (used for integration tests mainly)
+        // Default: false
+        public bool LogToUdp { get; set; }
+
+        // Gets/sets udp address to send log
+        public string LogToUdpAddress { get; set; }
+
+        // Gets/sets udp port to send logs
+        public int LogToUdpPort { get; set; } = 6000;
+    }
+
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/PktFwdMessage.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/PktFwdMessage.cs
@@ -16,8 +16,6 @@ namespace LoRaTools.LoRaPhysical
     /// </summary>
     public abstract class PktFwdMessage
     {
-        PktFwdType pktFwdType;
-
         public abstract PktFwdMessageAdapter GetPktFwdMessage();
         enum PktFwdType
         {

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/ABPTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/ABPTest.cs
@@ -6,24 +6,10 @@ namespace LoRaWan.IntegrationTest
 {
     // Tests ABP requests
     [Collection("ArduinoSerialCollection")] // run in serial
-    public sealed class ABPTest : IClassFixture<IntegrationTestFixture>, IDisposable
+    public sealed class ABPTest : IntegrationTestBase
     {
-
-        private readonly IntegrationTestFixture testFixture;
-        private LoRaArduinoSerial arduinoDevice;
-
-        public ABPTest(IntegrationTestFixture testFixture)
+        public ABPTest(IntegrationTestFixture testFixture) : base(testFixture)
         {
-            this.testFixture = testFixture;
-            this.arduinoDevice = LoRaArduinoSerial.CreateFromPort(testFixture.Configuration.LeafDeviceSerialPort);
-            this.testFixture.ClearNetworkServerModuleLog();
-        }
-
-        public void Dispose()
-        {
-            this.arduinoDevice?.Dispose();
-            this.arduinoDevice = null;
-            GC.SuppressFinalize(this);
         }
 
 
@@ -34,65 +20,65 @@ namespace LoRaWan.IntegrationTest
         {
             const int MESSAGES_COUNT = 10;
 
-            var device = this.testFixture.Device5_ABP;
-            Console.WriteLine($"Starting {nameof(Test_ABP_Confirmed_And_Unconfirmed_Message)} using device {device.DeviceID}");      
+            var device = this.TestFixture.Device5_ABP;
+            Log($"Starting {nameof(Test_ABP_Confirmed_And_Unconfirmed_Message)} using device {device.DeviceID}");      
 
-            await arduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWABP);
-            await arduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, null);
-            await arduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, null);
+            await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWABP);
+            await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, null);
+            await this.ArduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, null);
 
-            await arduinoDevice.SetupLora(this.testFixture.Configuration.LoraRegion); 
+            await this.ArduinoDevice.SetupLora(this.TestFixture.Configuration.LoraRegion); 
 
             // Sends 10x unconfirmed messages            
             for (var i=0; i < MESSAGES_COUNT; ++i)
             {
                 var msg = PayloadGenerator.Next().ToString();
-                Console.WriteLine($"{device.DeviceID}: Sending unconfirmed '{msg}' {i+1}/{MESSAGES_COUNT}");
-                await arduinoDevice.transferPacketAsync(msg, 10);
+                Log($"{device.DeviceID}: Sending unconfirmed '{msg}' {i+1}/{MESSAGES_COUNT}");
+                await this.ArduinoDevice.transferPacketAsync(msg, 10);
 
                 await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
 
                 // After transferPacket: Expectation from serial
                 // +MSG: Done                        
-                await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.arduinoDevice.SerialLogs);
+                await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
 
                 // 0000000000000005: valid frame counter, msg: 1 server: 0
-                await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: valid frame counter, msg:");
+                await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: valid frame counter, msg:");
 
                 // 0000000000000005: decoding with: DecoderValueSensor port: 8
-                await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: decoding with: {device.SensorDecoder} port:");
+                await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: decoding with: {device.SensorDecoder} port:");
             
                 // 0000000000000005: message '{"value": 51}' sent to hub
-                await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: message '{{\"value\":{msg}}}' sent to hub");
+                await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: message '{{\"value\":{msg}}}' sent to hub");
 
-                this.arduinoDevice.ClearSerialLogs();
-                testFixture.ClearNetworkServerModuleLog();
+                this.ArduinoDevice.ClearSerialLogs();
+                this.TestFixture.ClearNetworkServerModuleLog();
             }
 
             // Sends 10x confirmed messages
             for (var i=0; i < MESSAGES_COUNT; ++i)
             {
                 var msg = PayloadGenerator.Next().ToString();
-                Console.WriteLine($"{device.DeviceID}: Sending confirmed '{msg}' {i+1}/{MESSAGES_COUNT}");
-                await arduinoDevice.transferPacketWithConfirmedAsync(msg, 10);
+                Log($"{device.DeviceID}: Sending confirmed '{msg}' {i+1}/{MESSAGES_COUNT}");
+                await this.ArduinoDevice.transferPacketWithConfirmedAsync(msg, 10);
 
                 await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
 
                 // After transferPacketWithConfirmed: Expectation from serial
                 // +CMSG: ACK Received
-                await AssertUtils.ContainsWithRetriesAsync("+CMSG: ACK Received", this.arduinoDevice.SerialLogs);
+                await AssertUtils.ContainsWithRetriesAsync("+CMSG: ACK Received", this.ArduinoDevice.SerialLogs);
 
                 // 0000000000000005: valid frame counter, msg: 1 server: 0
-                await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: valid frame counter, msg:");
+                await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: valid frame counter, msg:");
 
                 // 0000000000000005: decoding with: DecoderValueSensor port: 8
-                await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: decoding with: {device.SensorDecoder} port:");
+                await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: decoding with: {device.SensorDecoder} port:");
             
                 // 0000000000000005: message '{"value": 51}' sent to hub
-                await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: message '{{\"value\":{msg}}}' sent to hub");
+                await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: message '{{\"value\":{msg}}}' sent to hub");
 
-                this.arduinoDevice.ClearSerialLogs();
-                testFixture.ClearNetworkServerModuleLog();
+                this.ArduinoDevice.ClearSerialLogs();
+                this.TestFixture.ClearNetworkServerModuleLog();
             }
         }
 
@@ -101,45 +87,45 @@ namespace LoRaWan.IntegrationTest
         [Fact]
         public async Task Test_ABP_Wrong_DevAddr_Is_Ignored()
         {
-            var device = this.testFixture.Device6_ABP;
-            Console.WriteLine($"Starting {nameof(Test_ABP_Wrong_DevAddr_Is_Ignored)} using device {device.DeviceID}");      
+            var device = this.TestFixture.Device6_ABP;
+            Log($"Starting {nameof(Test_ABP_Wrong_DevAddr_Is_Ignored)} using device {device.DeviceID}");      
 
             var devAddrToUse = "05060708";
             Assert.NotEqual(devAddrToUse, device.DevAddr);
-            await arduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWABP);
-            await arduinoDevice.setIdAsync(devAddrToUse, device.DeviceID, null);
-            await arduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, null);
+            await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWABP);
+            await this.ArduinoDevice.setIdAsync(devAddrToUse, device.DeviceID, null);
+            await this.ArduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, null);
 
-            await arduinoDevice.SetupLora(this.testFixture.Configuration.LoraRegion); 
+            await this.ArduinoDevice.SetupLora(this.TestFixture.Configuration.LoraRegion); 
             
-            await arduinoDevice.transferPacketAsync(PayloadGenerator.Next().ToString(), 10);
+            await this.ArduinoDevice.transferPacketAsync(PayloadGenerator.Next().ToString(), 10);
 
             await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
 
             // After transferPacket: Expectation from serial
             // +MSG: Done                        
-            await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.arduinoDevice.SerialLogs);
+            await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
 
             // 05060708: device is not our device, ignore message
-            await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{devAddrToUse}: device is not our device, ignore message");
+            await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{devAddrToUse}: device is not our device, ignore message");
 
             await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
 
-             this.arduinoDevice.ClearSerialLogs();
-            testFixture.ClearNetworkServerModuleLog();
+             this.ArduinoDevice.ClearSerialLogs();
+            this.TestFixture.ClearNetworkServerModuleLog();
 
             // Try with confirmed message
-            await arduinoDevice.transferPacketWithConfirmedAsync(PayloadGenerator.Next().ToString(), 10);
+            await this.ArduinoDevice.transferPacketWithConfirmedAsync(PayloadGenerator.Next().ToString(), 10);
 
             // wait for serial logs to be ready
             await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
 
             // After transferPacketWithConfirmed: Expectation from serial
             // +CMSG: ACK Received -- should not be there!
-            Assert.DoesNotContain("+CMSG: ACK Received", this.arduinoDevice.SerialLogs);
+            Assert.DoesNotContain("+CMSG: ACK Received", this.ArduinoDevice.SerialLogs);
 
             // 05060708: device is not our device, ignore message
-            await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{devAddrToUse}: device is not our device, ignore message");
+            await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{devAddrToUse}: device is not our device, ignore message");
 
         }
 
@@ -152,20 +138,20 @@ namespace LoRaWan.IntegrationTest
         [Fact]
         public async Task Test_ABP_Mismatch_NwkSKey_And_AppSKey_Fails_Mic_Validation()
         {
-            var device = this.testFixture.Device7_ABP;
-            Console.WriteLine($"Starting {nameof(Test_ABP_Mismatch_NwkSKey_And_AppSKey_Fails_Mic_Validation)} using device {device.DeviceID}");      
+            var device = this.TestFixture.Device7_ABP;
+            Log($"Starting {nameof(Test_ABP_Mismatch_NwkSKey_And_AppSKey_Fails_Mic_Validation)} using device {device.DeviceID}");      
 
             var appSKeyToUse = "000102030405060708090A0B0C0D0E0F";
             var nwkSKeyToUse = "01020304050607080910111213141516";
             Assert.NotEqual(appSKeyToUse, device.AppSKey);
             Assert.NotEqual(nwkSKeyToUse, device.NwkSKey);
-            await arduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWABP);
-            await arduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, null);
-            await arduinoDevice.setKeyAsync(nwkSKeyToUse, appSKeyToUse, null);
+            await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWABP);
+            await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, null);
+            await this.ArduinoDevice.setKeyAsync(nwkSKeyToUse, appSKeyToUse, null);
 
-            await arduinoDevice.SetupLora(this.testFixture.Configuration.LoraRegion); 
+            await this.ArduinoDevice.SetupLora(this.TestFixture.Configuration.LoraRegion); 
             
-            await arduinoDevice.transferPacketAsync(PayloadGenerator.Next().ToString(), 10);
+            await this.ArduinoDevice.transferPacketAsync(PayloadGenerator.Next().ToString(), 10);
 
             // wait for serial logs to be ready
             await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
@@ -176,24 +162,24 @@ namespace LoRaWan.IntegrationTest
             //await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.lora.SerialLogs);
        
             // 0000000000000005: with devAddr 0028B1B0 check MIC failed. Device will be ignored from now on
-            await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: with devAddr {device.DevAddr} check MIC failed. Device will be ignored from now on");
+            await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: with devAddr {device.DevAddr} check MIC failed. Device will be ignored from now on");
 
             await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
 
-            this.arduinoDevice.ClearSerialLogs();
-            testFixture.ClearNetworkServerModuleLog();
+            this.ArduinoDevice.ClearSerialLogs();
+            this.TestFixture.ClearNetworkServerModuleLog();
 
             // Try with confirmed message
 
-            await arduinoDevice.transferPacketWithConfirmedAsync(PayloadGenerator.Next().ToString(), 10);
+            await this.ArduinoDevice.transferPacketWithConfirmedAsync(PayloadGenerator.Next().ToString(), 10);
 
             await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
 
             // 0000000000000005: with devAddr 0028B1B0 check MIC failed. Device will be ignored from now on
-            await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: with devAddr {device.DevAddr} check MIC failed. Device will be ignored from now on");
+            await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: with devAddr {device.DevAddr} check MIC failed. Device will be ignored from now on");
 
             // wait until arduino stops trying to send confirmed msg
-            await this.arduinoDevice.WaitForIdleAsync();
+            await this.ArduinoDevice.WaitForIdleAsync();
         }    
 
         // Tests using a invalid Network Session key, resulting in mic failed
@@ -201,44 +187,44 @@ namespace LoRaWan.IntegrationTest
         [Fact]
         public async Task Test_ABP_Invalid_NwkSKey_Fails_With_Mic_Error()
         {
-            var device = this.testFixture.Device8_ABP;
-            Console.WriteLine($"Starting {nameof(Test_ABP_Invalid_NwkSKey_Fails_With_Mic_Error)} using device {device.DeviceID}");      
+            var device = this.TestFixture.Device8_ABP;
+            Log($"Starting {nameof(Test_ABP_Invalid_NwkSKey_Fails_With_Mic_Error)} using device {device.DeviceID}");      
 
             var nwkSKeyToUse = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
             Assert.NotEqual(nwkSKeyToUse, device.NwkSKey);
-            await arduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWABP);
-            await arduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, null);
-            await arduinoDevice.setKeyAsync(nwkSKeyToUse, device.AppSKey, null);
+            await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWABP);
+            await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, null);
+            await this.ArduinoDevice.setKeyAsync(nwkSKeyToUse, device.AppSKey, null);
 
-            await arduinoDevice.SetupLora(this.testFixture.Configuration.LoraRegion); 
+            await this.ArduinoDevice.SetupLora(this.TestFixture.Configuration.LoraRegion); 
             
-            await arduinoDevice.transferPacketAsync(PayloadGenerator.Next().ToString(), 10);
+            await this.ArduinoDevice.transferPacketAsync(PayloadGenerator.Next().ToString(), 10);
 
             await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
 
             // After transferPacket: Expectation from serial
             // +MSG: Done                        
-            await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.arduinoDevice.SerialLogs);
+            await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
 
             // 0000000000000008: with devAddr 0028B1B3 check MIC failed. Device will be ignored from now on
-            await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: with devAddr {device.DevAddr} check MIC failed. Device will be ignored from now on");
+            await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: with devAddr {device.DevAddr} check MIC failed. Device will be ignored from now on");
 
     
-            this.arduinoDevice.ClearSerialLogs();
-            testFixture.ClearNetworkServerModuleLog();
+            this.ArduinoDevice.ClearSerialLogs();
+            this.TestFixture.ClearNetworkServerModuleLog();
 
             // Try with confirmed message
 
-            await arduinoDevice.transferPacketWithConfirmedAsync(PayloadGenerator.Next().ToString(), 10);
+            await this.ArduinoDevice.transferPacketWithConfirmedAsync(PayloadGenerator.Next().ToString(), 10);
 
             await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
 
             // 0000000000000008: with devAddr 0028B1B3 check MIC failed. Device will be ignored from now on
-            await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: with devAddr {device.DevAddr} check MIC failed. Device will be ignored from now on");
+            await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: with devAddr {device.DevAddr} check MIC failed. Device will be ignored from now on");
 
 
             // Before starting new test, wait until Lora drivers stops sending/receiving data
-            await arduinoDevice.WaitForIdleAsync();
+            await this.ArduinoDevice.WaitForIdleAsync();
         }        
     }
 }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/EventHubDataCollector.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/EventHubDataCollector.cs
@@ -42,7 +42,7 @@ namespace LoRaWan.IntegrationTest
             
             if(this.LogToConsole)
             {
-                Console.WriteLine($"Connecting to IoT Hub Event Hub @{this.connectionString} using consumer group {this.ConsumerGroupName}");
+                TestLogger.Log($"Connecting to IoT Hub Event Hub @{this.connectionString} using consumer group {this.ConsumerGroupName}");
             }
 
             var rti = await this.eventHubClient.GetRuntimeInformationAsync();
@@ -67,7 +67,7 @@ namespace LoRaWan.IntegrationTest
                 if(this.LogToConsole)
                 {
                     var bodyText = Encoding.UTF8.GetString(item.Body);                    
-                    Console.WriteLine($"[EventHub]: {bodyText}");
+                    TestLogger.Log($"[EventHub]: {bodyText}");
                 }
             }
 
@@ -88,7 +88,7 @@ namespace LoRaWan.IntegrationTest
 
         protected virtual void Dispose(bool disposing)
         {
-            Console.WriteLine($"{nameof(EventHubDataCollector)} disposed");
+            TestLogger.Log($"{nameof(EventHubDataCollector)} disposed");
 
             if(!disposedValue)
             {
@@ -103,7 +103,7 @@ namespace LoRaWan.IntegrationTest
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine($"Error closing event hub receiver: {ex.ToString()}");
+                            TestLogger.Log($"Error closing event hub receiver: {ex.ToString()}");
                         }
 
                         this.receivers.RemoveAt(i);

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestBase.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestBase.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace LoRaWan.IntegrationTest
+{
+    public class IntegrationTestBase : IClassFixture<IntegrationTestFixture>, IDisposable
+    {
+        private IntegrationTestFixture testFixture;
+        protected IntegrationTestFixture TestFixture { get { return this.testFixture; } }
+
+        private LoRaArduinoSerial arduinoDevice;
+        protected LoRaArduinoSerial ArduinoDevice { get { return this.arduinoDevice; } }
+
+
+        public IntegrationTestBase(IntegrationTestFixture testFixture)
+        {
+            this.testFixture = testFixture;
+            this.arduinoDevice = LoRaArduinoSerial.CreateFromPort(this.TestFixture.Configuration.LeafDeviceSerialPort);
+            this.TestFixture.ClearNetworkServerModuleLog();
+        }
+
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    this.arduinoDevice?.Dispose();
+                    this.arduinoDevice = null;
+                }
+            
+                disposedValue = true;
+            }
+        }
+
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // TODO: uncomment the following line if the finalizer is overridden above.
+            GC.SuppressFinalize(this);
+        }
+        #endregion
+
+        protected void Log(string value) =>TestLogger.Log(value);
+    }
+}

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixture.Asserts.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixture.Asserts.cs
@@ -36,7 +36,7 @@ namespace LoRaWan.IntegrationTest
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Error searching device payload: {eventDataMessageBody}. {ex.ToString()}");
+                    TestLogger.Log($"Error searching device payload: {eventDataMessageBody}. {ex.ToString()}");
                 }
             } 
            
@@ -70,12 +70,12 @@ namespace LoRaWan.IntegrationTest
             {
                 if (searchResult.Found)
                 {
-                    Console.WriteLine($"'{expectedDataValue}' for device {deviceID} found in logs? {searchResult.Found}");
+                    TestLogger.Log($"'{expectedDataValue}' for device {deviceID} found in logs? {searchResult.Found}");
                 }
                 else
                 {
                     var logs = string.Join("\n\t", searchResult.Logs.TakeLast(5));
-                    Console.WriteLine($"'{expectedDataValue}' for device {deviceID} found in logs? {searchResult.Found}. Logs: [{logs}]");
+                    TestLogger.Log($"'{expectedDataValue}' for device {deviceID} found in logs? {searchResult.Found}. Logs: [{logs}]");
                 }
             }                    
         }
@@ -122,12 +122,12 @@ namespace LoRaWan.IntegrationTest
             {
                 if (searchResult.Found)
                 {
-                    Console.WriteLine($"'{options?.Description ?? "??"}' found in logs? {searchResult.Found}");
+                    TestLogger.Log($"'{options?.Description ?? "??"}' found in logs? {searchResult.Found}");
                 }
                 else
                 {
                     var logs = string.Join("\n\t", searchResult.Logs.TakeLast(5));
-                    Console.WriteLine($"'{options?.Description ?? "??"}' found in logs? {searchResult.Found}. Logs: [{logs}]");
+                    TestLogger.Log($"'{options?.Description ?? "??"}' found in logs? {searchResult.Found}. Logs: [{logs}]");
                 }
             }            
         }
@@ -143,11 +143,11 @@ namespace LoRaWan.IntegrationTest
                     var timeToWait = i * this.Configuration.EnsureHasEventDelayBetweenReadsInSeconds;
                     if (!string.IsNullOrEmpty(options?.Description))
                     {
-                        Console.WriteLine($"UDP log message '{options.Description}' not found, attempt {i}/{maxAttempts}, waiting {timeToWait} secs");
+                        TestLogger.Log($"UDP log message '{options.Description}' not found, attempt {i}/{maxAttempts}, waiting {timeToWait} secs");
                     }
                     else
                     {
-                        Console.WriteLine($"UDP log message not found, attempt {i}/{maxAttempts}, waiting {timeToWait} secs");
+                        TestLogger.Log($"UDP log message not found, attempt {i}/{maxAttempts}, waiting {timeToWait} secs");
                     }
                     await Task.Delay(TimeSpan.FromSeconds(timeToWait));
                 }
@@ -177,11 +177,11 @@ namespace LoRaWan.IntegrationTest
                     var timeToWait = i * this.Configuration.EnsureHasEventDelayBetweenReadsInSeconds;
                     if (!string.IsNullOrEmpty(options?.Description))
                     {
-                        Console.WriteLine($"IoT Hub message '{options.Description}' not found, attempt {i}/{maxAttempts}, waiting {timeToWait} secs");
+                        TestLogger.Log($"IoT Hub message '{options.Description}' not found, attempt {i}/{maxAttempts}, waiting {timeToWait} secs");
                     }
                     else
                     {
-                        Console.WriteLine($"IoT Hub message not found, attempt {i}/{maxAttempts}, waiting {timeToWait} secs");
+                        TestLogger.Log($"IoT Hub message not found, attempt {i}/{maxAttempts}, waiting {timeToWait} secs");
                     }
                     await Task.Delay(TimeSpan.FromSeconds(timeToWait));
                 }
@@ -212,11 +212,11 @@ namespace LoRaWan.IntegrationTest
                     var timeToWait = i * this.Configuration.EnsureHasEventDelayBetweenReadsInSeconds;
                     if (!string.IsNullOrEmpty(options?.Description))
                     {
-                        Console.WriteLine($"IoT Hub message '{options.Description}' not found, attempt {i}/{maxAttempts}, waiting {timeToWait} secs");
+                        TestLogger.Log($"IoT Hub message '{options.Description}' not found, attempt {i}/{maxAttempts}, waiting {timeToWait} secs");
                     }
                     else
                     {
-                        Console.WriteLine($"IoT Hub message not found, attempt {i}/{maxAttempts}, waiting {timeToWait} secs");
+                        TestLogger.Log($"IoT Hub message not found, attempt {i}/{maxAttempts}, waiting {timeToWait} secs");
                     }
                     await Task.Delay(TimeSpan.FromSeconds(timeToWait));
                 }
@@ -235,7 +235,7 @@ namespace LoRaWan.IntegrationTest
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine("Error searching in IoT Hub message log: " + ex.ToString());
+                        TestLogger.Log("Error searching in IoT Hub message log: " + ex.ToString());
                     }
                 }
             }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixture.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixture.cs
@@ -268,7 +268,7 @@ namespace LoRaWan.IntegrationTest
         bool disposed = false;
         public void Dispose()
         {
-            Console.WriteLine($"{nameof(IntegrationTestFixture)} disposed");
+            TestLogger.Log($"{nameof(IntegrationTestFixture)} disposed");
 
             if (disposed)
                 return;
@@ -317,7 +317,7 @@ namespace LoRaWan.IntegrationTest
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error replacing twin for device {deviceId}: {ex.ToString()}");
+                TestLogger.Log($"Error replacing twin for device {deviceId}: {ex.ToString()}");
                 throw;
             }
         }
@@ -357,12 +357,12 @@ namespace LoRaWan.IntegrationTest
                 var getDeviceResult = await registryManager.GetDeviceAsync(testDevice.DeviceID);
                 if (getDeviceResult == null)
                 {
-                    Console.WriteLine($"Device {testDevice.DeviceID} does not exist. Creating");
+                    TestLogger.Log($"Device {testDevice.DeviceID} does not exist. Creating");
                     var device = new Device(testDevice.DeviceID);
                     var twin = new Twin(testDevice.DeviceID);                                            
                     twin.Properties.Desired = new TwinCollection(JsonConvert.SerializeObject(testDevice.GetDesiredProperties()));
 
-                    Console.WriteLine($"Creating device {testDevice.DeviceID}");
+                    TestLogger.Log($"Creating device {testDevice.DeviceID}");
                     await registryManager.AddDeviceWithTwinAsync(device, twin);
                 }
                 else 
@@ -374,12 +374,12 @@ namespace LoRaWan.IntegrationTest
                     {
                         if (!deviceTwin.Properties.Desired.Contains(kv.Key) || (string)deviceTwin.Properties.Desired[kv.Key] != kv.Value)
                         {
-                            Console.WriteLine($"Unexpected value for device {testDevice.DeviceID} twin property {kv.Key}, expecting '{kv.Value}', actual is '{(string)deviceTwin.Properties.Desired[kv.Key]}'");
+                            TestLogger.Log($"Unexpected value for device {testDevice.DeviceID} twin property {kv.Key}, expecting '{kv.Value}', actual is '{(string)deviceTwin.Properties.Desired[kv.Key]}'");
                             
                             var patch = new Twin();
                             patch.Properties.Desired = new TwinCollection(JsonConvert.SerializeObject(desiredProperties));
                             await registryManager.UpdateTwinAsync(testDevice.DeviceID, patch, deviceTwin.ETag);
-                            Console.WriteLine($"Update twin for device {testDevice.DeviceID}");
+                            TestLogger.Log($"Update twin for device {testDevice.DeviceID}");
                             break;
                         }
                     }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaArduinoSerial.Helper.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaArduinoSerial.Helper.cs
@@ -16,26 +16,26 @@ namespace LoRaWan.IntegrationTest
 
             if (!isWindows)
             {
-                Console.WriteLine ($"Starting serial port '{port}' on non-Windows");
+                TestLogger.Log($"Starting serial port '{port}' on non-Windows");
 
                 var serialPort = new SerialDevice (port, BaudRate.B115200);
                 result = new LoRaArduinoSerial (serialPort);
 
-                Console.WriteLine ($"Opening serial port");
+                TestLogger.Log($"Opening serial port");
                 try
                 {
                     serialPort.Open ();
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine ($"Error opening serial port '{port}': {ex.ToString()}");
+                    TestLogger.Log($"Error opening serial port '{port}': {ex.ToString()}");
                     throw;
                 }
 
             }
             else
             {
-                Console.WriteLine ($"Starting serial port '{port}' on Windows");
+                TestLogger.Log($"Starting serial port '{port}' on Windows");
 
                 var serialPortWin = new SerialPort (port)
                 {
@@ -54,7 +54,7 @@ namespace LoRaWan.IntegrationTest
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine ($"Error opening serial port '{port}': {ex.ToString()}");
+                    TestLogger.Log($"Error opening serial port '{port}': {ex.ToString()}");
                     throw;
                 }
                 

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/LoraArduinoSerial.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/LoraArduinoSerial.cs
@@ -126,7 +126,7 @@ namespace LoRaWan.IntegrationTest
 
         void AppendSerialLog(string message)
         {
-            Console.WriteLine($"[Serial log] {message}");
+            TestLogger.Log($"[Serial log] {message}");
             this.serialLogs.Enqueue(message);
         }
         public IReadOnlyCollection<string> SerialLogs { get { return this.serialLogs; } }
@@ -724,8 +724,8 @@ namespace LoRaWan.IntegrationTest
         public async Task<bool> setOTAAJoinAsyncWithRetry(_otaa_join_cmd_t command, int timeoutPerTry, int retries, int delayBetweenRetries = 5000)
         {     
             for (var attempt=1; attempt <= retries; ++attempt)
-            {        
-                Console.WriteLine($"Join attempt #{attempt}/{retries}");
+            {
+                TestLogger.Log($"Join attempt #{attempt}/{retries}");
                 if (command == _otaa_join_cmd_t.JOIN) 
                     sendCommand ("AT+JOIN\r\n");
                 else if (command == _otaa_join_cmd_t.FORCE) 

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/OTAATest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/OTAATest.cs
@@ -8,24 +8,11 @@ namespace LoRaWan.IntegrationTest
 {
     // Tests OTAA requests
     [Collection("ArduinoSerialCollection")] // run in serial
-    public sealed class OTAATest : IClassFixture<IntegrationTestFixture>, IDisposable
+    public sealed class OTAATest : IntegrationTestBase
     {
-        private readonly IntegrationTestFixture testFixture;
-        private LoRaArduinoSerial arduinoDevice;
 
-        public OTAATest(IntegrationTestFixture testFixture)
+        public OTAATest(IntegrationTestFixture testFixture) : base(testFixture)
         {
-            this.testFixture = testFixture;
-            this.arduinoDevice = LoRaArduinoSerial.CreateFromPort(testFixture.Configuration.LeafDeviceSerialPort);
-            this.testFixture.ClearNetworkServerModuleLog();
-        }
-
-        public void Dispose()
-        {
-            this.arduinoDevice?.Dispose();
-            this.arduinoDevice = null;
-            GC.SuppressFinalize(this);
-
         }
 
         // Performs a OTAA join and sends N confirmed and unconfirmed messages
@@ -38,16 +25,16 @@ namespace LoRaWan.IntegrationTest
         {
             const int MESSAGES_COUNT = 10;
 
-            var device = this.testFixture.Device4_OTAA;
-            Console.WriteLine($"Starting {nameof(Test_OTAA_Confirmed_And_Unconfirmed_Message)} using device {device.DeviceID}");      
+            var device = this.TestFixture.Device4_OTAA;
+            Log($"Starting {nameof(Test_OTAA_Confirmed_And_Unconfirmed_Message)} using device {device.DeviceID}");      
 
-            await arduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
-            await arduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
-            await arduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, device.AppKey);
+            await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
+            await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
+            await this.ArduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, device.AppKey);
 
-            await arduinoDevice.SetupLora(this.testFixture.Configuration.LoraRegion);
+            await this.ArduinoDevice.SetupLora(this.TestFixture.Configuration.LoraRegion);
 
-             var joinSucceeded = await arduinoDevice.setOTAAJoinAsyncWithRetry(LoRaArduinoSerial._otaa_join_cmd_t.JOIN, 20000, 5);
+             var joinSucceeded = await this.ArduinoDevice.setOTAAJoinAsyncWithRetry(LoRaArduinoSerial._otaa_join_cmd_t.JOIN, 20000, 5);
 
             if (!joinSucceeded)
             {                
@@ -61,31 +48,31 @@ namespace LoRaWan.IntegrationTest
             for (var i=0; i < MESSAGES_COUNT; ++i)
             {
                 var msg = PayloadGenerator.Next().ToString();
-                await arduinoDevice.transferPacketAsync(msg, 10);
+                await this.ArduinoDevice.transferPacketAsync(msg, 10);
 
                 await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
 
                 // After transferPacket: Expectation from serial
                 // +MSG: Done                        
-                await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.arduinoDevice.SerialLogs);
+                await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
 
 
                 // 0000000000000004: valid frame counter, msg: 1 server: 0
-                await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: valid frame counter, msg:");
+                await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: valid frame counter, msg:");
 
                 // 0000000000000004: decoding with: DecoderValueSensor port: 8
-                await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: decoding with: {device.SensorDecoder} port:");
+                await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: decoding with: {device.SensorDecoder} port:");
             
                 // 0000000000000004: message '{"value": 51}' sent to hub
-                await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: message '{{\"value\":{msg}}}' sent to hub");
+                await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: message '{{\"value\":{msg}}}' sent to hub");
 
                 // Ensure device payload is available
                 // Data: {"value": 51}
                 var expectedPayload = $"{{\"value\":{msg}}}";
-                await this.testFixture.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, expectedPayload);
+                await this.TestFixture.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, expectedPayload);
 
-                this.arduinoDevice.ClearSerialLogs();
-                testFixture.ClearNetworkServerModuleLog();
+                this.ArduinoDevice.ClearSerialLogs();
+                this.TestFixture.ClearNetworkServerModuleLog();
 
                 await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
             }
@@ -94,27 +81,27 @@ namespace LoRaWan.IntegrationTest
             for (var i=0; i < MESSAGES_COUNT; ++i)
             {
                 var msg = PayloadGenerator.Next().ToString();
-                await arduinoDevice.transferPacketWithConfirmedAsync(msg, 10);
+                await this.ArduinoDevice.transferPacketWithConfirmedAsync(msg, 10);
 
                 await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
 
                 // After transferPacketWithConfirmed: Expectation from serial
                 // +CMSG: ACK Received
-                await AssertUtils.ContainsWithRetriesAsync("+CMSG: ACK Received", this.arduinoDevice.SerialLogs);
+                await AssertUtils.ContainsWithRetriesAsync("+CMSG: ACK Received", this.ArduinoDevice.SerialLogs);
 
                 // 0000000000000004: decoding with: DecoderValueSensor port: 8
-                await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: decoding with: {device.SensorDecoder} port:");
+                await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: decoding with: {device.SensorDecoder} port:");
             
                 // 0000000000000004: message '{"value": 51}' sent to hub
-                await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: message '{{\"value\":{msg}}}' sent to hub");
+                await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: message '{{\"value\":{msg}}}' sent to hub");
 
                 // Ensure device payload is available
                 // Data: {"value": 51}
                 var expectedPayload = $"{{\"value\":{msg}}}";
-                await this.testFixture.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, expectedPayload);
+                await this.TestFixture.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, expectedPayload);
 
-                this.arduinoDevice.ClearSerialLogs();
-                testFixture.ClearNetworkServerModuleLog();
+                this.ArduinoDevice.ClearSerialLogs();
+                this.TestFixture.ClearNetworkServerModuleLog();
 
                 await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
             }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/SensorDecodingTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/SensorDecodingTest.cs
@@ -8,25 +8,10 @@ namespace LoRaWan.IntegrationTest
 {
     // Tests sensor decoding test (http, reflection)
     [Collection("ArduinoSerialCollection")] // run in serial
-    public class SensorDecodingTest: IClassFixture<IntegrationTestFixture>, IDisposable
+    public class SensorDecodingTest: IntegrationTestBase
     {
-        private readonly IntegrationTestFixture testFixture;
-        private LoRaArduinoSerial arduinoDevice;
-        
-
-        public SensorDecodingTest(IntegrationTestFixture testFixture)
+        public SensorDecodingTest(IntegrationTestFixture testFixture) : base(testFixture)
         {
-            this.testFixture = testFixture;
-            this.arduinoDevice = LoRaArduinoSerial.CreateFromPort(testFixture.Configuration.LeafDeviceSerialPort);
-            this.testFixture.ClearNetworkServerModuleLog();
-        }
-
-        public void Dispose()
-        {
-            this.arduinoDevice?.Dispose();
-            this.arduinoDevice = null;
-            GC.SuppressFinalize(this);
-
         }
 
 
@@ -35,16 +20,16 @@ namespace LoRaWan.IntegrationTest
         [Fact]
         public async Task SensorDecoder_HttpBased_ValueSensorDecoder_DecodesPayload()
         {
-            var device = this.testFixture.Device11_OTAA;
-            Console.WriteLine($"Starting {nameof(SensorDecoder_HttpBased_ValueSensorDecoder_DecodesPayload)} using device {device.DeviceID}");      
+            var device = this.TestFixture.Device11_OTAA;
+            Log($"Starting {nameof(SensorDecoder_HttpBased_ValueSensorDecoder_DecodesPayload)} using device {device.DeviceID}");      
 
-            await arduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
-            await arduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
-            await arduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, device.AppKey);
+            await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
+            await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
+            await this.ArduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, device.AppKey);
 
-            await arduinoDevice.SetupLora(this.testFixture.Configuration.LoraRegion);
+            await this.ArduinoDevice.SetupLora(this.TestFixture.Configuration.LoraRegion);
 
-            var joinSucceeded = await arduinoDevice.setOTAAJoinAsyncWithRetry(LoRaArduinoSerial._otaa_join_cmd_t.JOIN, 20000, 5);
+            var joinSucceeded = await this.ArduinoDevice.setOTAAJoinAsyncWithRetry(LoRaArduinoSerial._otaa_join_cmd_t.JOIN, 20000, 5);
 
             if (!joinSucceeded)
             {                
@@ -55,18 +40,18 @@ namespace LoRaWan.IntegrationTest
             await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_JOIN); 
 
             
-            await arduinoDevice.transferPacketWithConfirmedAsync("1234", 10);
+            await this.ArduinoDevice.transferPacketWithConfirmedAsync("1234", 10);
 
             await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
 
             // +CMSG: ACK Received
-            await AssertUtils.ContainsWithRetriesAsync("+CMSG: ACK Received", this.arduinoDevice.SerialLogs);
+            await AssertUtils.ContainsWithRetriesAsync("+CMSG: ACK Received", this.ArduinoDevice.SerialLogs);
 
             // Find "0000000000000011: message '{"value":1234}' sent to hub" in network server logs
-            await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: message '{{\"value\":1234}}' sent to hub");
+            await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: message '{{\"value\":1234}}' sent to hub");
 
-            this.arduinoDevice.ClearSerialLogs();
-            testFixture.ClearNetworkServerModuleLog();
+            this.ArduinoDevice.ClearSerialLogs();
+            this.TestFixture.ClearNetworkServerModuleLog();
         }
 
         // Ensures that reflect based sensor decoder decodes payload
@@ -74,16 +59,16 @@ namespace LoRaWan.IntegrationTest
         [Fact]
         public async Task SensorDecoder_ReflectionBased_ValueSensorDecoder_DecodesPayload()
         {
-            var device = this.testFixture.Device12_OTAA;
-            Console.WriteLine($"Starting {nameof(SensorDecoder_HttpBased_ValueSensorDecoder_DecodesPayload)} using device {device.DeviceID}");      
+            var device = this.TestFixture.Device12_OTAA;
+            Log($"Starting {nameof(SensorDecoder_HttpBased_ValueSensorDecoder_DecodesPayload)} using device {device.DeviceID}");      
 
-            await arduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
-            await arduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
-            await arduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, device.AppKey);
+            await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
+            await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
+            await this.ArduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, device.AppKey);
 
-            await arduinoDevice.SetupLora(this.testFixture.Configuration.LoraRegion);
+            await this.ArduinoDevice.SetupLora(this.TestFixture.Configuration.LoraRegion);
 
-            var joinSucceeded = await arduinoDevice.setOTAAJoinAsyncWithRetry(LoRaArduinoSerial._otaa_join_cmd_t.JOIN, 20000, 5);
+            var joinSucceeded = await this.ArduinoDevice.setOTAAJoinAsyncWithRetry(LoRaArduinoSerial._otaa_join_cmd_t.JOIN, 20000, 5);
 
             if (!joinSucceeded)
             {                
@@ -94,18 +79,18 @@ namespace LoRaWan.IntegrationTest
             await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_JOIN); 
 
             
-            await arduinoDevice.transferPacketWithConfirmedAsync("4321", 10);
+            await this.ArduinoDevice.transferPacketWithConfirmedAsync("4321", 10);
 
             await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
 
             // +CMSG: ACK Received
-            await AssertUtils.ContainsWithRetriesAsync("+CMSG: ACK Received", this.arduinoDevice.SerialLogs);
+            await AssertUtils.ContainsWithRetriesAsync("+CMSG: ACK Received", this.ArduinoDevice.SerialLogs);
 
             // Find "0000000000000011: message '{"value":1234}' sent to hub" in network server logs
-            await this.testFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: message '{{\"value\":4321}}' sent to hub");
+            await this.TestFixture.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: message '{{\"value\":4321}}' sent to hub");
 
-            this.arduinoDevice.ClearSerialLogs();
-            testFixture.ClearNetworkServerModuleLog();
+            this.ArduinoDevice.ClearSerialLogs();
+            this.TestFixture.ClearNetworkServerModuleLog();
         }
     }
 

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/TestLogger.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/TestLogger.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace LoRaWan.IntegrationTest
+{
+    /// <summary>
+    /// Helper class enabling logging in Integration Test
+    /// When running the tests in Visual Studio Log does not output
+    /// </summary>
+    static class TestLogger
+    {
+        /// <summary>
+        /// Logs
+        /// </summary>
+        /// <param name="text"></param>
+        internal static void Log(string text)
+        {
+            // Log to diagnostics if a debbuger is attached
+            if (Debugger.IsAttached)
+            {
+                System.Diagnostics.Debug.WriteLine(text);
+            }
+            else
+            {
+                Console.WriteLine(text);
+            }
+        }
+
+    }
+}

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/UdpLogListener.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/UdpLogListener.cs
@@ -34,8 +34,8 @@ namespace LoRaWan.IntegrationTest
             this.events.Enqueue(msg);
 
             if(this.LogToConsole)
-            {                
-                Console.WriteLine($"[UDPLog]: {msg}");
+            {
+                TestLogger.Log($"[UDPLog]: {msg}");
             }
         }
 
@@ -59,7 +59,7 @@ namespace LoRaWan.IntegrationTest
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Error in UDP listener: {ex.ToString()}");
+                    TestLogger.Log($"Error in UDP listener: {ex.ToString()}");
                 }
             });
         }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/CaseInsensitiveEnvironmentVariablesTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/CaseInsensitiveEnvironmentVariablesTest.cs
@@ -1,0 +1,284 @@
+using System;
+using Xunit;
+using LoRaWan.NetworkServer;
+using System.Collections.Generic;
+
+namespace LoRaWan.NetworkServer.Test
+{
+
+    public class CaseInsensitiveEnvironmentVariablesTest
+    {
+        [Fact]
+        public void Should_Return_Null_If_Not_Found()
+        {
+            var variables = new Dictionary<string, string>() {
+                
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("NOT_EXISTS", null);
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void Should_Return_StringEmpty_If_Not_Found()
+        {
+            var variables = new Dictionary<string, string>() {
+                
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("NOT_EXISTS", string.Empty);
+            Assert.NotNull(actual);
+            Assert.Equal(0, actual.Length);
+        }
+
+        [Fact]
+        public void Should_Find_String_If_Case_Matches()
+        {
+            var variables = new Dictionary<string, string>() {
+                { "MYVAR", "VALUE" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", string.Empty);
+            Assert.NotNull(actual);
+            Assert.Equal("VALUE", actual);
+        }
+
+        [Fact]
+        public void Should_Find_String_If_Case_Does_Not_Match()
+        {
+            var variables = new Dictionary<string, string>() {
+                { "myvar", "VALUE" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", string.Empty);
+            Assert.NotNull(actual);
+            Assert.Equal("VALUE", actual);
+        }
+
+
+        [Fact]
+        public void Should_Return_Default_Bool_Value_False_If_Not_Found()
+        {
+            var variables = new Dictionary<string, string>() {
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", false);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Should_Return_Default_Bool_Value_True_If_Not_Found()
+        {
+            var variables = new Dictionary<string, string>()
+            {
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", true);
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Should_Return_Default_Bool_Value_If_Cannot_Parse()
+        {
+            var variables = new Dictionary<string, string>()
+            {
+                { "MYVAR", "ABC" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", true);
+            Assert.True(actual);
+        }
+
+
+
+        [Fact]
+        public void Should_Find_Bool_If_Case_Matches()
+        {
+            var variables = new Dictionary<string, string>() {
+                { "MYVAR", "true" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", false);
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Should_Find_Bool_If_Case_Does_Not_Match()
+        {
+            var variables = new Dictionary<string, string>() {
+                { "myvar", "true" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", false);
+            Assert.True(actual);
+        }
+
+
+        [Fact]
+        public void Should_Return_Default_Double_Value_True_If_Not_Found()
+        {
+            var variables = new Dictionary<string, string>()
+            {
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", 10.0);
+            Assert.Equal(10.0, actual);
+        }
+
+        [Fact]
+        public void Should_Return_Default_Double_Value_If_Cannot_Parse()
+        {
+            var variables = new Dictionary<string, string>()
+            {
+                { "MYVAR", "ABC" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", 12.0);
+            Assert.Equal(12.0, actual);
+        }
+
+
+
+        [Fact]
+        public void Should_Find_Double_If_Case_Matches()
+        {
+            var variables = new Dictionary<string, string>() {
+                { "MYVAR", "20" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", 0.0);
+            Assert.Equal(20.0, actual);
+        }
+
+        [Fact]
+        public void Should_Find_Double_If_Case_Does_Not_Match()
+        {
+            var variables = new Dictionary<string, string>() {
+                { "myvar", "89.31" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", 0.0);
+            Assert.Equal(89.31, actual);
+        }
+
+        [Fact]
+        public void Should_Return_Default_Int_Value_True_If_Not_Found()
+        {
+            var variables = new Dictionary<string, string>()
+            {
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", 10);
+            Assert.Equal(10, actual);
+        }
+
+        [Fact]
+        public void Should_Return_Default_Int_Value_If_Cannot_Parse()
+        {
+            var variables = new Dictionary<string, string>()
+            {
+                { "MYVAR", "ABC" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", 12);
+            Assert.Equal(12, actual);
+        }
+
+
+
+        [Fact]
+        public void Should_Find_Int_If_Case_Matches()
+        {
+            var variables = new Dictionary<string, string>() {
+                { "MYVAR", "20" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", 0);
+            Assert.Equal(20, actual);
+        }
+
+        [Fact]
+        public void Should_Find_Int_If_Case_Does_Not_Match()
+        {
+            var variables = new Dictionary<string, string>() {
+                { "myvar", "8931" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", 0);
+            Assert.Equal(8931, actual);
+        }
+
+
+
+
+
+        [Fact]
+        public void Should_Return_Default_Uint_Value_True_If_Not_Found()
+        {
+            var variables = new Dictionary<string, string>()
+            {
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", 10u);
+            Assert.Equal(10u, actual);
+        }
+
+        [Fact]
+        public void Should_Return_Default_Uint_Value_If_Cannot_Parse()
+        {
+            var variables = new Dictionary<string, string>()
+            {
+                { "MYVAR", "ABC" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", 12u);
+            Assert.Equal(12u, actual);
+        }
+
+
+
+        [Fact]
+        public void Should_Find_Uint_If_Case_Matches()
+        {
+            var variables = new Dictionary<string, string>() {
+                { "MYVAR", "20" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", 0u);
+            Assert.Equal(20u, actual);
+        }
+
+        [Fact]
+        public void Should_Find_Uint_If_Case_Does_Not_Match()
+        {
+            var variables = new Dictionary<string, string>() {
+                { "myvar", "8931" }
+            };
+
+            var target = new CaseInsensitiveEnvironmentVariables(variables);
+            var actual = target.GetEnvVar("MYVAR", 0u);
+            Assert.Equal(8931u, actual);
+        }
+    }
+
+}

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaWanNetworkServer.Test.csproj
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaWanNetworkServer.Test.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\modules\LoRaWanNetworkSrvModule\LoRaWan.NetworkServer\LoRaWan.NetworkServer.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Since I introduced a few changes to the core logic, we need to discuss them. It is a small step into decoupling the system.

Changes:
* Passing configuration as constructor to IoTHubConnector, MessageProcessor and UdpServer
* MessageProcessor.ProcessMessageAsync now returns a byte[] which is forwarded to pkt forwarder by the UdpServer. Previously MessageProcessor was calling UdpServer.UdpSendMessage directly. This changes decoupled message processing from the udp server. It won't work if processing message sends more than one message back to udp
* LoraDeviceInfoManager is now passed to dependent classes in the constructor (UdpServer, MessageProcessor). It was previously available as static methods which are hard to mock in unit tests.
* Environment variables resolution is case insensitive: LOG_TO_HUB == log_to_hub
* Debugging integration tests in Visual Studio now prints logs to debug window

Integration test succeeded with exception of C2D and device twin verification (EdgeHub having a bad day)