### PR TITLE
Update MessageProcessor.cs to fix bug 798

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
@@ -149,7 +149,7 @@ namespace LoRaWan.NetworkServer
                             // Decoder is set in LoRa Device Twin. Send decrpytedMessage (payload) and fportUp (fPort) to decoder.
                             else
                             {
-                                Logger.Log(loraDeviceInfo.DevEUI, $"decoding with: {loraDeviceInfo.SensorDecoder} port: {fportUp}", Logger.LoggingLevel.Info);
+                                Logger.Log(loraDeviceInfo.DevEUI, $"decoding with: {loraDeviceInfo.SensorDecoder} port: {fportUp}", Logger.LoggingLevel.Full);
                                 fullPayload.data = await LoraDecoders.DecodeMessage(decryptedMessage, fportUp, loraDeviceInfo.SensorDecoder);
                             }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
@@ -135,11 +135,18 @@ namespace LoRaWan.NetworkServer
                             fullPayload.port = fportUp;
                             fullPayload.fcnt = fcntup;
 
-                            if (isAckFromDevice)
+                           // ACK from device or no decoder set in LoRa Device Twin. Simply return decryptedMessage
+                            if (isAckFromDevice || String.IsNullOrEmpty(loraDeviceInfo.SensorDecoder))
                             {
+                                if (String.IsNullOrEmpty(loraDeviceInfo.SensorDecoder))
+                                {
+                                    Logger.Log(loraDeviceInfo.DevEUI, $"no decoder set in device twin. port: {fportUp}", Logger.LoggingLevel.Info);
+                                }
+
                                 jsonDataPayload = Convert.ToBase64String(decryptedMessage);
                                 fullPayload.data = jsonDataPayload;
                             }
+                            // Decoder is set in LoRa Device Twin. Send decrpytedMessage (payload) and fportUp (fPort) to decoder.
                             else
                             {
                                 Logger.Log(loraDeviceInfo.DevEUI, $"decoding with: {loraDeviceInfo.SensorDecoder} port: {fportUp}", Logger.LoggingLevel.Info);
@@ -172,15 +179,18 @@ namespace LoRaWan.NetworkServer
                             if (isAckFromDevice)
                             {
                                 Logger.Log(loraDeviceInfo.DevEUI, $"ack from device sent to hub", Logger.LoggingLevel.Info);
-
                             }
                             else
                             {
-                                var fullPayloadAsString = fullPayload.data as string;
-                                if (fullPayloadAsString == null)
+                                var fullPayloadAsString = string.Empty;
+                                if (fullPayload.data is JValue jvalue)
                                 {
-                                    fullPayloadAsString = ((JObject)fullPayload.data).ToString(Formatting.None);
+                                    fullPayloadAsString = jvalue.ToString();
                                 }
+                                else if (fullPayload.data is JObject jobject)
+                                {
+                                    fullPayloadAsString = jobject.ToString(Formatting.None);
+                                }   
                                 Logger.Log(loraDeviceInfo.DevEUI, $"message '{fullPayloadAsString}' sent to hub", Logger.LoggingLevel.Info);
                             }
                             loraDeviceInfo.FCntUp = fcntup;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
@@ -140,7 +140,7 @@ namespace LoRaWan.NetworkServer
                             {
                                 if (String.IsNullOrEmpty(loraDeviceInfo.SensorDecoder))
                                 {
-                                    Logger.Log(loraDeviceInfo.DevEUI, $"no decoder set in device twin. port: {fportUp}", Logger.LoggingLevel.Info);
+                                    Logger.Log(loraDeviceInfo.DevEUI, $"no decoder set in device twin. port: {fportUp}", Logger.LoggingLevel.Full);
                                 }
 
                                 jsonDataPayload = Convert.ToBase64String(decryptedMessage);

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -126,7 +126,7 @@ jobs:
     EDGEHUB_HTTPSETTINGS_ENABLED: false
     EDGEHUB_ROUTE: FROM /* INTO $upstream
     # LoRaWan Modules
-    NET_SRV_LOG_LEVEL: 2  
+    NET_SRV_LOG_LEVEL: 1  
     NET_SRV_LOGTO_UDP: true
     NET_SRV_LOGTO_HUB: false
     NET_SRV_IOTEDGE_TIMEOUT: 0


### PR DESCRIPTION
Now correctly accepts all of the following loraDeviceInfo.SensorDecoder:
- empty / null: Just return base64 decoded payload data
- local decoder name
- external decoder container url
