### PR TITLE
Handle wrong Fport inputs in C2D

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoraDeviceInfoManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoraDeviceInfoManager.cs
@@ -5,14 +5,10 @@
 
 using LoRaTools;
 using LoRaTools.Utils;
-using LoRaWan.Shared;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace LoRaWan.NetworkServer

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
@@ -242,9 +242,9 @@ namespace LoRaWan.NetworkServer
                         _ = loraDeviceInfo.HubSender.CompleteAsync(c2dMsg);
                         c2dMsg = null;
                     }
+
                     byte[] bytesC2dMsg = null;
                     byte[] fport = null;
-
 
                     //check if we got a c2d message to be added in the ack message and prepare the message
                     if (c2dMsg != null)
@@ -512,7 +512,7 @@ namespace LoRaWan.NetworkServer
             // ensure fport property has been set
             if (!c2dMessage.Properties.TryGetValueCaseInsensitive(FPORT_MSG_PROPERTY_KEY, out var fportValue))
             {
-                Logger.Log(loraDeviceInfo.DevEUI, $"missing {FPORT_MSG_PROPERTY_KEY} property in C2D message '{c2dMessage.MessageId}'", Logger.LoggingLevel.Info);
+                Logger.Log(loraDeviceInfo.DevEUI, $"missing {FPORT_MSG_PROPERTY_KEY} property in C2D message '{c2dMessage.MessageId}'", Logger.LoggingLevel.Error);
                 return false;
             }
 
@@ -525,7 +525,7 @@ namespace LoRaWan.NetworkServer
                     return true;
             }
 
-            Logger.Log(loraDeviceInfo.DevEUI, $"invalid fport '{fportValue}' in C2D message '{c2dMessage.MessageId}'", Logger.LoggingLevel.Info);
+            Logger.Log(loraDeviceInfo.DevEUI, $"invalid fport '{fportValue}' in C2D message '{c2dMessage.MessageId}'", Logger.LoggingLevel.Error);
             return false;
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
@@ -22,6 +22,15 @@ namespace LoRaWan.NetworkServer
 {
     public class MessageProcessor : IDisposable
     {
+        // Defines Cloud to device message property containing fport value
+        const string FPORT_MSG_PROPERTY_KEY = "fport";
+
+        // Fport value reserved for mac commands
+        const byte LORA_FPORT_RESERVED_MAC_MSG = 0;
+
+        // Starting Fport value reserved for future applications
+        const byte LORA_FPORT_RESERVED_FUTURE_START = 224;
+
         private DateTime startTimeProcessing;
         private List<byte[]> fOptsPending = new List<byte[]>();
         private readonly NetworkServerConfiguration configuration;
@@ -228,6 +237,11 @@ namespace LoRaWan.NetworkServer
                     //start checking for new c2d message, we do it even if the fcnt is invalid so we support replying to the ConfirmedDataUp
                     //todo ronnie should we wait up to 900 msec?
                     c2dMsg = await loraDeviceInfo.HubSender.ReceiveAsync(TimeSpan.FromMilliseconds(20));
+                    if (c2dMsg != null && !ValidateCloudToDeviceMessage(loraDeviceInfo, c2dMsg))
+                    {
+                        _ = loraDeviceInfo.HubSender.CompleteAsync(c2dMsg);
+                        c2dMsg = null;
+                    }
                     byte[] bytesC2dMsg = null;
                     byte[] fport = null;
 
@@ -491,6 +505,30 @@ namespace LoRaWan.NetworkServer
 
             return udpMsgForPktForwarder;
         }
+       
+        // Validate cloud to device message
+        private bool ValidateCloudToDeviceMessage(LoraDeviceInfo loraDeviceInfo, Message c2dMessage)
+        {
+            // ensure fport property has been set
+            if (!c2dMessage.Properties.TryGetValueCaseInsensitive(FPORT_MSG_PROPERTY_KEY, out var fportValue))
+            {
+                Logger.Log(loraDeviceInfo.DevEUI, $"missing {FPORT_MSG_PROPERTY_KEY} property in C2D message '{c2dMessage.MessageId}'", Logger.LoggingLevel.Info);
+                return false;
+            }
+
+            if (byte.TryParse(fportValue, out var fport))
+            {
+                // ensure fport follows LoRa specification
+                // 0    => reserved for mac commands
+                // 224+ => reserved for future applications 
+                if (fport != LORA_FPORT_RESERVED_MAC_MSG && fport < LORA_FPORT_RESERVED_FUTURE_START)
+                    return true;
+            }
+
+            Logger.Log(loraDeviceInfo.DevEUI, $"invalid fport '{fportValue}' in C2D message '{c2dMessage.MessageId}'", Logger.LoggingLevel.Info);
+            return false;
+        }
+
 
         private async Task<byte[]> ProcessJoinRequest(LoRaMessageWrapper loraMessage)
         {

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/ABPTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/ABPTest.cs
@@ -21,7 +21,7 @@ namespace LoRaWan.IntegrationTest
             const int MESSAGES_COUNT = 10;
 
             var device = this.TestFixture.Device5_ABP;
-            Log($"[INFO] ** Starting {nameof(Test_ABP_Confirmed_And_Unconfirmed_Message)} using device {device.DeviceID} **");      
+            LogTestStart(device);    
 
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWABP);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, null);
@@ -86,7 +86,7 @@ namespace LoRaWan.IntegrationTest
         public async Task Test_ABP_Wrong_DevAddr_Is_Ignored()
         {
             var device = this.TestFixture.Device6_ABP;
-            Log($"[INFO] ** Starting {nameof(Test_ABP_Wrong_DevAddr_Is_Ignored)} using device {device.DeviceID} **");      
+            LogTestStart(device);
 
             var devAddrToUse = "05060708";
             Assert.NotEqual(devAddrToUse, device.DevAddr);
@@ -136,7 +136,7 @@ namespace LoRaWan.IntegrationTest
         public async Task Test_ABP_Mismatch_NwkSKey_And_AppSKey_Fails_Mic_Validation()
         {
             var device = this.TestFixture.Device7_ABP;
-            Log($"[INFO] ** Starting {nameof(Test_ABP_Mismatch_NwkSKey_And_AppSKey_Fails_Mic_Validation)} using device {device.DeviceID} **");      
+            LogTestStart(device);
 
             var appSKeyToUse = "000102030405060708090A0B0C0D0E0F";
             var nwkSKeyToUse = "01020304050607080910111213141516";
@@ -184,7 +184,7 @@ namespace LoRaWan.IntegrationTest
         public async Task Test_ABP_Invalid_NwkSKey_Fails_With_Mic_Error()
         {
             var device = this.TestFixture.Device8_ABP;
-            Log($"[INFO] ** Starting {nameof(Test_ABP_Invalid_NwkSKey_Fails_With_Mic_Error)} using device {device.DeviceID} **");      
+            LogTestStart(device);     
 
             var nwkSKeyToUse = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
             Assert.NotEqual(nwkSKeyToUse, device.NwkSKey);
@@ -227,10 +227,8 @@ namespace LoRaWan.IntegrationTest
         [Fact]
         public async Task Test_ABP_Device_With_Same_DevAddr()
         {
-
-
             const int MESSAGES_COUNT = 2;
-            Log($"[INFO] ** Starting {nameof(Test_ABP_Device_With_Same_DevAddr)} using devices {this.TestFixture.Device16_ABP.DeviceID} and {this.TestFixture.Device17_ABP.DeviceID} **");
+            LogTestStart(new TestDeviceInfo[] { this.TestFixture.Device16_ABP, this.TestFixture.Device17_ABP});
 
             await SendABPMessages(MESSAGES_COUNT, this.TestFixture.Device16_ABP);
             await SendABPMessages(MESSAGES_COUNT, this.TestFixture.Device17_ABP);

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/C2DMessageTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/C2DMessageTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Azure.Devices;
 using Xunit;
 
 namespace LoRaWan.IntegrationTest
@@ -35,7 +36,7 @@ namespace LoRaWan.IntegrationTest
         public async Task Test_OTAA_Confirmed_Receives_C2D_Message()
         {
             var device = this.TestFixture.Device9_OTAA;
-            Log($"[INFO] ** Starting {nameof(Test_OTAA_Confirmed_Receives_C2D_Message)} using device {device.DeviceID}");      
+            LogTestStart(device);    
 
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
@@ -141,7 +142,7 @@ namespace LoRaWan.IntegrationTest
         public async Task Test_OTAA_Unconfirmed_Receives_C2D_Message()
         {
             var device = this.TestFixture.Device10_OTAA;
-            Log($"[INFO] ** Starting {nameof(Test_OTAA_Confirmed_Receives_C2D_Message)} using device {device.DeviceID} **");      
+            LogTestStart(device);   
 
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
@@ -242,7 +243,7 @@ namespace LoRaWan.IntegrationTest
         public async Task Test_OTAA_Unconfirmed_Receives_Confirmed_FPort_Message()
         {
             var device = this.TestFixture.Device15_OTAA;
-            Log($"Starting {nameof(Test_OTAA_Unconfirmed_Receives_Confirmed_C2D_Message)} using device {device.DeviceID}");
+            LogTestStart(device);
 
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
@@ -344,7 +345,7 @@ namespace LoRaWan.IntegrationTest
         public async Task Test_OTAA_Unconfirmed_Receives_Confirmed_C2D_Message()
         {
             var device = this.TestFixture.Device14_OTAA;
-            Log($"Starting {nameof(Test_OTAA_Unconfirmed_Receives_Confirmed_C2D_Message)} using device {device.DeviceID}");
+            LogTestStart(device);
 
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
@@ -441,5 +442,117 @@ namespace LoRaWan.IntegrationTest
             Assert.True(foundReceivePacket, $"Could not find lora receiving message '{expectedRxSerial}'");
 
         }
+
+        // Ensures that C2D messages using invalid fport
+        // - Message is not forwarded to device
+        // - error is logged with correlation-id
+        // - Invalid fport values:
+        // - 0: reserved for mac commands
+        // - 224+: reserved for future applications
+        // Uses Device16_OTAA and Device17_OTAA
+        [Theory]
+        [InlineData(0, nameof(IntegrationTestFixture.Device18_ABP))] // 0 => mac commands
+        [InlineData(224, nameof(IntegrationTestFixture.Device19_ABP))] // >= 224 is reserved
+        public async Task C2D_Using_Invalid_FPort_Should_Be_Ignored(byte fport, string devicePropertyName)
+        {
+            var device = this.TestFixture.GetDeviceByPropertyName(devicePropertyName);
+            LogTestStart(device);
+            
+            // Setup LoRa device properties
+            await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWABP);
+            await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
+            await this.ArduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, device.AppKey);
+
+            // Setup protocol properties
+            await this.ArduinoDevice.SetupLora(this.TestFixture.Configuration.LoraRegion);
+
+            // Sends 2x unconfirmed messages
+            for (var i = 1; i <= 2; ++i)
+            {
+                var msg = PayloadGenerator.Next().ToString();
+                Log($"{device.DeviceID}: Sending unconfirmed '{msg}' {i}/10");
+
+                await this.ArduinoDevice.transferPacketAsync(msg, 10);
+
+                await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
+
+                await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
+
+                this.TestFixture.ClearLogs();
+            }
+
+            // sends C2D - between 10 and 99
+            var c2dMessageBody = (100 + random.Next(90)).ToString();
+            var c2dMessage = new Message(Encoding.UTF8.GetBytes(c2dMessageBody))
+            {
+                MessageId = Guid.NewGuid().ToString(),
+            };            
+            c2dMessage.Properties["Fport"] = fport.ToString();
+            await this.TestFixture.SendCloudToDeviceMessage(device.DeviceID, c2dMessage);
+            Log($"Message {c2dMessageBody} sent to device");
+
+            // Following log will be generated in case C2D message has invalid fport:
+            // "<device-id>: invalid fport '<fport>' in C2D message '<message-id>'
+            var foundC2DInvalidFPortMessage = false;
+
+            // Serial port will print the following once the message is received
+            var expectedRxSerial = $"RX: \"{ToHexString(c2dMessageBody)}\"";
+            Log($"Expected C2D contains: {expectedRxSerial}");
+
+            // Sends 8x unconfirmed messages, stopping if C2D message is found
+            for (var i = 3; i <= 10; ++i)
+            {
+                var msg = PayloadGenerator.Next().ToString();
+                Log($"{device.DeviceID}: Sending unconfirmed '{msg}' {i}/10");
+                await this.ArduinoDevice.transferPacketAsync(msg, 10);
+
+                await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
+
+                await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
+
+                // ensure c2d message is not found
+                // 0000000000000016: C2D message: 58
+                var c2dLogMessage = $"{device.DeviceID}: C2D message: {c2dMessageBody}";
+                var searchC2DMessageLogResult = await this.TestFixture.SearchNetworkServerModuleAsync(
+                    (messageBody) => {
+                        return messageBody.StartsWith(c2dLogMessage);
+                    },
+                    new SearchLogOptions
+                    {
+                        Description = c2dLogMessage,
+                        MaxAttempts = 1
+                    }
+                );
+                Assert.False(searchC2DMessageLogResult.Found, $"Message with fport {fport} should not be forwarded to device");
+
+                // ensure log with error is found
+                if (!foundC2DInvalidFPortMessage)
+                {
+                    var invalidFportLog = $"{device.DeviceID}: invalid fport '{fport}' in C2D message '{c2dMessage.MessageId}'";
+                    var searchInvalidFportLog = await this.TestFixture.SearchNetworkServerModuleAsync(
+                        (messageBody) => {
+                            return messageBody.StartsWith(invalidFportLog);
+                        },
+                        new SearchLogOptions
+                        {
+                            Description = invalidFportLog,
+                            MaxAttempts = 1
+                        }
+                    );
+
+                    foundC2DInvalidFPortMessage = searchInvalidFportLog.Found;
+                }
+
+                // Should not contain in the serial the c2d message
+                Assert.DoesNotContain(this.ArduinoDevice.SerialLogs, log => log.Contains(expectedRxSerial, StringComparison.InvariantCultureIgnoreCase));
+
+                await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
+                
+                this.TestFixture.ClearLogs();
+            }
+
+            Assert.True(foundC2DInvalidFPortMessage, "Invalid fport message was not found in network server log");
+        }   
+
     }
 }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/C2DMessageTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/C2DMessageTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,7 +12,11 @@ namespace LoRaWan.IntegrationTest
     [Collection(Constants.TestCollectionName)] // run in serial
     public sealed class C2DMessageTest : IntegrationTestBase
     {
+        const string FportPropertyName = "fport";
+        const string ConfirmedPropertyName = "Confirmed";
+
         static Random random = new Random();
+   
 
         public C2DMessageTest(IntegrationTestFixture testFixture) : base(testFixture)
         {
@@ -70,7 +75,7 @@ namespace LoRaWan.IntegrationTest
 
             // sends C2D - between 10 and 99
             var c2dMessageBody = (100 + random.Next(90)).ToString();
-            await this.TestFixture.SendCloudToDeviceMessage(device.DeviceID, c2dMessageBody);
+            await this.TestFixture.SendCloudToDeviceMessage(device.DeviceID, c2dMessageBody, new Dictionary<string, string>{ { FportPropertyName, "1"} });
             Log($"Message {c2dMessageBody} sent to device, need to check if it receives");
 
             var foundC2DMessage = false;
@@ -175,7 +180,7 @@ namespace LoRaWan.IntegrationTest
 
             // sends C2D - between 10 and 99
             var c2dMessageBody = (100 + random.Next(90)).ToString();
-            await this.TestFixture.SendCloudToDeviceMessage(device.DeviceID, c2dMessageBody);
+            await this.TestFixture.SendCloudToDeviceMessage(device.DeviceID, c2dMessageBody, new Dictionary<string, string> { { FportPropertyName, "1"} });
             Log($"Message {c2dMessageBody} sent to device, need to check if it receives");
 
             var foundC2DMessage = false;
@@ -240,7 +245,7 @@ namespace LoRaWan.IntegrationTest
         // Ensures that C2D messages are received when working with unconfirmed messages
         // Uses Device15_OTAA
         [Fact]
-        public async Task Test_OTAA_Unconfirmed_Receives_Confirmed_FPort_Message()
+        public async Task Test_OTAA_Unconfirmed_Receives_Confirmed_FPort_2_Message()
         {
             var device = this.TestFixture.Device15_OTAA;
             LogTestStart(device);
@@ -276,7 +281,7 @@ namespace LoRaWan.IntegrationTest
 
             // sends C2D - between 10 and 99
             var c2dMessageBody = (100 + random.Next(90)).ToString();
-            await this.TestFixture.SendCloudToDeviceMessage(device.DeviceID, c2dMessageBody, new System.Collections.Generic.Dictionary<string, string>() { { "Fport","2"} });
+            await this.TestFixture.SendCloudToDeviceMessage(device.DeviceID, c2dMessageBody, new Dictionary<string, string>() { { FportPropertyName, "2"} });
             Log($"Message {c2dMessageBody} sent to device, need to check if it receives");
 
             var foundC2DMessage = false;
@@ -377,7 +382,11 @@ namespace LoRaWan.IntegrationTest
 
             // sends C2D - between 10 and 99
             var c2dMessageBody = (100 + random.Next(90)).ToString();
-            await this.TestFixture.SendCloudToDeviceMessage(device.DeviceID, c2dMessageBody, new System.Collections.Generic.Dictionary<string, string>() { { "Confirmed", "true" } });
+            await this.TestFixture.SendCloudToDeviceMessage(device.DeviceID, c2dMessageBody, new Dictionary<string, string>() 
+            { 
+                { FportPropertyName, "1" },
+                { ConfirmedPropertyName, "true" } 
+            });
             Log($"Message {c2dMessageBody} sent to device, need to check if it receives");
 
             var foundC2DMessage = false;
@@ -487,7 +496,7 @@ namespace LoRaWan.IntegrationTest
             {
                 MessageId = Guid.NewGuid().ToString(),
             };            
-            c2dMessage.Properties["Fport"] = fport.ToString();
+            c2dMessage.Properties[FportPropertyName] = fport.ToString();
             await this.TestFixture.SendCloudToDeviceMessage(device.DeviceID, c2dMessage);
             Log($"Message {c2dMessageBody} sent to device");
 

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestBase.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestBase.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Xunit;
 
@@ -52,5 +54,18 @@ namespace LoRaWan.IntegrationTest
         #endregion
 
         protected void Log(string value) =>TestLogger.Log(value);
+
+        // Logs starts of a test method call
+        protected void LogTestStart(TestDeviceInfo device, [CallerMemberName] string memberName = "")
+        {
+            Log($"[INFO] ** Starting {memberName} using device {device.DeviceID} **");
+        }
+
+        // Logs starts of a test method call
+        protected void LogTestStart(IEnumerable<TestDeviceInfo> devices, [CallerMemberName] string memberName = "")
+        {
+            var deviceIdList = string.Join(',', devices.Select(x => x.DeviceID));
+            Log($"[INFO] ** Starting {memberName} using devices {deviceIdList} **");
+        }
     }
 }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/OTAAJoinTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/OTAAJoinTest.cs
@@ -26,7 +26,7 @@ namespace LoRaWan.IntegrationTest
         public async Task OTAA_Join_With_Valid_Device_Updates_DeviceTwin()
         {   
             var device = this.TestFixture.Device1_OTAA; 
-            Log($"[INFO] ** Starting {nameof(OTAA_Join_With_Valid_Device_Updates_DeviceTwin)} using device {device.DeviceID} **");      
+            LogTestStart(device);     
 
             var twinBeforeJoin = await TestFixture.GetTwinAsync(device.DeviceID);
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
@@ -95,7 +95,7 @@ namespace LoRaWan.IntegrationTest
         public async Task OTAA_Join_With_Wrong_DevEUI_Fails()
         {
             var device = this.TestFixture.Device2_OTAA; 
-            Log($"[INFO] ** Starting {nameof(OTAA_Join_With_Wrong_DevEUI_Fails)} using device {device.DeviceID} **");
+            LogTestStart(device);
 
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
@@ -115,7 +115,7 @@ namespace LoRaWan.IntegrationTest
         public async Task OTAA_Join_With_Wrong_AppKey_Fails()
         {
             var device = this.TestFixture.Device3_OTAA; 
-            Log($"[INFO] ** Starting {nameof(OTAA_Join_With_Wrong_AppKey_Fails)} using device {device.DeviceID} **");      
+            LogTestStart(device);     
             var appKeyToUse = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
             Assert.NotEqual(appKeyToUse, device.AppKey);
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
@@ -138,7 +138,8 @@ namespace LoRaWan.IntegrationTest
         public async Task OTAA_Join_With_Wrong_AppEUI_Fails()
         {
             var device = this.TestFixture.Device13_OTAA; 
-            Log($"[INFO] ** Starting {nameof(OTAA_Join_With_Wrong_AppEUI_Fails)} using device {device.DeviceID} **");      
+            LogTestStart(device);
+
             var appEUIToUse = "FF7A00000000FCE3";
             Assert.NotEqual(appEUIToUse, device.AppEUI);
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/OTAATest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/OTAATest.cs
@@ -26,7 +26,7 @@ namespace LoRaWan.IntegrationTest
             const int MESSAGES_COUNT = 10;
 
             var device = this.TestFixture.Device4_OTAA;
-            Log($"[INFO] ** Starting {nameof(Test_OTAA_Confirmed_And_Unconfirmed_Message)} using device {device.DeviceID} **");      
+            LogTestStart(device);    
 
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/ReadMe.md
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/ReadMe.md
@@ -117,7 +117,7 @@ this.Device13_OTAA = new TestDeviceInfo()
 public async Task Test_ABP_Invalid_NwkSKey_Fails_With_Mic_Error()
 {
     var device = this.TestFixture.Device8_ABP;
-    Console.WriteLine($"Starting {nameof(Test_ABP_Invalid_NwkSKey_Fails_With_Mic_Error)} using device {device.DeviceID}");
+    LogTestStart(device);
 
     var nwkSKeyToUse = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
     Assert.NotEqual(nwkSKeyToUse, device.NwkSKey);
@@ -153,7 +153,6 @@ Example:
 [Collection(Constants.TestCollectionName)] // Set the same collection to ensure execution in serial
 public sealed class MyTest : IntegrationTestBase
 {
-    
     // Constructor receives the IntegrationTestFixture that is a singleton
     public MyTest(IntegrationTestFixture testFixture) : base(testFixture)
     {

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/SensorDecodingTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/SensorDecodingTest.cs
@@ -21,7 +21,7 @@ namespace LoRaWan.IntegrationTest
         public async Task SensorDecoder_HttpBased_ValueSensorDecoder_DecodesPayload()
         {
             var device = this.TestFixture.Device11_OTAA;
-            Log($"[INFO] ** Starting {nameof(SensorDecoder_HttpBased_ValueSensorDecoder_DecodesPayload)} using device {device.DeviceID} **");      
+            LogTestStart(device);    
 
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
@@ -54,7 +54,7 @@ namespace LoRaWan.IntegrationTest
         public async Task SensorDecoder_ReflectionBased_ValueSensorDecoder_DecodesPayload()
         {
             var device = this.TestFixture.Device12_OTAA;
-            Log($"[INFO] ** Starting {nameof(SensorDecoder_HttpBased_ValueSensorDecoder_DecodesPayload)} using device {device.DeviceID} **");      
+            LogTestStart(device);      
 
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/SimulatorTestCollection.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/SimulatorTestCollection.cs
@@ -71,7 +71,7 @@ namespace LoRaWan.IntegrationTest
         {
             const int MessageCount = 5;
 
-            var device = this.TestFixture.Device18_ABP;
+            var device = this.TestFixture.Device1001_Simulated_ABP;
             var simulatedDevice = new SimulatedDevice(device);
             var networkServerIPEndpoint = CreateNetworkServerEndpoint();
 
@@ -94,7 +94,7 @@ namespace LoRaWan.IntegrationTest
         {
             const int MessageCount = 5;
 
-            var device = this.TestFixture.Device19_OTAA;
+            var device = this.TestFixture.Device1002_Simulated_OTAA;
             var simulatedDevice = new SimulatedDevice(device);
             var networkServerIPEndpoint = CreateNetworkServerEndpoint();
 
@@ -127,7 +127,7 @@ namespace LoRaWan.IntegrationTest
         //[Fact]
         public async Task Simulated_Http_Based_Decoder_Scenario()
         {
-            var device = this.TestFixture.Device20_Simulated_HttpBasedDecoder;
+            var device = this.TestFixture.Device1003_Simulated_HttpBasedDecoder;
             var simulatedDevice = new SimulatedDevice(device);
             var networkServerIPEndpoint = CreateNetworkServerEndpoint();
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -244,7 +244,7 @@ jobs:
     - full_ci_deploy_arm
     - full_ci_deploy_facade_function
   condition: and(ne(variables['IoTEdgeDeviceARM'], ''), or(succeeded(), eq(variables['RunTestsOnly'], 'true')))
-  timeoutInMinutes: 60 # Raspberry PI is slow, allow taking 60 minutes
+  timeoutInMinutes: 120 # Raspberry PI is slow, allow taking 120 minutes
   pool:    
     name: Default
     demands: Agent.OSArchitecture -equals ARM # Run on pi atm


### PR DESCRIPTION
When sending C2D messages we can select the target fport by defining a value in the message property "fport".

Currently there is no validation for the value. The following should be checked:

|Fport|Description|
|-|-|
|0|reserved for mac operations, log information and ignore message|
|1..223|are application specific, accept and send to leaf device|
|224..255|are reserved for future standardised application extensions. Log information and ignore message|
|N/A|log information and ignore message|

In all cases the C2D message must be completed.

Additionally the logging of test starts has been simplified.

Fixes AB#786