### PR TITLE
Fix LinkADR Mac Command parsing

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/LinkADRCmd.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/LinkADRCmd.cs
@@ -13,6 +13,11 @@ namespace LoRaTools
         // private readonly byte dataRateTXPower;
         private readonly byte[] chMask = new byte[2];
 
+        public LinkADRCmd()
+        {
+            this.Length = 2;
+        }
+
         // private readonly byte redondancy;
         public override byte[] ToBytes()
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MacCommandHolder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MacCommandHolder.cs
@@ -79,6 +79,9 @@ namespace LoRaTools
                         this.MacCommand.Add(linkCheck);
                         break;
                     case CidEnum.LinkADRCmd:
+                        LinkADRCmd linkADRCmd = new LinkADRCmd();
+                        pointer += linkADRCmd.Length;
+                        this.MacCommand.Add(linkADRCmd);
                         Logger.Log("mac command detected : LinkADRCmd", LogLevel.Information);
                         break;
                     case CidEnum.DutyCycleCmd:
@@ -89,6 +92,9 @@ namespace LoRaTools
                         break;
                     case CidEnum.RXParamCmd:
                         Logger.Log("mac command detected : RXParamCmd", LogLevel.Information);
+                        RXParamSetupCmd rxParamSetupCmd = new RXParamSetupCmd();
+                        pointer += rxParamSetupCmd.Length;
+                        this.MacCommand.Add(rxParamSetupCmd);
                         break;
                     case CidEnum.DevStatusCmd:
                         Logger.Log("mac command detected : DevStatusCmd", LogLevel.Information);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MacCommandHolder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MacCommandHolder.cs
@@ -114,6 +114,9 @@ namespace LoRaTools
                         pointer += rXTimingSetup.Length;
                         this.MacCommand.Add(rXTimingSetup);
                         break;
+                    default:
+                        Logger.Log($"value {input[pointer]} as MAC command type is not recognized, aborting Mac command parsing", LogLevel.Error);
+                        return;
                 }
             }
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/RXParamSetupCmd.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/RXParamSetupCmd.cs
@@ -13,6 +13,11 @@ namespace LoRaTools
         // private readonly byte dlSettings;
         private readonly byte[] frequency = new byte[3];
 
+        public RXParamSetupCmd()
+        {
+            this.Length = 2;
+        }
+
         public override byte[] ToBytes()
         {
             throw new NotImplementedException();


### PR DESCRIPTION
* Fix bug in which a LinkADRMacAns would cause an infinite loop AB#1008

NB. A full refactor of the MAC command is underway but this won't be included in 0.4. This PR is only intended a a fix.