### PR TITLE
Add support for netId

### DIFF
--- a/Arduino/EU/TransmissionTestABPLoRa/TransmissionTestABPLoRa.ino
+++ b/Arduino/EU/TransmissionTestABPLoRa/TransmissionTestABPLoRa.ino
@@ -4,7 +4,7 @@
 bool confirmed = true;
 //application information, should be similar to what was provisiionned in the device twins
 char * deviceId = "46AAC86800430028";
-char * devAddr = "0028B1B1";
+char * devAddr = "0228B1B1";
 char * appSKey = "2B7E151628AED2A6ABF7158809CF4F3C";
 char * nwkSKey = "3B7E151628AED2A6ABF7158809CF4F3C";
 

--- a/LoRaEngine/LoraKeysManagerFacade/CreateEdgeDevice.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/CreateEdgeDevice.cs
@@ -118,7 +118,7 @@ namespace CreateDeviceFunction
                 await manager.AddDeviceAsync(ABPDevice);
                 Twin ABPTwin = new Twin();
                 ABPTwin.Properties.Desired = new TwinCollection(@"{AppSKey:'2B7E151628AED2A6ABF7158809CF4F3C',NwkSKey:'3B7E151628AED2A6ABF7158809CF4F3C',GatewayID:''," +
-                "DevAddr:'0028B1B1',SensorDecoder:'DecoderValueSensor'}");
+                "DevAddr:'0228B1B1',SensorDecoder:'DecoderValueSensor'}");
                 var ABPRemoteTwin = await manager.GetTwinAsync(ABPdeviceId);
                 await manager.UpdateTwinAsync(ABPdeviceId, ABPTwin, ABPRemoteTwin.ETag);
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
@@ -605,10 +605,8 @@ namespace LoRaWan.NetworkServer
         {
             var netIdBytes = BitConverter.GetBytes(netId);
             devAddrNwkid = (byte)(devAddrNwkid >> 1);
-            if (devAddrNwkid.Equals(netIdBytes[0] & 0b01111111))
-                return true;
-            else
-                return false;
+            return (devAddrNwkid.Equals(netIdBytes[0] & 0b01111111));
+  
         }
 
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
@@ -605,8 +605,7 @@ namespace LoRaWan.NetworkServer
         {
             var netIdBytes = BitConverter.GetBytes(netId);
             devAddrNwkid = (byte)(devAddrNwkid >> 1);
-            byte netIdToCompare = (byte)(netIdBytes[0] & 0b01111111);
-            if (devAddrNwkid.Equals(netIdToCompare))
+            if (devAddrNwkid.Equals(netIdBytes[0] & 0b01111111))
                 return true;
             else
                 return false;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
@@ -605,7 +605,7 @@ namespace LoRaWan.NetworkServer
         {
             var netIdBytes = BitConverter.GetBytes(netId);
             devAddrNwkid = (byte)(devAddrNwkid >> 1);
-            return (devAddrNwkid.Equals(netIdBytes[0] & 0b01111111));
+            return (devAddrNwkid==(netIdBytes[0] & 0b01111111));
   
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -68,6 +68,9 @@ namespace LoRaWan.NetworkServer
         // Gets/sets udp port to send logs
         public int LogToUdpPort { get; set; } = 6000;
 
+        // Gets/sets gateway NetId
+        public uint NetId { get; set; } = 1;
+
         // Creates a new instance of NetworkServerConfiguration
         public NetworkServerConfiguration()
         {    
@@ -98,6 +101,7 @@ namespace LoRaWan.NetworkServer
             config.LogToUdp = envVars.GetEnvVar("LOG_TO_UDP", config.LogToUdp);
             config.LogToUdpAddress = envVars.GetEnvVar("LOG_TO_UDP_ADDRESS", string.Empty);
             config.LogToUdpPort = envVars.GetEnvVar("LOG_TO_UDP_PORT", config.LogToUdpPort);
+            config.NetId = envVars.GetEnvVar("NETID", config.NetId);
 
             return config;
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -56,7 +56,7 @@ namespace LoRaTools.LoRaMessage
         /// <summary>
         /// Gets the DevAdd netID
         /// </summary>
-        public byte GetNetID() => (byte)(DevAddr.Span[0] & 0b01111111);
+        public byte GetDevAddrNetID() => (byte)(DevAddr.Span[0] & 0b11111110);
         
 
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
@@ -11,25 +11,21 @@ namespace LoRaTools
     public class OTAAKeysGenerator
     {
 
-
-
-
-        public static string getDevAddr(Byte[] netId)
+        public static string GetNwkId(Byte[] netId)
         {
-            int nwkPart = (netId[2] << 1);
+            int nwkPart = (netId[0] << 1);
 
             byte[] devAddr = new byte[4];
             Random rnd = new Random();
             rnd.NextBytes(devAddr);
-            //loosing a bit
-            devAddr[0] = (byte)nwkPart;
-
+            //loosing a bit      
+            devAddr[0] = (byte)((nwkPart&0b11111110)|(devAddr[0]&0b00000001));
             return ConversionHelper.ByteArrayToString(devAddr);
         }
 
         //type NwkSKey = 0x01 , AppSKey = 0x02
         //don't work with CFLIST atm
-        public static string calculateKey(byte[] type, byte[] appnonce, byte[] netid, byte[] devnonce, byte[] appKey)
+        public static string CalculateKey(byte[] type, byte[] appnonce, byte[] netid, byte[] devnonce, byte[] appKey)
         {
 
 
@@ -52,7 +48,7 @@ namespace LoRaTools
 
         //type NwkSKey = 0x01 , AppSKey = 0x02
         //don't work with CFLIST atm
-        public static string calculateKey(byte[] type, byte[] appnonce, byte[] netid, ReadOnlyMemory<byte> devnonce, byte[] appKey)
+        public static string CalculateKey(byte[] type, byte[] appnonce, byte[] netid, ReadOnlyMemory<byte> devnonce, byte[] appKey)
         {
             Aes aes = new AesManaged();
             aes.Key = appKey;
@@ -81,7 +77,7 @@ namespace LoRaTools
             return ConversionHelper.ByteArrayToString(key);
         }
 
-        public static string  getAppNonce()
+        public static string  GetAppNonce()
         {
             Random rnd = new Random();
             byte[] appNonce = new byte[3];

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/NetIdHelper.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/NetIdHelper.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LoRaTools.Utils
+{
+    public static class NetIdHelper
+    {
+        /// <summary>
+        /// Set the NetworkId Part of a devAddr with a given network Id.
+        /// </summary>
+        /// <param name="currentDevAddr"></param>
+        /// <param name="networkId"></param>
+        /// <returns></returns>
+        public static string SetNwkIdPart(string currentDevAddr, uint networkId)
+        {
+            byte[] netId = BitConverter.GetBytes(networkId);
+            int nwkPart = (netId[0] << 1);
+            byte[] deviceIdBytes = ConversionHelper.StringToByteArray(currentDevAddr);
+            deviceIdBytes[0] = (byte)((nwkPart&0b11111110)|(deviceIdBytes[0]&0b00000001));
+            return ConversionHelper.ByteArrayToString(deviceIdBytes);
+        }
+
+        public static uint GetNwkIdPart(string devAddr)
+        {
+            var devAddrBytes= ConversionHelper.StringToByteArray(devAddr);
+            return (uint)(devAddrBytes[0] >> 1);
+        }
+    }
+}

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixture.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixture.cs
@@ -28,8 +28,8 @@ namespace LoRaWan.IntegrationTest
         public TestConfiguration Configuration { get; }
 
         public EventHubDataCollector IoTHubMessages { get; private set; }
-     
-      
+
+
         // Device1_OTAA: used for join test only
         public TestDeviceInfo Device1_OTAA { get; private set; }
 
@@ -38,7 +38,7 @@ namespace LoRaWan.IntegrationTest
 
         // Device3_OTAA: used for failed join (wrong appKey)
         public TestDeviceInfo Device3_OTAA { get; private set; }
-        
+
 
         // Device4_OTAA: used for OTAA confirmed & unconfirmed messaging
         public TestDeviceInfo Device4_OTAA { get; private set; }
@@ -60,13 +60,13 @@ namespace LoRaWan.IntegrationTest
         public TestDeviceInfo Device9_OTAA { get; private set; }
 
         // Device10_OTAA: used for OTAA unconfirmed messages, C2D test
-        public TestDeviceInfo Device10_OTAA { get; private set; }  
+        public TestDeviceInfo Device10_OTAA { get; private set; }
 
         // Device11_OTAA: used for http decoder
-        public TestDeviceInfo Device11_OTAA { get; private set; }  
+        public TestDeviceInfo Device11_OTAA { get; private set; }
 
         // Device12_OTAA: used for reflection based decoder
-        public TestDeviceInfo Device12_OTAA { get; private set; } 
+        public TestDeviceInfo Device12_OTAA { get; private set; }
 
         // Device13_OTAA: used for wrong AppEUI OTAA join
         public TestDeviceInfo Device13_OTAA { get; private set; }
@@ -81,10 +81,10 @@ namespace LoRaWan.IntegrationTest
 
         // Device17_ABP: used for test on multiple device with same devaddr
         public TestDeviceInfo Device17_ABP { get; private set; }
-        
+
         // Device18_ABP: used for C2D invalid fport testing
-        public TestDeviceInfo Device18_ABP { get; private set; }        
-        
+        public TestDeviceInfo Device18_ABP { get; private set; }
+
         // Device19_ABP: used for C2D invalid fport testing
         public TestDeviceInfo Device19_ABP { get; private set; }
 
@@ -114,30 +114,41 @@ namespace LoRaWan.IntegrationTest
             AppDomain.CurrentDomain.UnhandledException += this.OnUnhandledException;
 
             SetupTestDevices();
-
-            // Fix device ID if a prefix was defined (DO NOT MOVE THIS LINE ABOVE DEVICE CREATION)             
-            if (!string.IsNullOrEmpty(Configuration.DevicePrefix))
+            foreach (var d in GetAllDevices())
             {
-                foreach (var d in GetAllDevices())
+                // Fix device ID if a prefix was defined (DO NOT MOVE THIS LINE ABOVE DEVICE CREATION)             
+                if (!string.IsNullOrEmpty(Configuration.DevicePrefix))
                 {
+
                     d.DeviceID = string.Concat(Configuration.DevicePrefix, d.DeviceID.Substring(Configuration.DevicePrefix.Length, d.DeviceID.Length - Configuration.DevicePrefix.Length));
                     if (!string.IsNullOrEmpty(d.AppEUI))
                         d.AppEUI = string.Concat(Configuration.DevicePrefix, d.AppEUI.Substring(Configuration.DevicePrefix.Length, d.AppEUI.Length - Configuration.DevicePrefix.Length));
-    
+
                     if (!string.IsNullOrEmpty(d.AppKey))
-                        d.AppKey = string.Concat(Configuration.DevicePrefix, d.AppKey.Substring(Configuration.DevicePrefix.Length, d.AppKey.Length - Configuration.DevicePrefix.Length));                    
+                        d.AppKey = string.Concat(Configuration.DevicePrefix, d.AppKey.Substring(Configuration.DevicePrefix.Length, d.AppKey.Length - Configuration.DevicePrefix.Length));
 
                     if (!string.IsNullOrEmpty(d.AppSKey))
                         d.AppSKey = string.Concat(Configuration.DevicePrefix, d.AppSKey.Substring(Configuration.DevicePrefix.Length, d.AppSKey.Length - Configuration.DevicePrefix.Length));
 
                     if (!string.IsNullOrEmpty(d.NwkSKey))
                         d.NwkSKey = string.Concat(Configuration.DevicePrefix, d.NwkSKey.Substring(Configuration.DevicePrefix.Length, d.NwkSKey.Length - Configuration.DevicePrefix.Length));
-                    
+
                     if (!string.IsNullOrEmpty(d.DevAddr))
-                        d.DevAddr = string.Concat(Configuration.DevicePrefix, d.DevAddr.Substring(Configuration.DevicePrefix.Length, d.DevAddr.Length - Configuration.DevicePrefix.Length));                    
+                    {
+                        d.DevAddr = LoRaTools.Utils.NetIdHelper.SetNwkIdPart(string.Concat(Configuration.DevicePrefix, d.DevAddr.Substring(Configuration.DevicePrefix.Length, d.DevAddr.Length - Configuration.DevicePrefix.Length)), Configuration.NetId);
+                    }
+                }
+                else
+                {
+                    if (!string.IsNullOrEmpty(d.DevAddr))
+                    {
+                        d.DevAddr = LoRaTools.Utils.NetIdHelper.SetNwkIdPart(d.DevAddr, Configuration.NetId);
+                    }
                 }
             }
+
         }
+
 
         private void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
@@ -148,7 +159,7 @@ namespace LoRaWan.IntegrationTest
         void SetupTestDevices()
         {
             var gatewayID = Environment.GetEnvironmentVariable("IOTEDGE_DEVICEID") ?? this.Configuration.LeafDeviceGatewayID;
-          
+
             // Device1_OTAA: used for join test only
             this.Device1_OTAA = new TestDeviceInfo()
             {
@@ -156,7 +167,7 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = "0000000000000001",
                 AppKey = "00000000000000000000000000000001",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true                            
+                IsIoTHubDevice = true
             };
 
             // Device2_OTAA: used for failed join (wrong devEUI)
@@ -180,7 +191,7 @@ namespace LoRaWan.IntegrationTest
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
-            
+
 
             // Device4_OTAA: used for OTAA confirmed & unconfirmed messaging
             this.Device4_OTAA = new TestDeviceInfo()
@@ -191,7 +202,7 @@ namespace LoRaWan.IntegrationTest
                 GatewayID = gatewayID,
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
-            };        
+            };
 
 
             // Device5_ABP: used for ABP confirmed & unconfirmed messaging
@@ -201,10 +212,10 @@ namespace LoRaWan.IntegrationTest
                 GatewayID = gatewayID,
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
-                AppSKey="00000000000000000000000000000005",
-                NwkSKey="00000000000000000000000000000005",
-                DevAddr="0028B1B0"
-            };     
+                AppSKey = "00000000000000000000000000000005",
+                NwkSKey = "00000000000000000000000000000005",
+                DevAddr = "0028B1B0"
+            };
 
             // Device6_ABP: used for ABP wrong devaddr
             this.Device6_ABP = new TestDeviceInfo()
@@ -213,10 +224,10 @@ namespace LoRaWan.IntegrationTest
                 GatewayID = gatewayID,
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = false,
-                AppSKey="00000000000000000000000000000006",
-                NwkSKey="00000000000000000000000000000006",
-                DevAddr="00000006",
-            };  
+                AppSKey = "00000000000000000000000000000006",
+                NwkSKey = "00000000000000000000000000000006",
+                DevAddr = "00000006",
+            };
 
             // Device7_ABP: used for ABP wrong nwkskey
             this.Device7_ABP = new TestDeviceInfo()
@@ -225,10 +236,10 @@ namespace LoRaWan.IntegrationTest
                 GatewayID = gatewayID,
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
-                AppSKey="00000000000000000000000000000007",
-                NwkSKey="00000000000000000000000000000007",
-                DevAddr="00000007"
-            };  
+                AppSKey = "00000000000000000000000000000007",
+                NwkSKey = "00000000000000000000000000000007",
+                DevAddr = "00000007"
+            };
 
             // Device8_ABP: used for ABP invalid nwkskey (mic fails)
             this.Device8_ABP = new TestDeviceInfo()
@@ -237,10 +248,10 @@ namespace LoRaWan.IntegrationTest
                 GatewayID = gatewayID,
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
-                AppSKey="00000000000000000000000000000008",
-                NwkSKey="00000000000000000000000000000008",
-                DevAddr="00000008"
-            };    
+                AppSKey = "00000000000000000000000000000008",
+                NwkSKey = "00000000000000000000000000000008",
+                DevAddr = "00000008"
+            };
 
             // Device9_OTAA: used for confirmed message & C2D
             this.Device9_OTAA = new TestDeviceInfo()
@@ -249,8 +260,8 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = "0000000000000009",
                 AppKey = "00000000000000000000000000000009",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true                            
-            };  
+                IsIoTHubDevice = true
+            };
 
             // Device10_OTAA: used for unconfirmed message & C2D
             this.Device10_OTAA = new TestDeviceInfo()
@@ -259,8 +270,8 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = "0000000000000010",
                 AppKey = "00000000000000000000000000000010",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true                            
-            };  
+                IsIoTHubDevice = true
+            };
 
             // Device11_OTAA: used for http decoder
             this.Device11_OTAA = new TestDeviceInfo()
@@ -269,9 +280,9 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = "0000000000000011",
                 AppKey = "00000000000000000000000000000011",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true,                                      
-                SensorDecoder = "http://sensordecodermodule/api/DecoderValueSensor",                           
-            };  
+                IsIoTHubDevice = true,
+                SensorDecoder = "http://sensordecodermodule/api/DecoderValueSensor",
+            };
 
             // Device12_OTAA: used for reflection based decoder
             this.Device12_OTAA = new TestDeviceInfo()
@@ -280,9 +291,9 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = "0000000000000012",
                 AppKey = "00000000000000000000000000000012",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true,                                      
-                SensorDecoder = "DecoderValueSensor",                           
-            };  
+                IsIoTHubDevice = true,
+                SensorDecoder = "DecoderValueSensor",
+            };
 
             // Device13_OTAA: used for Join with wrong AppEUI
             this.Device13_OTAA = new TestDeviceInfo()
@@ -291,8 +302,8 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = "0000000000000013",
                 AppKey = "00000000000000000000000000000013",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true,                                      
-                SensorDecoder = "DecoderValueSensor",                           
+                IsIoTHubDevice = true,
+                SensorDecoder = "DecoderValueSensor",
             };
 
             // Device14_OTAA: used for Confirmed C2D message
@@ -345,8 +356,8 @@ namespace LoRaWan.IntegrationTest
             {
                 DeviceID = "0000000000000018",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true,                                      
-                SensorDecoder = "DecoderValueSensor",  
+                IsIoTHubDevice = true,
+                SensorDecoder = "DecoderValueSensor",
                 AppSKey = "00000000000000000000000000000018",
                 NwkSKey = "00000000000000000000000000000018",
                 DevAddr = "00000018"
@@ -356,9 +367,10 @@ namespace LoRaWan.IntegrationTest
             this.Device19_ABP = new TestDeviceInfo()
             {
                 DeviceID = "0000000000000019",
+                AppEUI = "0000000000000019",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true,                                      
-                SensorDecoder = "DecoderValueSensor",  
+                IsIoTHubDevice = true,
+                SensorDecoder = "DecoderValueSensor",
                 AppSKey = "00000000000000000000000000000019",
                 NwkSKey = "00000000000000000000000000000019",
                 DevAddr = "00000019"
@@ -371,9 +383,9 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = "0000000000000020",
                 AppKey = "00000000000000000000000000000020",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true,                                      
-                SensorDecoder = "DecoderValueSensor",                           
-            };  
+                IsIoTHubDevice = true,
+                SensorDecoder = "DecoderValueSensor",
+            };
 
 
             // Simulated devices start at 1000
@@ -386,9 +398,9 @@ namespace LoRaWan.IntegrationTest
                 GatewayID = gatewayID,
                 SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
-                AppSKey="00000000000000000000000000000018",
-                NwkSKey="00000000000000000000000000000018",
-                DevAddr="00000018"
+                AppSKey = "00000000000000000000000000000018",
+                NwkSKey = "00000000000000000000000000000018",
+                DevAddr = "00000018"
             };
 
             // Device1002_Simulated_OTAA: used for simulator
@@ -400,7 +412,7 @@ namespace LoRaWan.IntegrationTest
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
                 SensorDecoder = "DecoderValueSensor",
-            }; 
+            };
 
             // Device1003_Simulated_HttpBasedDecoder: used for simulator http based decoding test
             this.Device1003_Simulated_HttpBasedDecoder = new TestDeviceInfo
@@ -413,7 +425,7 @@ namespace LoRaWan.IntegrationTest
                 SensorDecoder = "http://localhost:8888/api/DecoderValueSensor",
             };
 
-            for (var deviceID=1100; deviceID <= 1110; deviceID++)
+            for (var deviceID = 1100; deviceID <= 1110; deviceID++)
             {
                 this.deviceRange1000_ABP.Add(
                     new TestDeviceInfo
@@ -422,9 +434,9 @@ namespace LoRaWan.IntegrationTest
                         GatewayID = gatewayID,
                         IsIoTHubDevice = true,
                         SensorDecoder = "DecoderValueSensor",
-                        AppSKey=deviceID.ToString("00000000000000000000000000000000"),
-                        NwkSKey=deviceID.ToString("00000000000000000000000000000000"),
-                        DevAddr=deviceID.ToString("00000000"),
+                        AppSKey = deviceID.ToString("00000000000000000000000000000000"),
+                        NwkSKey = deviceID.ToString("00000000000000000000000000000000"),
+                        DevAddr = deviceID.ToString("00000000"),
                     }
                 );
             }
@@ -449,10 +461,10 @@ namespace LoRaWan.IntegrationTest
                 }
             }
         }
-      
+
         // Clear IoT Hub, Udp logs and Arduino serial logs
         public void ClearLogs()
-        { 
+        {
             this.IoTHubMessages?.ResetEvents();
             this.udpLogListener?.ResetEvents();
             this.ArduinoDevice?.ClearSerialLogs();
@@ -498,12 +510,12 @@ namespace LoRaWan.IntegrationTest
         }
         internal async Task<Twin> GetTwinAsync(string deviceId)
         {
-            return await GetRegistryManager().GetTwinAsync(deviceId);            
+            return await GetRegistryManager().GetTwinAsync(deviceId);
         }
 
-        internal Task SendCloudToDeviceMessage(string deviceId, string messageText, Dictionary<String,String> messageProperties=null) => SendCloudToDeviceMessage(deviceId, null, messageText, messageProperties);
+        internal Task SendCloudToDeviceMessage(string deviceId, string messageText, Dictionary<String, String> messageProperties = null) => SendCloudToDeviceMessage(deviceId, null, messageText, messageProperties);
 
-        internal async Task SendCloudToDeviceMessage(string deviceId, string messageId, string messageText, Dictionary<String,String> messageProperties=null)
+        internal async Task SendCloudToDeviceMessage(string deviceId, string messageId, string messageText, Dictionary<String, String> messageProperties = null)
         {
             var msg = new Message(Encoding.UTF8.GetBytes(messageText));
             if (messageProperties != null)
@@ -525,8 +537,8 @@ namespace LoRaWan.IntegrationTest
         internal async Task SendCloudToDeviceMessage(string deviceId, Message message)
         {
             ServiceClient sc = ServiceClient.CreateFromConnectionString(this.Configuration.IoTHubConnectionString);
-            
-            await sc.SendAsync(deviceId, message);         
+
+            await sc.SendAsync(deviceId, message);
         }
 
         internal async Task<Twin> ReplaceTwinAsync(string deviceId, Twin updatedTwin, string etag)
@@ -568,7 +580,7 @@ namespace LoRaWan.IntegrationTest
             if (!string.IsNullOrEmpty(Configuration.IoTHubEventHubConnectionString) && this.Configuration.NetworkServerModuleLogAssertLevel != LogValidationAssertLevel.Ignore)
             {
                 this.IoTHubMessages = new EventHubDataCollector(Configuration.IoTHubEventHubConnectionString, Configuration.IoTHubEventHubConsumerGroup);
-                await this.IoTHubMessages.StartAsync(); 
+                await this.IoTHubMessages.StartAsync();
             }
 
             if (Configuration.UdpLog)
@@ -595,13 +607,13 @@ namespace LoRaWan.IntegrationTest
                 {
                     TestLogger.Log($"Device {testDevice.DeviceID} does not exist. Creating");
                     var device = new Device(testDevice.DeviceID);
-                    var twin = new Twin(testDevice.DeviceID);                                            
+                    var twin = new Twin(testDevice.DeviceID);
                     twin.Properties.Desired = new TwinCollection(JsonConvert.SerializeObject(testDevice.GetDesiredProperties()));
 
                     TestLogger.Log($"Creating device {testDevice.DeviceID}");
                     await registryManager.AddDeviceWithTwinAsync(device, twin);
                 }
-                else 
+                else
                 {
                     // compare device twin and make changes if needed
                     var deviceTwin = await registryManager.GetTwinAsync(testDevice.DeviceID);
@@ -614,7 +626,7 @@ namespace LoRaWan.IntegrationTest
                             if (deviceTwin.Properties.Desired.Contains(kv.Key))
                                 existingValue = deviceTwin.Properties.Desired[kv.Key].ToString();
                             TestLogger.Log($"Unexpected value for device {testDevice.DeviceID} twin property {kv.Key}, expecting '{kv.Value}', actual is '{existingValue}'");
-                            
+
                             var patch = new Twin();
                             patch.Properties.Desired = new TwinCollection(JsonConvert.SerializeObject(desiredProperties));
                             await registryManager.UpdateTwinAsync(testDevice.DeviceID, patch, deviceTwin.ETag);
@@ -631,6 +643,6 @@ namespace LoRaWan.IntegrationTest
         internal TestDeviceInfo GetDeviceByPropertyName(string propertyName)
         {
             return (TestDeviceInfo)this.GetType().GetProperty(propertyName).GetValue(this);
-        }        
+        }
     }
 }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/OTAATest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/OTAATest.cs
@@ -44,7 +44,7 @@ namespace LoRaWan.IntegrationTest
             // Sends 10x unconfirmed messages            
             for (var i=0; i < MESSAGES_COUNT; ++i)            
             {
-                Console.WriteLine($"Starting sending OTTA unconfirmed message {i+1}/{MESSAGES_COUNT}");
+                Console.WriteLine($"Starting sending OTAA unconfirmed message {i+1}/{MESSAGES_COUNT}");
                 this.TestFixture.ClearLogs();
 
                 var msg = PayloadGenerator.Next().ToString();

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/TestConfiguration.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/TestConfiguration.cs
@@ -45,6 +45,9 @@ namespace LoRaWan.IntegrationTest
 
         // Gets/sets network server udp log port
         public int UdpLogPort { get; set; } = 6000;
+
+        // Gets/sets gateway NetId
+        public uint NetId { get; set; } = 1;
     }
 
 }

--- a/LoRaEngine/test/LoRaWan.Test.Shared/TestDeviceInfo.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/TestDeviceInfo.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using LoRaTools.Utils;
 using System;
 using System.Collections.Generic;
 
@@ -80,7 +81,6 @@ namespace LoRaWan.Test.Shared
             return desiredProperties;
         }
 
-
         /// <summary>
         /// Creates a <see cref="TestDeviceInfo"/> with ABP authentication
         /// </summary>
@@ -89,7 +89,7 @@ namespace LoRaWan.Test.Shared
         /// <param name="gatewayID"></param>
         /// <param name="sensorDecoder"></param>
         /// <returns></returns>
-        public static TestDeviceInfo CreateABPDevice(UInt32 deviceID, string prefix = null, string gatewayID = null, string sensorDecoder = "DecoderValueSensor")
+        public static TestDeviceInfo CreateABPDevice(UInt32 deviceID, string prefix = null, string gatewayID = null, string sensorDecoder = "DecoderValueSensor",uint netId=1)
         {
             var value8 =  deviceID.ToString("00000000");
             var value16 = deviceID.ToString("0000000000000000");
@@ -102,6 +102,7 @@ namespace LoRaWan.Test.Shared
                 value32 = string.Concat(prefix, value32.Substring(prefix.Length));
             }
 
+            var devAddrValue = NetIdHelper.SetNwkIdPart(value8,netId);
             var result = new TestDeviceInfo
             {
                 DeviceID = value16,
@@ -109,7 +110,7 @@ namespace LoRaWan.Test.Shared
                 SensorDecoder = sensorDecoder,
                 AppSKey = value32,
                 NwkSKey = value32,
-                DevAddr = value8,
+                DevAddr = devAddrValue,
             };
 
             return result;


### PR DESCRIPTION
* NetId verification at start of message processing
* NetId compliant DevAddress generated as part of Join process

Fix AB#651