### PR TITLE
Integration tests in AMD64 platform

### DIFF
--- a/LoRaEngine/deployment.test.template.json
+++ b/LoRaEngine/deployment.test.template.json
@@ -156,13 +156,13 @@
               },
               "VSTS_AGENT": {
                 "value": "$VSTS_AGENT"
-              } 
+              }
             }
           },
-          "sensordecodermodule":{
+          "sensordecodermodule": {
             "type": "docker",
             "settings": {
-              "image": "fbeltrao/decodersample:1.0-arm32v7",
+              "image": "fbeltrao/decodersample:1.0",
               "createOptions": {}
             },
             "status": "running",

--- a/LoRaEngine/example.env
+++ b/LoRaEngine/example.env
@@ -61,7 +61,7 @@ SIMULATOR_PORT=1681
 
 # For ARM32v7
 # Build the image and push to your ACR
-DEVOPS_AGENT_IMAGE=your.azurecr.io/azuredevopsagent:2.142.1-arm32v7
+DEVOPS_AGENT_IMAGE=your.azurecr.io/azuredevopsagent:2.142.1
 # For amd64 or Windows, use microsoft official image
 VSTS_AGENT=NameOfYourAgent
 VSTS_ACCOUNT=yourDevOpsAccount # The 'yourproject' from URL https://yourproject.visualstudio.com

--- a/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.amd64
+++ b/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk-stretch-arm32v7
+FROM microsoft/dotnet:2.1-sdk-stretch
 
 ENV VSTS_POOL=default VSTS_AGENT=myAgent
 
@@ -9,8 +9,8 @@ wget \
 git
  
 # Download compiles vsts-agent
-RUN curl https://vstsagentpackage.azureedge.net/agent/2.142.1/vsts-agent-linux-arm-2.142.1.tar.gz -o vsts-agent.tar.gz
-RUN mkdir vsts-agent
+RUN curl https://vstsagentpackage.azureedge.net/agent/2.142.1/vsts-agent-linux-x64-2.142.1.tar.gz -o vsts-agent.tar.gz
+RUN mkdir mkdir -p vsts-agent/_diag && chmod o+w ./vsts-agent
 RUN tar xzf vsts-agent.tar.gz -C ./vsts-agent
  
 # install node
@@ -20,4 +20,3 @@ RUN apt-get install -y nodejs
 COPY vsts.sh .
 
 ENTRYPOINT [ "/bin/bash", "./vsts.sh" ]
-

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
@@ -3,16 +3,23 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 
 namespace LoRaWan
 { 
     public class Logger
     {
+        // Interval where we try to estabilish connection to udp logger
+        const int RETRY_UDP_LOG_CONNECTION_INTERVAL_IN_MS = 1000 * 10;
+
         public enum LoggingLevel : int { Always=0, Full, Info, Error };
 
         static LoggerConfiguration configuration = new LoggerConfiguration();
-        static UdpClient udpClient;
+        static volatile UdpClient udpClient;
         static IPEndPoint udpEndpoint;
+
+        static volatile bool isInitializeUdpLoggerRunning = false;
+        private static Timer retryUdpLogInitializationTimer;
 
         public static void Init(LoggerConfiguration loggerConfiguration)
         {
@@ -20,48 +27,21 @@ namespace LoRaWan
 
             if (configuration.LogToUdp)
             {
-                try
+                InitializeUdpLogger(isRetry: false);
+                
+                
+                // If udp client was not created set a timer to retry every x seconds
+                // The listening container might not have started yet (i.e. AzureDevOpsAgent)
+                if (udpClient == null)
                 {
-                    if (string.IsNullOrEmpty(configuration.LogToUdpAddress))
-                    {                        
-                        udpEndpoint = new IPEndPoint(IPAddress.Broadcast, configuration.LogToUdpPort);
-                    }
-                    else
+                    // retry in 10 seconds
+                    retryUdpLogInitializationTimer = new Timer((state) =>
                     {
-                        if (IPAddress.TryParse(configuration.LogToUdpAddress, out var parsedIpAddress))
-                        {
-                            udpEndpoint = new IPEndPoint(parsedIpAddress, configuration.LogToUdpPort);
-                        }
-                        else
-                        {
-                            // try to parse the address as dns
-                            var addresses = Dns.GetHostAddresses(configuration.LogToUdpAddress);
-                            if (addresses == null || addresses.Length == 0)
-                            {
-                                LogToConsole($"Could not resolve ip address from '{configuration.LogToUdpAddress}'");
-                            }
-                            else
-                            {
-                                udpEndpoint = new IPEndPoint(addresses[0], configuration.LogToUdpPort);     
-                            }                            
-                        }
-                    }
-
-                    if (udpEndpoint == null)
-                    {
-                        LogToConsole($"Logging to Udp failed. Could not resolve ip address from '{configuration.LogToUdpAddress}'");
-                    }
-                    else
-                    {                    
-                        udpClient = new UdpClient();
-                        udpClient.ExclusiveAddressUse = false;
-
-                        LogToConsole(string.Concat("Logging to Udp: ", udpEndpoint.ToString()));
-                    }
-                }
-                catch (Exception ex)
-                {
-                    LogToConsole(string.Concat("Error starting UDP logging: ", ex.ToString()));
+                        InitializeUdpLogger(isRetry: true);
+                    },
+                    null,
+                    RETRY_UDP_LOG_CONNECTION_INTERVAL_IN_MS,
+                    RETRY_UDP_LOG_CONNECTION_INTERVAL_IN_MS);
                 }
             }
         }
@@ -75,12 +55,10 @@ namespace LoRaWan
         {            
             if ((int)loggingLevel >= configuration.LogLevel || loggingLevel == LoggingLevel.Always)
             {
-                string msg = "";
+                var msg = message;
 
-                if (string.IsNullOrEmpty(deviceId))
-                    msg = message;
-                else
-                    msg = $"{deviceId}: { message}";
+                if (!string.IsNullOrEmpty(deviceId))
+                    msg = $"{deviceId}: {message}";
 
                 if (configuration.LogToHub && configuration.ModuleClient != null)
                 {
@@ -95,6 +73,12 @@ namespace LoRaWan
             }
         }
         
+
+        static void LogToConsole(string message)
+        {
+            Console.WriteLine(String.Concat(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")," ", message));
+        }        
+
         static void LogToUdp(string message)
         {            
             try
@@ -104,13 +88,83 @@ namespace LoRaWan
             }
             catch (Exception ex)
             {
-                Console.WriteLine(string.Concat(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")," Error logging to UDP: ", ex.ToString()));
+                LogToConsole(string.Concat(" Error logging to UDP: ", ex.ToString()));
             }
         }
 
-        static void LogToConsole(string message)
+        // Initialize Udp Logger
+        // Might be called from a timer while it does not work
+        // Need to make this retries because NetworkServer might become alive 
+        // before listening container is started
+        static void InitializeUdpLogger(bool isRetry = false)
         {
-            Console.WriteLine(String.Concat(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")," ", message));
+            if (isInitializeUdpLoggerRunning)
+            {
+                LogToConsole("Retrying to connect to UDP log server skipped, one already running");
+                return;
+            }
+
+            if (isRetry)
+                LogToConsole("Retrying to connect to UDP log server");
+
+            try
+            {
+                if (string.IsNullOrEmpty(configuration.LogToUdpAddress))
+                {
+                    udpEndpoint = new IPEndPoint(IPAddress.Broadcast, configuration.LogToUdpPort);
+                }
+                else
+                {
+                    if (IPAddress.TryParse(configuration.LogToUdpAddress, out var parsedIpAddress))
+                    {
+                        udpEndpoint = new IPEndPoint(parsedIpAddress, configuration.LogToUdpPort);
+                    }
+                    else
+                    {
+                        try
+                        {
+                            // try to parse the address as dns
+                            var addresses = Dns.GetHostAddresses(configuration.LogToUdpAddress);
+                            if (addresses == null || addresses.Length == 0)
+                            {
+                                LogToConsole($"Could not resolve ip address from '{configuration.LogToUdpAddress}'");
+                            }
+                            else
+                            {
+                                udpEndpoint = new IPEndPoint(addresses[0], configuration.LogToUdpPort);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            LogToConsole($"Could not resolve ip address from '{configuration.LogToUdpAddress}'. {ex.Message}");
+                        }
+                    }
+                }
+
+                if (udpEndpoint != null)
+                {
+                    udpClient = new UdpClient
+                    {
+                        ExclusiveAddressUse = false
+                    };
+
+                    LogToConsole(string.Concat("Logging to Udp: ", udpEndpoint.ToString()));
+
+                    if (retryUdpLogInitializationTimer != null)
+                    {
+                        retryUdpLogInitializationTimer.Dispose();
+                        retryUdpLogInitializationTimer = null;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                LogToConsole(string.Concat("Error starting UDP logging: ", ex.ToString()));
+            }
+            finally
+            {
+                isInitializeUdpLoggerRunning = false;
+            }
         }
     }
 }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixture.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixture.cs
@@ -15,6 +15,7 @@ namespace LoRaWan.IntegrationTest
     public partial class IntegrationTestFixture : IDisposable, IAsyncLifetime
     {
         public const string MESSAGE_IDENTIFIER_PROPERTY_NAME = "messageIdentifier";
+
         RegistryManager registryManager;
         private UdpLogListener udpLogListener;
 
@@ -87,14 +88,20 @@ namespace LoRaWan.IntegrationTest
                 foreach (var d in GetAllDevices())
                 {
                     d.DeviceID = string.Concat(Configuration.DevicePrefix, d.DeviceID.Substring(Configuration.DevicePrefix.Length, d.DeviceID.Length - Configuration.DevicePrefix.Length));
-                    if (!string.IsNullOrEmpty(d.AppEUI))                    
+                    if (!string.IsNullOrEmpty(d.AppEUI))
                         d.AppEUI = string.Concat(Configuration.DevicePrefix, d.AppEUI.Substring(Configuration.DevicePrefix.Length, d.AppEUI.Length - Configuration.DevicePrefix.Length));
+    
+                    if (!string.IsNullOrEmpty(d.AppKey))
+                        d.AppKey = string.Concat(Configuration.DevicePrefix, d.AppKey.Substring(Configuration.DevicePrefix.Length, d.AppKey.Length - Configuration.DevicePrefix.Length));                    
 
-                    if (!string.IsNullOrEmpty(d.AppSKey))                    
+                    if (!string.IsNullOrEmpty(d.AppSKey))
                         d.AppSKey = string.Concat(Configuration.DevicePrefix, d.AppSKey.Substring(Configuration.DevicePrefix.Length, d.AppSKey.Length - Configuration.DevicePrefix.Length));
 
-                    if (!string.IsNullOrEmpty(d.NwkSKey))                    
-                        d.NwkSKey = string.Concat(Configuration.DevicePrefix, d.NwkSKey.Substring(Configuration.DevicePrefix.Length, d.NwkSKey.Length - Configuration.DevicePrefix.Length));                                            
+                    if (!string.IsNullOrEmpty(d.NwkSKey))
+                        d.NwkSKey = string.Concat(Configuration.DevicePrefix, d.NwkSKey.Substring(Configuration.DevicePrefix.Length, d.NwkSKey.Length - Configuration.DevicePrefix.Length));
+                    
+                    if (!string.IsNullOrEmpty(d.DevAddr))
+                        d.DevAddr = string.Concat(Configuration.DevicePrefix, d.DevAddr.Substring(Configuration.DevicePrefix.Length, d.DevAddr.Length - Configuration.DevicePrefix.Length));                    
                 }
             }
         }
@@ -113,8 +120,8 @@ namespace LoRaWan.IntegrationTest
             this.Device1_OTAA = new TestDeviceInfo()
             {
                 DeviceID = "0000000000000001",
-                AppEUI = "BE7A0000000014E3",
-                AppKey = "8AFE71A145B253E49C3031AD068277A3",                
+                AppEUI = "0000000000000001",
+                AppKey = "00000000000000000000000000000001",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true                            
             };
@@ -123,8 +130,8 @@ namespace LoRaWan.IntegrationTest
             this.Device2_OTAA = new TestDeviceInfo()
             {
                 DeviceID = "0000000000000002",
-                AppEUI = "BE7A0000000014E3",
-                AppKey = "8AFE71A145B253E49C3031AD068277A3",
+                AppEUI = "0000000000000002",
+                AppKey = "00000000000000000000000000000002",
                 GatewayID = gatewayID,
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = false,
@@ -134,8 +141,8 @@ namespace LoRaWan.IntegrationTest
             this.Device3_OTAA = new TestDeviceInfo()
             {
                 DeviceID = "0000000000000003",
-                AppEUI = "BE7A00000000FFE3",
-                AppKey = "8AFE71A145B253E49C3031AD068277A3",
+                AppEUI = "0000000000000003",
+                AppKey = "00000000000000000000000000000003",
                 GatewayID = gatewayID,
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
@@ -146,8 +153,8 @@ namespace LoRaWan.IntegrationTest
             this.Device4_OTAA = new TestDeviceInfo()
             {
                 DeviceID = "0000000000000004",
-                AppEUI = "BE7A0000000014E3",
-                AppKey = "8AFE71A145B253E49C3031AD068277A3",
+                AppEUI = "0000000000000004",
+                AppKey = "00000000000000000000000000000004",
                 GatewayID = gatewayID,
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
@@ -162,8 +169,8 @@ namespace LoRaWan.IntegrationTest
                 GatewayID = gatewayID,
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
-                AppSKey="2B7E151628AED2A6ABF7158809CF4F3C",
-                NwkSKey="3B7E151628AED2A6ABF7158809CF4F3C",
+                AppSKey="00000000000000000000000000000005",
+                NwkSKey="00000000000000000000000000000005",
                 DevAddr="0028B1B0"
             };     
 
@@ -175,9 +182,9 @@ namespace LoRaWan.IntegrationTest
                 GatewayID = gatewayID,
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = false,
-                AppSKey="2B7E151628AED2A6ABF7158809CF4F3C",
-                NwkSKey="3B7E151628AED2A6ABF7158809CF4F3C",
-                DevAddr="0028B1B1",
+                AppSKey="00000000000000000000000000000006",
+                NwkSKey="00000000000000000000000000000006",
+                DevAddr="00000006",
             };  
 
             // Device7_ABP: used for ABP wrong nwkskey
@@ -188,9 +195,9 @@ namespace LoRaWan.IntegrationTest
                 GatewayID = gatewayID,
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
-                AppSKey="2B7E151628AED2A6ABF7158809CF4F3C",
-                NwkSKey="3B7E151628AED2A6ABF7158809CF4F3C",
-                DevAddr="0028B1B2"
+                AppSKey="00000000000000000000000000000007",
+                NwkSKey="00000000000000000000000000000007",
+                DevAddr="00000007"
             };  
 
             // Device8_ABP: used for ABP invalid nwkskey (mic fails)
@@ -201,17 +208,17 @@ namespace LoRaWan.IntegrationTest
                 GatewayID = gatewayID,
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
-                AppSKey="2B7E151628AED2A6ABF7158809CF4F3C",
-                NwkSKey="3B7E151628AED2A6ABF7158809CF4F3C",
-                DevAddr="0028B1B3"
+                AppSKey="00000000000000000000000000000008",
+                NwkSKey="00000000000000000000000000000008",
+                DevAddr="00000008"
             };    
 
             // Device9_OTAA: used for confirmed message & C2D
             this.Device9_OTAA = new TestDeviceInfo()
             {
                 DeviceID = "0000000000000009",
-                AppEUI = "BE7A0000000014E3",
-                AppKey = "8AFE71A145B253E49C3031AD068277A3",                
+                AppEUI = "0000000000000009",
+                AppKey = "00000000000000000000000000000009",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true                            
             };  
@@ -220,8 +227,8 @@ namespace LoRaWan.IntegrationTest
             this.Device10_OTAA = new TestDeviceInfo()
             {
                 DeviceID = "0000000000000010",
-                AppEUI = "BE7A0000000014E3",
-                AppKey = "8AFE71A145B253E49C3031AD068277A3",                
+                AppEUI = "0000000000000010",
+                AppKey = "00000000000000000000000000000010",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true                            
             };  
@@ -230,8 +237,8 @@ namespace LoRaWan.IntegrationTest
             this.Device11_OTAA = new TestDeviceInfo()
             {
                 DeviceID = "0000000000000011",
-                AppEUI = "BE7A0000000014E3",
-                AppKey = "8AFE71A145B253E49C3031AD068277A3",                
+                AppEUI = "0000000000000011",
+                AppKey = "00000000000000000000000000000011",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,                                      
                 SensorDecoder = "http://sensordecodermodule/api/DecoderValueSensor",                           
@@ -241,8 +248,8 @@ namespace LoRaWan.IntegrationTest
             this.Device12_OTAA = new TestDeviceInfo()
             {
                 DeviceID = "0000000000000012",
-                AppEUI = "BE7A0000000014E3",
-                AppKey = "8AFE71A145B253E49C3031AD068277A3",                
+                AppEUI = "0000000000000012",
+                AppKey = "00000000000000000000000000000012",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,                                      
                 SensorDecoder = "DecoderValueSensor",                           
@@ -252,8 +259,8 @@ namespace LoRaWan.IntegrationTest
             this.Device13_OTAA = new TestDeviceInfo()
             {
                 DeviceID = "0000000000000013",
-                AppEUI = "BE7A00000000FEE3",
-                AppKey = "8AFE71A145B253E49C3031AD068277A3",                
+                AppEUI = "0000000000000013",
+                AppKey = "00000000000000000000000000000013",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,                                      
                 SensorDecoder = "DecoderValueSensor",                           
@@ -263,8 +270,8 @@ namespace LoRaWan.IntegrationTest
             this.Device14_OTAA = new TestDeviceInfo()
             {
                 DeviceID = "0000000000000014",
-                AppEUI = "BE7A00000000FEE3",
-                AppKey = "8AFE71A145B253E49C3031AD068277A3",
+                AppEUI = "0000000000000014",
+                AppKey = "00000000000000000000000000000014",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
                 SensorDecoder = "DecoderValueSensor",
@@ -274,8 +281,8 @@ namespace LoRaWan.IntegrationTest
             this.Device15_OTAA = new TestDeviceInfo()
             {
                 DeviceID = "0000000000000015",
-                AppEUI = "BE7A00000000FEE3",
-                AppKey = "8AFE71A145B253E49C3031AD068277A3",
+                AppEUI = "0000000000000015",
+                AppKey = "00000000000000000000000000000015",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
                 SensorDecoder = "DecoderValueSensor",
@@ -386,7 +393,14 @@ namespace LoRaWan.IntegrationTest
 
             if (this.Configuration.CreateDevices)
             {
-               await CreateOrUpdateDevicesAsync();
+                try
+                {
+                    await CreateOrUpdateDevicesAsync();
+                }
+                catch (Exception ex)
+                {
+                    TestLogger.Log($"[ERR] Failed to create devices in IoT Hub. {ex.ToString()}");
+                }
             }
 
             if (!string.IsNullOrEmpty(Configuration.IoTHubEventHubConnectionString) && this.Configuration.NetworkServerModuleLogAssertLevel != LogValidationAssertLevel.Ignore)

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/LoraArduinoSerial.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/LoraArduinoSerial.cs
@@ -157,6 +157,10 @@ namespace LoRaWan.IntegrationTest
         }
         public IReadOnlyCollection<string> SerialLogs { get { return this.serialLogs; } }
 
+        // Gets/sets if serial writes should be logged
+        // Disabled by default
+        public bool LogWrites { get; set; }
+
         public void ClearSerialLogs()
         {
             TestLogger.Log($"*** Clearing serial logs ({this.serialLogs.Count}) ***");
@@ -871,6 +875,9 @@ namespace LoRaWan.IntegrationTest
                     serialPort.Write (Encoding.UTF8.GetBytes (command));
                 else
                     serialPortWin.Write (command);
+
+                if (this.LogWrites)
+                    TestLogger.Log($"[SERIALW] {command}");
             }
             catch (Exception ex)
             {

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/appsettings.json
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/appsettings.json
@@ -10,6 +10,7 @@
     "IoTHubAssertLevel": "Warning",
     "UdpLog": "true",
     "CreateDevices": true,
-    "LeafDeviceGatewayID": "#{INTEGRATIONTEST_LeafDeviceGatewayID}#"
+    "LeafDeviceGatewayID": "#{INTEGRATIONTEST_LeafDeviceGatewayID}#",
+    "DevicePrefix": "#{INTEGRATIONTEST_DevicePrefix}#"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://dev.azure.com/epicstuff/Azure%20IoT%20Edge%20LoRaWAN%20Starter%20Kit/_apis/build/status/CI?branchName=master&label=master)](https://dev.azure.com/epicstuff/Azure%20IoT%20Edge%20LoRaWAN%20Starter%20Kit/_build/latest?definitionId=35?branchName=master)
+[![Build Status](https://dev.azure.com/epicstuff/Azure%20IoT%20Edge%20LoRaWAN%20Starter%20Kit/_apis/build/status/CI?branchName=dev&label=dev)](https://dev.azure.com/epicstuff/Azure%20IoT%20Edge%20LoRaWAN%20Starter%20Kit/_build/latest?definitionId=35&branchName=dev)
+
 # Azure IoT Edge LoRaWAN Starter Kit
 
 Experimental sample implementation of LoRaWAN components to connect LoRaWAN antenna gateway running IoT Edge directly with Azure IoT.

--- a/azure-pipeline-integration-test-steps-template.yaml
+++ b/azure-pipeline-integration-test-steps-template.yaml
@@ -1,0 +1,36 @@
+# File: azure-pipeline-integration-test-steps-template.yaml
+parameters:
+  platform: ''  
+
+steps:
+- task: qetza.replacetokens.replacetokens-task.replacetokens@3
+  displayName: 'Configure test in **/test/LoRaWan.IntegrationTest/appsettings.json'  
+  inputs:
+    targetFiles: '**/test/LoRaWan.IntegrationTest/appsettings.json'
+
+# Runs test with retries, only if no additional integration test arguments were passed
+- bash: ./test_runner.sh "$COMMON_TESTRESULTSDIRECTORY"
+  displayName: Execute integration tests (with retry)
+  condition: eq(variables['AdditionalIntegrationTestArguments'], '')
+  workingDirectory: ./LoRaEngine/test/LoRaWan.IntegrationTest
+  failOnStderr: true
+  timeoutInMinutes: 60 # up to 1 hour, increase if we need more
+
+# Run integration test with filters only, no built-in retries
+- task: DotNetCoreCLI@2
+  displayName: 'Run integration test with additional arguments (no retry)'
+  condition: ne(variables['AdditionalIntegrationTestArguments'], '')
+  inputs:
+    command: test
+    projects: '**/test/LoRaWan.IntegrationTest/LoRaWan.IntegrationTest.csproj'
+    arguments: '-p:ParallelizeTestCollections=false $(AdditionalIntegrationTestArguments)'
+
+  # Publish Test Results to Azure Pipelines/TFS
+- task: PublishTestResults@2
+  condition: always()
+  inputs:
+    testResultsFormat: 'VSTest' # Options: JUnit, NUnit, VSTest, xUnit
+    testResultsFiles: '**/*.trx'
+    searchFolder: '$(Common.TestResultsDirectory)'
+    testRunTitle: '${{ parameters.platform }}-Integration tests'
+    mergeTestResults: true

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -12,25 +12,26 @@ variables:
   # image tag prefix for dev branch (0.3.0-dev)
   DEV_IMAGE_TAG: dev
 
-  # Consumer group used by integration test monitoring IoT Hub
-  INTEGRATIONTEST_IoTHubEventHubConsumerGroup: reserved_integrationtest
-
   buildConfiguration: 'Release'
 
   # Name of service connection for resource group
   azureServiceConnectionName: 'IntegrationTestRG'
 
-  # Defines the leaf device for testing in ARM architecture
-  iotEdgeDeviceARM: itestArm1
-
-  # Defines the leaf device for testing in AMD64 architecture
-  iotEdgeDeviceAMD: ''
+  edgeAgentVersion: 1.0.4
+  edgeHubVersion: 1.0.4
+  edgeHubRoute: FROM /* INTO $upstream
   
   # Defines image version to use in case in ARM architecture
-  devOpsArmImageTag: 2.142.1  
+  DEVOPS_AGENT_IMAGE_VERSION: 2.142.1
 
   # Defines the name of the VSTS agent in ARM architecture
   vstsAgentARM: myAgent-arm32v7
+
+  # Defines the name of the VSTS agent in AMD64 architecture
+  vstsAgentAMD: ronnies-amd-agent
+
+  # Network Server module level: 1 in order to get decoder information
+  networkServerLogLevel: 1
 
 # Enable PR validation on branches master and dev
 pr:
@@ -113,30 +114,31 @@ jobs:
     condition: eq(variables['Build.Reason'], 'PullRequest')
     name: checkPrCILabel
 
-# [Job] Build, push and deploy IoT Edge Solution 
+# [Job] Build, push and deploy arm32v7 IoT Edge Solution
 - job: full_ci_deploy_arm
   displayName: Build, push and deploy arm32v7 IoT Edge Solution
   variables:
-    IOT_DEPLOYMENT_ID: integrationtest
+    IOT_DEPLOYMENT_ID: integrationtestarm
     # IoT Edge Runtime configuration
-    EDGE_AGENT_VERSION: 1.0.4
-    EDGE_HUB_VERSION: 1.0.4  
+    EDGE_AGENT_VERSION: $(edgeAgentVersion)
+    EDGE_HUB_VERSION: $(edgeHubVersion)
     EDGEHUB_OPTIMIZEFORPERFORMANCE: false
     EDGEHUB_MQTTSETTINGS_ENABLED: false
     EDGEHUB_HTTPSETTINGS_ENABLED: false
-    EDGEHUB_ROUTE: FROM /* INTO $upstream
+    EDGEHUB_ROUTE: $(edgeHubRoute)
     # LoRaWan Modules
-    NET_SRV_LOG_LEVEL: 1  
+    NET_SRV_LOG_LEVEL: $(networkServerLogLevel)  
     NET_SRV_LOGTO_UDP: true
     NET_SRV_LOGTO_HUB: false
     NET_SRV_IOTEDGE_TIMEOUT: 0
     NET_SRV_VERSION: "" # Network Server module version
     PKT_FWD_VERSION: "" # Packet Forward module version
-    DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(devOpsArmImageTag)-arm32v7"
-    VSTS_AGENT: "$(vstsAgentARM)"   
+    VSTS_AGENT: "$(vstsAgentARM)"
+    # Defines image version to use in case in ARM architecture
+    DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-arm32v7"
     
   dependsOn: build_and_test
-  condition: and(ne(variables['iotEdgeDeviceARM'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
+  condition: and(ne(variables['IoTEdgeDeviceARM'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
   pool:
     # name: docker
     # demands: Agent.OSArchitecture -equals X64
@@ -145,9 +147,42 @@ jobs:
     - template: azure-pipelines-buildpushiotedge-templates.yaml
       parameters:
         platform: arm32v7
-        deviceID: $(iotEdgeDeviceARM)
+        deviceID: $(IoTEdgeDeviceARM)
 
-
+# [Job] Build, push and deploy amd64 IoT Edge Solution 
+- job: full_ci_deploy_amd
+  displayName: Build, push and deploy amd64 IoT Edge Solution
+  variables:
+    IOT_DEPLOYMENT_ID: integrationtestamd
+    # IoT Edge Runtime configuration
+    EDGE_AGENT_VERSION: $(edgeAgentVersion)
+    EDGE_HUB_VERSION: $(edgeHubVersion)
+    EDGEHUB_OPTIMIZEFORPERFORMANCE: false
+    EDGEHUB_MQTTSETTINGS_ENABLED: false
+    EDGEHUB_HTTPSETTINGS_ENABLED: false
+    EDGEHUB_ROUTE: $(edgeHubRoute)
+    # LoRaWan Modules
+    NET_SRV_LOG_LEVEL: $(networkServerLogLevel)  
+    NET_SRV_LOGTO_UDP: true
+    NET_SRV_LOGTO_HUB: false
+    NET_SRV_IOTEDGE_TIMEOUT: 0
+    NET_SRV_VERSION: "" # Network Server module version
+    PKT_FWD_VERSION: "" # Packet Forward module version
+    VSTS_AGENT: "$(vstsAgentAMD)"
+    # Defines image version to use in case in AMD architecture
+    DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-amd64"
+    
+  dependsOn: build_and_test
+  condition: and(ne(variables['IoTEdgeDeviceAMD'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
+  pool:
+    # name: docker
+    # demands: Agent.OSArchitecture -equals X64
+    vmImage: 'Ubuntu 16.04'   
+  steps:
+    - template: azure-pipelines-buildpushiotedge-templates.yaml
+      parameters:
+        platform: amd64
+        deviceID: $(IoTEdgeDeviceAMD)
 
 # [Job] Build and deploy Facade Azure Function 
 - job: full_ci_deploy_facade_function
@@ -183,15 +218,33 @@ jobs:
 
 
 
-
+- job: test_runner_amd_eu
+  displayName: Run tests in AMD device (EU)
+  dependsOn: 
+    - full_ci_deploy_amd
+    - full_ci_deploy_facade_function
+  condition: and(ne(variables['IoTEdgeDeviceAMD'], ''), or(succeeded(), eq(variables['RunTestsOnly'], 'true')))
+  timeoutInMinutes: 60
+  pool:    
+    name: Default
+    demands: Agent.OSArchitecture -equals x64 # Run on AMD test device
+  variables:      
+    INTEGRATIONTEST_LeafDeviceSerialPort: "/dev/ttyACM0"
+    INTEGRATIONTEST_IoTHubEventHubConsumerGroup: "reserved_integrationtest_amd" 
+    INTEGRATIONTEST_LeafDeviceGatewayID: $(IoTEdgeDeviceAMD)
+    INTEGRATIONTEST_DevicePrefix: ''
+  steps:
+  - template: azure-pipeline-integration-test-steps-template.yaml
+    parameters:
+      platform: amd64
 
 # [Job] Runs the test in ARM device using VSTS Agent
 - job: test_runner_arm_eu
-  displayName: Run tests in ARM device
+  displayName: Run tests in ARM device (EU)
   dependsOn: 
     - full_ci_deploy_arm
     - full_ci_deploy_facade_function
-  condition: or(succeeded(), eq(variables['RunTestsOnly'], 'true'))
+  condition: and(ne(variables['IoTEdgeDeviceARM'], ''), or(succeeded(), eq(variables['RunTestsOnly'], 'true')))
   timeoutInMinutes: 60 # Raspberry PI is slow, allow taking 60 minutes
   pool:    
     name: Default
@@ -199,38 +252,10 @@ jobs:
   variables:      
     INTEGRATIONTEST_LeafDeviceSerialPort: "/dev/ttyACM0"
     INTEGRATIONTEST_IoTHubEventHubConsumerGroup: "reserved_integrationtest" 
-    INTEGRATIONTEST_LeafDeviceGatewayID: $(iotEdgeDeviceARM)
-
-  # Replaces test configuration with variables  
-  steps:
-  - task: qetza.replacetokens.replacetokens-task.replacetokens@3
-    displayName: 'Configure test in **/test/LoRaWan.IntegrationTest/appsettings.json'  
-    inputs:
-      targetFiles: '**/test/LoRaWan.IntegrationTest/appsettings.json'
-
-  # Runs test with retries, only if no additional integration test arguments were passed
-  - bash: ./test_runner.sh "$COMMON_TESTRESULTSDIRECTORY"
-    displayName: Execute integration tests (with retry)
-    condition: eq(variables['AdditionalIntegrationTestArguments'], '')
-    workingDirectory: ./LoRaEngine/test/LoRaWan.IntegrationTest
-    failOnStderr: true
-    timeoutInMinutes: 60 # up to 1 hour, increase if we need more
-
-  # Run integration test with filters only, no built-in retries
-  - task: DotNetCoreCLI@2
-    displayName: 'Run integration test with additional arguments (no retry)'
-    condition: ne(variables['AdditionalIntegrationTestArguments'], '')
-    inputs:
-      command: test
-      projects: '**/test/LoRaWan.IntegrationTest/LoRaWan.IntegrationTest.csproj'
-      arguments: '-p:ParallelizeTestCollections=false $(AdditionalIntegrationTestArguments)'
+    INTEGRATIONTEST_LeafDeviceGatewayID: $(IoTEdgeDeviceARM)
+    INTEGRATIONTEST_DevicePrefix: '01'
   
-   # Publish Test Results to Azure Pipelines/TFS
-  - task: PublishTestResults@2
-    condition: always()
-    inputs:
-      testResultsFormat: 'VSTest' # Options: JUnit, NUnit, VSTest, xUnit
-      testResultsFiles: '**/*.trx'
-      searchFolder: '$(Common.TestResultsDirectory)'
-      testRunTitle: ARM Integration tests
-      mergeTestResults: true
+  steps:
+  - template: azure-pipeline-integration-test-steps-template.yaml
+    parameters:
+      platform: arm32v7


### PR DESCRIPTION
This changes expand the current CI, adding the possibility of testing versus a amd64 based device.

Contents:
* Using a pre-built multi-arch image for http based decoder tests
* Added AzureDevOpsAgent image building for amd64. No using the official image because we don't need all the bits (php, Java, go, etc.)
* Fixed a problem with UDP logging if the target address container is not running when network server module starts. Before change it would not log until restarted
* Split of the pipeline in reusable templates, making it simpler to follow
* Add possibility at queue time to decide if tests should run on amd64 and/or arm32v7 device
* Added build badge status for dev and master branches