### PR TITLE
Update template to use IoT Edge 1.0.5

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoraMessageWrapper.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoraMessageWrapper.cs
@@ -179,7 +179,15 @@ namespace LoRaTools.LoRaMessage
             LoRaPayloadMessage = payload;
             PktFwdPayload = new DownlinkPktFwdMessage(Convert.ToBase64String(LoRaPayloadMessage.GetByteMessage()), datr, rfch, freq, tmst);
             var jsonMsg = JsonConvert.SerializeObject(PktFwdPayload);
-            Logger.Log(ConversionHelper.ByteArrayToString(payload.DevAddr.Span.ToArray()),$"{((MType)(payload.Mhdr.Span[0])).ToString()} {jsonMsg}", Logger.LoggingLevel.Full);
+            var devEUI = payload.GetLoRaMessage().DevEUI;
+            if (devEUI.Length != 0)
+            {
+                Logger.Log(ConversionHelper.ByteArrayToString(devEUI.Span.ToArray()), $"{((MType)(payload.Mhdr.Span[0])).ToString()} {jsonMsg}", Logger.LoggingLevel.Full);
+            }else
+            {
+                Logger.Log(ConversionHelper.ByteArrayToString(payload.DevAddr.Span.ToArray()), $"{((MType)(payload.Mhdr.Span[0])).ToString()} {jsonMsg}", Logger.LoggingLevel.Full);
+            }
+
             var messageBytes = Encoding.Default.GetBytes(jsonMsg);
             PhysicalPayload = new PhysicalPayload(physicalToken, PhysicalIdentifier.PULL_RESP, messageBytes);
         }

--- a/Template/deviceConfiguration.json
+++ b/Template/deviceConfiguration.json
@@ -14,14 +14,14 @@
 					"edgeAgent": {
 						"type": "docker",
 						"settings": {
-							"image": "mcr.microsoft.com/azureiotedge-agent:1.0.4",
+							"image": "mcr.microsoft.com/azureiotedge-agent:1.0.5",
 							"createOptions": "{}"
 						}
 					},
 					"edgeHub": {
 						"type": "docker",
 						"settings": {
-							"image": "mcr.microsoft.com/azureiotedge-hub:1.0.4",
+							"image": "mcr.microsoft.com/azureiotedge-hub:1.0.5",
 							"createOptions": "{ \"HostConfig\": {   \"PortBindings\": {\"8883/tcp\": [  {\"HostPort\": \"8883\" }  ], \"443/tcp\": [ { \"HostPort\": \"443\" } ], \"5671/tcp\": [ { \"HostPort\": \"5671\"  }] } }}"
 						},
 						"env": {


### PR DESCRIPTION
* Update template version to use latest IoT Edge version (AB#884)
* Corrected log of DevAddr instead of DevEUI when we can (AB#785)