### PR TITLE
Update Logger to log using Microsoft.Extensions.Logging.LogLevel Enum

### DIFF
--- a/LoRaEngine/README.md
+++ b/LoRaEngine/README.md
@@ -254,7 +254,7 @@ It is possible to run the bits in the LoRaEngine locally with from Visual Studio
 3. Open the properties of the project *LoRaWanNetworkServerModule* and set the following values under the Debug tab:
   - IOTEDGE_IOTHUBHOSTNAME : XXX.azure-devices.net (XXX = your iot hub hostname)
   - ENABLE_GATEWAY : false
-  - LOG_LEVEL : 1 (optional, to activate most verbose logging level)
+  - LOG_LEVEL : 1 or Debug (optional, to activate most verbose logging level)
   - FacadeServerUrl : http://localhost:7071/api/ (or pointer to the function you want to use)
   - FacadeAuthCode : <your function auth code, do not set this variable if running locally>
 4. Add a local.settings.json in the project LoRa KeysManagerFacade with

--- a/LoRaEngine/modules/LoRaSimulator/LoRaSimulator/SimulatedDevice.cs
+++ b/LoRaEngine/modules/LoRaSimulator/LoRaSimulator/SimulatedDevice.cs
@@ -90,7 +90,7 @@
                 Array.Reverse(DevNonce);
             }
 
-            Logger.Log(this.LoRaDevice.DevEUI, $"Join request sent DevNonce: {BitConverter.ToString(DevNonce).Replace("-","")}", Logger.LoggingLevel.Always);
+            Logger.LogAlways(this.LoRaDevice.DevEUI, $"Join request sent DevNonce: {BitConverter.ToString(DevNonce).Replace("-","")}");
             var join = new LoRaPayloadJoinRequest(AppEUI, DevEUI, DevNonce);
             join.SetMic(this.LoRaDevice.AppKey);
 
@@ -111,7 +111,7 @@
             // Random random = new Random();
             // int temp = random.Next(-50, 70);
             this.IncrementalData++;
-            Logger.Log(this.LoRaDevice.DevEUI, $"Simulated data: {this.IncrementalData.ToString()}", Logger.LoggingLevel.Always);
+            Logger.LogAlways(this.LoRaDevice.DevEUI, $"Simulated data: {this.IncrementalData.ToString()}");
             byte[] payload = Encoding.ASCII.GetBytes(this.IncrementalData.ToString());
             Array.Reverse(payload);
             // 0 = uplink, 1 = downlink

--- a/LoRaEngine/modules/LoRaSimulator/LoRaSimulator/Simulator.cs
+++ b/LoRaEngine/modules/LoRaSimulator/LoRaSimulator/Simulator.cs
@@ -15,6 +15,7 @@
     using LoRaTools.LoRaMessage;
     using LoRaTools.LoRaPhysical;
     using LoRaWan;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
@@ -36,19 +37,19 @@
         public async Task RunServer()
         {
             mac = GetMacAddress();
-            Logger.Log("Starting LoRaWAN Simulator...", Logger.LoggingLevel.Always);
+            Logger.LogAlways("Starting LoRaWAN Simulator...");
 
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SIMULATOR_PORT")))
             {
                 PORT = Convert.ToInt32(Environment.GetEnvironmentVariable("SIMULATOR_PORT"));
-                Logger.Log($"Changing port to {PORT}", Logger.LoggingLevel.Always);
+                Logger.LogAlways($"Changing port to {PORT}");
             }
 
             // Creating the endpoint
             IPEndPoint endPoint = new IPEndPoint(IPAddress.Any, PORT);
             udpClient = new UdpClient(endPoint);
 
-            Logger.Log($"LoRaWAN Simulator started on port {PORT}", Logger.LoggingLevel.Always);
+            Logger.LogAlways($"LoRaWAN Simulator started on port {PORT}");
 
             // send first sync
             _ = Task.Factory.StartNew(async () =>
@@ -149,7 +150,7 @@
                             Array.Copy(gat, 0, data, header.Length, gat.Length);
 
                             await UdpSendMessage(data);
-                            Logger.Log(devicetosend, $"Sending data: {BitConverter.ToString(header).Replace("-", string.Empty)}{Encoding.Default.GetString(gat)}", Logger.LoggingLevel.Always);
+                            Logger.LogAlways(devicetosend, $"Sending data: {BitConverter.ToString(header).Replace("-", string.Empty)}{Encoding.Default.GetString(gat)}");
                         }
                     }
                 });
@@ -201,7 +202,7 @@
             {
                 UdpReceiveResult receivedResults = await udpClient.ReceiveAsync();
 
-                // Logger.Log($"UDP message received ({receivedResults.Buffer.Length} bytes) from port: {receivedResults.RemoteEndPoint.Port}", Logger.LoggingLevel.Always);
+                // Logger.LogAlways($"UDP message received ({receivedResults.Buffer.Length} bytes) from port: {receivedResults.RemoteEndPoint.Port}");
 
                 // If 4, it may mean we received a confirmation
                 if (receivedResults.Buffer.Length >= 4)
@@ -231,11 +232,11 @@
                                     {
                                         if (dev.LastPayload.Identifier == PhysicalIdentifier.PUSH_DATA)
                                         {
-                                            Logger.Log(device, $"PUSH_DATA confirmation receiveced from NetworkServer", Logger.LoggingLevel.Info);
+                                            Logger.Log(device, $"PUSH_DATA confirmation receiveced from NetworkServer", LogLevel.Information);
                                         }
                                         else
                                         {
-                                            Logger.Log(device, $"PUSH_ACK confirmation receiveced from ", Logger.LoggingLevel.Info);
+                                            Logger.Log(device, $"PUSH_ACK confirmation receiveced from ", LogLevel.Information);
                                         }
                                     }
                                     else if (identifier == PhysicalIdentifier.PULL_RESP)
@@ -247,7 +248,7 @@
                                         // Check if the device is not joined, then it is maybe the answer
                                         if ((loraMessage.LoRaMessageType == LoRaMessageType.JoinAccept) && (dev.LoRaDevice.DevAddr == string.Empty))
                                             {
-                                                Logger.Log(device, $"Received join accept", Logger.LoggingLevel.Info);
+                                                Logger.Log(device, $"Received join accept", LogLevel.Information);
 
                                                 var payload = (LoRaPayloadJoinAccept)loraMessage;
 
@@ -280,13 +281,13 @@
                     catch (Exception ex)
                     {
 
-                        Logger.Log($"Something when wrong: {ex.Message}", Logger.LoggingLevel.Error);
+                        Logger.Log($"Something when wrong: {ex.Message}", LogLevel.Error);
                     }
 
                     // if (receivedResults.Buffer[3] == (byte)PhysicalIdentifier.PUSH_ACK)
                     // {
                     //    //Bingo
-                    //    Logger.Log($"Confirmation receiveced", Logger.LoggingLevel.Always);
+                    //    Logger.LogAlways($"Confirmation receiveced");
                     // }
                 }
 
@@ -298,7 +299,7 @@
                 // }
                 // catch (Exception ex)
                 // {
-                //    Logger.Log($"Error processing the message {ex.Message}", Logger.LoggingLevel.Error);
+                //    Logger.Log($"Error processing the message {ex.Message}", LogLevel.Error);
                 // }
             }
         }

--- a/LoRaEngine/modules/LoRaSimulator/readme.md
+++ b/LoRaEngine/modules/LoRaSimulator/readme.md
@@ -120,9 +120,12 @@ and add the following environment variables:
 * IOTEDGE_IOTHUBHOSTNAME: XXX.azure-devices.net where XXX is your IoT Hub registry name
 * FACADE_AUTH_CODE: key. Where key is the secret key to access the function used to gather the device information like twins, get their own secret key to realize posting operation in Azure IoT Hub
 * FACADE_SERVER_URL: https://XXX.azurewebsites.net/api where XXX is the name of your function. If you want as well to bebug the functions, you can do it. See full documentation [here](/LoRaEngine/README.md) if needed.
-* NET_SRV_LOG_LEVEL: 0 to get a full log view or any other level to get less information
+* LOG_LEVEL: 
+  * "1" or "Debug": Everything is logged, including the up- and downstream messages to the packet forwarder
+  * "2" or "Information": Errors and information are logged.
+  * "3" or "Error": Only errors are logged. 
 * ENABLE_GATEWAY: false this will allow to directly post the data from the devices to Azure IoT Hub. If you have a gateway, you'll need to specify true and adjust other environment variable. See full documentation [here](/LoRaEngine/README.md) if needed.
-* NET_SRV_LOGTO_HUB: false. So you won't log the data into Azure IoT Hub
+* LOG_TO_HUB: false. So you won't log the data into Azure IoT Hub
 
 ### Setting up the LoRaSimulator
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinDeviceLoader.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinDeviceLoader.cs
@@ -5,6 +5,7 @@ namespace LoRaWan.NetworkServer
 {
     using System;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Loads devices for join requests
@@ -37,11 +38,11 @@ namespace LoRaWan.NetworkServer
 
             try
             {
-                Logger.Log(loRaDevice.DevEUI, $"getting twins for OTAA for device", Logger.LoggingLevel.Info);
+                Logger.Log(loRaDevice.DevEUI, $"getting twins for OTAA for device", LogLevel.Information);
 
                 if (await loRaDevice.InitializeAsync())
                 {
-                    Logger.Log(loRaDevice.DevEUI, $"done getting twins for OTAA device", Logger.LoggingLevel.Info);
+                    Logger.Log(loRaDevice.DevEUI, $"done getting twins for OTAA device", LogLevel.Information);
 
                     return loRaDevice;
                 }
@@ -51,13 +52,13 @@ namespace LoRaWan.NetworkServer
                     // object is non usable, must try to read twin again
                     // for the future we could retry here
                     this.canCache = false;
-                    Logger.Log(loRaDevice.DevEUI, "join refused: error initializing OTAA device, getting twin failed", Logger.LoggingLevel.Error);
+                    Logger.Log(loRaDevice.DevEUI, "join refused: error initializing OTAA device, getting twin failed", LogLevel.Error);
                 }
             }
             catch (Exception ex)
             {
                 // will reach here if the device does not have required properties in the twin
-                Logger.Log(loRaDevice.DevEUI, $"join refused: error initializing OTAA device. {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(loRaDevice.DevEUI, $"join refused: error initializing OTAA device. {ex.Message}", LogLevel.Error);
             }
 
             return null;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
@@ -7,6 +7,7 @@ namespace LoRaWan.NetworkServer
     using System.Collections.Generic;
     using System.Text;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -26,14 +27,14 @@ namespace LoRaWan.NetworkServer
 
         public override async Task<ushort> NextFCntDownAsync(string devEUI, int fcntDown, int fcntUp, string gatewayId)
         {
-            Logger.Log(devEUI, $"syncing FCntDown for multigateway", Logger.LoggingLevel.Info);
+            Logger.Log(devEUI, $"syncing FCntDown for multigateway", LogLevel.Information);
 
             var client = this.serviceFacadeHttpClientProvider.GetHttpClient();
             var url = $"{this.URL}NextFCntDown?code={this.AuthCode}&DevEUI={devEUI}&FCntDown={fcntDown}&FCntUp={fcntUp}&GatewayId={gatewayId}";
             var response = await client.GetAsync(url);
             if (!response.IsSuccessStatusCode)
             {
-                Logger.Log(devEUI, $"error calling the NextFCntDown function, check the function log. {response.ReasonPhrase}", Logger.LoggingLevel.Error);
+                Logger.Log(devEUI, $"error calling the NextFCntDown function, check the function log. {response.ReasonPhrase}", LogLevel.Error);
                 return 0;
             }
 
@@ -47,13 +48,13 @@ namespace LoRaWan.NetworkServer
 
         public override async Task<bool> ABPFcntCacheResetAsync(string devEUI)
         {
-            Logger.Log(devEUI, $"ABP FCnt cache reset for multigateway", Logger.LoggingLevel.Info);
+            Logger.Log(devEUI, $"ABP FCnt cache reset for multigateway", LogLevel.Information);
             var client = this.serviceFacadeHttpClientProvider.GetHttpClient();
             var url = $"{this.URL}NextFCntDown?code={this.AuthCode}&DevEUI={devEUI}&ABPFcntCacheReset=true";
             var response = await client.GetAsync(url);
             if (!response.IsSuccessStatusCode)
             {
-                Logger.Log(devEUI, $"error calling the NextFCntDown function, check the function log, {response.ReasonPhrase}", Logger.LoggingLevel.Error);
+                Logger.Log(devEUI, $"error calling the NextFCntDown function, check the function log, {response.ReasonPhrase}", LogLevel.Error);
                 return false;
             }
 
@@ -124,7 +125,7 @@ namespace LoRaWan.NetworkServer
 
                     if (!string.IsNullOrEmpty(badReqResult) && string.Equals(badReqResult, "UsedDevNonce", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        Logger.Log(devEUI ?? string.Empty, $"DevNonce already used by this device", Logger.LoggingLevel.Info);
+                        Logger.Log(devEUI ?? string.Empty, $"DevNonce already used by this device", LogLevel.Information);
                         return new SearchDevicesResult
                         {
                             IsDevNonceAlreadyUsed = true,
@@ -132,7 +133,7 @@ namespace LoRaWan.NetworkServer
                     }
                 }
 
-                Logger.Log(devAddr, $"error calling façade api: {response.ReasonPhrase}, status: {response.StatusCode}, check the azure function log", Logger.LoggingLevel.Error);
+                Logger.Log(devAddr, $"error calling façade api: {response.ReasonPhrase}, status: {response.StatusCode}, check the azure function log", LogLevel.Error);
 
                 // TODO: FBE check if we return null or throw exception
                 return new SearchDevicesResult();

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
@@ -9,6 +9,7 @@ namespace LoRaWan.NetworkServer
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -44,7 +45,7 @@ namespace LoRaWan.NetworkServer
                 if (this.deviceClient != null)
                 {
                     this.deviceClient.SetRetryPolicy(this.exponentialBackoff);
-                    // Logger.Log(DevEUI, $"retry is on", Logger.LoggingLevel.Full);
+                    // Logger.Log(DevEUI, $"retry is on", LogLevel.Debug);
                 }
             }
             else
@@ -52,7 +53,7 @@ namespace LoRaWan.NetworkServer
                 if (this.deviceClient != null)
                 {
                     this.deviceClient.SetRetryPolicy(this.noRetryPolicy);
-                    // Logger.Log(DevEUI, $"retry is off", Logger.LoggingLevel.Full);
+                    // Logger.Log(DevEUI, $"retry is off", LogLevel.Debug);
                 }
             }
         }
@@ -65,17 +66,17 @@ namespace LoRaWan.NetworkServer
 
                 this.SetRetry(true);
 
-                Logger.Log(this.devEUI, $"getting device twins", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"getting device twins", LogLevel.Debug);
 
                 var twins = await this.deviceClient.GetTwinAsync();
 
-                Logger.Log(this.devEUI, $"done getting device twins", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"done getting device twins", LogLevel.Debug);
 
                 return twins;
             }
             catch (Exception ex)
             {
-                Logger.Log(this.devEUI, $"Could not retrieve device twins with error: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(this.devEUI, $"Could not retrieve device twins with error: {ex.Message}", LogLevel.Error);
                 return null;
             }
             finally
@@ -93,22 +94,22 @@ namespace LoRaWan.NetworkServer
                 this.SetRetry(true);
 
                 string reportedPropertiesJson = string.Empty;
-                if (Logger.LoggerLevel == Logger.LoggingLevel.Full)
+                if (Logger.LoggerLevel == LogLevel.Debug)
                 {
                     reportedPropertiesJson = reportedProperties.ToJson(Newtonsoft.Json.Formatting.None);
-                    Logger.Log(this.devEUI, $"updating twins {reportedPropertiesJson}", Logger.LoggingLevel.Full);
+                    Logger.Log(this.devEUI, $"updating twins {reportedPropertiesJson}", LogLevel.Debug);
                 }
 
                 await this.deviceClient.UpdateReportedPropertiesAsync(reportedProperties);
 
-                if (Logger.LoggerLevel == Logger.LoggingLevel.Full)
-                    Logger.Log(this.devEUI, $"twins updated {reportedPropertiesJson}", Logger.LoggingLevel.Full);
+                if (Logger.LoggerLevel == LogLevel.Debug)
+                    Logger.Log(this.devEUI, $"twins updated {reportedPropertiesJson}", LogLevel.Debug);
 
                 return true;
             }
             catch (Exception ex)
             {
-                Logger.Log(this.devEUI, $"could not update twins with error: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(this.devEUI, $"could not update twins with error: {ex.Message}", LogLevel.Error);
                 return false;
             }
             finally
@@ -131,7 +132,7 @@ namespace LoRaWan.NetworkServer
                     var messageJson = JsonConvert.SerializeObject(telemetry, Formatting.None);
                     var message = new Message(Encoding.UTF8.GetBytes(messageJson));
 
-                    Logger.Log(this.devEUI, $"sending message {messageJson} to hub", Logger.LoggingLevel.Full);
+                    Logger.Log(this.devEUI, $"sending message {messageJson} to hub", LogLevel.Debug);
 
                     message.ContentType = System.Net.Mime.MediaTypeNames.Application.Json;
                     message.ContentEncoding = Encoding.UTF8.BodyName;
@@ -144,13 +145,13 @@ namespace LoRaWan.NetworkServer
 
                     await this.deviceClient.SendEventAsync(message);
 
-                    Logger.Log(this.devEUI, $"sent message {messageJson} to hub", Logger.LoggingLevel.Full);
+                    Logger.Log(this.devEUI, $"sent message {messageJson} to hub", LogLevel.Debug);
 
                     return true;
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log(this.devEUI, $"could not send message to IoTHub/Edge with error: {ex.Message}", Logger.LoggingLevel.Error);
+                    Logger.Log(this.devEUI, $"could not send message to IoTHub/Edge with error: {ex.Message}", LogLevel.Error);
                 }
                 finally
                 {
@@ -173,23 +174,23 @@ namespace LoRaWan.NetworkServer
                 if (timeout.TotalMilliseconds > MaxReceiveMessageTimeoutInMs)
                     timeout = TimeSpan.FromMilliseconds(MaxReceiveMessageTimeoutInMs);
 
-                Logger.Log(this.devEUI, $"checking c2d message for {timeout}", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"checking c2d message for {timeout}", LogLevel.Debug);
 
                 Message msg = await this.deviceClient.ReceiveAsync(timeout);
 
-                if (Logger.LoggerLevel >= Logger.LoggingLevel.Full)
+                if (Logger.LoggerLevel >= LogLevel.Debug)
                 {
                     if (msg == null)
-                        Logger.Log(this.devEUI, "done checking c2d message, found no message", Logger.LoggingLevel.Full);
+                        Logger.Log(this.devEUI, "done checking c2d message, found no message", LogLevel.Debug);
                     else
-                        Logger.Log(this.devEUI, $"done checking c2d message, found message id: {msg.MessageId ?? "undefined"}", Logger.LoggingLevel.Full);
+                        Logger.Log(this.devEUI, $"done checking c2d message, found message id: {msg.MessageId ?? "undefined"}", LogLevel.Debug);
                 }
 
                 return msg;
             }
             catch (Exception ex)
             {
-                Logger.Log(this.devEUI, $"Could not retrieve c2d message with error: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(this.devEUI, $"Could not retrieve c2d message with error: {ex.Message}", LogLevel.Error);
                 return null;
             }
             finally
@@ -207,17 +208,17 @@ namespace LoRaWan.NetworkServer
 
                 this.SetRetry(true);
 
-                Logger.Log(this.devEUI, $"completing c2d message, id: {message.MessageId ?? "undefined"}", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"completing c2d message, id: {message.MessageId ?? "undefined"}", LogLevel.Debug);
 
                 await this.deviceClient.CompleteAsync(message);
 
-                Logger.Log(this.devEUI, $"done completing c2d message, id: {message.MessageId ?? "undefined"}", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"done completing c2d message, id: {message.MessageId ?? "undefined"}", LogLevel.Debug);
 
                 return true;
             }
             catch (Exception ex)
             {
-                Logger.Log(this.devEUI, $"could not complete c2d message (id: {message.MessageId ?? "undefined"}) with error: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(this.devEUI, $"could not complete c2d message (id: {message.MessageId ?? "undefined"}) with error: {ex.Message}", LogLevel.Error);
                 return false;
             }
             finally
@@ -235,17 +236,17 @@ namespace LoRaWan.NetworkServer
 
                 this.SetRetry(true);
 
-                Logger.Log(this.devEUI, $"abandoning c2d message, id: {message.MessageId ?? "undefined"}", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"abandoning c2d message, id: {message.MessageId ?? "undefined"}", LogLevel.Debug);
 
                 await this.deviceClient.AbandonAsync(message);
 
-                Logger.Log(this.devEUI, $"done abandoning c2d message, id: {message.MessageId ?? "undefined"}", Logger.LoggingLevel.Full);
+                Logger.Log(this.devEUI, $"done abandoning c2d message, id: {message.MessageId ?? "undefined"}", LogLevel.Debug);
 
                 return true;
             }
             catch (Exception ex)
             {
-                Logger.Log(this.devEUI, $"could not abandon c2d message (id: {message.MessageId ?? "undefined"}) with error: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(this.devEUI, $"could not abandon c2d message (id: {message.MessageId ?? "undefined"}) with error: {ex.Message}", LogLevel.Error);
                 return false;
             }
             finally

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
@@ -6,6 +6,7 @@ namespace LoRaWan.NetworkServer
     using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
+    using Microsoft.Extensions.Logging;
 
     public class LoRaDeviceFactory : ILoRaDeviceFactory
     {
@@ -34,7 +35,7 @@ namespace LoRaWan.NetworkServer
 
             if (string.IsNullOrEmpty(this.configuration.IoTHubHostName))
             {
-                Logger.Log("Configuration/Environment variable IOTEDGE_IOTHUBHOSTNAME not found, creation of iothub connection not possible", Logger.LoggingLevel.Error);
+                Logger.Log("Configuration/Environment variable IOTEDGE_IOTHUBHOSTNAME not found, creation of iothub connection not possible", LogLevel.Error);
             }
 
             connectionString += $"HostName={this.configuration.IoTHubHostName};";
@@ -42,11 +43,11 @@ namespace LoRaWan.NetworkServer
             if (this.configuration.EnableGateway)
             {
                 connectionString += $"GatewayHostName={this.configuration.GatewayHostName};";
-                Logger.Log(devEUI, $"using edgeHub local queue", Logger.LoggingLevel.Info);
+                Logger.Log(devEUI, $"using edgeHub local queue", LogLevel.Information);
             }
             else
             {
-                Logger.Log(devEUI, $"using iotHub directly, no edgeHub queue", Logger.LoggingLevel.Info);
+                Logger.Log(devEUI, $"using iotHub directly, no edgeHub queue", LogLevel.Information);
             }
 
             return connectionString;
@@ -64,7 +65,7 @@ namespace LoRaWan.NetworkServer
             }
             catch (Exception ex)
             {
-                Logger.Log(devEUI, $"could not create IoT Hub DeviceClient with error: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log(devEUI, $"could not create IoT Hub DeviceClient with error: {ex.Message}", LogLevel.Error);
                 throw;
             }
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaPayloadDecoder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaPayloadDecoder.cs
@@ -9,6 +9,7 @@ namespace LoRaWan.NetworkServer
     using System.Text;
     using System.Threading.Tasks;
     using System.Web;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
@@ -114,7 +115,7 @@ namespace LoRaWan.NetworkServer
             }
             catch (Exception ex)
             {
-                Logger.Log($"Error in decoder handling: {ex.Message}", Logger.LoggingLevel.Error);
+                Logger.Log($"Error in decoder handling: {ex.Message}", LogLevel.Error);
 
                 result = JsonConvert.SerializeObject(new
                 {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
@@ -16,6 +16,7 @@ namespace LoRaWan.NetworkServer
     using LoRaTools.Regions;
     using LoRaTools.Utils;
     using Microsoft.Azure.Devices.Client;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -77,7 +78,7 @@ namespace LoRaWan.NetworkServer
         {
             if (!LoRaPayload.TryCreateLoRaPayload(rxpk, out LoRaPayload loRaPayload))
             {
-                Logger.Log("There was a problem in decoding the Rxpk", Logger.LoggingLevel.Error);
+                Logger.Log("There was a problem in decoding the Rxpk", LogLevel.Error);
                 return null;
             }
 
@@ -117,7 +118,7 @@ namespace LoRaWan.NetworkServer
             {
                 if (!this.IsValidNetId(loraPayload.GetDevAddrNetID(), this.configuration.NetId))
                 {
-                    Logger.Log(ConversionHelper.ByteArrayToString(devAddr), "device is using another network id, ignoring this message", Logger.LoggingLevel.Info);
+                    Logger.Log(ConversionHelper.ByteArrayToString(devAddr), "device is using another network id, ignoring this message", LogLevel.Information);
                     return null;
                 }
 
@@ -128,7 +129,7 @@ namespace LoRaWan.NetworkServer
                 var loRaDevice = await this.deviceRegistry.GetDeviceForPayloadAsync(loraPayload);
                 if (loRaDevice == null)
                 {
-                    Logger.Log(ConversionHelper.ByteArrayToString(devAddr), $"device is not from our network, ignoring message", Logger.LoggingLevel.Info);
+                    Logger.Log(ConversionHelper.ByteArrayToString(devAddr), $"device is not from our network, ignoring message", LogLevel.Information);
                     return null;
                 }
 
@@ -178,11 +179,11 @@ namespace LoRaWan.NetworkServer
                         if (requiresConfirmation && payloadFcnt == loRaDevice.FCntUp)
                         {
                             isConfirmedResubmit = true;
-                            Logger.Log(loRaDevice.DevEUI, $"resubmit from confirmed message detected, msg: {payloadFcnt} server: {loRaDevice.FCntUp}", Logger.LoggingLevel.Info);
+                            Logger.Log(loRaDevice.DevEUI, $"resubmit from confirmed message detected, msg: {payloadFcnt} server: {loRaDevice.FCntUp}", LogLevel.Information);
                         }
                         else
                         {
-                            Logger.Log(loRaDevice.DevEUI, $"invalid frame counter, message ignored, msg: {payloadFcnt} server: {loRaDevice.FCntUp}", Logger.LoggingLevel.Info);
+                            Logger.Log(loRaDevice.DevEUI, $"invalid frame counter, message ignored, msg: {payloadFcnt} server: {loRaDevice.FCntUp}", LogLevel.Information);
                             return null;
                         }
                     }
@@ -200,12 +201,12 @@ namespace LoRaWan.NetworkServer
                         {
                             // update our fcntup anyway?
                             // loRaDevice.SetFcntUp(payloadFcnt);
-                            Logger.Log(loRaDevice.DevEUI, "another gateway has already sent ack or downlink msg", Logger.LoggingLevel.Info);
+                            Logger.Log(loRaDevice.DevEUI, "another gateway has already sent ack or downlink msg", LogLevel.Information);
 
                             return null;
                         }
 
-                        Logger.Log(loRaDevice.DevEUI, $"down frame counter: {loRaDevice.FCntDown}", Logger.LoggingLevel.Info);
+                        Logger.Log(loRaDevice.DevEUI, $"down frame counter: {loRaDevice.FCntDown}", LogLevel.Information);
                     }
 
                     if (!isConfirmedResubmit)
@@ -213,7 +214,7 @@ namespace LoRaWan.NetworkServer
                         var validFcntUp = isFrameCounterFromNewlyStartedDevice || (payloadFcnt > loRaDevice.FCntUp);
                         if (validFcntUp)
                         {
-                            Logger.Log(loRaDevice.DevEUI, $"valid frame counter, msg: {payloadFcnt} server: {loRaDevice.FCntUp}", Logger.LoggingLevel.Info);
+                            Logger.Log(loRaDevice.DevEUI, $"valid frame counter, msg: {payloadFcnt} server: {loRaDevice.FCntUp}", LogLevel.Information);
 
                             object payloadData = null;
 
@@ -229,19 +230,19 @@ namespace LoRaWan.NetworkServer
                                 }
                                 catch (Exception ex)
                                 {
-                                    Logger.Log(loRaDevice.DevEUI, $"failed to decrypt message: {ex.Message}", Logger.LoggingLevel.Error);
+                                    Logger.Log(loRaDevice.DevEUI, $"failed to decrypt message: {ex.Message}", LogLevel.Error);
                                 }
 
                                 var fportUp = loraPayload.GetFPort();
 
                                 if (string.IsNullOrEmpty(loRaDevice.SensorDecoder))
                                 {
-                                    Logger.Log(loRaDevice.DevEUI, $"no decoder set in device twin. port: {fportUp}", Logger.LoggingLevel.Full);
+                                    Logger.Log(loRaDevice.DevEUI, $"no decoder set in device twin. port: {fportUp}", LogLevel.Debug);
                                     payloadData = Convert.ToBase64String(decryptedPayloadData);
                                 }
                                 else
                                 {
-                                    Logger.Log(loRaDevice.DevEUI, $"decoding with: {loRaDevice.SensorDecoder} port: {fportUp}", Logger.LoggingLevel.Full);
+                                    Logger.Log(loRaDevice.DevEUI, $"decoding with: {loRaDevice.SensorDecoder} port: {fportUp}", LogLevel.Debug);
                                     payloadData = await this.payloadDecoder.DecodeMessageAsync(decryptedPayloadData, fportUp, loRaDevice.SensorDecoder);
                                 }
                             }
@@ -255,7 +256,7 @@ namespace LoRaWan.NetworkServer
                         }
                         else
                         {
-                            Logger.Log(loRaDevice.DevEUI, $"invalid frame counter, msg: {payloadFcnt} server: {loRaDevice.FCntUp}", Logger.LoggingLevel.Info);
+                            Logger.Log(loRaDevice.DevEUI, $"invalid frame counter, msg: {payloadFcnt} server: {loRaDevice.FCntUp}", LogLevel.Information);
                         }
                     }
 
@@ -266,7 +267,7 @@ namespace LoRaWan.NetworkServer
                     {
                         if (requiresConfirmation)
                         {
-                            Logger.Log(loRaDevice.DevEUI, $"too late for down message ({timeWatcher.GetElapsedTime()}), sending only ACK to gateway", Logger.LoggingLevel.Info);
+                            Logger.Log(loRaDevice.DevEUI, $"too late for down message ({timeWatcher.GetElapsedTime()}), sending only ACK to gateway", LogLevel.Information);
                         }
 
                         return null;
@@ -322,7 +323,7 @@ namespace LoRaWan.NetworkServer
                                 {
                                     requiresConfirmation = true;
 
-                                    Logger.Log(loRaDevice.DevEUI, $"down frame counter: {loRaDevice.FCntDown}", Logger.LoggingLevel.Info);
+                                    Logger.Log(loRaDevice.DevEUI, $"down frame counter: {loRaDevice.FCntDown}", LogLevel.Information);
                                 }
                             }
 
@@ -417,7 +418,7 @@ namespace LoRaWan.NetworkServer
             {
                 if (cloudToDeviceMessage.Properties.TryGetValueCaseInsensitive("cidtype", out var cidTypeValue))
                 {
-                    Logger.Log(loraDeviceInfo.DevEUI, $"Cloud to device MAC command received", Logger.LoggingLevel.Info);
+                    Logger.Log(loraDeviceInfo.DevEUI, $"Cloud to device MAC command received", LogLevel.Information);
                     MacCommandHolder macCommandHolder = new MacCommandHolder(Convert.ToByte(cidTypeValue));
                     macbytes = macCommandHolder.MacCommand[0].ToBytes();
                 }
@@ -433,11 +434,11 @@ namespace LoRaWan.NetworkServer
                     fport = byte.Parse(fPortValue);
                 }
 
-                Logger.Log(loraDeviceInfo.DevEUI, $"Sending a downstream message with ID {ConversionHelper.ByteArrayToString(rndToken)}", Logger.LoggingLevel.Full);
+                Logger.Log(loraDeviceInfo.DevEUI, $"Sending a downstream message with ID {ConversionHelper.ByteArrayToString(rndToken)}", LogLevel.Debug);
 
                 frmPayload = cloudToDeviceMessage?.GetBytes();
 
-                Logger.Log(loraDeviceInfo.DevEUI, $"C2D message: {Encoding.UTF8.GetString(frmPayload)}, id: {cloudToDeviceMessage.MessageId ?? "undefined"}, fport: {fport}, confirmed: {requiresDeviceAcknowlegement}, cidType: {cidTypeValue}", Logger.LoggingLevel.Info);
+                Logger.Log(loraDeviceInfo.DevEUI, $"C2D message: {Encoding.UTF8.GetString(frmPayload)}, id: {cloudToDeviceMessage.MessageId ?? "undefined"}, fport: {fport}, confirmed: {requiresDeviceAcknowlegement}, cidType: {cidTypeValue}", LogLevel.Information);
 
                 // cut to the max payload of lora for any EU datarate
                 if (frmPayload.Length > 51)
@@ -484,7 +485,7 @@ namespace LoRaWan.NetworkServer
 
                 if (string.IsNullOrEmpty(this.configuration.Rx2DataRate))
                 {
-                    Logger.Log(loraDeviceInfo.DevEUI, $"using standard second receive windows", Logger.LoggingLevel.Info);
+                    Logger.Log(loraDeviceInfo.DevEUI, $"using standard second receive windows", LogLevel.Information);
                     freq = this.loraRegion.RX2DefaultReceiveWindows.frequency;
                     datr = this.loraRegion.DRtoConfiguration[this.loraRegion.RX2DefaultReceiveWindows.dr].configuration;
                 }
@@ -494,7 +495,7 @@ namespace LoRaWan.NetworkServer
                 {
                     freq = this.configuration.Rx2DataFrequency;
                     datr = this.configuration.Rx2DataRate;
-                    Logger.Log(loraDeviceInfo.DevEUI, $"using custom DR second receive windows freq : {freq}, datr:{datr}", Logger.LoggingLevel.Info);
+                    Logger.Log(loraDeviceInfo.DevEUI, $"using custom DR second receive windows freq : {freq}, datr:{datr}", LogLevel.Information);
                 }
             }
             else
@@ -514,7 +515,7 @@ namespace LoRaWan.NetworkServer
             // ensure fport property has been set
             if (!cloudToDeviceMsg.Properties.TryGetValueCaseInsensitive(FPORT_MSG_PROPERTY_KEY, out var fportValue))
             {
-                Logger.Log(loRaDevice.DevEUI, $"missing {FPORT_MSG_PROPERTY_KEY} property in C2D message '{cloudToDeviceMsg.MessageId}'", Logger.LoggingLevel.Error);
+                Logger.Log(loRaDevice.DevEUI, $"missing {FPORT_MSG_PROPERTY_KEY} property in C2D message '{cloudToDeviceMsg.MessageId}'", LogLevel.Error);
                 return false;
             }
 
@@ -527,7 +528,7 @@ namespace LoRaWan.NetworkServer
                     return true;
             }
 
-            Logger.Log(loRaDevice.DevEUI, $"invalid fport '{fportValue}' in C2D message '{cloudToDeviceMsg.MessageId}'", Logger.LoggingLevel.Error);
+            Logger.Log(loRaDevice.DevEUI, $"invalid fport '{fportValue}' in C2D message '{cloudToDeviceMsg.MessageId}'", LogLevel.Error);
             return false;
         }
 
@@ -545,7 +546,7 @@ namespace LoRaWan.NetworkServer
             if (loRaPayloadData.IsUpwardAck())
             {
                 eventProperties = new Dictionary<string, string>();
-                Logger.Log(loRaDevice.DevEUI, $"Message ack received for C2D message id {loRaDevice.LastConfirmedC2DMessageID}", Logger.LoggingLevel.Info);
+                Logger.Log(loRaDevice.DevEUI, $"Message ack received for C2D message id {loRaDevice.LastConfirmedC2DMessageID}", LogLevel.Information);
                 eventProperties.Add(C2D_MSG_PROPERTY_VALUE_NAME, loRaDevice.LastConfirmedC2DMessageID ?? C2D_MSG_ID_PLACEHOLDER);
                 loRaDevice.LastConfirmedC2DMessageID = null;
             }
@@ -575,7 +576,7 @@ namespace LoRaWan.NetworkServer
                     payloadAsRaw = JsonConvert.SerializeObject(deviceTelemetry.Data, Formatting.None);
                 }
 
-                Logger.Log(loRaDevice.DevEUI, $"message '{payloadAsRaw}' sent to hub", Logger.LoggingLevel.Info);
+                Logger.Log(loRaDevice.DevEUI, $"message '{payloadAsRaw}' sent to hub", LogLevel.Information);
             }
         }
 
@@ -603,7 +604,7 @@ namespace LoRaWan.NetworkServer
                 processLogger.SetDevEUI(devEUI);
 
                 var devNonce = joinReq.GetDevNonceAsString();
-                Logger.Log(devEUI, $"join request received", Logger.LoggingLevel.Info);
+                Logger.Log(devEUI, $"join request received", LogLevel.Information);
 
                 var loRaDevice = await this.deviceRegistry.GetDeviceForJoinRequestAsync(devEUI, appEUI, devNonce);
                 if (loRaDevice == null)
@@ -611,26 +612,26 @@ namespace LoRaWan.NetworkServer
 
                 if (string.IsNullOrEmpty(loRaDevice.AppKey))
                 {
-                    Logger.Log(loRaDevice.DevEUI, "join refused: missing AppKey for OTAA device", Logger.LoggingLevel.Error);
+                    Logger.Log(loRaDevice.DevEUI, "join refused: missing AppKey for OTAA device", LogLevel.Error);
                     return null;
                 }
 
                 if (loRaDevice.AppEUI != appEUI)
                 {
-                    Logger.Log(devEUI, "join refused: AppEUI for OTAA does not match device", Logger.LoggingLevel.Error);
+                    Logger.Log(devEUI, "join refused: AppEUI for OTAA does not match device", LogLevel.Error);
                     return null;
                 }
 
                 if (!joinReq.CheckMic(loRaDevice.AppKey))
                 {
-                    Logger.Log(devEUI, "join refused: invalid MIC", Logger.LoggingLevel.Error);
+                    Logger.Log(devEUI, "join refused: invalid MIC", LogLevel.Error);
                     return null;
                 }
 
                 // Make sure that is a new request and not a replay
                 if (!string.IsNullOrEmpty(loRaDevice.DevNonce) && loRaDevice.DevNonce == devNonce)
                 {
-                    Logger.Log(devEUI, "join refused: DevNonce already used by this device", Logger.LoggingLevel.Info);
+                    Logger.Log(devEUI, "join refused: DevNonce already used by this device", LogLevel.Information);
                     loRaDevice.IsOurDevice = false;
                     return null;
                 }
@@ -638,7 +639,7 @@ namespace LoRaWan.NetworkServer
                 // Check that the device is joining through the linked gateway and not another
                 if (!string.IsNullOrEmpty(loRaDevice.GatewayID) && !string.Equals(loRaDevice.GatewayID, this.configuration.GatewayID, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    Logger.Log(devEUI, $"join refused: trying to join not through its linked gateway, ignoring join request", Logger.LoggingLevel.Info);
+                    Logger.Log(devEUI, $"join refused: trying to join not through its linked gateway, ignoring join request", LogLevel.Information);
                     loRaDevice.IsOurDevice = false;
                     return null;
                 }
@@ -660,24 +661,24 @@ namespace LoRaWan.NetworkServer
                 if (!timeWatcher.InTimeForJoinAccept())
                 {
                     // in this case it's too late, we need to break and avoid saving twins
-                    Logger.Log(devEUI, $"join refused: processing of the join request took too long, sending no message", Logger.LoggingLevel.Info);
+                    Logger.Log(devEUI, $"join refused: processing of the join request took too long, sending no message", LogLevel.Information);
                     return null;
                 }
 
-                Logger.Log(loRaDevice.DevEUI, $"saving join properties twins", Logger.LoggingLevel.Full);
+                Logger.Log(loRaDevice.DevEUI, $"saving join properties twins", LogLevel.Debug);
                 var deviceUpdateSucceeded = await loRaDevice.UpdateAfterJoinAsync(devAddr, nwkSKey, appSKey, appNonce, devNonce, LoRaTools.Utils.ConversionHelper.ByteArrayToString(netId));
-                Logger.Log(loRaDevice.DevEUI, $"done saving join properties twins", Logger.LoggingLevel.Full);
+                Logger.Log(loRaDevice.DevEUI, $"done saving join properties twins", LogLevel.Debug);
 
                 if (!deviceUpdateSucceeded)
                 {
-                    Logger.Log(devEUI, $"join refused: join request could not save twins", Logger.LoggingLevel.Error);
+                    Logger.Log(devEUI, $"join refused: join request could not save twins", LogLevel.Error);
                     return null;
                 }
 
                 var windowToUse = timeWatcher.ResolveJoinAcceptWindowToUse(loRaDevice);
                 if (windowToUse == 0)
                 {
-                    Logger.Log(devEUI, $"join refused: processing of the join request took too long, sending no message", Logger.LoggingLevel.Info);
+                    Logger.Log(devEUI, $"join refused: processing of the join request took too long, sending no message", LogLevel.Information);
                     return null;
                 }
 
@@ -694,11 +695,11 @@ namespace LoRaWan.NetworkServer
                 }
                 else
                 {
-                    Logger.Log(devEUI, $"processing of the join request took too long, using second join accept receive window", Logger.LoggingLevel.Info);
+                    Logger.Log(devEUI, $"processing of the join request took too long, using second join accept receive window", LogLevel.Information);
                     tmst = rxpk.Tmst + this.loraRegion.Join_accept_delay2 * 1000000;
                     if (string.IsNullOrEmpty(this.configuration.Rx2DataRate))
                     {
-                        Logger.Log(devEUI, $"using standard second receive windows for join request", Logger.LoggingLevel.Info);
+                        Logger.Log(devEUI, $"using standard second receive windows for join request", LogLevel.Information);
                         // using EU fix DR for RX2
                         freq = this.loraRegion.RX2DefaultReceiveWindows.frequency;
                         datr = this.loraRegion.DRtoConfiguration[RegionFactory.CurrentRegion.RX2DefaultReceiveWindows.dr].configuration;
@@ -707,7 +708,7 @@ namespace LoRaWan.NetworkServer
                     // if specific twins are set, specify second channel to be as specified
                     else
                     {
-                        Logger.Log(devEUI, $"using custom  second receive windows for join request", Logger.LoggingLevel.Info);
+                        Logger.Log(devEUI, $"using custom  second receive windows for join request", LogLevel.Information);
                         freq = this.configuration.Rx2DataFrequency;
                         datr = this.configuration.Rx2DataRate;
                     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -50,8 +50,8 @@ namespace LoRaWan.NetworkServer
         public bool LogToConsole { get; set; } = true;
 
         // Gets/sets the logging level
-        // Default: 0 (Always logging)
-        public int LogLevel { get; set; } = 0;
+        // Default: 4 (Log Errors)
+        public string LogLevel { get; set; } = "4";
 
         // Gets/sets if logging to IoT Hub is enabled
         // Default: false

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ProcessLogger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ProcessLogger.cs
@@ -5,6 +5,7 @@ namespace LoRaWan.NetworkServer
 {
     using System;
     using System.Collections.Generic;
+    using Microsoft.Extensions.Logging;
 
     // Helper class to log process operations
     internal sealed class ProcessLogger : IDisposable
@@ -30,7 +31,7 @@ namespace LoRaWan.NetworkServer
 
         public void Dispose()
         {
-            Logger.Log(this.devEUI ?? LoRaTools.Utils.ConversionHelper.ByteArrayToString(this.devAddr), $"processing time: {this.timeWatcher.GetElapsedTime()}", Logger.LoggingLevel.Info);
+            Logger.Log(this.devEUI ?? LoRaTools.Utils.ConversionHelper.ByteArrayToString(this.devAddr), $"processing time: {this.timeWatcher.GetElapsedTime()}", LogLevel.Information);
             GC.SuppressFinalize(this);
         }
     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
@@ -66,7 +66,7 @@ namespace LoRaWan
 
         public static void Log(string deviceId, string message, LogLevel logLevel)
         {
-            if ((int)logLevel >= configuration.LogLevel)
+            if ((int)logLevel >= (int)configuration.LogLevel)
             {
                 var msg = message;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
@@ -66,7 +66,7 @@ namespace LoRaWan
 
         public static void Log(string deviceId, string message, LogLevel logLevel)
         {
-            if ((int)logLevel >= (int)configuration.LogLevel)
+            if (logLevel >= configuration.LogLevel)
             {
                 var msg = message;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
@@ -9,26 +9,18 @@ namespace LoRaWan
     using System.Text;
     using System.Threading;
     using Microsoft.Azure.Devices.Client;
+    using Microsoft.Extensions.Logging;
 
     public class Logger
     {
         // Interval where we try to estabilish connection to udp logger
         const int RETRY_UDP_LOG_CONNECTION_INTERVAL_IN_MS = 1000 * 10;
 
-        public enum LoggingLevel : int
-        {
-            Always = 0,
-            Full,
-            Info,
-            Error
-        }
-
-        public static LoggingLevel LoggerLevel => (LoggingLevel)configuration.LogLevel;
+        public static LogLevel LoggerLevel => (LogLevel)configuration.LogLevel;
 
         static LoggerConfiguration configuration = new LoggerConfiguration();
         static volatile UdpClient udpClient;
         static IPEndPoint udpEndpoint;
-
         static volatile bool isInitializeUdpLoggerRunning = false;
         private static Timer retryUdpLogInitializationTimer;
 
@@ -57,14 +49,24 @@ namespace LoRaWan
             }
         }
 
-        public static void Log(string message, LoggingLevel loggingLevel)
+        public static void LogAlways(string message)
         {
-            Log(null, message, loggingLevel);
+            LogAlways(null, message);
         }
 
-        public static void Log(string deviceId, string message, LoggingLevel loggingLevel)
+        public static void LogAlways(string deviceId, string message)
         {
-            if ((int)loggingLevel >= configuration.LogLevel || loggingLevel == LoggingLevel.Always)
+            Log(null, message, LogLevel.Critical);
+        }
+
+        public static void Log(string message, LogLevel logLevel)
+        {
+            Log(null, message, logLevel);
+        }
+
+        public static void Log(string deviceId, string message, LogLevel logLevel)
+        {
+            if ((int)logLevel >= configuration.LogLevel)
             {
                 var msg = message;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/LoggerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/LoggerConfiguration.cs
@@ -16,8 +16,8 @@ namespace LoRaWan
         public bool LogToConsole { get; set; } = true;
 
         // Gets/sets the logging level
-        // Default: 0 (Always logging)
-        public int LogLevel { get; set; } = 0;
+        // Default: 4 (Error)
+        public int LogLevel { get; set; } = 4;
 
         // Gets/sets if logging to IoT Hub is enabled
         // Default: false
@@ -32,5 +32,26 @@ namespace LoRaWan
 
         // Gets/sets udp port to send logs
         public int LogToUdpPort { get; set; } = 6000;
+
+        public static int InitLogLevel(string logLevel)
+        {
+            int logLevelInt = 4;
+            logLevel = logLevel.ToUpper();
+
+            if (logLevel == "1" || logLevel == "DEBUG")
+            {
+                logLevelInt = 1;
+            }
+            else if (logLevel == "2" || logLevel == "INFORMATION" || logLevel == "INFO")
+            {
+                logLevelInt = 2;
+            }
+            else if (logLevel == "3" || logLevel == "4" || logLevel == "ERROR")
+            {
+                logLevelInt = 4;
+            }
+
+            return logLevelInt;
+        }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/LoggerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/LoggerConfiguration.cs
@@ -3,7 +3,9 @@
 
 namespace LoRaWan
 {
+    using System;
     using Microsoft.Azure.Devices.Client;
+    using Microsoft.Extensions.Logging;
 
     // Defines the logger configuration
     public class LoggerConfiguration
@@ -17,7 +19,7 @@ namespace LoRaWan
 
         // Gets/sets the logging level
         // Default: 4 (Error)
-        public int LogLevel { get; set; } = 4;
+        public LogLevel LogLevel { get; set; } = LogLevel.Error;
 
         // Gets/sets if logging to IoT Hub is enabled
         // Default: false
@@ -33,25 +35,25 @@ namespace LoRaWan
         // Gets/sets udp port to send logs
         public int LogToUdpPort { get; set; } = 6000;
 
-        public static int InitLogLevel(string logLevel)
+        public static LogLevel InitLogLevel(string logLevelIn)
         {
-            int logLevelInt = 4;
-            logLevel = logLevel.ToUpper();
+            LogLevel logLevelOut;
 
-            if (logLevel == "1" || logLevel == "DEBUG")
+            if (logLevelIn == "1" || string.Equals(logLevelIn, "debug", StringComparison.InvariantCultureIgnoreCase))
             {
-                logLevelInt = 1;
+                logLevelOut = LogLevel.Debug;
             }
-            else if (logLevel == "2" || logLevel == "INFORMATION" || logLevel == "INFO")
+            else if (logLevelIn == "2" || string.Equals(logLevelIn, "information", StringComparison.InvariantCultureIgnoreCase)
+                || string.Equals(logLevelIn, "info", StringComparison.InvariantCultureIgnoreCase))
             {
-                logLevelInt = 2;
+                logLevelOut = LogLevel.Information;
             }
-            else if (logLevel == "3" || logLevel == "4" || logLevel == "ERROR")
+            else
             {
-                logLevelInt = 4;
+                logLevelOut = LogLevel.Error;
             }
 
-            return logLevelInt;
+            return logLevelOut;
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -10,6 +10,7 @@ namespace LoRaTools.LoRaMessage
     using LoRaTools.LoRaPhysical;
     using LoRaTools.Utils;
     using LoRaWan;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
     using Org.BouncyCastle.Crypto;
     using Org.BouncyCastle.Crypto.Engines;
@@ -242,17 +243,17 @@ namespace LoRaTools.LoRaMessage
             this.PerformEncryption(appSKey);
             this.SetMic(nwkSKey);
             var downlinkPktFwdMessage = new DownlinkPktFwdMessage(this.GetByteMessage(), datr, freq, tmst);
-            if (Logger.LoggerLevel < Logger.LoggingLevel.Info)
+            if (Logger.LoggerLevel < LogLevel.Information)
             {
                 var jsonMsg = JsonConvert.SerializeObject(downlinkPktFwdMessage);
 
                 if (devEUI.Length != 0)
                 {
-                    Logger.Log(devEUI, $"{((LoRaMessageType)this.Mhdr.Span[0]).ToString()} {jsonMsg}", Logger.LoggingLevel.Full);
+                    Logger.Log(devEUI, $"{((LoRaMessageType)this.Mhdr.Span[0]).ToString()} {jsonMsg}", LogLevel.Debug);
                 }
                 else
                 {
-                    Logger.Log(ConversionHelper.ByteArrayToString(this.DevAddr.Span.ToArray()), $"{((LoRaMessageType)this.Mhdr.Span[0]).ToString()} {jsonMsg}", Logger.LoggingLevel.Full);
+                    Logger.Log(ConversionHelper.ByteArrayToString(this.DevAddr.Span.ToArray()), $"{((LoRaMessageType)this.Mhdr.Span[0]).ToString()} {jsonMsg}", LogLevel.Debug);
                 }
             }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
@@ -10,6 +10,7 @@ namespace LoRaTools.LoRaMessage
     using LoRaTools.LoRaPhysical;
     using LoRaTools.Utils;
     using LoRaWan;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
     using Org.BouncyCastle.Crypto.Engines;
     using Org.BouncyCastle.Crypto.Parameters;
@@ -242,17 +243,17 @@ namespace LoRaTools.LoRaMessage
             this.PerformEncryption(appKey);
 
             var downlinkPktFwdMessage = new DownlinkPktFwdMessage(this.GetByteMessage(), datr, freq, tmst);
-            if (Logger.LoggerLevel < Logger.LoggingLevel.Info)
+            if (Logger.LoggerLevel < LogLevel.Information)
             {
                 var jsonMsg = JsonConvert.SerializeObject(downlinkPktFwdMessage);
 
                 if (devEUI.Length != 0)
                 {
-                    Logger.Log(devEUI, $"{((LoRaMessageType)this.Mhdr.Span[0]).ToString()} {jsonMsg}", Logger.LoggingLevel.Full);
+                    Logger.Log(devEUI, $"{((LoRaMessageType)this.Mhdr.Span[0]).ToString()} {jsonMsg}", LogLevel.Debug);
                 }
                 else
                 {
-                    Logger.Log(ConversionHelper.ByteArrayToString(this.DevAddr.Span.ToArray()), $"{((LoRaMessageType)this.Mhdr.Span[0]).ToString()} {jsonMsg}", Logger.LoggingLevel.Full);
+                    Logger.Log(ConversionHelper.ByteArrayToString(this.DevAddr.Span.ToArray()), $"{((LoRaMessageType)this.Mhdr.Span[0]).ToString()} {jsonMsg}", LogLevel.Debug);
                 }
             }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/PhysicalPayload.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/PhysicalPayload.cs
@@ -6,6 +6,7 @@ namespace LoRaTools
     using System;
     using System.Collections.Generic;
     using LoRaWan;
+    using Microsoft.Extensions.Logging;
 
     public enum PhysicalIdentifier
     {
@@ -65,7 +66,7 @@ namespace LoRaTools
                 // TX_ACK That packet type is used by the gateway to send a feedback to the to inform if a downlink request has been accepted or rejected by the gateway.
                 if (this.Identifier == PhysicalIdentifier.TX_ACK)
                 {
-                    Logger.Log($"Tx ack received from gateway", Logger.LoggingLevel.Info);
+                    Logger.Log($"Tx ack received from gateway", LogLevel.Information);
                     Array.Copy(input, 4, this.gatewayIdentifier, 0, 8);
                     if (input.Length - 12 > 0)
                     {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Rxpk.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Rxpk.cs
@@ -6,6 +6,7 @@ namespace LoRaTools.LoRaPhysical
     using System.Collections.Generic;
     using System.Text;
     using LoRaWan;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
     public class Rxpk
@@ -100,7 +101,7 @@ namespace LoRaTools.LoRaPhysical
                 var payload = Encoding.UTF8.GetString(physicalPayload.Message);
                 if (!payload.StartsWith("{\"stat"))
                 {
-                    Logger.Log($"Physical dataUp {payload}", Logger.LoggingLevel.Full);
+                    Logger.Log($"Physical dataUp {payload}", LogLevel.Debug);
                     var payloadObject = JsonConvert.DeserializeObject<UplinkPktFwdMessage>(payload);
                     if (payloadObject != null)
                     {
@@ -112,7 +113,7 @@ namespace LoRaTools.LoRaPhysical
                 }
                 else
                 {
-                    Logger.Log($"Statistic: {payload}", Logger.LoggingLevel.Full);
+                    Logger.Log($"Statistic: {payload}", LogLevel.Debug);
                 }
             }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Txpk.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Txpk.cs
@@ -5,6 +5,7 @@ namespace LoRaTools.LoRaPhysical
 {
     using System.Text;
     using LoRaWan;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
     public class Txpk
@@ -63,7 +64,7 @@ namespace LoRaTools.LoRaPhysical
                 }
                 else
                 {
-                    Logger.Log("Error: " + payloadDownObject.Txpk, Logger.LoggingLevel.Full);
+                    Logger.Log("Error: " + payloadDownObject.Txpk, LogLevel.Debug);
                 }
             }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MacCommandHolder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MacCommandHolder.cs
@@ -6,6 +6,7 @@ namespace LoRaTools
     using System;
     using System.Collections.Generic;
     using LoRaWan;
+    using Microsoft.Extensions.Logging;
 
     public class MacCommandHolder
     {
@@ -32,17 +33,17 @@ namespace LoRaTools
                     this.MacCommand.Add(linkCheck);
                     break;
                 case CidEnum.LinkADRCmd:
-                    Logger.Log("mac command detected : LinkADRCmd", Logger.LoggingLevel.Info);
+                    Logger.Log("mac command detected : LinkADRCmd", LogLevel.Information);
                     break;
                 case CidEnum.DutyCycleCmd:
                     DutyCycleCmd dutyCycle = new DutyCycleCmd();
                     this.MacCommand.Add(dutyCycle);
                     break;
                 case CidEnum.RXParamCmd:
-                    Logger.Log("mac command detected : RXParamCmd", Logger.LoggingLevel.Info);
+                    Logger.Log("mac command detected : RXParamCmd", LogLevel.Information);
                     break;
                 case CidEnum.DevStatusCmd:
-                    Logger.Log("mac command detected : DevStatusCmd", Logger.LoggingLevel.Info);
+                    Logger.Log("mac command detected : DevStatusCmd", LogLevel.Information);
                     DevStatusCmd devStatus = new DevStatusCmd();
                     this.MacCommand.Add(devStatus);
                     break;
@@ -72,37 +73,37 @@ namespace LoRaTools
                 switch (cid)
                 {
                     case CidEnum.LinkCheckCmd:
-                        Logger.Log("mac command detected : LinkCheckCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : LinkCheckCmd", LogLevel.Information);
                         LinkCheckCmd linkCheck = new LinkCheckCmd();
                         pointer += linkCheck.Length;
                         this.MacCommand.Add(linkCheck);
                         break;
                     case CidEnum.LinkADRCmd:
-                        Logger.Log("mac command detected : LinkADRCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : LinkADRCmd", LogLevel.Information);
                         break;
                     case CidEnum.DutyCycleCmd:
-                        Logger.Log("mac command detected : DutyCycleCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : DutyCycleCmd", LogLevel.Information);
                         DutyCycleCmd dutyCycle = new DutyCycleCmd();
                         pointer += dutyCycle.Length;
                         this.MacCommand.Add(dutyCycle);
                         break;
                     case CidEnum.RXParamCmd:
-                        Logger.Log("mac command detected : RXParamCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : RXParamCmd", LogLevel.Information);
                         break;
                     case CidEnum.DevStatusCmd:
-                        Logger.Log("mac command detected : DevStatusCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : DevStatusCmd", LogLevel.Information);
                         DevStatusCmd devStatus = new DevStatusCmd(input[pointer + 1], input[pointer + 2]);
                         pointer += devStatus.Length;
                         this.MacCommand.Add(devStatus);
                         break;
                     case CidEnum.NewChannelCmd:
-                        Logger.Log("mac command detected : NewChannelCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : NewChannelCmd", LogLevel.Information);
                         NewChannelAns newChannel = new NewChannelAns(Convert.ToBoolean(input[pointer + 1] & 1), Convert.ToBoolean(input[pointer + 1] & 2));
                         pointer += newChannel.Length;
                         this.MacCommand.Add(newChannel);
                         break;
                     case CidEnum.RXTimingCmd:
-                        Logger.Log("mac command detected : RXTimingCmd", Logger.LoggingLevel.Info);
+                        Logger.Log("mac command detected : RXTimingCmd", LogLevel.Information);
                         RXTimingSetupCmd rXTimingSetup = new RXTimingSetupCmd();
                         pointer += rXTimingSetup.Length;
                         this.MacCommand.Add(rXTimingSetup);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionFactory.cs
@@ -6,6 +6,7 @@ namespace LoRaTools.Regions
     using LoRaTools.LoRaPhysical;
     using LoRaTools.Utils;
     using LoRaWan;
+    using Microsoft.Extensions.Logging;
 
     public static class RegionFactory
     {
@@ -29,7 +30,7 @@ namespace LoRaTools.Regions
             }
             else
             {
-                Logger.Log("RegionFactory", "The current frequency plan is not supported. Currently only EU868 and US915 frequency bands are supported.", Logger.LoggingLevel.Error);
+                Logger.Log("RegionFactory", "The current frequency plan is not supported. Currently only EU868 and US915 frequency bands are supported.", LogLevel.Error);
                 return false;
             }
         }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorTestBase.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorTestBase.cs
@@ -11,6 +11,7 @@ namespace LoRaWan.NetworkServer.Test
     using LoRaTools.Regions;
     using LoRaWan.NetworkServer;
     using LoRaWan.Test.Shared;
+    using Microsoft.Extensions.Logging;
     using Moq;
 
     public class MessageProcessorTestBase
@@ -42,7 +43,7 @@ namespace LoRaWan.NetworkServer.Test
             {
                 GatewayID = ServerGatewayID,
                 LogToConsole = true,
-                LogLevel = (int)Logger.LoggingLevel.Full,
+                LogLevel = ((int)LogLevel.Debug).ToString(),
             };
 
             this.frameCounterUpdateStrategy = new Mock<ILoRaDeviceFrameCounterUpdateStrategy>(MockBehavior.Strict);

--- a/README.md
+++ b/README.md
@@ -298,25 +298,35 @@ To clear the cache and allow the device to connect follow these steps:
 
 Alternatively you can restart the Gateway or the LoRaWanNetworkSrvModule container.
 
-## Monitoring
+## Monitoring and Logging
 
-There is a logging mechanisms that output valuable information on the console of the docker container and/or as module message to IoT Hub
+There is a logging mechanism that outputs valuable information to the console of the docker container and can optionally forward these messages to IoT Hub.
 
-You can control the logging with the following environment variables on the LoRaWanNetworkSrvModule module:
+You can control logging with the following environment variables in the **LoRaWanNetworkSrvModule** IoT Edge module:
 
-LOG_LEVEL 3 Only errors are logged 
+| Variable  | Value                | Explanation                                                                              |
+|-----------|----------------------|------------------------------------------------------------------------------------------|
+| LOG_LEVEL | "1" or "Debug"       | Everything is logged, including the up- and downstream messages to the packet forwarder. |
+|           | "2" or "Information" | Errors and information are logged.                                                       |
+|           | "3" or "Error"       | Only errors are logged. (default if omitted)                                             |
 
-LOG_LEVEL 2 Errors and information are logged (default if omitted)
+For production environments, the **LOG_LEVEL** should be set to **Error**.
 
-LOG_LEVEL 1 Everything is logged including the up and down messages to the packet forwarder
+Setting **LOG_LEVEL** to **Debug** causes a lot of messages to be generated. Make sure to set **LOG_TO_HUB** to **false** in this case.
 
-LOG_TO_HUB true Log info are sent from the module to IoT Hub. You can used VSCode, [IoTHub explorer](https://github.com/Azure/iothub-explorer) or [Device Explorer](https://github.com/Azure/azure-iot-sdk-csharp/tree/master/tools/DeviceExplorer) to monitor the log messages
+| Variable   | Value | Explanation                                          |
+|------------|-------|------------------------------------------------------|
+| LOG_TO_HUB | true  | Log info are sent from the module to IoT Hub.        |
+|            | false | Log info is not sent to IoT Hub (default if omitted) |
 
-LOG_TO_HUB false Log info is not sent to IoT Hub (default if omitted)
+You can use VSCode, [IoTHub explorer](https://github.com/Azure/iothub-explorer) or [Device Explorer](https://github.com/Azure/azure-iot-sdk-csharp/tree/master/tools/DeviceExplorer) to monitor the log messages directly in IoT Hub if **LOG_TO_HUB** is set to **true**.
 
-LOG_TO_CONSOLE true Log info in docker log (default if omitted). Log in to the gateway and use "sudo docker logs LoRaWanNetworkSrvModule -f" to follow the log
+Log in to the gateway and use `sudo docker logs LoRaWanNetworkSrvModule -f` to follow the logs if you are not logging to IoT Hub.
 
-LOG_TO_CONSOLE false No log info in the docker log
+| Variable       | Value | Explanation                             |
+|----------------|-------|-----------------------------------------|
+| LOG_TO_CONSOLE | true  | Log to docker logs (default if omitted) |
+|                | false | Does not log to docker logs             |
 
 ## Customize the solution & Deep dive
 


### PR DESCRIPTION
- Logger: Log using Microsoft.Extensions.Logging.LogLevel Enum
- Logger: new LogAlways method
- LoggerConfiguration: handle various LOG_LEVEL env var values: 
-- 1 or Debug
-- 2 or Information or Info
-- 3 or Error
- UdpServer: Output Log Level on startup
- Other classes: Adapt for new Logger.Log and Logger.LogAlways methods, include using Microsoft.Extensions.Logging;
- ReadMe: Update with new LOG_LEVEL env var settings and point out to use LOG_LEVEL=Error in production and not combine LOG_LEVEL=Debug and LOG_TO_HUB=true