### PR TITLE
[DON'T MERGE YET] Apply ci-succeeded to PRs that pass a full CI test

### DIFF
--- a/azure-pipeline-integration-test-steps-template.yaml
+++ b/azure-pipeline-integration-test-steps-template.yaml
@@ -34,3 +34,12 @@ steps:
     searchFolder: '$(Common.TestResultsDirectory)'
     testRunTitle: '${{ parameters.platform }}-Integration tests'
     mergeTestResults: true
+    
+  # add ci-succeeded for PRs
+- task: fbeltrao.githubprlabels.task.githubprlabels@0
+  displayName: 'GitHub PR label (add ci-succeeded)'
+  condition: and(and(succeeded(), eq(variables['Build.Reason'], 'PullRequest')), ne(variables['RunTestsOnly'], 'true'))
+  inputs:
+    gitHubConnection: $(GitHubConnectionName)
+    action: add
+    label: 'ci-succeeded'

--- a/azure-pipeline-integration-test-steps-template.yaml
+++ b/azure-pipeline-integration-test-steps-template.yaml
@@ -40,6 +40,6 @@ steps:
   displayName: 'GitHub PR label (add ci-succeeded)'
   condition: and(and(succeeded(), eq(variables['Build.Reason'], 'PullRequest')), ne(variables['RunTestsOnly'], 'true'))
   inputs:
-    gitHubConnection: $(GitHubConnectionName)
+    gitHubConnection: kaizimmerm
     action: add
     label: 'ci-succeeded'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -39,7 +39,7 @@ pr:
     - dev
 
 # Enable CI on branches master and dev
-# Batch builds
+# Batch builds 
 trigger:
   batch: true
   branches:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -12,6 +12,7 @@ variables:
   # image tag prefix for dev branch (0.3.0-dev)
   DEV_IMAGE_TAG: dev
 
+  # Build configuration for .NET components
   buildConfiguration: 'Release'
 
   # Name of service connection for resource group

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -59,6 +59,15 @@ jobs:
     vmImage: 'Ubuntu 16.04'   
 
   steps:
+  # remove ci-succeeded for PRs
+  - task: fbeltrao.githubprlabels.task.githubprlabels@0
+    displayName: 'GitHub PR label (remove ci-succeed)'
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    inputs:
+      gitHubConnection: $(GitHubConnectionName)
+      action: remove
+      label: 'ci-succeeded'
+
   # build LoRa Engine
   - script: dotnet build --configuration $(buildConfiguration) ./LoRaEngine/LoRaEngine.sln
     displayName: Build LoRa Engine

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -64,7 +64,7 @@ jobs:
     displayName: 'GitHub PR label (remove ci-succeed)'
     condition: eq(variables['Build.Reason'], 'PullRequest')
     inputs:
-      gitHubConnection: $(GitHubConnectionName)
+      gitHubConnection: kaizimmerm
       action: remove
       label: 'ci-succeeded'
 


### PR DESCRIPTION
Apply ci-succeeded label to PRs that succeeded a full CI test pipeline. It only applies to the complete build.