### PR TITLE
Update DevOpsAgent to 2.147.0 and amd64 to Release

### DIFF
--- a/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.amd64
+++ b/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.amd64
@@ -1,6 +1,6 @@
 FROM microsoft/dotnet:2.1-sdk-stretch
 
-ENV VSTS_POOL=default VSTS_AGENT=myAgent VSTS_AGENT_VERSION=2.144.2
+ENV VSTS_POOL=default VSTS_AGENT=myAgent VSTS_AGENT_VERSION=2.146.0
 
 # Install curl, wget and git
 RUN apt-get update && apt-get install -y \

--- a/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.amd64
+++ b/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.amd64
@@ -1,6 +1,6 @@
 FROM microsoft/dotnet:2.1-sdk-stretch
 
-ENV VSTS_POOL=default VSTS_AGENT=myAgent VSTS_AGENT_VERSION=2.146.0
+ENV VSTS_POOL=default VSTS_AGENT=myAgent VSTS_AGENT_VERSION=2.147.0
 
 # Install curl, wget and git
 RUN apt-get update && apt-get install -y \

--- a/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.arm32v7
@@ -1,6 +1,6 @@
 FROM microsoft/dotnet:2.1-sdk-stretch-arm32v7
 
-ENV VSTS_POOL=default VSTS_AGENT=myAgent VSTS_AGENT_VERSION=2.144.2
+ENV VSTS_POOL=default VSTS_AGENT=myAgent VSTS_AGENT_VERSION=2.146.0
 
 # Install curl, wget and git
 RUN apt-get update && apt-get install -y \

--- a/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.arm32v7
@@ -1,6 +1,6 @@
 FROM microsoft/dotnet:2.1-sdk-stretch-arm32v7
 
-ENV VSTS_POOL=default VSTS_AGENT=myAgent VSTS_AGENT_VERSION=2.146.0
+ENV VSTS_POOL=default VSTS_AGENT=myAgent VSTS_AGENT_VERSION=2.147.0
 
 # Install curl, wget and git
 RUN apt-get update && apt-get install -y \

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64
@@ -12,7 +12,7 @@ COPY ./LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule ./LoRa
 WORKDIR /build/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule
 RUN dotnet restore
 
-RUN dotnet publish -c Debug -o out
+RUN dotnet publish -c Release -o out
 
 FROM microsoft/dotnet:2.1-runtime
 WORKDIR /app


### PR DESCRIPTION
Changes
- Updated AzureDevOpsAgent to 2.147.0
- Updated amd64 Dockerfile to use Release version