### PR TITLE
Update Logger to use Microsoft.Extensions.Logging.LogLevel Enum

### DIFF
--- a/LoRaEngine/README.md
+++ b/LoRaEngine/README.md
@@ -254,7 +254,7 @@ It is possible to run the bits in the LoRaEngine locally with from Visual Studio
 3. Open the properties of the project *LoRaWanNetworkServerModule* and set the following values under the Debug tab:
   - IOTEDGE_IOTHUBHOSTNAME : XXX.azure-devices.net (XXX = your iot hub hostname)
   - ENABLE_GATEWAY : false
-  - LOG_LEVEL : 1 (optional, to activate most verbose logging level)
+  - LOG_LEVEL : 1 or Debug (optional, to activate most verbose logging level)
   - FacadeServerUrl : http://localhost:7071/api/ (or pointer to the function you want to use)
   - FacadeAuthCode : <your function auth code, do not set this variable if running locally>
 4. Add a local.settings.json in the project LoRa KeysManagerFacade with

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinDeviceLoader.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinDeviceLoader.cs
@@ -5,6 +5,7 @@ namespace LoRaWan.NetworkServer
 {
     using System;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Loads devices for join requests
@@ -37,11 +38,11 @@ namespace LoRaWan.NetworkServer
 
             try
             {
-                Logger.Log(loRaDevice.DevEUI, $"getting twins for OTAA for device", Logger.LoggingLevel.Info);
+                Logger.Log(loRaDevice.DevEUI, $"getting twins for OTAA for device", LogLevel.Information);
 
                 if (await loRaDevice.InitializeAsync())
                 {
-                    Logger.Log(loRaDevice.DevEUI, $"done getting twins for OTAA device", Logger.LoggingLevel.Info);
+                    Logger.Log(loRaDevice.DevEUI, $"done getting twins for OTAA device", LogLevel.Information);
 
                     return loRaDevice;
                 }
@@ -51,13 +52,13 @@ namespace LoRaWan.NetworkServer
                     // object is non usable, must try to read twin again
                     // for the future we could retry here
                     this.canCache = false;
-                    Logger.Log(loRaDevice.DevEUI, "join refused: error initializing OTAA device, getting twin failed", Logger.LoggingLevel.Error);
+                    Logger.Log(loRaDevice.DevEUI, "join refused: error initializing OTAA device, getting twin failed", LogLevel.Error);
                 }
             }
             catch (Exception ex)
             {
                 // will reach here if the device does not have required properties in the twin
-                Logger.Log(loRaDevice.DevEUI, $"join refused: error initializing OTAA device. {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(loRaDevice.DevEUI, $"join refused: error initializing OTAA device. {ex.Message}", LogLevel.Error);
             }
 
             return null;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
@@ -7,6 +7,7 @@ namespace LoRaWan.NetworkServer
     using System.Collections.Generic;
     using System.Text;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -26,14 +27,14 @@ namespace LoRaWan.NetworkServer
 
         public override async Task<ushort> NextFCntDownAsync(string devEUI, int fcntDown, int fcntUp, string gatewayId)
         {
-            Logger.Log(devEUI, $"syncing FCntDown for multigateway", Logger.LoggingLevel.Info);
+            Logger.Log(devEUI, $"syncing FCntDown for multigateway", LogLevel.Information);
 
             var client = this.serviceFacadeHttpClientProvider.GetHttpClient();
             var url = $"{this.URL}NextFCntDown?code={this.AuthCode}&DevEUI={devEUI}&FCntDown={fcntDown}&FCntUp={fcntUp}&GatewayId={gatewayId}";
             var response = await client.GetAsync(url);
             if (!response.IsSuccessStatusCode)
             {
-                Logger.Log(devEUI, $"error calling the NextFCntDown function, check the function log. {response.ReasonPhrase}", Logger.LoggingLevel.Error);
+                Logger.Log(devEUI, $"error calling the NextFCntDown function, check the function log. {response.ReasonPhrase}", LogLevel.Error);
                 return 0;
             }
 
@@ -47,13 +48,13 @@ namespace LoRaWan.NetworkServer
 
         public override async Task<bool> ABPFcntCacheResetAsync(string devEUI)
         {
-            Logger.Log(devEUI, $"ABP FCnt cache reset for multigateway", Logger.LoggingLevel.Info);
+            Logger.Log(devEUI, $"ABP FCnt cache reset for multigateway", LogLevel.Information);
             var client = this.serviceFacadeHttpClientProvider.GetHttpClient();
             var url = $"{this.URL}NextFCntDown?code={this.AuthCode}&DevEUI={devEUI}&ABPFcntCacheReset=true";
             var response = await client.GetAsync(url);
             if (!response.IsSuccessStatusCode)
             {
-                Logger.Log(devEUI, $"error calling the NextFCntDown function, check the function log, {response.ReasonPhrase}", Logger.LoggingLevel.Error);
+                Logger.Log(devEUI, $"error calling the NextFCntDown function, check the function log, {response.ReasonPhrase}", LogLevel.Error);
                 return false;
             }
 
@@ -124,7 +125,7 @@ namespace LoRaWan.NetworkServer
 
                     if (!string.IsNullOrEmpty(badReqResult) && string.Equals(badReqResult, "UsedDevNonce", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        Logger.Log(devEUI ?? string.Empty, $"DevNonce already used by this device", Logger.LoggingLevel.Info);
+                        Logger.Log(devEUI ?? string.Empty, $"DevNonce already used by this device", LogLevel.Information);
                         return new SearchDevicesResult
                         {
                             IsDevNonceAlreadyUsed = true,
@@ -132,7 +133,7 @@ namespace LoRaWan.NetworkServer
                     }
                 }
 
-                Logger.Log(devAddr, $"error calling façade api: {response.ReasonPhrase}, status: {response.StatusCode}, check the azure function log", Logger.LoggingLevel.Error);
+                Logger.Log(devAddr, $"error calling façade api: {response.ReasonPhrase}, status: {response.StatusCode}, check the azure function log", LogLevel.Error);
 
                 // TODO: FBE check if we return null or throw exception
                 return new SearchDevicesResult();

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
@@ -9,6 +9,7 @@ namespace LoRaWan.NetworkServer
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -44,7 +45,7 @@ namespace LoRaWan.NetworkServer
                 if (this.deviceClient != null)
                 {
                     this.deviceClient.SetRetryPolicy(this.exponentialBackoff);
-                    // Logger.Log(DevEUI, $"retry is on", Logger.LoggingLevel.Full);
+                    // Logger.Log(DevEUI, $"retry is on", LogLevel.Debug);
                 }
             }
             else
@@ -52,7 +53,7 @@ namespace LoRaWan.NetworkServer
                 if (this.deviceClient != null)
                 {
                     this.deviceClient.SetRetryPolicy(this.noRetryPolicy);
-                    // Logger.Log(DevEUI, $"retry is off", Logger.LoggingLevel.Full);
+                    // Logger.Log(DevEUI, $"retry is off", LogLevel.Debug);
                 }
             }
         }
@@ -65,17 +66,17 @@ namespace LoRaWan.NetworkServer
 
                 this.SetRetry(true);
 
-                Logger.Log(this.devEUI, $"getting device twins", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"getting device twins", LogLevel.Debug);
 
                 var twins = await this.deviceClient.GetTwinAsync();
 
-                Logger.Log(this.devEUI, $"done getting device twins", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"done getting device twins", LogLevel.Debug);
 
                 return twins;
             }
             catch (Exception ex)
             {
-                Logger.Log(this.devEUI, $"Could not retrieve device twins with error: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(this.devEUI, $"Could not retrieve device twins with error: {ex.Message}", LogLevel.Error);
                 return null;
             }
             finally
@@ -93,22 +94,22 @@ namespace LoRaWan.NetworkServer
                 this.SetRetry(true);
 
                 string reportedPropertiesJson = string.Empty;
-                if (Logger.LoggerLevel == Logger.LoggingLevel.Full)
+                if (Logger.LoggerLevel == LogLevel.Debug)
                 {
                     reportedPropertiesJson = reportedProperties.ToJson(Newtonsoft.Json.Formatting.None);
-                    Logger.Log(this.devEUI, $"updating twins {reportedPropertiesJson}", Logger.LoggingLevel.Full);
+                    Logger.Log(this.devEUI, $"updating twins {reportedPropertiesJson}", LogLevel.Debug);
                 }
 
                 await this.deviceClient.UpdateReportedPropertiesAsync(reportedProperties);
 
-                if (Logger.LoggerLevel == Logger.LoggingLevel.Full)
-                    Logger.Log(this.devEUI, $"twins updated {reportedPropertiesJson}", Logger.LoggingLevel.Full);
+                if (Logger.LoggerLevel == LogLevel.Debug)
+                    Logger.Log(this.devEUI, $"twins updated {reportedPropertiesJson}", LogLevel.Debug);
 
                 return true;
             }
             catch (Exception ex)
             {
-                Logger.Log(this.devEUI, $"could not update twins with error: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(this.devEUI, $"could not update twins with error: {ex.Message}", LogLevel.Error);
                 return false;
             }
             finally
@@ -131,7 +132,7 @@ namespace LoRaWan.NetworkServer
                     var messageJson = JsonConvert.SerializeObject(telemetry, Formatting.None);
                     var message = new Message(Encoding.UTF8.GetBytes(messageJson));
 
-                    Logger.Log(this.devEUI, $"sending message {messageJson} to hub", Logger.LoggingLevel.Full);
+                    Logger.Log(this.devEUI, $"sending message {messageJson} to hub", LogLevel.Debug);
 
                     message.ContentType = System.Net.Mime.MediaTypeNames.Application.Json;
                     message.ContentEncoding = Encoding.UTF8.BodyName;
@@ -144,13 +145,13 @@ namespace LoRaWan.NetworkServer
 
                     await this.deviceClient.SendEventAsync(message);
 
-                    Logger.Log(this.devEUI, $"sent message {messageJson} to hub", Logger.LoggingLevel.Full);
+                    Logger.Log(this.devEUI, $"sent message {messageJson} to hub", LogLevel.Debug);
 
                     return true;
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log(this.devEUI, $"could not send message to IoTHub/Edge with error: {ex.Message}", Logger.LoggingLevel.Error);
+                    Logger.Log(this.devEUI, $"could not send message to IoTHub/Edge with error: {ex.Message}", LogLevel.Error);
                 }
                 finally
                 {
@@ -173,23 +174,23 @@ namespace LoRaWan.NetworkServer
                 if (timeout.TotalMilliseconds > MaxReceiveMessageTimeoutInMs)
                     timeout = TimeSpan.FromMilliseconds(MaxReceiveMessageTimeoutInMs);
 
-                Logger.Log(this.devEUI, $"checking c2d message for {timeout}", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"checking c2d message for {timeout}", LogLevel.Debug);
 
                 Message msg = await this.deviceClient.ReceiveAsync(timeout);
 
-                if (Logger.LoggerLevel >= Logger.LoggingLevel.Full)
+                if (Logger.LoggerLevel >= LogLevel.Debug)
                 {
                     if (msg == null)
-                        Logger.Log(this.devEUI, "done checking c2d message, found no message", Logger.LoggingLevel.Full);
+                        Logger.Log(this.devEUI, "done checking c2d message, found no message", LogLevel.Debug);
                     else
-                        Logger.Log(this.devEUI, $"done checking c2d message, found message id: {msg.MessageId ?? "undefined"}", Logger.LoggingLevel.Full);
+                        Logger.Log(this.devEUI, $"done checking c2d message, found message id: {msg.MessageId ?? "undefined"}", LogLevel.Debug);
                 }
 
                 return msg;
             }
             catch (Exception ex)
             {
-                Logger.Log(this.devEUI, $"Could not retrieve c2d message with error: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(this.devEUI, $"Could not retrieve c2d message with error: {ex.Message}", LogLevel.Error);
                 return null;
             }
             finally
@@ -207,17 +208,17 @@ namespace LoRaWan.NetworkServer
 
                 this.SetRetry(true);
 
-                Logger.Log(this.devEUI, $"completing c2d message, id: {message.MessageId ?? "undefined"}", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"completing c2d message, id: {message.MessageId ?? "undefined"}", LogLevel.Debug);
 
                 await this.deviceClient.CompleteAsync(message);
 
-                Logger.Log(this.devEUI, $"done completing c2d message, id: {message.MessageId ?? "undefined"}", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"done completing c2d message, id: {message.MessageId ?? "undefined"}", LogLevel.Debug);
 
                 return true;
             }
             catch (Exception ex)
             {
-                Logger.Log(this.devEUI, $"could not complete c2d message (id: {message.MessageId ?? "undefined"}) with error: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(this.devEUI, $"could not complete c2d message (id: {message.MessageId ?? "undefined"}) with error: {ex.Message}", LogLevel.Error);
                 return false;
             }
             finally
@@ -235,17 +236,17 @@ namespace LoRaWan.NetworkServer
 
                 this.SetRetry(true);
 
-                Logger.Log(this.devEUI, $"abandoning c2d message, id: {message.MessageId ?? "undefined"}", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"abandoning c2d message, id: {message.MessageId ?? "undefined"}", LogLevel.Debug);
 
                 await this.deviceClient.AbandonAsync(message);
 
-                Logger.Log(this.devEUI, $"done abandoning c2d message, id: {message.MessageId ?? "undefined"}", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"done abandoning c2d message, id: {message.MessageId ?? "undefined"}", LogLevel.Debug);
 
                 return true;
             }
             catch (Exception ex)
             {
-                Logger.Log(this.devEUI, $"could not abandon c2d message (id: {message.MessageId ?? "undefined"}) with error: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(this.devEUI, $"could not abandon c2d message (id: {message.MessageId ?? "undefined"}) with error: {ex.Message}", LogLevel.Error);
                 return false;
             }
             finally

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
@@ -6,6 +6,7 @@ namespace LoRaWan.NetworkServer
     using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
+    using Microsoft.Extensions.Logging;
 
     public class LoRaDeviceFactory : ILoRaDeviceFactory
     {
@@ -34,7 +35,7 @@ namespace LoRaWan.NetworkServer
 
             if (string.IsNullOrEmpty(this.configuration.IoTHubHostName))
             {
-                Logger.Log("Configuration/Environment variable IOTEDGE_IOTHUBHOSTNAME not found, creation of iothub connection not possible", Logger.LoggingLevel.Error);
+                Logger.Log("Configuration/Environment variable IOTEDGE_IOTHUBHOSTNAME not found, creation of iothub connection not possible", LogLevel.Error);
             }
 
             connectionString += $"HostName={this.configuration.IoTHubHostName};";
@@ -42,11 +43,11 @@ namespace LoRaWan.NetworkServer
             if (this.configuration.EnableGateway)
             {
                 connectionString += $"GatewayHostName={this.configuration.GatewayHostName};";
-                Logger.Log(devEUI, $"using edgeHub local queue", Logger.LoggingLevel.Info);
+                Logger.Log(devEUI, $"using edgeHub local queue", LogLevel.Information);
             }
             else
             {
-                Logger.Log(devEUI, $"using iotHub directly, no edgeHub queue", Logger.LoggingLevel.Info);
+                Logger.Log(devEUI, $"using iotHub directly, no edgeHub queue", LogLevel.Information);
             }
 
             return connectionString;
@@ -64,7 +65,7 @@ namespace LoRaWan.NetworkServer
             }
             catch (Exception ex)
             {
-                Logger.Log(devEUI, $"could not create IoT Hub DeviceClient with error: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(devEUI, $"could not create IoT Hub DeviceClient with error: {ex.Message}", LogLevel.Error);
                 throw;
             }
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaPayloadDecoder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaPayloadDecoder.cs
@@ -9,6 +9,7 @@ namespace LoRaWan.NetworkServer
     using System.Text;
     using System.Threading.Tasks;
     using System.Web;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
@@ -114,7 +115,7 @@ namespace LoRaWan.NetworkServer
             }
             catch (Exception ex)
             {
-                Logger.Log($"Error in decoder handling: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log($"Error in decoder handling: {ex.Message}", LogLevel.Error);
 
                 result = JsonConvert.SerializeObject(new
                 {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -50,8 +50,8 @@ namespace LoRaWan.NetworkServer
         public bool LogToConsole { get; set; } = true;
 
         // Gets/sets the logging level
-        // Default: 0 (Always logging)
-        public int LogLevel { get; set; } = 0;
+        // Default: 4 (Log Errors)
+        public string LogLevel { get; set; } = "4";
 
         // Gets/sets if logging to IoT Hub is enabled
         // Default: false

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ProcessLogger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ProcessLogger.cs
@@ -5,6 +5,7 @@ namespace LoRaWan.NetworkServer
 {
     using System;
     using System.Collections.Generic;
+    using Microsoft.Extensions.Logging;
 
     // Helper class to log process operations
     internal sealed class ProcessLogger : IDisposable
@@ -30,7 +31,7 @@ namespace LoRaWan.NetworkServer
 
         public void Dispose()
         {
-            Logger.Log(this.devEUI ?? LoRaTools.Utils.ConversionHelper.ByteArrayToString(this.devAddr), $"processing time: {this.timeWatcher.GetElapsedTime()}", Logger.LoggingLevel.Info);
+            Logger.Log(this.devEUI ?? LoRaTools.Utils.ConversionHelper.ByteArrayToString(this.devAddr), $"processing time: {this.timeWatcher.GetElapsedTime()}", LogLevel.Information);
             GC.SuppressFinalize(this);
         }
     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
@@ -9,26 +9,18 @@ namespace LoRaWan
     using System.Text;
     using System.Threading;
     using Microsoft.Azure.Devices.Client;
+    using Microsoft.Extensions.Logging;
 
     public class Logger
     {
         // Interval where we try to estabilish connection to udp logger
         const int RETRY_UDP_LOG_CONNECTION_INTERVAL_IN_MS = 1000 * 10;
 
-        public enum LoggingLevel : int
-        {
-            Always = 0,
-            Full,
-            Info,
-            Error
-        }
-
-        public static LoggingLevel LoggerLevel => (LoggingLevel)configuration.LogLevel;
+        public static LogLevel LoggerLevel => (LogLevel)configuration.LogLevel;
 
         static LoggerConfiguration configuration = new LoggerConfiguration();
         static volatile UdpClient udpClient;
         static IPEndPoint udpEndpoint;
-
         static volatile bool isInitializeUdpLoggerRunning = false;
         private static Timer retryUdpLogInitializationTimer;
 
@@ -57,14 +49,24 @@ namespace LoRaWan
             }
         }
 
-        public static void Log(string message, LoggingLevel loggingLevel)
+        public static void LogAlways(string message)
         {
-            Log(null, message, loggingLevel);
+            LogAlways(null, message);
         }
 
-        public static void Log(string deviceId, string message, LoggingLevel loggingLevel)
+        public static void LogAlways(string deviceId, string message)
         {
-            if ((int)loggingLevel >= configuration.LogLevel || loggingLevel == LoggingLevel.Always)
+            Log(null, message, LogLevel.Critical);
+        }
+
+        public static void Log(string message, LogLevel logLevel)
+        {
+            Log(null, message, logLevel);
+        }
+
+        public static void Log(string deviceId, string message, LogLevel logLevel)
+        {
+            if ((int)logLevel >= configuration.LogLevel)
             {
                 var msg = message;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/LoggerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/LoggerConfiguration.cs
@@ -16,8 +16,8 @@ namespace LoRaWan
         public bool LogToConsole { get; set; } = true;
 
         // Gets/sets the logging level
-        // Default: 0 (Always logging)
-        public int LogLevel { get; set; } = 0;
+        // Default: 4 (Error)
+        public int LogLevel { get; set; } = 4;
 
         // Gets/sets if logging to IoT Hub is enabled
         // Default: false
@@ -32,5 +32,26 @@ namespace LoRaWan
 
         // Gets/sets udp port to send logs
         public int LogToUdpPort { get; set; } = 6000;
+
+        public static int InitLogLevel(string logLevel)
+        {
+            int logLevelInt = 4;
+            logLevel = logLevel.ToUpper();
+
+            if (logLevel == "1" || logLevel == "DEBUG")
+            {
+                logLevelInt = 1;
+            }
+            else if (logLevel == "2" || logLevel == "INFORMATION" || logLevel == "INFO")
+            {
+                logLevelInt = 2;
+            }
+            else if (logLevel == "3" || logLevel == "4" || logLevel == "ERROR")
+            {
+                logLevelInt = 4;
+            }
+
+            return logLevelInt;
+        }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -1,19 +1,19 @@
-﻿using LoRaTools.LoRaPhysical;
-using LoRaTools.Utils;
-using LoRaWan;
-using Newtonsoft.Json;
-using Org.BouncyCastle.Crypto;
-using Org.BouncyCastle.Crypto.Engines;
-using Org.BouncyCastle.Crypto.Parameters;
-using Org.BouncyCastle.Security;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-
-namespace LoRaTools.LoRaMessage
+﻿namespace LoRaTools.LoRaMessage
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Runtime.InteropServices;
+    using System.Text;
+    using LoRaTools.LoRaPhysical;
+    using LoRaTools.Utils;
+    using LoRaWan;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+    using Org.BouncyCastle.Crypto;
+    using Org.BouncyCastle.Crypto.Engines;
+    using Org.BouncyCastle.Crypto.Parameters;
+    using Org.BouncyCastle.Security;
 
     public enum FctrlEnum : short
     {
@@ -240,17 +240,17 @@ namespace LoRaTools.LoRaMessage
             PerformEncryption(appSKey);
             SetMic(nwkSKey);
             var downlinkPktFwdMessage = new DownlinkPktFwdMessage(this.GetByteMessage(), datr, freq, tmst);
-            if (Logger.LoggerLevel < Logger.LoggingLevel.Info)
+            if (Logger.LoggerLevel < LogLevel.Information)
             {
                 var jsonMsg = JsonConvert.SerializeObject(downlinkPktFwdMessage);
                
                 if (devEUI.Length != 0)
                 {
-                    Logger.Log(devEUI, $"{((LoRaMessageType)(Mhdr.Span[0])).ToString()} {jsonMsg}", Logger.LoggingLevel.Full);
+                    Logger.Log(devEUI, $"{((LoRaMessageType)(Mhdr.Span[0])).ToString()} {jsonMsg}", LogLevel.Debug);
                 }
                 else
                 {
-                    Logger.Log(ConversionHelper.ByteArrayToString(this.DevAddr.Span.ToArray()), $"{((LoRaMessageType)(Mhdr.Span[0])).ToString()} {jsonMsg}", Logger.LoggingLevel.Full);
+                    Logger.Log(ConversionHelper.ByteArrayToString(this.DevAddr.Span.ToArray()), $"{((LoRaMessageType)(Mhdr.Span[0])).ToString()} {jsonMsg}", LogLevel.Debug);
                 }
             }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
@@ -1,17 +1,18 @@
-﻿using LoRaTools.LoRaPhysical;
-using LoRaTools.Utils;
-using LoRaWan;
-using Newtonsoft.Json;
-using Org.BouncyCastle.Crypto.Engines;
-using Org.BouncyCastle.Crypto.Parameters;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
-
-namespace LoRaTools.LoRaMessage
+﻿namespace LoRaTools.LoRaMessage
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Cryptography;
+    using System.Text;
+    using LoRaTools.LoRaPhysical;
+    using LoRaTools.Utils;
+    using LoRaWan;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+    using Org.BouncyCastle.Crypto.Engines;
+    using Org.BouncyCastle.Crypto.Parameters;
+
     /// <summary>
     /// Implementation of a LoRa Join-Accept frame
     /// </summary>
@@ -234,17 +235,17 @@ namespace LoRaTools.LoRaMessage
             PerformEncryption(appKey);
 
             var downlinkPktFwdMessage = new DownlinkPktFwdMessage(this.GetByteMessage(), datr, freq, tmst);
-            if (Logger.LoggerLevel < Logger.LoggingLevel.Info)
+            if (Logger.LoggerLevel < LogLevel.Information)
             {
                 var jsonMsg = JsonConvert.SerializeObject(downlinkPktFwdMessage);
 
                 if (devEUI.Length != 0)
                 {
-                    Logger.Log(devEUI, $"{((LoRaMessageType)(Mhdr.Span[0])).ToString()} {jsonMsg}", Logger.LoggingLevel.Full);
+                    Logger.Log(devEUI, $"{((LoRaMessageType)(Mhdr.Span[0])).ToString()} {jsonMsg}", LogLevel.Debug);
                 }
                 else
                 {
-                    Logger.Log(ConversionHelper.ByteArrayToString(this.DevAddr.Span.ToArray()), $"{((LoRaMessageType)(Mhdr.Span[0])).ToString()} {jsonMsg}", Logger.LoggingLevel.Full);
+                    Logger.Log(ConversionHelper.ByteArrayToString(this.DevAddr.Span.ToArray()), $"{((LoRaMessageType)(Mhdr.Span[0])).ToString()} {jsonMsg}", LogLevel.Debug);
                 }
             }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoraMessageWrapper.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoraMessageWrapper.cs
@@ -2,16 +2,18 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
-using LoRaWan;
-using Newtonsoft.Json;
-using System;
-using System.Text;
-using LoRaTools.LoRaPhysical;
-using LoRaTools.Utils;
-using static LoRaTools.LoRaMessage.LoRaPayloadData;
 
 namespace LoRaTools.LoRaMessage
 {
+    using System;
+    using System.Text;
+    using LoRaTools.LoRaPhysical;
+    using LoRaTools.Utils;
+    using LoRaWan;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+    using static LoRaTools.LoRaMessage.LoRaPayloadData;
+
     public enum LoRaMessageType:byte
     {
         // Request sent by device to join
@@ -132,10 +134,10 @@ namespace LoRaTools.LoRaMessage
             var devEUI = payload.GetLoRaMessage().DevEUI;
             if (devEUI.Length != 0)
             {
-                Logger.Log(ConversionHelper.ByteArrayToString(devEUI.Span.ToArray()), $"{((LoRaMessageType)(payload.Mhdr.Span[0])).ToString()} {jsonMsg}", Logger.LoggingLevel.Full);
+                Logger.Log(ConversionHelper.ByteArrayToString(devEUI.Span.ToArray()), $"{((LoRaMessageType)(payload.Mhdr.Span[0])).ToString()} {jsonMsg}", LogLevel.Debug);
             }else
             {
-                Logger.Log(ConversionHelper.ByteArrayToString(payload.DevAddr.Span.ToArray()), $"{((LoRaMessageType)(payload.Mhdr.Span[0])).ToString()} {jsonMsg}", Logger.LoggingLevel.Full);
+                Logger.Log(ConversionHelper.ByteArrayToString(payload.DevAddr.Span.ToArray()), $"{((LoRaMessageType)(payload.Mhdr.Span[0])).ToString()} {jsonMsg}", LogLevel.Debug);
             }
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/PhysicalPayload.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/PhysicalPayload.cs
@@ -3,6 +3,7 @@ using LoRaWan;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace LoRaTools
 {
@@ -61,7 +62,7 @@ namespace LoRaTools
                 //TX_ACK That packet type is used by the gateway to send a feedback to the to inform if a downlink request has been accepted or rejected by the gateway.
                 if (identifier == PhysicalIdentifier.TX_ACK)
                 {
-                    Logger.Log($"Tx ack received from gateway", Logger.LoggingLevel.Info);
+                    Logger.Log($"Tx ack received from gateway", LogLevel.Information);
                     Array.Copy(input, 4, gatewayIdentifier, 0, 8);
                     if (input.Length - 12 > 0)
                     {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Rxpk.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Rxpk.cs
@@ -1,10 +1,11 @@
-﻿using LoRaWan;
-using Newtonsoft.Json;
-using System.Collections.Generic;
-using System.Text;
-
-namespace LoRaTools.LoRaPhysical
+﻿namespace LoRaTools.LoRaPhysical
 {
+    using System.Collections.Generic;
+    using System.Text;
+    using LoRaWan;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+
     public class Rxpk
     {
         public string time;
@@ -71,7 +72,7 @@ namespace LoRaTools.LoRaPhysical
                 var payload = Encoding.UTF8.GetString(PhysicalPayload.message);
                 if (!payload.StartsWith("{\"stat"))
                 {
-                    Logger.Log($"Physical dataUp {payload}", Logger.LoggingLevel.Full);
+                    Logger.Log($"Physical dataUp {payload}", LogLevel.Debug);
                     var payloadObject = JsonConvert.DeserializeObject<UplinkPktFwdMessage>(payload);
                     if (payloadObject != null)
                     {
@@ -83,7 +84,7 @@ namespace LoRaTools.LoRaPhysical
                 }
                 else
                 {
-                    Logger.Log($"Statistic: {payload}", Logger.LoggingLevel.Full);
+                    Logger.Log($"Statistic: {payload}", LogLevel.Debug);
                 }
             }
             return new List<Rxpk>();

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Txpk.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Txpk.cs
@@ -1,11 +1,13 @@
-﻿using LoRaWan;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace LoRaTools.LoRaPhysical
+﻿namespace LoRaTools.LoRaPhysical
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using LoRaWan;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+    using static LoRaWan.Logger;
+
     public class Txpk
     {
         public bool imme;
@@ -42,7 +44,7 @@ namespace LoRaTools.LoRaPhysical
                 }
                 else
                 {
-                    Logger.Log("Error: " + payloadDownObject.txpk, Logger.LoggingLevel.Full);
+                    Logger.Log("Error: " + payloadDownObject.txpk, LogLevel.Debug);
                 }
             }
             return null;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/Maccommand.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/Maccommand.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace LoRaTools
 {
@@ -28,17 +29,17 @@ namespace LoRaTools
                     macCommand.Add(linkCheck);
                     break;
                 case CidEnum.LinkADRCmd:
-                    Logger.Log("mac command detected : LinkADRCmd", Logger.LoggingLevel.Info);
+                    Logger.Log("mac command detected : LinkADRCmd", LogLevel.Information);
                     break;
                 case CidEnum.DutyCycleCmd:
                     DutyCycleCmd dutyCycle = new DutyCycleCmd();
                     macCommand.Add(dutyCycle);
                     break;
                 case CidEnum.RXParamCmd:
-                    Logger.Log("mac command detected : RXParamCmd", Logger.LoggingLevel.Info);
+                    Logger.Log("mac command detected : RXParamCmd", LogLevel.Information);
                     break;
                 case CidEnum.DevStatusCmd:
-                    Logger.Log("mac command detected : DevStatusCmd", Logger.LoggingLevel.Info);
+                    Logger.Log("mac command detected : DevStatusCmd", LogLevel.Information);
                     DevStatusCmd devStatus = new DevStatusCmd();
                     macCommand.Add(devStatus);
                     break;
@@ -69,37 +70,37 @@ namespace LoRaTools
                 switch (cid)
                 {
                     case CidEnum.LinkCheckCmd:
-                        Logger.Log("mac command detected : LinkCheckCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : LinkCheckCmd", LogLevel.Information);
                         LinkCheckCmd linkCheck = new LinkCheckCmd();
                         pointer += linkCheck.Length;
                         macCommand.Add(linkCheck);
                         break;
                     case CidEnum.LinkADRCmd:
-                        Logger.Log("mac command detected : LinkADRCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : LinkADRCmd", LogLevel.Information);
                         break;
                     case CidEnum.DutyCycleCmd:
-                        Logger.Log("mac command detected : DutyCycleCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : DutyCycleCmd", LogLevel.Information);
                         DutyCycleCmd dutyCycle = new DutyCycleCmd();
                         pointer += dutyCycle.Length;
                         macCommand.Add(dutyCycle);
                         break;
                     case CidEnum.RXParamCmd:
-                        Logger.Log("mac command detected : RXParamCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : RXParamCmd", LogLevel.Information);
                         break;
                     case CidEnum.DevStatusCmd:
-                        Logger.Log("mac command detected : DevStatusCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : DevStatusCmd", LogLevel.Information);
                         DevStatusCmd devStatus = new DevStatusCmd(input[pointer + 1], input[pointer + 2]);
                         pointer += devStatus.Length;
                         macCommand.Add(devStatus);
                         break;
                     case CidEnum.NewChannelCmd:
-                        Logger.Log("mac command detected : NewChannelCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : NewChannelCmd", LogLevel.Information);
                         NewChannelAns newChannel = new NewChannelAns(Convert.ToBoolean(input[pointer + 1] & 1), Convert.ToBoolean(input[pointer + 1] & 2));
                         pointer += newChannel.Length;
                         macCommand.Add(newChannel);
                         break;
                     case CidEnum.RXTimingCmd:
-                        Logger.Log("mac command detected : RXTimingCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : RXTimingCmd", LogLevel.Information);
                         RXTimingSetupCmd rXTimingSetup = new RXTimingSetupCmd();
                         pointer += rXTimingSetup.Length;
                         macCommand.Add(rXTimingSetup);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionFactory.cs
@@ -1,13 +1,14 @@
-﻿using LoRaTools.LoRaPhysical;
-using LoRaTools.Utils;
-using LoRaWan;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace LoRaTools.Regions
+﻿namespace LoRaTools.Regions
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using LoRaTools.LoRaPhysical;
+    using LoRaTools.Utils;
+    using LoRaWan;
+    using Microsoft.Extensions.Logging;
+
     public static class RegionFactory
     {
         public static Region CurrentRegion
@@ -30,7 +31,7 @@ namespace LoRaTools.Regions
             }
             else
             {
-                Logger.Log("RegionFactory", "The current frequency plan is not supported. Currently only EU868 and US915 frequency bands are supported.", Logger.LoggingLevel.Error);
+                Logger.Log("RegionFactory", "The current frequency plan is not supported. Currently only EU868 and US915 frequency bands are supported.", LogLevel.Error);
                 return false;
             }
         }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorTestBase.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorTestBase.cs
@@ -11,6 +11,7 @@ namespace LoRaWan.NetworkServer.Test
     using LoRaTools.Regions;
     using LoRaWan.NetworkServer;
     using LoRaWan.Test.Shared;
+    using Microsoft.Extensions.Logging;
     using Moq;
 
     public class MessageProcessorTestBase
@@ -42,7 +43,7 @@ namespace LoRaWan.NetworkServer.Test
             {
                 GatewayID = ServerGatewayID,
                 LogToConsole = true,
-                LogLevel = (int)Logger.LoggingLevel.Full,
+                LogLevel = ((int)LogLevel.Debug).ToString(),
             };
 
             this.frameCounterUpdateStrategy = new Mock<ILoRaDeviceFrameCounterUpdateStrategy>(MockBehavior.Strict);

--- a/README.md
+++ b/README.md
@@ -298,25 +298,35 @@ To clear the cache and allow the device to connect follow these steps:
 
 Alternatively you can restart the Gateway or the LoRaWanNetworkSrvModule container.
 
-## Monitoring
+## Monitoring and Logging
 
-There is a logging mechanisms that output valuable information on the console of the docker container and/or as module message to IoT Hub
+There is a logging mechanism that outputs valuable information to the console of the docker container and can optionally forward these messages to IoT Hub.
 
-You can control the logging with the following environment variables on the LoRaWanNetworkSrvModule module:
+You can control logging with the following environment variables in the **LoRaWanNetworkSrvModule** IoT Edge module:
 
-LOG_LEVEL 3 Only errors are logged 
+| Variable  | Value                | Explanation                                                                              |
+|-----------|----------------------|------------------------------------------------------------------------------------------|
+| LOG_LEVEL | "1" or "Debug"       | Everything is logged, including the up- and downstream messages to the packet forwarder. |
+|           | "2" or "Information" | Errors and information are logged.                                                       |
+|           | "3" or "Error"       | Only errors are logged. (default if omitted)                                             |
 
-LOG_LEVEL 2 Errors and information are logged (default if omitted)
+For production environments, the **LOG_LEVEL** should be set to **Error**.
 
-LOG_LEVEL 1 Everything is logged including the up and down messages to the packet forwarder
+Setting **LOG_LEVEL** to **Debug** causes a lot of messages to be generated. Make sure to set **LOG_TO_HUB** to **false** in this case.
 
-LOG_TO_HUB true Log info are sent from the module to IoT Hub. You can used VSCode, [IoTHub explorer](https://github.com/Azure/iothub-explorer) or [Device Explorer](https://github.com/Azure/azure-iot-sdk-csharp/tree/master/tools/DeviceExplorer) to monitor the log messages
+| Variable   | Value | Explanation                                          |
+|------------|-------|------------------------------------------------------|
+| LOG_TO_HUB | true  | Log info are sent from the module to IoT Hub.        |
+|            | false | Log info is not sent to IoT Hub (default if omitted) |
 
-LOG_TO_HUB false Log info is not sent to IoT Hub (default if omitted)
+You can use VSCode, [IoTHub explorer](https://github.com/Azure/iothub-explorer) or [Device Explorer](https://github.com/Azure/azure-iot-sdk-csharp/tree/master/tools/DeviceExplorer) to monitor the log messages directly in IoT Hub if **LOG_TO_HUB** is set to **true**.
 
-LOG_TO_CONSOLE true Log info in docker log (default if omitted). Log in to the gateway and use "sudo docker logs LoRaWanNetworkSrvModule -f" to follow the log
+Log in to the gateway and use `sudo docker logs LoRaWanNetworkSrvModule -f` to follow the logs if you are not logging to IoT Hub.
 
-LOG_TO_CONSOLE false No log info in the docker log
+| Variable       | Value | Explanation                             |
+|----------------|-------|-----------------------------------------|
+| LOG_TO_CONSOLE | true  | Log to docker logs (default if omitted) |
+|                | false | Does not log to docker logs             |
 
 ## Customize the solution & Deep dive
 


### PR DESCRIPTION
- Logger: Log using Microsoft.Extensions.Logging.LogLevel Enum
- Logger: new LogAlways method
- LoggerConfiguration: handle various LOG_LEVEL env var values: 1 or Debug, 2 or Information or Info, 3 or Error
- UdpServer: Output Log Level on startup
- Other classes: Adapt for new Logger.Log and Logger.LogAlways methods
- ReadMe: Update with new LOG_LEVEL env var settings and point out to use LOG_LEVEL=Error in production and not combine LOG_LEVEL=Debug and LOG_TO_HUB=true