### PR TITLE
Introduce request queue for data payloads

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Constants.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Constants.cs
@@ -19,5 +19,14 @@ namespace LoRaWan.NetworkServer
 
         // Name of the upstream message property reporint a confirmed message
         internal const string C2D_MSG_PROPERTY_VALUE_NAME = "C2DMsgConfirmed";
+
+        // Receive window 1 (RX1)
+        public const int RECEIVE_WINDOW_2 = 2;
+
+        // Receive window 2 (RX2)
+        public const int RECEIVE_WINDOW_1 = 1;
+
+        // Invalid receive window (when trying to resolve the window to use)
+        public const int INVALID_RECEIVE_WINDOW = 0;
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Constants.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Constants.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer
+{
+    public static class Constants
+    {
+        // Defines Cloud to device message property containing fport value
+        internal const string FPORT_MSG_PROPERTY_KEY = "fport";
+
+        // Fport value reserved for mac commands
+        internal const byte LORA_FPORT_RESERVED_MAC_MSG = 0;
+
+        // Starting Fport value reserved for future applications
+        internal const byte LORA_FPORT_RESERVED_FUTURE_START = 224;
+
+        // Default value of a C2D message id if missing from the message
+        internal const string C2D_MSG_ID_PLACEHOLDER = "ConfirmationC2DMessageWithNoId";
+
+        // Name of the upstream message property reporint a confirmed message
+        internal const string C2D_MSG_PROPERTY_VALUE_NAME = "C2DMsgConfirmed";
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -1,0 +1,505 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading.Tasks;
+    using LoRaTools;
+    using LoRaTools.LoRaMessage;
+    using LoRaTools.LoRaPhysical;
+    using LoRaTools.Utils;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+
+    public class DefaultLoRaDataRequestHandler : ILoRaDataRequestHandler
+    {
+        private readonly NetworkServerConfiguration configuration;
+        private readonly ILoRaDeviceFrameCounterUpdateStrategyFactory frameCounterUpdateStrategyFactory;
+        private readonly ILoRaPayloadDecoder payloadDecoder;
+
+        public DefaultLoRaDataRequestHandler(
+            NetworkServerConfiguration configuration,
+            ILoRaDeviceFrameCounterUpdateStrategyFactory frameCounterUpdateStrategyFactory,
+            ILoRaPayloadDecoder payloadDecoder)
+        {
+            this.configuration = configuration;
+            this.frameCounterUpdateStrategyFactory = frameCounterUpdateStrategyFactory;
+            this.payloadDecoder = payloadDecoder;
+        }
+
+        public async Task<LoRaDeviceRequestProcessResult> ProcessRequestAsync(LoRaRequest request, LoRaDevice loRaDevice)
+        {
+            var timeWatcher = new LoRaOperationTimeWatcher(request.LoRaRegion, request.StartTime);
+            var loraPayload = (LoRaPayloadData)request.Payload;
+            var isMultiGateway = !string.Equals(loRaDevice.GatewayID, this.configuration.GatewayID, StringComparison.InvariantCultureIgnoreCase);
+            var frameCounterStrategy = isMultiGateway ?
+                this.frameCounterUpdateStrategyFactory.GetMultiGatewayStrategy() :
+                this.frameCounterUpdateStrategyFactory.GetSingleGatewayStrategy();
+
+            var payloadFcnt = loraPayload.GetFcnt();
+            var requiresConfirmation = loraPayload.IsConfirmed();
+
+            using (new LoRaDeviceFrameCounterSession(loRaDevice, frameCounterStrategy))
+            {
+                // Leaf devices that restart lose the counter. In relax mode we accept the incoming frame counter
+                // ABP device does not reset the Fcnt so in relax mode we should reset for 0 (LMIC based) or 1
+                var isFrameCounterFromNewlyStartedDevice = false;
+                if (payloadFcnt <= 1)
+                {
+                    if (loRaDevice.IsABP)
+                    {
+                        if (loRaDevice.IsABPRelaxedFrameCounter && loRaDevice.FCntUp >= 0 && payloadFcnt <= 1)
+                        {
+                            // known problem when device restarts, starts fcnt from zero
+                            _ = frameCounterStrategy.ResetAsync(loRaDevice);
+                            isFrameCounterFromNewlyStartedDevice = true;
+                        }
+                    }
+                    else if (loRaDevice.FCntUp == payloadFcnt && payloadFcnt == 0)
+                    {
+                        // Some devices start with frame count 0
+                        isFrameCounterFromNewlyStartedDevice = true;
+                    }
+                }
+
+                // Reply attack or confirmed reply
+                // Confirmed resubmit: A confirmed message that was received previously but we did not answer in time
+                // Device will send it again and we just need to return an ack (but also check for C2D to send it over)
+                var isConfirmedResubmit = false;
+                if (!isFrameCounterFromNewlyStartedDevice && payloadFcnt <= loRaDevice.FCntUp)
+                {
+                    // if it is confirmed most probably we did not ack in time before or device lost the ack packet so we should continue but not send the msg to iothub
+                    if (requiresConfirmation && payloadFcnt == loRaDevice.FCntUp)
+                    {
+                        if (!loRaDevice.ValidateConfirmResubmit(payloadFcnt))
+                        {
+                            Logger.Log(loRaDevice.DevEUI, $"resubmit from confirmed message exceeds threshold of {LoRaDevice.MaxConfirmationResubmitCount}, message ignored, msg: {payloadFcnt} server: {loRaDevice.FCntUp}", LogLevel.Debug);
+                            return new LoRaDeviceRequestProcessResult(loRaDevice, request, LoRaDeviceRequestFailedReason.ConfirmationResubmitThresholdExceeded);
+                        }
+
+                        isConfirmedResubmit = true;
+                        Logger.Log(loRaDevice.DevEUI, $"resubmit from confirmed message detected, msg: {payloadFcnt} server: {loRaDevice.FCntUp}", LogLevel.Information);
+                    }
+                    else
+                    {
+                        Logger.Log(loRaDevice.DevEUI, $"invalid frame counter, message ignored, msg: {payloadFcnt} server: {loRaDevice.FCntUp}", LogLevel.Information);
+                        return new LoRaDeviceRequestProcessResult(loRaDevice, request, LoRaDeviceRequestFailedReason.InvalidFrameCounter);
+                    }
+                }
+
+                var fcntDown = 0;
+                // If it is confirmed it require us to update the frame counter down
+                // Multiple gateways: in redis, otherwise in device twin
+                if (requiresConfirmation)
+                {
+                    fcntDown = await frameCounterStrategy.NextFcntDown(loRaDevice, payloadFcnt);
+
+                    // Failed to update the fcnt down
+                    // In multi gateway scenarios it means the another gateway was faster than using, can stop now
+                    if (fcntDown <= 0)
+                    {
+                        // update our fcntup anyway?
+                        // loRaDevice.SetFcntUp(payloadFcnt);
+                        Logger.Log(loRaDevice.DevEUI, "another gateway has already sent ack or downlink msg", LogLevel.Information);
+
+                        return new LoRaDeviceRequestProcessResult(loRaDevice, request, LoRaDeviceRequestFailedReason.HandledByAnotherGateway);
+                    }
+
+                    Logger.Log(loRaDevice.DevEUI, $"down frame counter: {loRaDevice.FCntDown}", LogLevel.Information);
+                }
+
+                if (!isConfirmedResubmit)
+                {
+                    var validFcntUp = isFrameCounterFromNewlyStartedDevice || (payloadFcnt > loRaDevice.FCntUp);
+                    if (validFcntUp)
+                    {
+                        Logger.Log(loRaDevice.DevEUI, $"valid frame counter, msg: {payloadFcnt} server: {loRaDevice.FCntUp}", LogLevel.Information);
+
+                        object payloadData = null;
+
+                        // if it is an upward acknowledgement from the device it does not have a payload
+                        // This is confirmation from leaf device that he received a C2D confirmed
+                        // if a message payload is null we don't try to decrypt it.
+                        if (loraPayload.Frmpayload.Length != 0)
+                        {
+                            byte[] decryptedPayloadData = null;
+                            try
+                            {
+                                decryptedPayloadData = loraPayload.GetDecryptedPayload(loRaDevice.AppSKey);
+                            }
+                            catch (Exception ex)
+                            {
+                                Logger.Log(loRaDevice.DevEUI, $"failed to decrypt message: {ex.Message}", LogLevel.Error);
+                            }
+
+                            var fportUp = loraPayload.GetFPort();
+
+                            if (string.IsNullOrEmpty(loRaDevice.SensorDecoder))
+                            {
+                                Logger.Log(loRaDevice.DevEUI, $"no decoder set in device twin. port: {fportUp}", LogLevel.Debug);
+                                payloadData = Convert.ToBase64String(decryptedPayloadData);
+                            }
+                            else
+                            {
+                                Logger.Log(loRaDevice.DevEUI, $"decoding with: {loRaDevice.SensorDecoder} port: {fportUp}", LogLevel.Debug);
+                                payloadData = await this.payloadDecoder.DecodeMessageAsync(decryptedPayloadData, fportUp, loRaDevice.SensorDecoder);
+                            }
+                        }
+
+                        if (!await this.SendDeviceEventAsync(request, loRaDevice, timeWatcher, payloadData))
+                        {
+                            // failed to send event to IoT Hub, stop now
+                            return new LoRaDeviceRequestProcessResult(loRaDevice, request, LoRaDeviceRequestFailedReason.IoTHubProblem);
+                        }
+
+                        loRaDevice.SetFcntUp(payloadFcnt);
+                    }
+                    else
+                    {
+                        Logger.Log(loRaDevice.DevEUI, $"invalid frame counter, msg: {payloadFcnt} server: {loRaDevice.FCntUp}", LogLevel.Information);
+                    }
+                }
+
+                // We check if we have time to futher progress or not
+                // C2D checks are quite expensive so if we are really late we just stop here
+                var timeToSecondWindow = timeWatcher.GetRemainingTimeToReceiveSecondWindow(loRaDevice);
+                if (timeToSecondWindow < LoRaOperationTimeWatcher.ExpectedTimeToPackageAndSendMessage)
+                {
+                    if (requiresConfirmation)
+                    {
+                        Logger.Log(loRaDevice.DevEUI, $"too late for down message ({timeWatcher.GetElapsedTime()}), sending only ACK to gateway", LogLevel.Information);
+                    }
+
+                    return new LoRaDeviceRequestProcessResult(loRaDevice, request);
+                }
+
+                // If it is confirmed and
+                // - Downlink is disabled for the device or
+                // - we don't have time to check c2d and send to device we return now
+                if (requiresConfirmation && (!loRaDevice.DownlinkEnabled || timeToSecondWindow.Subtract(LoRaOperationTimeWatcher.ExpectedTimeToPackageAndSendMessage) <= LoRaOperationTimeWatcher.MinimumAvailableTimeToCheckForCloudMessage))
+                {
+                    var downlinkMessage = this.CreateDownlinkMessage(
+                        null,
+                        request,
+                        loRaDevice,
+                        timeWatcher,
+                        false, // fpending
+                        (ushort)fcntDown);
+
+                    if (downlinkMessage != null)
+                    {
+                        _ = request.PacketForwarder.SendDownstreamAsync(downlinkMessage);
+                    }
+
+                    return new LoRaDeviceRequestProcessResult(loRaDevice, request, downlinkMessage);
+                }
+
+                // Flag indicating if there is another C2D message waiting
+                var fpending = false;
+
+                // Contains the Cloud to message we need to send
+                Message cloudToDeviceMessage = null;
+
+                if (loRaDevice.DownlinkEnabled)
+                {
+                    // ReceiveAsync has a longer timeout
+                    // But we wait less that the timeout (available time before 2nd window)
+                    // if message is received after timeout, keep it in loraDeviceInfo and return the next call
+                    var timeAvailableToCheckCloudToDeviceMessages = timeWatcher.GetAvailableTimeToCheckCloudToDeviceMessage(loRaDevice);
+                    if (timeAvailableToCheckCloudToDeviceMessages >= LoRaOperationTimeWatcher.MinimumAvailableTimeToCheckForCloudMessage)
+                    {
+                        cloudToDeviceMessage = await loRaDevice.ReceiveCloudToDeviceAsync(timeAvailableToCheckCloudToDeviceMessages);
+                        if (cloudToDeviceMessage != null && !this.ValidateCloudToDeviceMessage(loRaDevice, cloudToDeviceMessage))
+                        {
+                            _ = loRaDevice.CompleteCloudToDeviceMessageAsync(cloudToDeviceMessage);
+                            cloudToDeviceMessage = null;
+                        }
+
+                        if (cloudToDeviceMessage != null)
+                        {
+                            if (!requiresConfirmation)
+                            {
+                                // The message coming from the device was not confirmed, therefore we did not computed the frame count down
+                                // Now we need to increment because there is a C2D message to be sent
+                                fcntDown = await frameCounterStrategy.NextFcntDown(loRaDevice, payloadFcnt);
+
+                                if (fcntDown == 0)
+                                {
+                                    // We did not get a valid frame count down, therefore we should not process the message
+                                    _ = loRaDevice.AbandonCloudToDeviceMessageAsync(cloudToDeviceMessage);
+
+                                    cloudToDeviceMessage = null;
+                                }
+                                else
+                                {
+                                    requiresConfirmation = true;
+                                }
+
+                                Logger.Log(loRaDevice.DevEUI, $"down frame counter: {loRaDevice.FCntDown}", LogLevel.Information);
+                            }
+
+                            // Checking again if cloudToDeviceMessage is valid because the fcntDown resolution could have failed,
+                            // causing us to drop the message
+                            if (cloudToDeviceMessage != null)
+                            {
+                                var remainingTimeForFPendingCheck = timeWatcher.GetRemainingTimeToReceiveSecondWindow(loRaDevice) - (LoRaOperationTimeWatcher.CheckForCloudMessageCallEstimatedOverhead + LoRaOperationTimeWatcher.MinimumAvailableTimeToCheckForCloudMessage);
+                                if (remainingTimeForFPendingCheck >= LoRaOperationTimeWatcher.MinimumAvailableTimeToCheckForCloudMessage)
+                                {
+                                    var additionalMsg = await loRaDevice.ReceiveCloudToDeviceAsync(LoRaOperationTimeWatcher.MinimumAvailableTimeToCheckForCloudMessage);
+                                    if (additionalMsg != null)
+                                    {
+                                        fpending = true;
+                                        _ = loRaDevice.AbandonCloudToDeviceMessageAsync(additionalMsg);
+                                        Logger.Log(loRaDevice.DevEUI, $"found fpending c2d message id: {additionalMsg.MessageId ?? "undefined"}", LogLevel.Information);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // No C2D message and request was not confirmed, return nothing
+                if (!requiresConfirmation)
+                {
+                    return new LoRaDeviceRequestProcessResult(loRaDevice, request);
+                }
+
+                var confirmDownstream = this.CreateDownlinkMessage(
+                    cloudToDeviceMessage,
+                    request,
+                    loRaDevice,
+                    timeWatcher,
+                    fpending,
+                    (ushort)fcntDown);
+
+                if (cloudToDeviceMessage != null)
+                {
+                    if (confirmDownstream == null)
+                    {
+                        Logger.Log(loRaDevice.DevEUI, $"out of time for downstream message, will abandon c2d message id: {cloudToDeviceMessage.MessageId ?? "undefined"}", LogLevel.Information);
+                        _ = loRaDevice.AbandonCloudToDeviceMessageAsync(cloudToDeviceMessage);
+                    }
+                    else
+                    {
+                        _ = loRaDevice.CompleteCloudToDeviceMessageAsync(cloudToDeviceMessage);
+                    }
+                }
+
+                if (confirmDownstream != null)
+                {
+                    _ = request.PacketForwarder.SendDownstreamAsync(confirmDownstream);
+                }
+
+                return new LoRaDeviceRequestProcessResult(loRaDevice, request, confirmDownstream);
+            }
+        }
+
+        private bool ValidateCloudToDeviceMessage(LoRaDevice loRaDevice, Message cloudToDeviceMsg)
+        {
+            // ensure fport property has been set
+            if (!cloudToDeviceMsg.Properties.TryGetValueCaseInsensitive(Constants.FPORT_MSG_PROPERTY_KEY, out var fportValue))
+            {
+                Logger.Log(loRaDevice.DevEUI, $"missing {Constants.FPORT_MSG_PROPERTY_KEY} property in C2D message '{cloudToDeviceMsg.MessageId}'", LogLevel.Error);
+                return false;
+            }
+
+            if (byte.TryParse(fportValue, out var fport))
+            {
+                // ensure fport follows LoRa specification
+                // 0    => reserved for mac commands
+                // 224+ => reserved for future applications
+                if (fport != Constants.LORA_FPORT_RESERVED_MAC_MSG && fport < Constants.LORA_FPORT_RESERVED_FUTURE_START)
+                    return true;
+            }
+
+            Logger.Log(loRaDevice.DevEUI, $"invalid fport '{fportValue}' in C2D message '{cloudToDeviceMsg.MessageId}'", LogLevel.Error);
+            return false;
+        }
+
+        /// <summary>
+        /// Creates downlink message with ack for confirmation or cloud to device message
+        /// </summary>
+        private DownlinkPktFwdMessage CreateDownlinkMessage(
+            Message cloudToDeviceMessage,
+            LoRaRequest request,
+            LoRaDevice loRaDevice,
+            LoRaOperationTimeWatcher timeWatcher,
+            bool fpending,
+            ushort fcntDown)
+        {
+            var upstreamPayload = (LoRaPayloadData)request.Payload;
+            var rxpk = request.Rxpk;
+            var loraRegion = request.LoRaRegion;
+
+            // default fport
+            byte fctrl = 0;
+            if (upstreamPayload.LoRaMessageType == LoRaMessageType.ConfirmedDataUp)
+            {
+                // Confirm receiving message to device
+                fctrl = (byte)FctrlEnum.Ack;
+            }
+
+            byte? fport = null;
+            var requiresDeviceAcknowlegement = false;
+            byte[] macbytes = null;
+
+            byte[] rndToken = new byte[2];
+            Random rnd = new Random();
+            rnd.NextBytes(rndToken);
+
+            byte[] frmPayload = null;
+
+            if (cloudToDeviceMessage != null)
+            {
+                if (cloudToDeviceMessage.Properties.TryGetValueCaseInsensitive("cidtype", out var cidTypeValue))
+                {
+                    Logger.Log(loRaDevice.DevEUI, "Cloud to device MAC command received", LogLevel.Information);
+                    MacCommandHolder macCommandHolder = new MacCommandHolder(Convert.ToByte(cidTypeValue));
+                    macbytes = macCommandHolder.MacCommand[0].ToBytes();
+                }
+
+                if (cloudToDeviceMessage.Properties.TryGetValueCaseInsensitive("confirmed", out var confirmedValue) && confirmedValue.Equals("true", StringComparison.OrdinalIgnoreCase))
+                {
+                    requiresDeviceAcknowlegement = true;
+                    loRaDevice.LastConfirmedC2DMessageID = cloudToDeviceMessage.MessageId ?? Constants.C2D_MSG_ID_PLACEHOLDER;
+                }
+
+                if (cloudToDeviceMessage.Properties.TryGetValueCaseInsensitive("fport", out var fPortValue))
+                {
+                    fport = byte.Parse(fPortValue);
+                }
+
+                Logger.Log(loRaDevice.DevEUI, $"Sending a downstream message with ID {ConversionHelper.ByteArrayToString(rndToken)}", LogLevel.Debug);
+
+                frmPayload = cloudToDeviceMessage?.GetBytes();
+
+                Logger.Log(loRaDevice.DevEUI, $"C2D message: {Encoding.UTF8.GetString(frmPayload)}, id: {cloudToDeviceMessage.MessageId ?? "undefined"}, fport: {fport}, confirmed: {requiresDeviceAcknowlegement}, cidType: {cidTypeValue}", LogLevel.Information);
+
+                // cut to the max payload of lora for any EU datarate
+                if (frmPayload.Length > 51)
+                    Array.Resize(ref frmPayload, 51);
+
+                Array.Reverse(frmPayload);
+            }
+
+            if (fpending)
+            {
+                fctrl |= (int)FctrlEnum.FpendingOrClassB;
+            }
+
+            // if (macbytes != null && linkCheckCmdResponse != null)
+            //     macbytes = macbytes.Concat(linkCheckCmdResponse).ToArray();
+            var srcDevAddr = upstreamPayload.DevAddr.Span;
+            var reversedDevAddr = new byte[srcDevAddr.Length];
+            for (int i = reversedDevAddr.Length - 1; i >= 0; --i)
+            {
+                reversedDevAddr[i] = srcDevAddr[srcDevAddr.Length - (1 + i)];
+            }
+
+            var msgType = requiresDeviceAcknowlegement ? LoRaMessageType.ConfirmedDataDown : LoRaMessageType.UnconfirmedDataDown;
+            var ackLoRaMessage = new LoRaPayloadData(
+                msgType,
+                reversedDevAddr,
+                new byte[] { fctrl },
+                BitConverter.GetBytes(fcntDown),
+                macbytes,
+                fport.HasValue ? new byte[] { fport.Value } : null,
+                frmPayload,
+                1);
+
+            // var firstWindowTime = timeWatcher.GetRemainingTimeToReceiveFirstWindow(loRaDevice);
+            // if (firstWindowTime > TimeSpan.Zero)
+            //     System.Threading.Thread.Sleep(firstWindowTime);
+            var receiveWindow = timeWatcher.ResolveReceiveWindowToUse(loRaDevice);
+            if (receiveWindow == 0)
+                return null;
+
+            string datr;
+            double freq;
+            long tmst;
+            if (receiveWindow == 2)
+            {
+                tmst = rxpk.Tmst + timeWatcher.GetReceiveWindow2Delay(loRaDevice) * 1000000;
+
+                if (string.IsNullOrEmpty(this.configuration.Rx2DataRate))
+                {
+                    Logger.Log(loRaDevice.DevEUI, "using standard second receive windows", LogLevel.Information);
+                    freq = loraRegion.RX2DefaultReceiveWindows.frequency;
+                    datr = loraRegion.DRtoConfiguration[loraRegion.RX2DefaultReceiveWindows.dr].configuration;
+                }
+
+                // if specific twins are set, specify second channel to be as specified
+                else
+                {
+                    freq = this.configuration.Rx2DataFrequency;
+                    datr = this.configuration.Rx2DataRate;
+                    Logger.Log(loRaDevice.DevEUI, $"using custom DR second receive windows freq : {freq}, datr:{datr}", LogLevel.Information);
+                }
+            }
+            else
+            {
+                datr = loraRegion.GetDownstreamDR(rxpk);
+                freq = loraRegion.GetDownstreamChannelFrequency(rxpk);
+                tmst = rxpk.Tmst + timeWatcher.GetReceiveWindow1Delay(loRaDevice) * 1000000;
+            }
+
+            // todo: check the device twin preference if using confirmed or unconfirmed down
+            return ackLoRaMessage.Serialize(loRaDevice.AppSKey, loRaDevice.NwkSKey, datr, freq, tmst, loRaDevice.DevEUI);
+        }
+
+        private async Task<bool> SendDeviceEventAsync(LoRaRequest request, LoRaDevice loRaDevice, LoRaOperationTimeWatcher timeWatcher, object decodedValue)
+        {
+            var loRaPayloadData = (LoRaPayloadData)request.Payload;
+            var deviceTelemetry = new LoRaDeviceTelemetry(request.Rxpk, loRaPayloadData, decodedValue)
+            {
+                DeviceEUI = loRaDevice.DevEUI,
+                GatewayID = this.configuration.GatewayID,
+                Edgets = (long)(timeWatcher.Start - DateTime.UnixEpoch).TotalMilliseconds
+            };
+
+            Dictionary<string, string> eventProperties = null;
+            if (loRaPayloadData.IsUpwardAck())
+            {
+                eventProperties = new Dictionary<string, string>();
+                Logger.Log(loRaDevice.DevEUI, $"Message ack received for C2D message id {loRaDevice.LastConfirmedC2DMessageID}", LogLevel.Information);
+                eventProperties.Add(Constants.C2D_MSG_PROPERTY_VALUE_NAME, loRaDevice.LastConfirmedC2DMessageID ?? Constants.C2D_MSG_ID_PLACEHOLDER);
+                loRaDevice.LastConfirmedC2DMessageID = null;
+            }
+
+            var macCommand = loRaPayloadData.GetMacCommands();
+            if (macCommand.MacCommand.Count > 0)
+            {
+                eventProperties = eventProperties ?? new Dictionary<string, string>();
+
+                for (int i = 0; i < macCommand.MacCommand.Count; i++)
+                {
+                    eventProperties[macCommand.MacCommand[i].Cid.ToString()] = JsonConvert.SerializeObject(macCommand.MacCommand[i], Formatting.None);
+
+                    // in case it is a link check mac, we need to send it downstream.
+                    if (macCommand.MacCommand[i].Cid == CidEnum.LinkCheckCmd)
+                    {
+                        // linkCheckCmdResponse = new LinkCheckCmd(rxPk.GetModulationMargin(), 1).ToBytes();
+                    }
+                }
+            }
+
+            if (await loRaDevice.SendEventAsync(deviceTelemetry, eventProperties))
+            {
+                var payloadAsRaw = deviceTelemetry.Data as string;
+                if (payloadAsRaw == null && deviceTelemetry.Data != null)
+                {
+                    payloadAsRaw = JsonConvert.SerializeObject(deviceTelemetry.Data, Formatting.None);
+                }
+
+                Logger.Log(loRaDevice.DevEUI, $"message '{payloadAsRaw}' sent to hub", LogLevel.Information);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExternalGatewayLoRaRequestQueue.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExternalGatewayLoRaRequestQueue.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer
+{
+    using Microsoft.Extensions.Logging;
+
+    internal class ExternalGatewayLoRaRequestQueue : ILoRaDeviceRequestQueue
+    {
+        private readonly LoRaDevice loRaDevice;
+
+        public ExternalGatewayLoRaRequestQueue(LoRaDevice loRaDevice)
+        {
+            this.loRaDevice = loRaDevice;
+        }
+
+        public void Queue(LoRaRequest request)
+        {
+            Logger.Log(this.loRaDevice.DevEUI, $"device is not our device, ignore message", LogLevel.Debug);
+            request.NotifyFailed(this.loRaDevice, LoRaDeviceRequestFailedReason.BelongsToAnotherGateway);
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FrameCounterLoRaDeviceInitializer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FrameCounterLoRaDeviceInitializer.cs
@@ -18,11 +18,14 @@ namespace LoRaWan.NetworkServer
 
         public void Initialize(LoRaDevice loRaDevice)
         {
-            var isMultiGateway = !string.Equals(this.gatewayID, loRaDevice.GatewayID, StringComparison.InvariantCultureIgnoreCase);
-            var strategy = isMultiGateway ? this.frameCounterUpdateStrategyFactory.GetMultiGatewayStrategy() : this.frameCounterUpdateStrategyFactory.GetSingleGatewayStrategy();
-            if (strategy is ILoRaDeviceInitializer initializer)
+            if (loRaDevice.IsOurDevice)
             {
-                initializer.Initialize(loRaDevice);
+                var isMultiGateway = !string.Equals(this.gatewayID, loRaDevice.GatewayID, StringComparison.InvariantCultureIgnoreCase);
+                var strategy = isMultiGateway ? this.frameCounterUpdateStrategyFactory.GetMultiGatewayStrategy() : this.frameCounterUpdateStrategyFactory.GetSingleGatewayStrategy();
+                if (strategy is ILoRaDeviceInitializer initializer)
+                {
+                    initializer.Initialize(loRaDevice);
+                }
             }
         }
     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FrameCounterLoRaDeviceInitializer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FrameCounterLoRaDeviceInitializer.cs
@@ -20,9 +20,8 @@ namespace LoRaWan.NetworkServer
         {
             if (loRaDevice.IsOurDevice)
             {
-                var isMultiGateway = !string.Equals(this.gatewayID, loRaDevice.GatewayID, StringComparison.InvariantCultureIgnoreCase);
-                var strategy = isMultiGateway ? this.frameCounterUpdateStrategyProvider.GetMultiGatewayStrategy() : this.frameCounterUpdateStrategyProvider.GetSingleGatewayStrategy();
-                if (strategy is ILoRaDeviceInitializer initializer)
+                var strategy = this.frameCounterUpdateStrategyProvider.GetStrategy(loRaDevice.GatewayID);
+                if (strategy != null && strategy is ILoRaDeviceInitializer initializer)
                 {
                     initializer.Initialize(loRaDevice);
                 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FrameCounterLoRaDeviceInitializer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FrameCounterLoRaDeviceInitializer.cs
@@ -8,12 +8,12 @@ namespace LoRaWan.NetworkServer
     public class FrameCounterLoRaDeviceInitializer : ILoRaDeviceInitializer
     {
         private readonly string gatewayID;
-        private readonly ILoRaDeviceFrameCounterUpdateStrategyFactory frameCounterUpdateStrategyFactory;
+        private readonly ILoRaDeviceFrameCounterUpdateStrategyProvider frameCounterUpdateStrategyProvider;
 
-        public FrameCounterLoRaDeviceInitializer(string gatewayID, ILoRaDeviceFrameCounterUpdateStrategyFactory frameCounterUpdateStrategyFactory)
+        public FrameCounterLoRaDeviceInitializer(string gatewayID, ILoRaDeviceFrameCounterUpdateStrategyProvider frameCounterUpdateStrategyProvider)
         {
             this.gatewayID = gatewayID;
-            this.frameCounterUpdateStrategyFactory = frameCounterUpdateStrategyFactory;
+            this.frameCounterUpdateStrategyProvider = frameCounterUpdateStrategyProvider;
         }
 
         public void Initialize(LoRaDevice loRaDevice)
@@ -21,7 +21,7 @@ namespace LoRaWan.NetworkServer
             if (loRaDevice.IsOurDevice)
             {
                 var isMultiGateway = !string.Equals(this.gatewayID, loRaDevice.GatewayID, StringComparison.InvariantCultureIgnoreCase);
-                var strategy = isMultiGateway ? this.frameCounterUpdateStrategyFactory.GetMultiGatewayStrategy() : this.frameCounterUpdateStrategyFactory.GetSingleGatewayStrategy();
+                var strategy = isMultiGateway ? this.frameCounterUpdateStrategyProvider.GetMultiGatewayStrategy() : this.frameCounterUpdateStrategyProvider.GetSingleGatewayStrategy();
                 if (strategy is ILoRaDeviceInitializer initializer)
                 {
                     initializer.Initialize(loRaDevice);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDataRequestHandler.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer
+{
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Request handler for data requests
+    /// </summary>
+    public interface ILoRaDataRequestHandler
+    {
+        Task<LoRaDeviceRequestProcessResult> ProcessRequestAsync(LoRaRequest request, LoRaDevice loRaDevice);
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClient.cs
@@ -44,5 +44,10 @@ namespace LoRaWan.NetworkServer
         /// Abandon a cloud to device message
         /// </summary>
         Task<bool> AbandonAsync(Message cloudToDeviceMessage);
+
+        /// <summary>
+        /// Disconnects device client
+        /// </summary>
+        Task<bool> DisconnectAsync();
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceFrameCounterUpdateStrategyProvider.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceFrameCounterUpdateStrategyProvider.cs
@@ -3,7 +3,7 @@
 
 namespace LoRaWan.NetworkServer
 {
-    public interface ILoRaDeviceFrameCounterUpdateStrategyFactory
+    public interface ILoRaDeviceFrameCounterUpdateStrategyProvider
     {
         ILoRaDeviceFrameCounterUpdateStrategy GetMultiGatewayStrategy();
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceFrameCounterUpdateStrategyProvider.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceFrameCounterUpdateStrategyProvider.cs
@@ -5,8 +5,6 @@ namespace LoRaWan.NetworkServer
 {
     public interface ILoRaDeviceFrameCounterUpdateStrategyProvider
     {
-        ILoRaDeviceFrameCounterUpdateStrategy GetMultiGatewayStrategy();
-
-        ILoRaDeviceFrameCounterUpdateStrategy GetSingleGatewayStrategy();
+        ILoRaDeviceFrameCounterUpdateStrategy GetStrategy(string deviceGatewayID);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceRegistry.cs
@@ -19,6 +19,7 @@ namespace LoRaWan.NetworkServer
         // In order to handle a scenario where the network server is restarted and the fcntDown was not yet saved (we save every 10)
         // If device does not have gatewayid this will be handled by the service facade function (NextFCntDown)
         // 4. if (loraDeviceInfo.IsABP() && loraDeviceInfo.GatewayID != null && loraDeviceInfo was not read from cache)  device.FcntDown += 10;
+        [Obsolete("replaced by GetLoRaRequestQueue", true)]
         Task<LoRaDevice> GetDeviceForPayloadAsync(LoRaTools.LoRaMessage.LoRaPayloadData loraPayload);
 
         /// <summary>
@@ -40,5 +41,10 @@ namespace LoRaWan.NetworkServer
         /// Resets the device cache
         /// </summary>
         void ResetDeviceCache();
+
+        /// <summary>
+        /// Gets a <see cref="ILoRaDeviceRequestQueue"/> where requests can be queued
+        /// </summary>
+        ILoRaDeviceRequestQueue GetLoRaRequestQueue(LoRaRequest request);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceRequestQueue.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceRequestQueue.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer
+{
+    using System;
+    using LoRaTools.LoRaPhysical;
+
+    /// <summary>
+    /// Defines a loRa device request queue
+    /// </summary>
+    public interface ILoRaDeviceRequestQueue
+    {
+        /// <summary>
+        /// Queues a request
+        /// </summary>
+        void Queue(LoRaRequest request);
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/IPacketForwarder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/IPacketForwarder.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer
+{
+    using System.Threading.Tasks;
+    using LoRaTools.LoRaPhysical;
+
+    // Packet forwarder
+    public interface IPacketForwarder
+    {
+        /// <summary>
+        /// Send downstream message to LoRa device
+        /// </summary>
+        Task SendDownstreamAsync(DownlinkPktFwdMessage message);
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -500,7 +500,9 @@ namespace LoRaWan.NetworkServer
             }
 
             this.runningRequest = requestToStart;
-            _ = RunAndQueueNext(requestToStart);
+
+            // Ensure that this is schedule in a new thread, releasing the lock asap
+            Task.Run(() => { _ = RunAndQueueNext(requestToStart); });
         }
 
         public void Dispose()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -69,7 +69,7 @@ namespace LoRaWan.NetworkServer
 
             set
             {
-                if (value != 1 && value != 2)
+                if (value != Constants.RECEIVE_WINDOW_1 && value != Constants.RECEIVE_WINDOW_2)
                     throw new ArgumentOutOfRangeException(nameof(this.PreferredWindow), value, $"{nameof(this.PreferredWindow)} must bet 1 or 2");
 
                 this.preferredWindow = value;
@@ -192,7 +192,7 @@ namespace LoRaWan.NetworkServer
                 if (twin.Properties.Desired.Contains(TwinProperty.PreferredWindow))
                 {
                     var preferredWindowTwinValue = this.GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.PreferredWindow].Value);
-                    if (preferredWindowTwinValue == 2)
+                    if (preferredWindowTwinValue == Constants.RECEIVE_WINDOW_2)
                         this.PreferredWindow = preferredWindowTwinValue;
                 }
 
@@ -450,7 +450,7 @@ namespace LoRaWan.NetworkServer
             }
         }
 
-        private void QueueNext()
+        private void ProcessNext()
         {
             // Access to runningRequest and queuedRequests must be
             // thread safe
@@ -482,7 +482,7 @@ namespace LoRaWan.NetworkServer
                 }
                 finally
                 {
-                    this.QueueNext();
+                    this.ProcessNext();
                 }
 
                 if (processingError != null)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -8,8 +8,9 @@ namespace LoRaWan.NetworkServer
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Logging;
 
-    public sealed class LoRaDevice : IDisposable
+    public sealed class LoRaDevice : IDisposable, ILoRaDeviceRequestQueue
     {
         /// <summary>
         /// Defines the maximum amount of times an ack resubmit will be sent
@@ -76,10 +77,13 @@ namespace LoRaWan.NetworkServer
         }
 
         readonly object fcntLock;
+        readonly Queue<LoRaRequest> queuedRequests;
         volatile bool hasFrameCountChanges;
         byte confirmationResubmitCount = 0;
         volatile int fcntUp;
         volatile int fcntDown;
+        volatile LoRaRequest runningRequest;
+        private ILoRaDataRequestHandler dataRequestHandler;
 
         /// <summary>
         ///  Gets or sets a value indicating whether cloud to device messages are enabled for the device
@@ -98,6 +102,7 @@ namespace LoRaWan.NetworkServer
             this.hasFrameCountChanges = false;
             this.fcntLock = new object();
             this.confirmationResubmitCount = 0;
+            this.queuedRequests = new Queue<LoRaRequest>();
         }
 
         /// <summary>
@@ -361,6 +366,11 @@ namespace LoRaWan.NetworkServer
         }
 
         /// <summary>
+        /// Disconnects device from IoT Hub
+        /// </summary>
+        public Task<bool> DisconnectAsync() => this.loRaDeviceClient.DisconnectAsync();
+
+        /// <summary>
         /// Indicates whether or not we can resubmit an ack for the confirmation up message
         /// </summary>
         /// <returns><c>true</c>, if resubmit is allowed, <c>false</c> otherwise.</returns>
@@ -419,6 +429,78 @@ namespace LoRaWan.NetworkServer
             }
 
             return succeeded;
+        }
+
+        internal void SetRequestHandler(ILoRaDataRequestHandler dataRequestHandler) => this.dataRequestHandler = dataRequestHandler;
+
+        public void Queue(LoRaRequest request)
+        {
+            // Access to runningRequest and queuedRequests must be
+            // thread safe
+            lock (this)
+            {
+                if (this.runningRequest == null)
+                {
+                    this.StartNextRequest(request);
+                }
+                else
+                {
+                    this.queuedRequests.Enqueue(request);
+                }
+            }
+        }
+
+        private void QueueNext()
+        {
+            // Access to runningRequest and queuedRequests must be
+            // thread safe
+            lock (this)
+            {
+                this.runningRequest = null;
+                if (this.queuedRequests.TryDequeue(out var nextRequest))
+                {
+                    this.StartNextRequest(nextRequest);
+                }
+            }
+        }
+
+        void StartNextRequest(LoRaRequest requestToStart)
+        {
+            async Task RunAndQueueNext(LoRaRequest request)
+            {
+                LoRaDeviceRequestProcessResult result = null;
+                Exception processingError = null;
+
+                try
+                {
+                    result = await this.dataRequestHandler.ProcessRequestAsync(request, this);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log(this.DevEUI, $"Error processing request: {ex.Message}", LogLevel.Error);
+                    processingError = ex;
+                }
+                finally
+                {
+                    this.QueueNext();
+                }
+
+                if (processingError != null)
+                {
+                    request.NotifyFailed(this, processingError);
+                }
+                else if (result.FailedReason.HasValue)
+                {
+                    request.NotifyFailed(this, result.FailedReason.Value);
+                }
+                else
+                {
+                    request.NotifySucceeded(this, result?.DownlinkMessage);
+                }
+            }
+
+            this.runningRequest = requestToStart;
+            _ = RunAndQueueNext(requestToStart);
         }
 
         public void Dispose()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
@@ -262,7 +262,7 @@ namespace LoRaWan.NetworkServer
                 await this.deviceClient.CloseAsync();
                 this.deviceClient = null;
 
-                Logger.Log(this.devEUI, $"device client disconnected", LogLevel.Debug);
+                Logger.Log(this.devEUI, "device client disconnected", LogLevel.Debug);
 
                 return true;
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
@@ -252,6 +252,27 @@ namespace LoRaWan.NetworkServer
             }
         }
 
+        /// <summary>
+        /// Disconnects device client
+        /// </summary>
+        public async Task<bool> DisconnectAsync()
+        {
+            try
+            {
+                await this.deviceClient.CloseAsync();
+                this.deviceClient = null;
+
+                Logger.Log(this.devEUI, $"device client disconnected", LogLevel.Debug);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(this.devEUI, $"could not disconnect device client with error: {ex.Message}", LogLevel.Error);
+                return false;
+            }
+        }
+
         public void Dispose()
         {
             this.deviceClient.Dispose();

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
@@ -11,10 +11,12 @@ namespace LoRaWan.NetworkServer
     public class LoRaDeviceFactory : ILoRaDeviceFactory
     {
         private readonly NetworkServerConfiguration configuration;
+        private readonly DefaultLoRaDataRequestHandler dataRequestHandler;
 
-        public LoRaDeviceFactory(NetworkServerConfiguration configuration)
+        public LoRaDeviceFactory(NetworkServerConfiguration configuration, DefaultLoRaDataRequestHandler dataRequestHandler)
         {
             this.configuration = configuration;
+            this.dataRequestHandler = dataRequestHandler;
         }
 
         public LoRaDevice Create(IoTHubDeviceInfo deviceInfo)
@@ -25,6 +27,9 @@ namespace LoRaWan.NetworkServer
                 devAddr: deviceInfo.DevAddr,
                 devEUI: deviceInfo.DevEUI,
                 loRaDeviceClient: loraDeviceClient);
+
+            if (this.dataRequestHandler != null)
+                loRaDevice.SetRequestHandler(this.dataRequestHandler);
 
             return loRaDevice;
         }
@@ -63,14 +68,14 @@ namespace LoRaWan.NetworkServer
                 // Enabling AMQP multiplexing
                 var transportSettings = new ITransportSettings[]
                 {
-                new AmqpTransportSettings(TransportType.Amqp_Tcp_Only)
-                {
-                    AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings()
+                    new AmqpTransportSettings(TransportType.Amqp_Tcp_Only)
                     {
-                        Pooling = true,
-                        MaxPoolSize = 1
+                        AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings()
+                        {
+                            Pooling = true,
+                            MaxPoolSize = 1
+                        }
                     }
-                }
                 };
 
                 var deviceClient = DeviceClient.CreateFromConnectionString(deviceConnectionStr, transportSettings);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
@@ -28,8 +28,7 @@ namespace LoRaWan.NetworkServer
                 devEUI: deviceInfo.DevEUI,
                 loRaDeviceClient: loraDeviceClient);
 
-            if (this.dataRequestHandler != null)
-                loRaDevice.SetRequestHandler(this.dataRequestHandler);
+            loRaDevice.SetRequestHandler(this.dataRequestHandler);
 
             return loRaDevice;
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFrameCounterUpdateStrategyProvider.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFrameCounterUpdateStrategyProvider.cs
@@ -3,19 +3,30 @@
 
 namespace LoRaWan.NetworkServer
 {
+    using System;
+
     public class LoRaDeviceFrameCounterUpdateStrategyProvider : ILoRaDeviceFrameCounterUpdateStrategyProvider
     {
+        private readonly string gatewayID;
         private readonly MultiGatewayFrameCounterUpdateStrategy multiGateway;
         private readonly SingleGatewayFrameCounterUpdateStrategy singleGateway;
 
         public LoRaDeviceFrameCounterUpdateStrategyProvider(string gatewayID, LoRaDeviceAPIServiceBase loRaDeviceAPIService)
         {
+            this.gatewayID = gatewayID;
             this.multiGateway = new MultiGatewayFrameCounterUpdateStrategy(gatewayID, loRaDeviceAPIService);
             this.singleGateway = new SingleGatewayFrameCounterUpdateStrategy();
         }
 
-        public ILoRaDeviceFrameCounterUpdateStrategy GetMultiGatewayStrategy() => this.multiGateway;
+        public ILoRaDeviceFrameCounterUpdateStrategy GetStrategy(string deviceGatewayID)
+        {
+            if (string.IsNullOrEmpty(deviceGatewayID))
+                return this.multiGateway;
 
-        public ILoRaDeviceFrameCounterUpdateStrategy GetSingleGatewayStrategy() => this.singleGateway;
+            if (string.Equals(this.gatewayID, deviceGatewayID, StringComparison.InvariantCultureIgnoreCase))
+                return this.singleGateway;
+
+            return null;
+        }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFrameCounterUpdateStrategyProvider.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFrameCounterUpdateStrategyProvider.cs
@@ -3,12 +3,12 @@
 
 namespace LoRaWan.NetworkServer
 {
-    public class LoRaDeviceFrameCounterUpdateStrategyFactory : ILoRaDeviceFrameCounterUpdateStrategyFactory
+    public class LoRaDeviceFrameCounterUpdateStrategyProvider : ILoRaDeviceFrameCounterUpdateStrategyProvider
     {
         private readonly MultiGatewayFrameCounterUpdateStrategy multiGateway;
         private readonly SingleGatewayFrameCounterUpdateStrategy singleGateway;
 
-        public LoRaDeviceFrameCounterUpdateStrategyFactory(string gatewayID, LoRaDeviceAPIServiceBase loRaDeviceAPIService)
+        public LoRaDeviceFrameCounterUpdateStrategyProvider(string gatewayID, LoRaDeviceAPIServiceBase loRaDeviceAPIService)
         {
             this.multiGateway = new MultiGatewayFrameCounterUpdateStrategy(gatewayID, loRaDeviceAPIService);
             this.singleGateway = new SingleGatewayFrameCounterUpdateStrategy();

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRequestFailedReason.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRequestFailedReason.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer
+{
+    public enum LoRaDeviceRequestFailedReason
+    {
+        ApplicationError,
+        NotMatchingDeviceByDevAddr,
+        NotMatchingDeviceByMicCheck,
+        InvalidNetId,
+        InvalidRxpk,
+        InvalidRegion,
+        UnknownDevice,
+        InvalidJoinRequest,
+        HandledByAnotherGateway,
+        BelongsToAnotherGateway,
+        JoinDevNonceAlreadyUsed,
+        JoinMicCheckFailed,
+        ReceiveWindowMissed,
+        ConfirmationResubmitThresholdExceeded,
+        InvalidFrameCounter,
+        IoTHubProblem,
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRequestProcessResult.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRequestProcessResult.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer
+{
+    using LoRaTools.LoRaPhysical;
+
+    public class LoRaDeviceRequestProcessResult
+    {
+        public LoRaDeviceRequestProcessResult(LoRaDevice loRaDevice, LoRaRequest request, DownlinkPktFwdMessage downlinkMessage = null)
+        {
+            this.LoRaDevice = loRaDevice;
+            this.Request = request;
+            this.DownlinkMessage = downlinkMessage;
+        }
+
+        public LoRaDeviceRequestProcessResult(LoRaDevice loRaDevice, LoRaRequest request, LoRaDeviceRequestFailedReason failedReason)
+        {
+            this.LoRaDevice = loRaDevice;
+            this.Request = request;
+            this.FailedReason = failedReason;
+        }
+
+        public DownlinkPktFwdMessage DownlinkMessage { get; }
+
+        public LoRaRequest Request { get; }
+
+        public LoRaDevice LoRaDevice { get; }
+
+        public LoRaDeviceRequestFailedReason? FailedReason { get; }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaOperationTimeWatcher.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaOperationTimeWatcher.cs
@@ -137,16 +137,16 @@ namespace LoRaWan.NetworkServer
         public int ResolveReceiveWindowToUse(LoRaDevice loRaDevice)
         {
             var elapsed = this.GetElapsedTime();
-            if (loRaDevice.PreferredWindow == 1 && this.InTimeForReceiveFirstWindow(loRaDevice, elapsed))
+            if (loRaDevice.PreferredWindow == Constants.RECEIVE_WINDOW_1 && this.InTimeForReceiveFirstWindow(loRaDevice, elapsed))
             {
-                return 1;
+                return Constants.RECEIVE_WINDOW_1;
             }
             else if (this.InTimeForReceiveSecondWindow(loRaDevice, elapsed))
             {
-                return 2;
+                return Constants.RECEIVE_WINDOW_2;
             }
 
-            return 0;
+            return Constants.INVALID_RECEIVE_WINDOW;
         }
 
         /// <summary>
@@ -157,14 +157,14 @@ namespace LoRaWan.NetworkServer
             var elapsed = this.GetElapsedTime();
             if (this.InTimeForJoinAcceptFirstWindow(loRaDevice, elapsed))
             {
-                return 1;
+                return Constants.RECEIVE_WINDOW_1;
             }
             else if (this.InTimeForJoinAcceptSecondWindow(loRaDevice, elapsed))
             {
-                return 2;
+                return Constants.RECEIVE_WINDOW_2;
             }
 
-            return 0;
+            return Constants.INVALID_RECEIVE_WINDOW;
         }
 
         bool InTimeForJoinAcceptFirstWindow(LoRaDevice loRaDevice, TimeSpan elapsed)
@@ -185,7 +185,7 @@ namespace LoRaWan.NetworkServer
         public TimeSpan GetAvailableTimeToCheckCloudToDeviceMessage(LoRaDevice loRaDevice)
         {
             var elapsed = this.GetElapsedTime();
-            if (loRaDevice.PreferredWindow == 1)
+            if (loRaDevice.PreferredWindow == Constants.RECEIVE_WINDOW_1)
             {
                 var availableTimeForFirstWindow = TimeSpan.FromSeconds(this.GetReceiveWindow1Delay(loRaDevice)).Subtract(elapsed.Add(ExpectedTimeToPackageAndSendMessageAndCheckForCloudMessageOverhead));
                 if (availableTimeForFirstWindow >= LoRaOperationTimeWatcher.MinimumAvailableTimeToCheckForCloudMessage)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaRequest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaRequest.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer
+{
+    using System;
+    using LoRaTools.LoRaMessage;
+    using LoRaTools.LoRaPhysical;
+    using LoRaTools.Regions;
+
+    public class LoRaRequest
+    {
+        public virtual Rxpk Rxpk { get; }
+
+        public virtual LoRaPayload Payload { get; private set; }
+
+        public virtual IPacketForwarder PacketForwarder { get; }
+
+        public virtual DateTime StartTime { get; }
+
+        public virtual Region LoRaRegion { get; private set; }
+
+        protected LoRaRequest()
+        {
+        }
+
+        protected LoRaRequest(LoRaPayload payload)
+        {
+            this.Payload = payload;
+        }
+
+        public LoRaRequest(
+            Rxpk rxpk,
+            IPacketForwarder packetForwarder,
+            DateTime startTime)
+        {
+            this.Rxpk = rxpk;
+            this.PacketForwarder = packetForwarder;
+            this.StartTime = startTime;
+        }
+
+        internal void NotifyFailed(LoRaDevice loRaDevice, Exception error) => this.NotifyFailed(loRaDevice, LoRaDeviceRequestFailedReason.ApplicationError, error);
+
+        public virtual void NotifyFailed(LoRaDevice loRaDevice, LoRaDeviceRequestFailedReason reason, Exception exception = null)
+        {
+        }
+
+        public virtual void NotifySucceeded(LoRaDevice loRaDevice, DownlinkPktFwdMessage downlink)
+        {
+        }
+
+        internal void SetPayload(LoRaPayload loRaPayload) => this.Payload = loRaPayload;
+
+        internal void SetRegion(Region loRaRegion) => this.LoRaRegion = loRaRegion;
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoggingLoRaRequest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoggingLoRaRequest.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer
+{
+    using System;
+    using LoRaTools.LoRaMessage;
+    using LoRaTools.LoRaPhysical;
+    using LoRaTools.Regions;
+    using LoRaTools.Utils;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// Composition of a <see cref="LoRaRequest"/> that logs at the end of the process
+    /// </summary>
+    public class LoggingLoRaRequest : LoRaRequest
+    {
+        private readonly LoRaRequest wrappedRequest;
+
+        public override IPacketForwarder PacketForwarder => this.wrappedRequest.PacketForwarder;
+
+        public override Region LoRaRegion => this.wrappedRequest.LoRaRegion;
+
+        public override LoRaPayload Payload => this.wrappedRequest.Payload;
+
+        public override Rxpk Rxpk => this.wrappedRequest.Rxpk;
+
+        public override DateTime StartTime => this.wrappedRequest.StartTime;
+
+        public LoggingLoRaRequest(LoRaRequest wrappedRequest)
+        {
+            this.wrappedRequest = wrappedRequest;
+        }
+
+        public override void NotifyFailed(LoRaDevice loRaDevice, LoRaDeviceRequestFailedReason reason, Exception exception = null)
+        {
+            this.wrappedRequest.NotifyFailed(loRaDevice, reason, exception);
+            this.LogProcessingTime(loRaDevice);
+        }
+
+        public override void NotifySucceeded(LoRaDevice loRaDevice, DownlinkPktFwdMessage downlink)
+        {
+            this.wrappedRequest.NotifySucceeded(loRaDevice, downlink);
+            this.LogProcessingTime(loRaDevice);
+        }
+
+        private void LogProcessingTime(LoRaDevice loRaDevice)
+        {
+            var deviceId = loRaDevice?.DevEUI ?? ConversionHelper.ByteArrayToString(this.wrappedRequest.Payload.DevAddr);
+            Logger.Log(deviceId, $"processing time: {DateTime.UtcNow.Subtract(this.wrappedRequest.StartTime)}", LogLevel.Information);
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
@@ -1,0 +1,315 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading.Tasks;
+    using LoRaTools;
+    using LoRaTools.LoRaMessage;
+    using LoRaTools.LoRaPhysical;
+    using LoRaTools.Regions;
+    using LoRaTools.Utils;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Message dispatcher
+    /// </summary>
+    public class MessageDispatcher
+    {
+        // Defines Cloud to device message property containing fport value
+        internal const string FPORT_MSG_PROPERTY_KEY = "fport";
+
+        // Fport value reserved for mac commands
+        const byte LORA_FPORT_RESERVED_MAC_MSG = 0;
+
+        // Starting Fport value reserved for future applications
+        const byte LORA_FPORT_RESERVED_FUTURE_START = 224;
+
+        // Default value of a C2D message id if missing from the message
+        internal const string C2D_MSG_ID_PLACEHOLDER = "ConfirmationC2DMessageWithNoId";
+
+        // Name of the upstream message property reporint a confirmed message
+        internal const string C2D_MSG_PROPERTY_VALUE_NAME = "C2DMsgConfirmed";
+
+        private readonly NetworkServerConfiguration configuration;
+        private readonly ILoRaDeviceRegistry deviceRegistry;
+        private readonly ILoRaDeviceFrameCounterUpdateStrategyFactory frameCounterUpdateStrategyFactory;
+        private volatile Region loraRegion;
+
+        public MessageDispatcher(
+            NetworkServerConfiguration configuration,
+            ILoRaDeviceRegistry deviceRegistry,
+            ILoRaDeviceFrameCounterUpdateStrategyFactory frameCounterUpdateStrategyFactory)
+        {
+            this.configuration = configuration;
+            this.deviceRegistry = deviceRegistry;
+            this.frameCounterUpdateStrategyFactory = frameCounterUpdateStrategyFactory;
+
+            // Register frame counter initializer
+            // It will take care of seeding ABP devices created here for single gateway scenarios
+            this.deviceRegistry.RegisterDeviceInitializer(new FrameCounterLoRaDeviceInitializer(configuration.GatewayID, frameCounterUpdateStrategyFactory));
+        }
+
+        /// <summary>
+        /// Dispatches a request
+        /// </summary>
+        public void DispatchRequest(LoRaRequest request)
+        {
+            if (!LoRaPayload.TryCreateLoRaPayload(request.Rxpk, out LoRaPayload loRaPayload))
+            {
+                Logger.Log("There was a problem in decoding the Rxpk", LogLevel.Error);
+                request.NotifyFailed(null, LoRaDeviceRequestFailedReason.InvalidRxpk);
+                return;
+            }
+
+            if (this.loraRegion == null)
+            {
+                if (!RegionFactory.TryResolveRegion(request.Rxpk))
+                {
+                    // log is generated in Region factory
+                    // move here once V2 goes GA
+                    request.NotifyFailed(null, LoRaDeviceRequestFailedReason.InvalidRegion);
+                    return;
+                }
+
+                this.loraRegion = RegionFactory.CurrentRegion;
+            }
+
+            request.SetPayload(loRaPayload);
+            request.SetRegion(this.loraRegion);
+
+            var loggingRequest = new LoggingLoRaRequest(request);
+
+            if (loRaPayload.LoRaMessageType == LoRaMessageType.JoinRequest)
+            {
+                _ = this.ProcessJoinRequestAsync(loggingRequest);
+            }
+            else if (loRaPayload.LoRaMessageType == LoRaMessageType.UnconfirmedDataUp || loRaPayload.LoRaMessageType == LoRaMessageType.ConfirmedDataUp)
+            {
+                this.DispatchLoRaDataMessage(loggingRequest);
+            }
+            else
+            {
+                Logger.Log("Unknwon message type in rxpk, message ignored", LogLevel.Error);
+            }
+        }
+
+        void DispatchLoRaDataMessage(LoRaRequest request)
+        {
+            var loRaPayload = (LoRaPayloadData)request.Payload;
+            if (!this.IsValidNetId(loRaPayload.GetDevAddrNetID(), this.configuration.NetId))
+            {
+                Logger.Log(ConversionHelper.ByteArrayToString(loRaPayload.DevAddr), $"device is using another network id, ignoring this message (network: {this.configuration.NetId}, devAddr: {loRaPayload.GetDevAddrNetID()})", LogLevel.Debug);
+                request.NotifyFailed(null, LoRaDeviceRequestFailedReason.InvalidNetId);
+                return;
+            }
+
+            this.deviceRegistry.GetLoRaRequestQueue(request).Queue(request);
+        }
+
+        bool IsValidNetId(byte devAddrNwkid, uint netId)
+        {
+            var netIdBytes = BitConverter.GetBytes(netId);
+            devAddrNwkid = (byte)(devAddrNwkid >> 1);
+            return devAddrNwkid == (netIdBytes[0] & 0b01111111);
+        }
+
+        /// <summary>
+        /// Process OTAA join request
+        /// </summary>
+        async Task ProcessJoinRequestAsync(LoRaRequest request)
+        {
+            LoRaDevice loRaDevice = null;
+            string devEUI = null;
+
+            try
+            {
+                var timeWatcher = new LoRaOperationTimeWatcher(this.loraRegion, request.StartTime);
+
+                var joinReq = (LoRaPayloadJoinRequest)request.Payload;
+                byte[] udpMsgForPktForwarder = new byte[0];
+
+                devEUI = joinReq.GetDevEUIAsString();
+                var appEUI = joinReq.GetAppEUIAsString();
+
+                var devNonce = joinReq.GetDevNonceAsString();
+                Logger.Log(devEUI, $"join request received", LogLevel.Information);
+
+                loRaDevice = await this.deviceRegistry.GetDeviceForJoinRequestAsync(devEUI, appEUI, devNonce);
+                if (loRaDevice == null)
+                {
+                    request.NotifyFailed(null, LoRaDeviceRequestFailedReason.UnknownDevice);
+                    return;
+                }
+
+                if (string.IsNullOrEmpty(loRaDevice.AppKey))
+                {
+                    Logger.Log(loRaDevice.DevEUI, "join refused: missing AppKey for OTAA device", LogLevel.Error);
+                    request.NotifyFailed(null, LoRaDeviceRequestFailedReason.InvalidJoinRequest);
+                    return;
+                }
+
+                if (loRaDevice.AppEUI != appEUI)
+                {
+                    Logger.Log(devEUI, "join refused: AppEUI for OTAA does not match device", LogLevel.Error);
+                    request.NotifyFailed(null, LoRaDeviceRequestFailedReason.InvalidJoinRequest);
+                    return;
+                }
+
+                if (!joinReq.CheckMic(loRaDevice.AppKey))
+                {
+                    Logger.Log(devEUI, "join refused: invalid MIC", LogLevel.Error);
+                    request.NotifyFailed(null, LoRaDeviceRequestFailedReason.JoinMicCheckFailed);
+                    return;
+                }
+
+                // Make sure that is a new request and not a replay
+                if (!string.IsNullOrEmpty(loRaDevice.DevNonce) && loRaDevice.DevNonce == devNonce)
+                {
+                    Logger.Log(devEUI, "join refused: DevNonce already used by this device", LogLevel.Information);
+                    loRaDevice.IsOurDevice = false;
+                    request.NotifyFailed(null, LoRaDeviceRequestFailedReason.JoinDevNonceAlreadyUsed);
+                    return;
+                }
+
+                // Check that the device is joining through the linked gateway and not another
+                if (!string.IsNullOrEmpty(loRaDevice.GatewayID) && !string.Equals(loRaDevice.GatewayID, this.configuration.GatewayID, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    Logger.Log(devEUI, $"join refused: trying to join not through its linked gateway, ignoring join request", LogLevel.Information);
+                    loRaDevice.IsOurDevice = false;
+                    request.NotifyFailed(null, LoRaDeviceRequestFailedReason.HandledByAnotherGateway);
+                    return;
+                }
+
+                var netIdBytes = BitConverter.GetBytes(this.configuration.NetId);
+                var netId = new byte[3]
+                {
+                    netIdBytes[0],
+                    netIdBytes[1],
+                    netIdBytes[2]
+                };
+                var appNonce = OTAAKeysGenerator.GetAppNonce();
+                var appNonceBytes = LoRaTools.Utils.ConversionHelper.StringToByteArray(appNonce);
+                var appKeyBytes = LoRaTools.Utils.ConversionHelper.StringToByteArray(loRaDevice.AppKey);
+                var appSKey = OTAAKeysGenerator.CalculateKey(new byte[1] { 0x02 }, appNonceBytes, netId, joinReq.DevNonce, appKeyBytes);
+                var nwkSKey = OTAAKeysGenerator.CalculateKey(new byte[1] { 0x01 }, appNonceBytes, netId, joinReq.DevNonce, appKeyBytes);
+                var devAddr = OTAAKeysGenerator.GetNwkId(netId);
+
+                if (!timeWatcher.InTimeForJoinAccept())
+                {
+                    // in this case it's too late, we need to break and avoid saving twins
+                    Logger.Log(devEUI, $"join refused: processing of the join request took too long, sending no message", LogLevel.Information);
+                    request.NotifyFailed(null, LoRaDeviceRequestFailedReason.ReceiveWindowMissed);
+                    return;
+                }
+
+                Logger.Log(loRaDevice.DevEUI, $"saving join properties twins", LogLevel.Debug);
+                var deviceUpdateSucceeded = await loRaDevice.UpdateAfterJoinAsync(devAddr, nwkSKey, appSKey, appNonce, devNonce, LoRaTools.Utils.ConversionHelper.ByteArrayToString(netId));
+                Logger.Log(loRaDevice.DevEUI, $"done saving join properties twins", LogLevel.Debug);
+
+                if (!deviceUpdateSucceeded)
+                {
+                    Logger.Log(devEUI, $"join refused: join request could not save twins", LogLevel.Error);
+                    request.NotifyFailed(null, LoRaDeviceRequestFailedReason.ApplicationError);
+                    return;
+                }
+
+                var windowToUse = timeWatcher.ResolveJoinAcceptWindowToUse(loRaDevice);
+                if (windowToUse == 0)
+                {
+                    Logger.Log(devEUI, $"join refused: processing of the join request took too long, sending no message", LogLevel.Information);
+                    request.NotifyFailed(null, LoRaDeviceRequestFailedReason.ReceiveWindowMissed);
+                    return;
+                }
+
+                double freq = 0;
+                string datr = null;
+                uint tmst = 0;
+                if (windowToUse == 1)
+                {
+                    datr = this.loraRegion.GetDownstreamDR(request.Rxpk);
+                    freq = this.loraRegion.GetDownstreamChannelFrequency(request.Rxpk);
+
+                    // set tmst for the normal case
+                    tmst = request.Rxpk.Tmst + this.loraRegion.Join_accept_delay1 * 1000000;
+                }
+                else
+                {
+                    Logger.Log(devEUI, $"processing of the join request took too long, using second join accept receive window", LogLevel.Information);
+                    tmst = request.Rxpk.Tmst + this.loraRegion.Join_accept_delay2 * 1000000;
+                    if (string.IsNullOrEmpty(this.configuration.Rx2DataRate))
+                    {
+                        Logger.Log(devEUI, $"using standard second receive windows for join request", LogLevel.Information);
+                        // using EU fix DR for RX2
+                        freq = this.loraRegion.RX2DefaultReceiveWindows.frequency;
+                        datr = this.loraRegion.DRtoConfiguration[RegionFactory.CurrentRegion.RX2DefaultReceiveWindows.dr].configuration;
+                    }
+                    else
+                    {
+                        Logger.Log(devEUI, $"using custom  second receive windows for join request", LogLevel.Information);
+                        freq = this.configuration.Rx2DataFrequency;
+                        datr = this.configuration.Rx2DataRate;
+                    }
+                }
+
+                loRaDevice.IsOurDevice = true;
+                this.deviceRegistry.UpdateDeviceAfterJoin(loRaDevice);
+
+                // Build join accept downlink message
+                Array.Reverse(netId);
+                Array.Reverse(appNonceBytes);
+
+                var joinAccept = this.CreateJoinAcceptDownlinkMessage(
+                    netId,
+                    loRaDevice.AppKey,
+                    devAddr,
+                    appNonceBytes,
+                    datr,
+                    freq,
+                    tmst,
+                    devEUI);
+
+                if (joinAccept != null)
+                {
+                    _ = request.PacketForwarder.SendDownstreamAsync(joinAccept);
+                    request.NotifySucceeded(loRaDevice, joinAccept);
+                }
+            }
+            catch (Exception ex)
+            {
+                var deviceId = devEUI ?? ConversionHelper.ByteArrayToString(request.Payload.DevAddr);
+                Logger.Log(deviceId, $"Failed to handle join request. {ex.Message}", LogLevel.Error);
+                request.NotifyFailed(loRaDevice, ex);
+            }
+        }
+
+        /// <summary>
+        /// Creates downlink message for join accept
+        /// </summary>
+        DownlinkPktFwdMessage CreateJoinAcceptDownlinkMessage(
+            ReadOnlyMemory<byte> netId,
+            string appKey,
+            string devAddr,
+            ReadOnlyMemory<byte> appNonce,
+            string datr,
+            double freq,
+            long tmst,
+            string devEUI)
+        {
+            var loRaPayloadJoinAccept = new LoRaTools.LoRaMessage.LoRaPayloadJoinAccept(
+                LoRaTools.Utils.ConversionHelper.ByteArrayToString(netId), // NETID 0 / 1 is default test
+                ConversionHelper.StringToByteArray(devAddr), // todo add device address management
+                appNonce.ToArray(),
+                new byte[] { 0 },
+                new byte[] { 0 },
+                null);
+
+            return loRaPayloadJoinAccept.Serialize(appKey, datr, freq, tmst, devEUI);
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
@@ -19,6 +19,7 @@ namespace LoRaWan.NetworkServer
     /// <summary>
     /// Message processor
     /// </summary>
+    [Obsolete("replaced by MessageDispatcher", true)]
     public class MessageProcessor
     {
         // Defines Cloud to device message property containing fport value

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
@@ -39,24 +39,24 @@ namespace LoRaWan.NetworkServer
 
         private readonly NetworkServerConfiguration configuration;
         private readonly ILoRaDeviceRegistry deviceRegistry;
-        private readonly ILoRaDeviceFrameCounterUpdateStrategyFactory frameCounterUpdateStrategyFactory;
+        private readonly ILoRaDeviceFrameCounterUpdateStrategyProvider frameCounterUpdateStrategyProvider;
         private readonly ILoRaPayloadDecoder payloadDecoder;
         private volatile Region loraRegion;
 
         public MessageProcessor(
             NetworkServerConfiguration configuration,
             ILoRaDeviceRegistry deviceRegistry,
-            ILoRaDeviceFrameCounterUpdateStrategyFactory frameCounterUpdateStrategyFactory,
+            ILoRaDeviceFrameCounterUpdateStrategyProvider frameCounterUpdateStrategyProvider,
             ILoRaPayloadDecoder payloadDecoder)
         {
             this.configuration = configuration;
             this.deviceRegistry = deviceRegistry;
-            this.frameCounterUpdateStrategyFactory = frameCounterUpdateStrategyFactory;
+            this.frameCounterUpdateStrategyProvider = frameCounterUpdateStrategyProvider;
             this.payloadDecoder = payloadDecoder;
 
             // Register frame counter initializer
             // It will take care of seeding ABP devices created here for single gateway scenarios
-            this.deviceRegistry.RegisterDeviceInitializer(new FrameCounterLoRaDeviceInitializer(configuration.GatewayID, frameCounterUpdateStrategyFactory));
+            this.deviceRegistry.RegisterDeviceInitializer(new FrameCounterLoRaDeviceInitializer(configuration.GatewayID, frameCounterUpdateStrategyProvider));
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace LoRaWan.NetworkServer
                 processLogger.SetDevEUI(loRaDevice.DevEUI);
 
                 var isMultiGateway = !string.Equals(loRaDevice.GatewayID, this.configuration.GatewayID, StringComparison.InvariantCultureIgnoreCase);
-                var frameCounterStrategy = isMultiGateway ? this.frameCounterUpdateStrategyFactory.GetMultiGatewayStrategy() : this.frameCounterUpdateStrategyFactory.GetSingleGatewayStrategy();
+                var frameCounterStrategy = isMultiGateway ? this.frameCounterUpdateStrategyProvider.GetMultiGatewayStrategy() : this.frameCounterUpdateStrategyProvider.GetSingleGatewayStrategy();
 
                 var payloadFcnt = loraPayload.GetFcnt();
                 var requiresConfirmation = loraPayload.IsConfirmed();
@@ -484,13 +484,13 @@ namespace LoRaWan.NetworkServer
             // if (firstWindowTime > TimeSpan.Zero)
             //     System.Threading.Thread.Sleep(firstWindowTime);
             var receiveWindow = timeWatcher.ResolveReceiveWindowToUse(loRaDevice);
-            if (receiveWindow == 0)
+            if (receiveWindow == Constants.INVALID_RECEIVE_WINDOW)
                 return null;
 
             string datr = null;
             double freq = 0;
             long tmst = 0;
-            if (receiveWindow == 2)
+            if (receiveWindow == Constants.RECEIVE_WINDOW_2)
             {
                 tmst = rxpk.Tmst + timeWatcher.GetReceiveWindow2Delay(loRaDevice) * 1000000;
 
@@ -706,7 +706,7 @@ namespace LoRaWan.NetworkServer
                 double freq = 0;
                 string datr = null;
                 uint tmst = 0;
-                if (windowToUse == 1)
+                if (windowToUse == Constants.RECEIVE_WINDOW_1)
                 {
                     try
                     {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageProcessor.cs
@@ -136,8 +136,7 @@ namespace LoRaWan.NetworkServer
                 // Add context to logger
                 processLogger.SetDevEUI(loRaDevice.DevEUI);
 
-                var isMultiGateway = !string.Equals(loRaDevice.GatewayID, this.configuration.GatewayID, StringComparison.InvariantCultureIgnoreCase);
-                var frameCounterStrategy = isMultiGateway ? this.frameCounterUpdateStrategyProvider.GetMultiGatewayStrategy() : this.frameCounterUpdateStrategyProvider.GetSingleGatewayStrategy();
+                var frameCounterStrategy = this.frameCounterUpdateStrategyProvider.GetStrategy(loRaDevice.GatewayID);
 
                 var payloadFcnt = loraPayload.GetFcnt();
                 var requiresConfirmation = loraPayload.IsConfirmed();

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
@@ -69,18 +69,18 @@ namespace LoRaWan.NetworkServer
 
 #if USING_MSG_DISPATCHER
             var loRaDeviceAPIService = new LoRaDeviceAPIService(configuration, new ServiceFacadeHttpClientProvider(configuration, ApiVersion.LatestVersion));
-            var frameCounterStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(configuration.GatewayID, loRaDeviceAPIService);
-            var dataHandlerImplementation = new DefaultLoRaDataRequestHandler(configuration, frameCounterStrategyFactory, new LoRaPayloadDecoder());
+            var frameCounterStrategyProvider = new LoRaDeviceFrameCounterUpdateStrategyProvider(configuration.GatewayID, loRaDeviceAPIService);
+            var dataHandlerImplementation = new DefaultLoRaDataRequestHandler(configuration, frameCounterStrategyProvider, new LoRaPayloadDecoder());
             var loRaDeviceFactory = new LoRaDeviceFactory(configuration, dataHandlerImplementation);
             var loRaDeviceRegistry = new LoRaDeviceRegistry(configuration, new MemoryCache(new MemoryCacheOptions()), loRaDeviceAPIService, loRaDeviceFactory);
-            var messageDispatcher = new MessageDispatcher(configuration, loRaDeviceRegistry, frameCounterStrategyFactory);
+            var messageDispatcher = new MessageDispatcher(configuration, loRaDeviceRegistry, frameCounterStrategyProvider);
             return new UdpServer(configuration, messageDispatcher, loRaDeviceAPIService, loRaDeviceRegistry);
 #else
             var loRaDeviceFactory = new LoRaDeviceFactory(configuration, null);
             var loRaDeviceAPIService = new LoRaDeviceAPIService(configuration, new ServiceFacadeHttpClientProvider(configuration, ApiVersion.LatestVersion));
             var loRaDeviceRegistry = new LoRaDeviceRegistry(configuration, new MemoryCache(new MemoryCacheOptions()), loRaDeviceAPIService, loRaDeviceFactory);
-            var frameCounterStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(configuration.GatewayID, loRaDeviceAPIService);
-            var messageProcessor = new MessageProcessor(configuration, loRaDeviceRegistry, frameCounterStrategyFactory, new LoRaPayloadDecoder());
+            var frameCounterStrategyProvider = new LoRaDeviceFrameCounterUpdateStrategyProvider(configuration.GatewayID, loRaDeviceAPIService);
+            var messageProcessor = new MessageProcessor(configuration, loRaDeviceRegistry, frameCounterStrategyProvider, new LoRaPayloadDecoder());
 
             return new UdpServer(configuration, messageProcessor, loRaDeviceAPIService, loRaDeviceRegistry);
 #endif

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+#define USING_MSG_DISPATCHER
 namespace LoRaWan.NetworkServer
 {
     using System;
@@ -27,12 +27,16 @@ namespace LoRaWan.NetworkServer
     /// <summary>
     /// Defines udp Server communicating with packet forwarder
     /// </summary>
-    public class UdpServer : IDisposable
+    public class UdpServer : IDisposable, IPacketForwarder
     {
         const int PORT = 1680;
         private readonly NetworkServerConfiguration configuration;
 
+#if USING_MSG_DISPATCHER
+        private readonly MessageDispatcher messageDispatcher;
+#else
         private readonly MessageProcessor messageProcessor;
+#endif
         private readonly LoRaDeviceAPIServiceBase loRaDeviceAPIService;
         private readonly ILoRaDeviceRegistry loRaDeviceRegistry;
         readonly SemaphoreSlim randomLock = new SemaphoreSlim(1);
@@ -40,6 +44,7 @@ namespace LoRaWan.NetworkServer
 
         ModuleClient ioTHubModuleClient;
         private volatile int pullAckRemoteLoRaAggregatorPort = 0;
+        private volatile string pullAckRemoteLoRaAddress = null;
         UdpClient udpClient;
 
         private async Task<byte[]> GetTokenAsync()
@@ -62,15 +67,70 @@ namespace LoRaWan.NetworkServer
         {
             var configuration = NetworkServerConfiguration.CreateFromEnviromentVariables();
 
-            var loRaDeviceFactory = new LoRaDeviceFactory(configuration);
+#if USING_MSG_DISPATCHER
+            var loRaDeviceAPIService = new LoRaDeviceAPIService(configuration, new ServiceFacadeHttpClientProvider(configuration, ApiVersion.LatestVersion));
+            var frameCounterStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(configuration.GatewayID, loRaDeviceAPIService);
+            var dataHandlerImplementation = new DefaultLoRaDataRequestHandler(configuration, frameCounterStrategyFactory, new LoRaPayloadDecoder());
+            var loRaDeviceFactory = new LoRaDeviceFactory(configuration, dataHandlerImplementation);
+            var loRaDeviceRegistry = new LoRaDeviceRegistry(configuration, new MemoryCache(new MemoryCacheOptions()), loRaDeviceAPIService, loRaDeviceFactory);
+            var messageDispatcher = new MessageDispatcher(configuration, loRaDeviceRegistry, frameCounterStrategyFactory);
+            return new UdpServer(configuration, messageDispatcher, loRaDeviceAPIService, loRaDeviceRegistry);
+#else
+            var loRaDeviceFactory = new LoRaDeviceFactory(configuration, null);
             var loRaDeviceAPIService = new LoRaDeviceAPIService(configuration, new ServiceFacadeHttpClientProvider(configuration, ApiVersion.LatestVersion));
             var loRaDeviceRegistry = new LoRaDeviceRegistry(configuration, new MemoryCache(new MemoryCacheOptions()), loRaDeviceAPIService, loRaDeviceFactory);
             var frameCounterStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(configuration.GatewayID, loRaDeviceAPIService);
             var messageProcessor = new MessageProcessor(configuration, loRaDeviceRegistry, frameCounterStrategyFactory, new LoRaPayloadDecoder());
+
             return new UdpServer(configuration, messageProcessor, loRaDeviceAPIService, loRaDeviceRegistry);
+#endif
         }
 
+#if USING_MSG_DISPATCHER
         // Creates a new instance of UdpServer
+        public UdpServer(
+            NetworkServerConfiguration configuration,
+            MessageDispatcher messageDispatcher,
+            LoRaDeviceAPIServiceBase loRaDeviceAPIService,
+            ILoRaDeviceRegistry loRaDeviceRegistry)
+        {
+            this.configuration = configuration;
+            this.messageDispatcher = messageDispatcher;
+            this.loRaDeviceAPIService = loRaDeviceAPIService;
+            this.loRaDeviceRegistry = loRaDeviceRegistry;
+        }
+
+        async Task IPacketForwarder.SendDownstreamAsync(DownlinkPktFwdMessage downstreamMessage)
+        {
+            try
+            {
+                if (downstreamMessage?.Txpk != null)
+                {
+                    var jsonMsg = JsonConvert.SerializeObject(downstreamMessage);
+                    var messageByte = Encoding.UTF8.GetBytes(jsonMsg);
+                    var token = await this.GetTokenAsync();
+                    PhysicalPayload pyld = new PhysicalPayload(token, PhysicalIdentifier.PULL_RESP, messageByte);
+                    if (this.pullAckRemoteLoRaAggregatorPort != 0)
+                    {
+                        await this.UdpSendMessage(pyld.GetMessage(), this.pullAckRemoteLoRaAddress, this.pullAckRemoteLoRaAggregatorPort);
+                        Logger.Log("UDP", $"message sent with ID {ConversionHelper.ByteArrayToString(token)}", LogLevel.Information);
+                    }
+                    else
+                    {
+                        Logger.Log(
+                            "UDP",
+                            "Waiting for first pull_ack message from the packet forwarder. The received message was discarded as the network server is still starting.",
+                            LogLevel.Debug);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Error processing the message {ex.Message}, {ex.StackTrace}", LogLevel.Error);
+            }
+        }
+#else
+         // Creates a new instance of UdpServer
         public UdpServer(
             NetworkServerConfiguration configuration,
             MessageProcessor messageProcessor,
@@ -82,6 +142,7 @@ namespace LoRaWan.NetworkServer
             this.loRaDeviceAPIService = loRaDeviceAPIService;
             this.loRaDeviceRegistry = loRaDeviceRegistry;
         }
+#endif
 
         public async Task RunServer()
         {
@@ -89,7 +150,11 @@ namespace LoRaWan.NetworkServer
 
             await this.InitCallBack();
 
+#if USING_MSG_DISPATCHER
+            await this.RunUdpListener_Dispatcher();
+#else
             await this.RunUdpListener();
+#endif
         }
 
         public async Task UdpSendMessage(byte[] messageToSend, string remoteLoRaAggregatorIp, int remoteLoRaAggregatorPort)
@@ -100,6 +165,86 @@ namespace LoRaWan.NetworkServer
             }
         }
 
+#if USING_MSG_DISPATCHER
+        async Task RunUdpListener_Dispatcher()
+        {
+            IPEndPoint endPoint = new IPEndPoint(IPAddress.Any, PORT);
+            this.udpClient = new UdpClient(endPoint);
+
+            Logger.LogAlways($"LoRaWAN server started on port {PORT}");
+
+            while (true)
+            {
+                UdpReceiveResult receivedResults = await this.udpClient.ReceiveAsync();
+                var startTimeProcessing = DateTime.UtcNow;
+                // Logger.LogAlways($"UDP message received ({receivedResults.Buffer[3]}) from port: {receivedResults.RemoteEndPoint.Port} and IP: {receivedResults.RemoteEndPoint.Address.ToString()}");
+                switch (PhysicalPayload.GetIdentifierFromPayload(receivedResults.Buffer))
+                {
+                    // In this case we have a keep-alive PULL_DATA packet we don't need to start the engine and can return immediately a response to the challenge
+                    case PhysicalIdentifier.PULL_DATA:
+                        if (this.pullAckRemoteLoRaAggregatorPort == 0)
+                        {
+                            this.pullAckRemoteLoRaAggregatorPort = receivedResults.RemoteEndPoint.Port;
+                            this.pullAckRemoteLoRaAddress = receivedResults.RemoteEndPoint.Address.ToString();
+                        }
+
+                        this.SendAcknowledgementMessage(receivedResults, (int)PhysicalIdentifier.PULL_ACK, receivedResults.RemoteEndPoint);
+                        break;
+
+                    // This is a PUSH_DATA (upstream message).
+                    case PhysicalIdentifier.PUSH_DATA:
+                        this.SendAcknowledgementMessage(receivedResults, (int)PhysicalIdentifier.PUSH_ACK, receivedResults.RemoteEndPoint);
+                        this.DispatchMessages(receivedResults.Buffer, startTimeProcessing);
+
+                        break;
+
+                    // This is a ack to a transmission we did previously
+                    case PhysicalIdentifier.TX_ACK:
+                        if (receivedResults.Buffer.Length == 12)
+                        {
+                            Logger.Log(
+                                "UDP",
+                                $"Packet with id {ConversionHelper.ByteArrayToString(receivedResults.Buffer.RangeSubset(1, 2))} successfully transmitted by the aggregator",
+                                LogLevel.Debug);
+                        }
+                        else
+                        {
+                            var logMsg = string.Format(
+                                    "Packet with id {0} had a problem to be transmitted over the air :{1}",
+                                    receivedResults.Buffer.Length > 2 ? ConversionHelper.ByteArrayToString(receivedResults.Buffer.RangeSubset(1, 2)) : string.Empty,
+                                    receivedResults.Buffer.Length > 12 ? Encoding.UTF8.GetString(receivedResults.Buffer.RangeSubset(12, receivedResults.Buffer.Length - 12)) : string.Empty);
+                            Logger.Log("UDP", logMsg, LogLevel.Error);
+                        }
+
+                        break;
+
+                    default:
+                        Logger.Log("UDP", "Unknown packet type or length being received", LogLevel.Error);
+                        break;
+                }
+            }
+        }
+
+        private void DispatchMessages(byte[] buffer, DateTime startTimeProcessing)
+        {
+            try
+            {
+                List<Rxpk> messageRxpks = Rxpk.CreateRxpk(buffer);
+                if (messageRxpks != null)
+                {
+                    foreach (var rxpk in messageRxpks)
+                    {
+                        this.messageDispatcher.DispatchRequest(new LoRaRequest(rxpk, this, startTimeProcessing));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("UDP", $"Failed to dispatch messages: {ex.Message}", LogLevel.Error);
+            }
+        }
+
+#else
         async Task RunUdpListener()
         {
             IPEndPoint endPoint = new IPEndPoint(IPAddress.Any, PORT);
@@ -213,7 +358,7 @@ namespace LoRaWan.NetworkServer
                 Logger.Log($"Error processing the message {ex.Message}, {ex.StackTrace}", LogLevel.Error);
             }
         }
-
+#endif
         private void SendAcknowledgementMessage(UdpReceiveResult receivedResults, byte messageType, IPEndPoint remoteEndpoint)
         {
             byte[] response = new byte[4]
@@ -285,7 +430,6 @@ namespace LoRaWan.NetworkServer
                     await this.ioTHubModuleClient.SetDesiredPropertyUpdateCallbackAsync(this.OnDesiredPropertiesUpdate, null);
 
                     await this.ioTHubModuleClient.SetMethodDefaultHandlerAsync(this.OnDirectMethodCalled, null);
-                    // await this.ioTHubModuleClient.SetMethodHandlerAsync("ClearCache", this.ClearCache, null);
                 }
 
                 // running as non edge module for test and debugging

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/ABPTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/ABPTest.cs
@@ -183,7 +183,7 @@ namespace LoRaWan.IntegrationTest
             // await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.lora.SerialLogs);
 
             // 0000000000000005: with devAddr 0028B1B0 check MIC failed. Device will be ignored from now on
-            await this.TestFixtureCi.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: with devAddr {device.DevAddr} check MIC failed");
+            await this.TestFixtureCi.AssertNetworkServerModuleLogStartsWithAsync($"{device.DevAddr}: with devAddr {device.DevAddr} check MIC failed");
 
             await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
 
@@ -195,7 +195,7 @@ namespace LoRaWan.IntegrationTest
             await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
 
             // 0000000000000005: with devAddr 0028B1B0 check MIC failed
-            await this.TestFixtureCi.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: with devAddr {device.DevAddr} check MIC failed");
+            await this.TestFixtureCi.AssertNetworkServerModuleLogStartsWithAsync($"{device.DevAddr}: with devAddr {device.DevAddr} check MIC failed");
 
             // wait until arduino stops trying to send confirmed msg
             await this.ArduinoDevice.WaitForIdleAsync();
@@ -226,7 +226,7 @@ namespace LoRaWan.IntegrationTest
             await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
 
             // 0000000000000008: with devAddr 0028B1B3 check MIC failed. Device will be ignored from now on
-            await this.TestFixtureCi.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: with devAddr {device.DevAddr} check MIC failed");
+            await this.TestFixtureCi.AssertNetworkServerModuleLogStartsWithAsync($"{device.DevAddr}: with devAddr {device.DevAddr} check MIC failed");
 
             this.TestFixtureCi.ClearLogs();
 
@@ -236,14 +236,14 @@ namespace LoRaWan.IntegrationTest
             await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
 
             // 0000000000000008: with devAddr 0028B1B3 check MIC failed.
-            await this.TestFixtureCi.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: with devAddr {device.DevAddr} check MIC failed");
+            await this.TestFixtureCi.AssertNetworkServerModuleLogStartsWithAsync($"{device.DevAddr}: with devAddr {device.DevAddr} check MIC failed");
 
             // Before starting new test, wait until Lora drivers stops sending/receiving data
             await this.ArduinoDevice.WaitForIdleAsync();
         }
 
         // Verifies that ABP confirmed and unconfirmed messages are working
-        // Uses Device5_ABP
+        // Uses Device16_ABP and Device17_ABP
         [Fact]
         public async Task Test_ABP_Device_With_Same_DevAddr()
         {

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
@@ -303,7 +303,7 @@ namespace LoRaWan.IntegrationTest
                 IsIoTHubDevice = true,
                 AppSKey = "00000000000000000000000000000017",
                 NwkSKey = "00000000000000000000000000000017",
-                DevAddr = "00000017",
+                DevAddr = this.Device16_ABP.DevAddr, // MUST match DevAddr from Device16
             };
 
             // Device18_ABP: used for C2D invalid fport testing

--- a/LoRaEngine/test/LoRaWan.Test.Shared/SimulatedDevice.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/SimulatedDevice.cs
@@ -45,7 +45,11 @@ namespace LoRaWan.Test.Shared
 
         public string AppEUI => this.LoRaDevice.AppEUI;
 
-        public string DevAddr => this.LoRaDevice.DevAddr;
+        public string DevAddr
+        {
+            get { return this.LoRaDevice.DevAddr; }
+            set { this.LoRaDevice.DevAddr = value; }
+        }
 
         public string DevEUI => this.LoRaDevice.DeviceID;
 

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/DeviceLoaderSynchronizerTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/DeviceLoaderSynchronizerTest.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using LoRaTools.LoRaMessage;
+    using LoRaWan.NetworkServer;
+    using LoRaWan.Test.Shared;
+    using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Caching.Memory;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Xunit;
+
+    public class DeviceLoaderSynchronizerTest
+    {
+        private readonly NetworkServerConfiguration serverConfiguration;
+
+        public DeviceLoaderSynchronizerTest()
+        {
+            this.serverConfiguration = new NetworkServerConfiguration()
+            {
+                GatewayID = "test-gateway",
+                LogLevel = "Debug",
+            };
+
+            Logger.Init(new LoggerConfiguration()
+            {
+                LogLevel = LogLevel.Debug,
+            });
+        }
+
+        [Fact]
+        public async Task When_Device_Api_Throws_Error_Should_Not_Create_Any_Device()
+        {
+            const string devAddr = "039090";
+
+            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
+            var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234");
+            payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey);
+
+            var apiService = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
+            apiService.Setup(x => x.SearchByDevAddrAsync(It.IsNotNull<string>()))
+                .Throws(new Exception());
+
+            var deviceFactory = new Mock<ILoRaDeviceFactory>(MockBehavior.Strict);
+
+            var destinationDictionary = new DevEUIToLoRaDeviceDictionary();
+            var finished = new SemaphoreSlim(0);
+            var target = new DeviceLoaderSynchronizer(
+                devAddr,
+                apiService.Object,
+                deviceFactory.Object,
+                destinationDictionary,
+                null,
+                this.serverConfiguration,
+                (_) => { finished.Release(); });
+
+            await finished.WaitAsync();
+
+            Assert.Empty(destinationDictionary);
+
+            // Device was searched by DevAddr
+            apiService.VerifyAll();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1000)]
+        public async Task When_Device_Does_Not_Exist_Should_Complete_Requests_As_Failed(int loadDevicesDurationInMs)
+        {
+            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
+            var devAddr = simulatedDevice.DevAddr;
+            var payload1 = simulatedDevice.CreateUnconfirmedDataUpMessage("1");
+            payload1.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey);
+
+            var apiService = new Mock<LoRaDeviceAPIServiceBase>();
+            var searchMock = apiService.Setup(x => x.SearchByDevAddrAsync(devAddr));
+            if (loadDevicesDurationInMs > 0)
+            {
+                searchMock.ReturnsAsync(new SearchDevicesResult(), TimeSpan.FromMilliseconds(loadDevicesDurationInMs));
+            }
+            else
+            {
+                searchMock.ReturnsAsync(new SearchDevicesResult());
+            }
+
+            var deviceFactory = new Mock<ILoRaDeviceFactory>(MockBehavior.Strict);
+
+            var destinationDictionary = new DevEUIToLoRaDeviceDictionary();
+            var finished = new SemaphoreSlim(0);
+            var target = new DeviceLoaderSynchronizer(
+                devAddr,
+                apiService.Object,
+                deviceFactory.Object,
+                destinationDictionary,
+                null,
+                this.serverConfiguration,
+                (_) => { finished.Release(); });
+
+            var req1 = new WaitableLoRaRequest(payload1);
+            target.Queue(req1);
+
+            await finished.WaitAsync();
+
+            Assert.True(await req1.WaitCompleteAsync());
+            Assert.Equal(LoRaDeviceRequestFailedReason.NotMatchingDeviceByDevAddr, req1.ProcessingFailedReason);
+
+            var payload2 = simulatedDevice.CreateUnconfirmedDataUpMessage("2");
+            payload2.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey);
+            var req2 = new WaitableLoRaRequest(payload2);
+            target.Queue(req2);
+
+            Assert.True(await req2.WaitCompleteAsync());
+            Assert.Equal(LoRaDeviceRequestFailedReason.NotMatchingDeviceByDevAddr, req2.ProcessingFailedReason);
+
+            // Device was searched by DevAddr
+            apiService.VerifyAll();
+        }
+
+        [Fact]
+        public async Task When_Device_Does_Not_Match_Gateway_Should_Fail_Request()
+        {
+            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: "a_different_one"));
+            var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234");
+            payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey);
+
+            var apiService = new Mock<LoRaDeviceAPIServiceBase>();
+            var iotHubDeviceInfo = new IoTHubDeviceInfo(simulatedDevice.LoRaDevice.DevAddr, simulatedDevice.LoRaDevice.DeviceID, string.Empty);
+            apiService.Setup(x => x.SearchByDevAddrAsync(It.IsNotNull<string>()))
+                .ReturnsAsync(new SearchDevicesResult(iotHubDeviceInfo.AsList()));
+
+            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
+            // device will be initialized
+            loRaDeviceClient.Setup(x => x.GetTwinAsync())
+                .ReturnsAsync(TestUtils.CreateABPTwin(simulatedDevice));
+            // device will be disconnected
+            loRaDeviceClient.Setup(x => x.DisconnectAsync())
+                .ReturnsAsync(true);
+
+            var deviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
+
+            var destinationDictionary = new DevEUIToLoRaDeviceDictionary();
+            var finished = new SemaphoreSlim(0);
+            var target = new DeviceLoaderSynchronizer(
+                simulatedDevice.DevAddr,
+                apiService.Object,
+                deviceFactory,
+                destinationDictionary,
+                null,
+                this.serverConfiguration,
+                (_) => { finished.Release(); });
+
+            var request = new WaitableLoRaRequest(payload);
+            target.Queue(request);
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.True(request.ProcessingFailed);
+            Assert.Equal(LoRaDeviceRequestFailedReason.BelongsToAnotherGateway, request.ProcessingFailedReason);
+
+            // Device was searched by DevAddr
+            apiService.VerifyAll();
+
+            // Device was created by factory
+            loRaDeviceClient.VerifyAll();
+        }
+
+        [Theory]
+        [InlineData("test-gateway")]
+        [InlineData(null)]
+        public async Task When_Device_Is_Not_In_Cache_And_Found_In_Api_Does_Not_Match_Mic_Should_Fail_Request(string deviceGatewayID)
+        {
+            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID));
+
+            var apiService = new Mock<LoRaDeviceAPIServiceBase>();
+            var iotHubDeviceInfo = new IoTHubDeviceInfo(simulatedDevice.LoRaDevice.DevAddr, simulatedDevice.LoRaDevice.DeviceID, string.Empty);
+            apiService.Setup(x => x.SearchByDevAddrAsync(It.IsNotNull<string>()))
+                .ReturnsAsync(new SearchDevicesResult(iotHubDeviceInfo.AsList()));
+
+            // Will get device twin
+            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
+            loRaDeviceClient.Setup(x => x.GetTwinAsync())
+                .ReturnsAsync(TestUtils.CreateABPTwin(simulatedDevice));
+
+            var deviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
+
+            var destinationDictionary = new DevEUIToLoRaDeviceDictionary();
+            var finished = new SemaphoreSlim(0);
+            var target = new DeviceLoaderSynchronizer(
+                simulatedDevice.DevAddr,
+                apiService.Object,
+                deviceFactory,
+                destinationDictionary,
+                null,
+                this.serverConfiguration,
+                (_) => { finished.Release(); });
+
+            var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234");
+            payload.SerializeUplink(simulatedDevice.AppSKey, "00000000000000000000000000EEAAFF");
+
+            var request = new WaitableLoRaRequest(payload);
+            target.Queue(request);
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.True(request.ProcessingFailed);
+            Assert.Equal(LoRaDeviceRequestFailedReason.NotMatchingDeviceByMicCheck, request.ProcessingFailedReason);
+
+            // Device was searched by DevAddr
+            apiService.VerifyAll();
+            loRaDeviceClient.VerifyAll();
+        }
+    }
+}

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaDeviceFrameCounterUpdateStrategyProviderTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaDeviceFrameCounterUpdateStrategyProviderTest.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using LoRaTools.LoRaMessage;
+    using LoRaWan.NetworkServer;
+    using LoRaWan.Test.Shared;
+    using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Caching.Memory;
+    using Moq;
+    using Xunit;
+
+    public class LoRaDeviceFrameCounterUpdateStrategyProviderTest
+    {
+        private Mock<LoRaDeviceAPIServiceBase> loRaDeviceApi;
+
+        public LoRaDeviceFrameCounterUpdateStrategyProviderTest()
+        {
+            this.loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void When_Device_Has_No_GatewayID_Should_Return_MultiGateway(string deviceGatewayID)
+        {
+            var target = new LoRaDeviceFrameCounterUpdateStrategyProvider("test-gateway", this.loRaDeviceApi.Object);
+            var actual = target.GetStrategy(deviceGatewayID);
+            Assert.NotNull(actual);
+            Assert.IsType<MultiGatewayFrameCounterUpdateStrategy>(actual);
+        }
+
+        [Theory]
+        [InlineData("test-gateway")]
+        [InlineData("TEST-GATEWAY")]
+        public void When_Device_Has_Matching_GatewayID_Should_Return_SingleGateway(string deviceGatewayID)
+        {
+            var target = new LoRaDeviceFrameCounterUpdateStrategyProvider("test-gateway", this.loRaDeviceApi.Object);
+            var actual = target.GetStrategy(deviceGatewayID);
+            Assert.NotNull(actual);
+            Assert.IsType<SingleGatewayFrameCounterUpdateStrategy>(actual);
+        }
+
+        [Theory]
+        [InlineData("test-gateway1")]
+        [InlineData("TEST-GATEWAY2")]
+        public void When_Device_Has_No_Matching_GatewayID_Should_Return_Null(string deviceGatewayID)
+        {
+            var target = new LoRaDeviceFrameCounterUpdateStrategyProvider("test-gateway", this.loRaDeviceApi.Object);
+            var actual = target.GetStrategy(deviceGatewayID);
+            Assert.Null(actual);
+        }
+    }
+}

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaOperationTimeWatcherTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaOperationTimeWatcherTest.cs
@@ -57,10 +57,10 @@ namespace LoRaWan.NetworkServer.Test
             var target = new LoRaOperationTimeWatcher(RegionFactory.CreateEU868Region(), DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMilliseconds(delayInMs)));
             var loRaDevice = new LoRaDevice("31312", "312321321", null)
             {
-                PreferredWindow = 2,
+                PreferredWindow = Constants.RECEIVE_WINDOW_2,
             };
 
-            Assert.Equal(2, target.ResolveReceiveWindowToUse(loRaDevice));
+            Assert.Equal(Constants.RECEIVE_WINDOW_2, target.ResolveReceiveWindowToUse(loRaDevice));
         }
 
         [Theory]
@@ -71,7 +71,7 @@ namespace LoRaWan.NetworkServer.Test
             var target = new LoRaOperationTimeWatcher(RegionFactory.CreateEU868Region(), DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMilliseconds(delayInMs)));
             var loRaDevice = new LoRaDevice("31312", "312321321", null);
 
-            Assert.Equal(1, target.ResolveReceiveWindowToUse(loRaDevice));
+            Assert.Equal(Constants.RECEIVE_WINDOW_1, target.ResolveReceiveWindowToUse(loRaDevice));
         }
 
         [Theory]
@@ -83,7 +83,7 @@ namespace LoRaWan.NetworkServer.Test
             var target = new LoRaOperationTimeWatcher(RegionFactory.CreateEU868Region(), DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMilliseconds(delayInMs)));
             var loRaDevice = new LoRaDevice("31312", "312321321", null);
 
-            Assert.Equal(2, target.ResolveReceiveWindowToUse(loRaDevice));
+            Assert.Equal(Constants.RECEIVE_WINDOW_2, target.ResolveReceiveWindowToUse(loRaDevice));
         }
 
         [Theory]
@@ -95,7 +95,7 @@ namespace LoRaWan.NetworkServer.Test
             var target = new LoRaOperationTimeWatcher(RegionFactory.CreateEU868Region(), DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMilliseconds(delayInMs)));
             var loRaDevice = new LoRaDevice("31312", "312321321", null);
 
-            Assert.Equal(0, target.ResolveReceiveWindowToUse(loRaDevice));
+            Assert.Equal(Constants.INVALID_RECEIVE_WINDOW, target.ResolveReceiveWindowToUse(loRaDevice));
         }
 
         [Theory]

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorJoinTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorJoinTest.cs
@@ -44,7 +44,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 loRaDeviceRegistryMock.Object,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);
@@ -89,7 +89,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 loRaDeviceRegistryMock.Object,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);
@@ -155,7 +155,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 loRaDeviceRegistryMock.Object,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);
@@ -201,7 +201,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 loRaDeviceRegistryMock.Object,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);
@@ -246,7 +246,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 loRaDeviceRegistryMock.Object,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);
@@ -288,7 +288,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 loRaDeviceRegistryMock.Object,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);
@@ -353,7 +353,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);
@@ -407,7 +407,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorMultipleGatewayTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorMultipleGatewayTest.cs
@@ -30,7 +30,7 @@ namespace LoRaWan.NetworkServer.Test
 
         public Mock<LoRaDeviceAPIServiceBase> SecondLoRaDeviceApi { get; }
 
-        public LoRaDeviceFrameCounterUpdateStrategyFactory SecondFrameCounterUpdateStrategyFactory { get; }
+        public LoRaDeviceFrameCounterUpdateStrategyProvider SecondFrameCounterUpdateStrategyProvider { get; }
 
         private DefaultLoRaDataRequestHandler secondRequestHandlerImplementation;
 
@@ -51,10 +51,10 @@ namespace LoRaWan.NetworkServer.Test
 
             this.SecondPacketForwarder = new TestPacketForwarder();
             this.SecondLoRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            this.SecondFrameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(SecondServerGatewayID, this.SecondLoRaDeviceApi.Object);
-            this.secondRequestHandlerImplementation = new DefaultLoRaDataRequestHandler(this.SecondServerConfiguration, this.SecondFrameCounterUpdateStrategyFactory, new LoRaPayloadDecoder());
+            this.SecondFrameCounterUpdateStrategyProvider = new LoRaDeviceFrameCounterUpdateStrategyProvider(SecondServerGatewayID, this.SecondLoRaDeviceApi.Object);
+            this.secondRequestHandlerImplementation = new DefaultLoRaDataRequestHandler(this.SecondServerConfiguration, this.SecondFrameCounterUpdateStrategyProvider, new LoRaPayloadDecoder());
             this.SecondLoRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            this.SecondLoRaDeviceFactory = new TestLoRaDeviceFactory(this.SecondServerConfiguration, this.SecondFrameCounterUpdateStrategyFactory, this.SecondLoRaDeviceClient.Object);
+            this.SecondLoRaDeviceFactory = new TestLoRaDeviceFactory(this.SecondServerConfiguration, this.SecondFrameCounterUpdateStrategyProvider, this.SecondLoRaDeviceClient.Object);
         }
 
         [Fact]
@@ -87,12 +87,12 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor1 = new MessageDispatcher(
                 this.ServerConfiguration,
                 loRaDeviceRegistry1,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var messageProcessor2 = new MessageDispatcher(
                 this.SecondServerConfiguration,
                 loRaDeviceRegistry2,
-                this.SecondFrameCounterUpdateStrategyFactory);
+                this.SecondFrameCounterUpdateStrategyProvider);
 
             // Starts with fcnt up zero
             Assert.Equal(0, loRaDevice1.FCntUp);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorMultipleGatewayTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorMultipleGatewayTest.cs
@@ -12,6 +12,8 @@ namespace LoRaWan.NetworkServer.Test
     using LoRaWan.Test.Shared;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Caching.Memory;
+    using Microsoft.Extensions.Logging;
     using Moq;
     using Xunit;
 
@@ -20,12 +22,39 @@ namespace LoRaWan.NetworkServer.Test
     /// </summary>
     public class MessageProcessorMultipleGatewayTest : MessageProcessorTestBase
     {
-        private readonly Mock<ILoRaDeviceRegistry> loRaDeviceRegistry2;
+        const string SecondServerGatewayID = "second-gateway";
+
+        public NetworkServerConfiguration SecondServerConfiguration { get; }
+
+        public TestPacketForwarder SecondPacketForwarder { get; }
+
+        public Mock<LoRaDeviceAPIServiceBase> SecondLoRaDeviceApi { get; }
+
+        public LoRaDeviceFrameCounterUpdateStrategyFactory SecondFrameCounterUpdateStrategyFactory { get; }
+
+        private DefaultLoRaDataRequestHandler secondRequestHandlerImplementation;
+
+        public Mock<ILoRaDeviceClient> SecondLoRaDeviceClient { get; }
+
+        internal TestLoRaDeviceFactory SecondLoRaDeviceFactory { get; }
+
+        LoRaDevice CreateSecondLoRaDevice(SimulatedDevice simulatedDevice) => TestUtils.CreateFromSimulatedDevice(simulatedDevice, this.SecondLoRaDeviceClient.Object, this.secondRequestHandlerImplementation);
 
         public MessageProcessorMultipleGatewayTest()
         {
-            this.loRaDeviceRegistry2 = new Mock<ILoRaDeviceRegistry>(MockBehavior.Strict);
-            this.loRaDeviceRegistry2.Setup(x => x.RegisterDeviceInitializer(It.IsAny<ILoRaDeviceInitializer>()));
+            this.SecondServerConfiguration = new NetworkServerConfiguration
+            {
+                GatewayID = SecondServerGatewayID,
+                LogToConsole = true,
+                LogLevel = ((int)LogLevel.Debug).ToString(),
+            };
+
+            this.SecondPacketForwarder = new TestPacketForwarder();
+            this.SecondLoRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
+            this.SecondFrameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(SecondServerGatewayID, this.SecondLoRaDeviceApi.Object);
+            this.secondRequestHandlerImplementation = new DefaultLoRaDataRequestHandler(this.SecondServerConfiguration, this.SecondFrameCounterUpdateStrategyFactory, new LoRaPayloadDecoder());
+            this.SecondLoRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
+            this.SecondLoRaDeviceFactory = new TestLoRaDeviceFactory(this.SecondServerConfiguration, this.SecondFrameCounterUpdateStrategyFactory, this.SecondLoRaDeviceClient.Object);
         }
 
         [Fact]
@@ -33,78 +62,69 @@ namespace LoRaWan.NetworkServer.Test
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
 
-            var loraDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-
-            // 2 messages will be sent
-            loraDeviceClient.SetupSequence(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
-                .ReturnsAsync(true)
+            // 1 messages will be sent
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .ReturnsAsync(true);
+            this.SecondLoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
 
             // cloud to device messages will be checked twice
-            loraDeviceClient.SetupSequence(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+            this.LoRaDeviceClient.SetupSequence(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null)
                 .ReturnsAsync((Message)null);
 
-            var loraDevice1 = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loraDeviceClient.Object);
-            var loraDevice2 = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loraDeviceClient.Object);
+            this.SecondLoRaDeviceClient.SetupSequence(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+                .ReturnsAsync((Message)null)
+                .ReturnsAsync((Message)null);
 
-            var payloadDecoder = new Mock<ILoRaPayloadDecoder>();
+            var loRaDevice1 = this.CreateLoRaDevice(simulatedDevice);
+            var loRaDevice2 = this.CreateSecondLoRaDevice(simulatedDevice);
 
-            this.LoRaDeviceRegistry.Setup(x => x.GetDeviceForPayloadAsync(It.IsAny<LoRaTools.LoRaMessage.LoRaPayloadData>()))
-                .ReturnsAsync(loraDevice1);
-
-            this.loRaDeviceRegistry2.Setup(x => x.GetDeviceForPayloadAsync(It.IsAny<LoRaTools.LoRaMessage.LoRaPayloadData>()))
-                .ReturnsAsync(loraDevice2);
-
-            // Setup frame counter strategy
-            this.FrameCounterUpdateStrategyFactory.Setup(x => x.GetMultiGatewayStrategy())
-                .Returns(new TestMultiGatewayUpdateFrameStrategy());
-
-            // Frame counter will be asked to save changes
-            this.FrameCounterUpdateStrategy.Setup(x => x.SaveChangesAsync(loraDevice1)).ReturnsAsync(true);
-            this.FrameCounterUpdateStrategy.Setup(x => x.SaveChangesAsync(loraDevice2)).ReturnsAsync(true);
+            var loRaDeviceRegistry1 = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loRaDevice1), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+            var loRaDeviceRegistry2 = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loRaDevice2), this.SecondLoRaDeviceApi.Object, this.SecondLoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor1 = new MessageProcessor(
+            var messageProcessor1 = new MessageDispatcher(
                 this.ServerConfiguration,
-                this.LoRaDeviceRegistry.Object,
-                this.FrameCounterUpdateStrategyFactory.Object,
-                payloadDecoder.Object);
+                loRaDeviceRegistry1,
+                this.FrameCounterUpdateStrategyFactory);
 
-            var messageProcessor2 = new MessageProcessor(
-                new NetworkServerConfiguration() { GatewayID = "test-gateway-2" },
-                this.loRaDeviceRegistry2.Object,
-                this.FrameCounterUpdateStrategyFactory.Object,
-                payloadDecoder.Object);
+            var messageProcessor2 = new MessageDispatcher(
+                this.SecondServerConfiguration,
+                loRaDeviceRegistry2,
+                this.SecondFrameCounterUpdateStrategyFactory);
 
             // Starts with fcnt up zero
-            Assert.Equal(0, loraDevice1.FCntUp);
-            Assert.Equal(0, loraDevice2.FCntUp);
+            Assert.Equal(0, loRaDevice1.FCntUp);
+            Assert.Equal(0, loRaDevice2.FCntUp);
 
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: 1);
 
             // Create Rxpk
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
+            var request1 = this.CreateWaitableRequest(rxpk);
+            var request2 = this.CreateWaitableRequest(rxpk, this.SecondPacketForwarder);
+            messageProcessor1.DispatchRequest(request1);
+            messageProcessor2.DispatchRequest(request2);
 
-            var t1 = messageProcessor1.ProcessMessageAsync(rxpk);
-            var t2 = messageProcessor2.ProcessMessageAsync(rxpk);
-
-            await Task.WhenAll(t1, t2);
+            await Task.WhenAll(request1.WaitCompleteAsync(), request2.WaitCompleteAsync());
 
             // Expectations
-            // 1. Message was sent to IoT Hub twice
-            loraDeviceClient.VerifyAll();
+            // 1. Message was sent to IoT Hub
+            this.LoRaDeviceClient.VerifyAll();
+            this.SecondLoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+            this.SecondLoRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.Verify(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null), Times.Once());
+            this.SecondLoRaDeviceClient.Verify(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null), Times.Once());
 
-            // 2. Single gateway frame counter strategy was used
-            this.FrameCounterUpdateStrategyFactory.VerifyAll();
+            // 2. Return is null (there is nothing to send downstream)
+            Assert.Null(request1.ResponseDownlink);
+            Assert.Null(request2.ResponseDownlink);
 
-            // 3. Return is null (there is nothing to send downstream)
-            Assert.Null(t1.Result);
-            Assert.Null(t2.Result);
-
-            // 4. Frame counter up was updated to 1
-            Assert.Equal(1, loraDevice1.FCntUp);
-            Assert.Equal(1, loraDevice2.FCntUp);
+            // 3. Frame counter up was updated to 1
+            Assert.Equal(1, loRaDevice1.FCntUp);
+            Assert.Equal(1, loRaDevice2.FCntUp);
         }
     }
 }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorSingleGatewayTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorSingleGatewayTest.cs
@@ -54,7 +54,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);
@@ -97,7 +97,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // Send request #1
             var payload1 = simulatedDevice.CreateUnconfirmedDataUpMessage("1", fcnt: 2);
@@ -144,7 +144,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);
@@ -181,7 +181,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);
@@ -223,7 +223,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);
@@ -281,7 +281,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
 
@@ -347,7 +347,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);
@@ -387,7 +387,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var payload1 = simulatedDevice.CreateUnconfirmedDataUpMessage("1", fcnt: 10);
             var rxpk1 = payload1.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
@@ -451,7 +451,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("11", fcnt: 11);
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
@@ -541,7 +541,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage("hello", fcnt: payloadFcntUp);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorSingleGatewayTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorSingleGatewayTest.cs
@@ -4,12 +4,11 @@
 namespace LoRaWan.NetworkServer.Test
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Runtime.InteropServices;
-    using System.Text;
     using System.Threading.Tasks;
     using LoRaTools.LoRaMessage;
-    using LoRaTools.LoRaPhysical;
-    using LoRaTools.Regions;
     using LoRaWan.NetworkServer;
     using LoRaWan.Test.Shared;
     using Microsoft.Azure.Devices.Client;
@@ -26,8 +25,10 @@ namespace LoRaWan.NetworkServer.Test
         {
         }
 
-        [Fact]
-        public async Task Unknown_Device_Should_Return_Null()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(2100)]
+        public async Task Unknown_Device_Should_Not_Send_Messages(int searchDevicesDelayMs)
         {
             // Setup
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
@@ -36,23 +37,94 @@ namespace LoRaWan.NetworkServer.Test
             // Create Rxpk
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
 
-            var payloadDecoder = new Mock<ILoRaPayloadDecoder>();
+            if (searchDevicesDelayMs > 0)
+            {
+                this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(simulatedDevice.DevAddr))
+                    .Returns(Task.Delay(searchDevicesDelayMs).ContinueWith((_) => new SearchDevicesResult()));
+            }
+            else
+            {
+                this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(simulatedDevice.DevAddr))
+                    .ReturnsAsync(new SearchDevicesResult());
+            }
 
-            this.LoRaDeviceRegistry.Setup(x => x.GetDeviceForPayloadAsync(It.IsAny<LoRaTools.LoRaMessage.LoRaPayloadData>()))
-                .ReturnsAsync(() => null);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewMemoryCache(), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
-                this.LoRaDeviceRegistry.Object,
-                this.FrameCounterUpdateStrategyFactory.Object,
-                payloadDecoder.Object);
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
 
-            var actual = await messageProcessor.ProcessMessageAsync(rxpk);
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
 
             // Expectations
             // 1. Returns null
-            Assert.Null(actual);
+            Assert.Null(request.ResponseDownlink);
+            Assert.True(request.ProcessingFailed);
+            Assert.Equal(LoRaDeviceRequestFailedReason.NotMatchingDeviceByDevAddr, request.ProcessingFailedReason);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(2100)]
+        public async Task When_Payload_Has_Invalid_Mic_Should_Not_Send_Messages(int searchDevicesDelayMs)
+        {
+            // Setup
+            const string wrongSKey = "00000000000000000000000000EEDDFF";
+            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
+
+            var searchResult = new SearchDevicesResult(new IoTHubDeviceInfo(simulatedDevice.DevAddr, simulatedDevice.DevEUI, "1321").AsList());
+            if (searchDevicesDelayMs > 0)
+            {
+                this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(simulatedDevice.DevAddr))
+                    .ReturnsAsync(searchResult, TimeSpan.FromMilliseconds(searchDevicesDelayMs));
+            }
+            else
+            {
+                this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(simulatedDevice.DevAddr))
+                    .ReturnsAsync(searchResult);
+            }
+
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync())
+                .ReturnsAsync(TestUtils.CreateABPTwin(simulatedDevice));
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewMemoryCache(), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageProcessor = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
+
+            // Send request #1
+            var payload1 = simulatedDevice.CreateUnconfirmedDataUpMessage("1", fcnt: 2);
+            var request1 = this.CreateWaitableRequest(payload1.SerializeUplink(simulatedDevice.AppSKey, wrongSKey).Rxpk[0]);
+            messageProcessor.DispatchRequest(request1);
+            Assert.True(await request1.WaitCompleteAsync());
+            Assert.Null(request1.ResponseDownlink);
+            Assert.True(request1.ProcessingFailed);
+            Assert.Equal(LoRaDeviceRequestFailedReason.NotMatchingDeviceByMicCheck, request1.ProcessingFailedReason);
+
+            await Task.Delay(2000);
+            Assert.Single(deviceRegistry.InternalGetCachedDevicesForDevAddr(simulatedDevice.DevAddr));
+
+            // Send request #2
+            var payload2 = simulatedDevice.CreateUnconfirmedDataUpMessage("2", fcnt: 3);
+            var request2 = this.CreateWaitableRequest(payload2.SerializeUplink(simulatedDevice.AppSKey, wrongSKey).Rxpk[0]);
+            messageProcessor.DispatchRequest(request2);
+            Assert.True(await request2.WaitCompleteAsync());
+            Assert.Null(request2.ResponseDownlink);
+            Assert.True(request2.ProcessingFailed);
+            Assert.Equal(LoRaDeviceRequestFailedReason.NotMatchingDeviceByMicCheck, request2.ProcessingFailedReason);
+            Assert.Single(deviceRegistry.InternalGetCachedDevicesForDevAddr(simulatedDevice.DevAddr));
+
+            this.LoRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+
+            this.LoRaDeviceApi.Verify(x => x.SearchByDevAddrAsync(simulatedDevice.DevAddr), Times.Exactly(1));
         }
 
         [Fact]
@@ -66,20 +138,23 @@ namespace LoRaWan.NetworkServer.Test
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
             rxpk.Freq = 0;
 
-            var payloadDecoder = new Mock<ILoRaPayloadDecoder>(MockBehavior.Strict);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewMemoryCache(), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
-                this.LoRaDeviceRegistry.Object,
-                this.FrameCounterUpdateStrategyFactory.Object,
-                payloadDecoder.Object);
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
 
-            var actual = await messageProcessor.ProcessMessageAsync(rxpk);
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
 
             // Expectations
             // 1. Returns null
-            Assert.Null(actual);
+            Assert.Null(request.ResponseDownlink);
+            Assert.True(request.ProcessingFailed);
+            Assert.Equal(LoRaDeviceRequestFailedReason.InvalidRegion, request.ProcessingFailedReason);
         }
 
         [Fact]
@@ -92,44 +167,36 @@ namespace LoRaWan.NetworkServer.Test
             // Create Rxpk
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
 
-            var loraDeviceClient = new Mock<ILoRaDeviceClient>();
-            var loraDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loraDeviceClient.Object);
+            var loraDevice = this.CreateLoRaDevice(simulatedDevice);
 
-            loraDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
 
-            var payloadDecoder = new Mock<ILoRaPayloadDecoder>();
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+                .ReturnsAsync((Message)null);
 
-            this.LoRaDeviceRegistry.Setup(x => x.GetDeviceForPayloadAsync(It.IsAny<LoRaTools.LoRaMessage.LoRaPayloadData>()))
-                .ReturnsAsync(loraDevice);
-
-            // Setup frame counter strategy
-            this.FrameCounterUpdateStrategyFactory.Setup(x => x.GetSingleGatewayStrategy())
-                .Returns(this.FrameCounterUpdateStrategy.Object);
-
-            // Frame counter will be asked to save changes
-            this.FrameCounterUpdateStrategy.Setup(x => x.SaveChangesAsync(loraDevice)).ReturnsAsync(true);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
-                this.LoRaDeviceRegistry.Object,
-                this.FrameCounterUpdateStrategyFactory.Object,
-                payloadDecoder.Object);
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
 
-            var actual = await messageProcessor.ProcessMessageAsync(rxpk);
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
 
             // Expectations
             // 1. Message was sent to IoT Hub
-            loraDeviceClient.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+            Assert.True(request.ProcessingSucceeded);
 
-            // 2. Single gateway frame counter strategy was used
-            this.FrameCounterUpdateStrategyFactory.VerifyAll();
+            // 2. Return is null (there is nothing to send downstream)
+            Assert.Null(request.ResponseDownlink);
 
-            // 3. Return is null (there is nothing to send downstream)
-            Assert.Null(actual);
-
-            // 4. Frame counter up was updated
+            // 3. Frame counter up was updated
             Assert.Equal(10, loraDevice.FCntUp);
         }
 
@@ -142,44 +209,36 @@ namespace LoRaWan.NetworkServer.Test
             // Create Rxpk
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
 
-            var loraDeviceClient = new Mock<ILoRaDeviceClient>();
-            var loraDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loraDeviceClient.Object);
+            var loraDevice = this.CreateLoRaDevice(simulatedDevice);
 
-            loraDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
 
-            var payloadDecoder = new Mock<ILoRaPayloadDecoder>();
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+                .ReturnsAsync((Message)null);
 
-            this.LoRaDeviceRegistry.Setup(x => x.GetDeviceForPayloadAsync(It.IsAny<LoRaTools.LoRaMessage.LoRaPayloadData>()))
-                .ReturnsAsync(loraDevice);
-
-            // Setup frame counter strategy
-            this.FrameCounterUpdateStrategyFactory.Setup(x => x.GetSingleGatewayStrategy())
-                .Returns(new SingleGatewayFrameCounterUpdateStrategy());
-
-            // Frame counter will be asked to save changes
-            this.FrameCounterUpdateStrategy.Setup(x => x.SaveChangesAsync(loraDevice)).ReturnsAsync(true);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
-                this.LoRaDeviceRegistry.Object,
-                this.FrameCounterUpdateStrategyFactory.Object,
-                payloadDecoder.Object);
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
 
-            var actual = await messageProcessor.ProcessMessageAsync(rxpk);
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
 
             // Expectations
             // 1. Message was sent to IoT Hub
-            loraDeviceClient.VerifyAll();
-
-            // 2. Single gateway frame counter strategy was used
-            this.FrameCounterUpdateStrategyFactory.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
 
             // 3. Return is downstream message
-            Assert.NotNull(actual);
-            Assert.IsType<DownlinkPktFwdMessage>(actual);
-            var downlinkMessage = (DownlinkPktFwdMessage)actual;
+            Assert.NotNull(request.ResponseDownlink);
+            Assert.True(request.ProcessingSucceeded);
+            Assert.Single(this.PacketForwarder.DownlinkMessages);
+            var downlinkMessage = this.PacketForwarder.DownlinkMessages.First();
             var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
             Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
             Assert.False(payloadDataDown.IsConfirmed());
@@ -205,50 +264,42 @@ namespace LoRaWan.NetworkServer.Test
                 frmCntUp: InitialDeviceFcntUp,
                 frmCntDown: InitialDeviceFcntDown);
 
-            var loraDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            var loraDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loraDeviceClient.Object);
+            var loraDevice = this.CreateLoRaDevice(simulatedDevice);
 
-            loraDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
 
-            loraDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
                 .ReturnsAsync(true);
 
-            loraDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
-            var payloadDecoder = new Mock<ILoRaPayloadDecoder>();
-
-            this.LoRaDeviceRegistry.Setup(x => x.GetDeviceForPayloadAsync(It.IsAny<LoRaTools.LoRaMessage.LoRaPayloadData>()))
-                .ReturnsAsync(loraDevice);
-
-            // Setup frame counter strategy
-            this.FrameCounterUpdateStrategyFactory.Setup(x => x.GetSingleGatewayStrategy())
-                .Returns(new SingleGatewayFrameCounterUpdateStrategy());
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
-                this.LoRaDeviceRegistry.Object,
-                this.FrameCounterUpdateStrategyFactory.Object,
-                payloadDecoder.Object);
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
 
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
 
             // Create Rxpk
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
 
-            var actual = await messageProcessor.ProcessMessageAsync(rxpk);
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
 
             // Expectations
             // 1. Message was sent to IoT Hub
-            loraDeviceClient.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
 
-            // 2. Single gateway frame counter strategy was used
-            this.FrameCounterUpdateStrategyFactory.VerifyAll();
-
-            // 3. Return nothing
-            Assert.Null(actual);
+            // 2. Return nothing
+            Assert.Null(request.ResponseDownlink);
+            Assert.True(request.ProcessingSucceeded);
 
             // 4. Frame counter up was updated
             Assert.Equal(PayloadFcnt, loraDevice.FCntUp);
@@ -278,49 +329,254 @@ namespace LoRaWan.NetworkServer.Test
             // Create Rxpk
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
 
-            var loraDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            var loraDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loraDeviceClient.Object);
+            var loraDevice = this.CreateLoRaDevice(simulatedDevice);
 
             // Will send the event to IoT Hub
-            loraDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
 
             // will try to get C2D message
-            loraDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>())).ReturnsAsync((Message)null);
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>())).ReturnsAsync((Message)null);
 
             // Will save the fcnt up/down to zero
-            loraDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.Is<TwinCollection>((t) => this.IsTwinFcntZero(t))));
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.Is<TwinCollection>((t) => this.IsTwinFcntZero(t))));
 
-            var payloadDecoder = new Mock<ILoRaPayloadDecoder>();
-
-            this.LoRaDeviceRegistry.Setup(x => x.GetDeviceForPayloadAsync(It.IsAny<LoRaTools.LoRaMessage.LoRaPayloadData>()))
-                .ReturnsAsync(loraDevice);
-
-            // Setup frame counter strategy
-            this.FrameCounterUpdateStrategyFactory.Setup(x => x.GetSingleGatewayStrategy())
-                .Returns(new SingleGatewayFrameCounterUpdateStrategy());
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
-                this.LoRaDeviceRegistry.Object,
-                this.FrameCounterUpdateStrategyFactory.Object,
-                payloadDecoder.Object);
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
 
-            var actual = await messageProcessor.ProcessMessageAsync(rxpk);
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
 
             // Expectations
             // 1. Message was sent to IoT Hub
-            loraDeviceClient.VerifyAll();
-
-            // 2. Single gateway frame counter strategy was used
-            this.FrameCounterUpdateStrategyFactory.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
 
             // 3. Return is null (there is nothing to send downstream)
-            Assert.Null(actual);
+            Assert.Null(request.ResponseDownlink);
+            Assert.True(request.ProcessingSucceeded);
 
             // 4. Frame counter up was updated
             Assert.Equal(payloadFCnt, loraDevice.FCntUp);
+        }
+
+        [Fact]
+        public async Task ABP_From_Another_Gateway_Unconfirmed_Message_Should_Load_Device_Cache_And_Disconnect()
+        {
+            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: "another-gateway"));
+            simulatedDevice.FrmCntUp = 9;
+
+            this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(simulatedDevice.DevAddr))
+                .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(simulatedDevice.DevAddr, simulatedDevice.DevEUI, "1234").AsList()));
+
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync())
+                .ReturnsAsync(TestUtils.CreateABPTwin(simulatedDevice));
+
+            this.LoRaDeviceClient.Setup(x => x.DisconnectAsync())
+                .ReturnsAsync(true);
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewMemoryCache(), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageProcessor = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
+
+            var payload1 = simulatedDevice.CreateUnconfirmedDataUpMessage("1", fcnt: 10);
+            var rxpk1 = payload1.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
+            var request1 = this.CreateWaitableRequest(rxpk1);
+            messageProcessor.DispatchRequest(request1);
+            Assert.True(await request1.WaitCompleteAsync());
+            Assert.True(request1.ProcessingFailed);
+            Assert.Equal(LoRaDeviceRequestFailedReason.BelongsToAnotherGateway, request1.ProcessingFailedReason);
+
+            // device should be cached
+            var cachedDevices = deviceRegistry.InternalGetCachedDevicesForDevAddr(simulatedDevice.DevAddr);
+            Assert.Single(cachedDevices);
+            Assert.True(cachedDevices.TryGetValue(simulatedDevice.DevEUI, out var cachedDevice));
+            Assert.Equal(9, cachedDevice.FCntUp);
+
+            var payload2 = simulatedDevice.CreateUnconfirmedDataUpMessage("2", fcnt: 11);
+            var rxpk2 = payload2.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
+            var request2 = this.CreateWaitableRequest(rxpk2);
+            messageProcessor.DispatchRequest(request2);
+            Assert.True(await request2.WaitCompleteAsync());
+            Assert.True(request2.ProcessingFailed);
+            Assert.Equal(LoRaDeviceRequestFailedReason.BelongsToAnotherGateway, request2.ProcessingFailedReason);
+
+            // Expectations
+            // 1. Message was sent to IoT Hub
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+            this.LoRaDeviceApi.Verify(x => x.SearchByDevAddrAsync(simulatedDevice.DevAddr), Times.Once());
+
+            // 2. Frame counter up was not updated
+            cachedDevices = deviceRegistry.InternalGetCachedDevicesForDevAddr(simulatedDevice.DevAddr);
+            Assert.Single(cachedDevices);
+            cachedDevice = null;
+            Assert.True(cachedDevices.TryGetValue(simulatedDevice.DevEUI, out cachedDevice));
+            Assert.Equal(9, cachedDevice.FCntUp);
+        }
+
+        [Fact]
+        public async Task When_New_ABP_Device_Instance_Is_Created_Should_Increment_FCntDown()
+        {
+            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: ServerGatewayID));
+
+            var iotHubDeviceInfo = new IoTHubDeviceInfo(simulatedDevice.LoRaDevice.DevAddr, simulatedDevice.LoRaDevice.DeviceID, string.Empty);
+            this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(It.IsNotNull<string>()))
+                .ReturnsAsync(new SearchDevicesResult(iotHubDeviceInfo.AsList()));
+
+            // device will:
+            // - be initialized
+            // - send event
+            // - receive c2d
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync())
+                .ReturnsAsync(simulatedDevice.CreateABPTwin());
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .ReturnsAsync(true);
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+                .ReturnsAsync((Message)null);
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewMemoryCache(), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageProcessor = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
+
+            var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("11", fcnt: 11);
+            var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.True(request.ProcessingSucceeded);
+
+            var devices = deviceRegistry.InternalGetCachedDevicesForDevAddr(simulatedDevice.DevAddr);
+            Assert.Single(devices);
+            Assert.True(devices.TryGetValue(simulatedDevice.DevEUI, out var cachedDevice));
+            Assert.True(cachedDevice.IsOurDevice);
+            Assert.Equal(10, cachedDevice.FCntDown);
+            Assert.Equal(payload.GetFcnt(), (ushort)cachedDevice.FCntUp);
+
+            // Device was searched by DevAddr
+            this.LoRaDeviceApi.VerifyAll();
+
+            // Device was created by factory
+            this.LoRaDeviceClient.VerifyAll();
+        }
+
+        [Theory]
+        [InlineData(0, null, null)]
+        [InlineData(0, 1, 1)]
+        [InlineData(0, 100, 20)]
+        [InlineData(1, null, null)]
+        [InlineData(1, 1, 1)]
+        [InlineData(1, 100, 20)]
+        public async Task When_ABP_New_Loaded_Device_With_Fcnt_1_Or_0_Should_Reset_Fcnt_And_Send_To_IotHub(
+            int payloadFcntUp,
+            int? deviceTwinFcntUp,
+            int? deviceTwinFcntDown)
+        {
+            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
+
+            var devEUI = simulatedDevice.LoRaDevice.DeviceID;
+            var devAddr = simulatedDevice.LoRaDevice.DevAddr;
+
+            // message will be sent
+            LoRaDeviceTelemetry loRaDeviceTelemetry = null;
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) => loRaDeviceTelemetry = t)
+                .ReturnsAsync(true);
+
+            // C2D message will be checked
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+                .ReturnsAsync((Message)null);
+
+            // twin will be loaded
+            var initialTwin = new Twin();
+            initialTwin.Properties.Desired[TwinProperty.DevEUI] = devEUI;
+            initialTwin.Properties.Desired[TwinProperty.AppEUI] = simulatedDevice.LoRaDevice.AppEUI;
+            initialTwin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey;
+            initialTwin.Properties.Desired[TwinProperty.NwkSKey] = simulatedDevice.LoRaDevice.NwkSKey;
+            initialTwin.Properties.Desired[TwinProperty.AppSKey] = simulatedDevice.LoRaDevice.AppSKey;
+            initialTwin.Properties.Desired[TwinProperty.DevAddr] = devAddr;
+            initialTwin.Properties.Desired[TwinProperty.GatewayID] = this.ServerConfiguration.GatewayID;
+            initialTwin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
+            if (deviceTwinFcntDown.HasValue)
+                initialTwin.Properties.Reported[TwinProperty.FCntDown] = deviceTwinFcntDown.Value;
+            if (deviceTwinFcntUp.HasValue)
+                initialTwin.Properties.Reported[TwinProperty.FCntUp] = deviceTwinFcntUp.Value;
+
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(initialTwin);
+
+            // twin will be updated with new fcnt
+            int? fcntUpSavedInTwin = null;
+            int? fcntDownSavedInTwin = null;
+
+            // Twin will be save (0, 0) only if it was not 0, 0
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+                .Callback<TwinCollection>((t) =>
+                {
+                    fcntUpSavedInTwin = (int)t[TwinProperty.FCntUp];
+                    fcntDownSavedInTwin = (int)t[TwinProperty.FCntDown];
+                })
+                .ReturnsAsync(true);
+
+            // device api will be searched for payload
+            this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))
+                .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "abc").AsList()));
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewMemoryCache(), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageDispatcher = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
+
+            // sends unconfirmed message
+            var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage("hello", fcnt: payloadFcntUp);
+            var rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
+            var request = new WaitableLoRaRequest(rxpk, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.Null(request.ResponseDownlink);
+
+            // Ensure that a telemetry was sent
+            Assert.NotNull(loRaDeviceTelemetry);
+            // Assert.Equal(msgPayload, loRaDeviceTelemetry.data);
+
+            // Ensure that the device twins were saved
+            Assert.NotNull(fcntDownSavedInTwin);
+            Assert.NotNull(fcntUpSavedInTwin);
+            Assert.Equal(0, fcntDownSavedInTwin.Value);
+            Assert.Equal(0, fcntUpSavedInTwin.Value);
+
+            // verify that the device in device registry has correct properties and frame counters
+            var devicesForDevAddr = deviceRegistry.InternalGetCachedDevicesForDevAddr(devAddr);
+            Assert.Single(devicesForDevAddr);
+            Assert.True(devicesForDevAddr.TryGetValue(devEUI, out var loRaDevice));
+            Assert.Equal(devAddr, loRaDevice.DevAddr);
+            Assert.Equal(devEUI, loRaDevice.DevEUI);
+            Assert.True(loRaDevice.IsABP);
+            Assert.Equal(payloadFcntUp, loRaDevice.FCntUp);
+            Assert.Equal(0, loRaDevice.FCntDown);
+            if (payloadFcntUp == 0)
+                Assert.False(loRaDevice.HasFrameCountChanges); // no changes
+            else
+                Assert.True(loRaDevice.HasFrameCountChanges); // there are pending changes (fcntUp 0 => 1)
+
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
     }
 }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorTestBase.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorTestBase.cs
@@ -26,7 +26,7 @@ namespace LoRaWan.NetworkServer.Test
 
         protected Mock<LoRaDeviceAPIServiceBase> LoRaDeviceApi { get; }
 
-        protected ILoRaDeviceFrameCounterUpdateStrategyFactory FrameCounterUpdateStrategyFactory { get; }
+        protected ILoRaDeviceFrameCounterUpdateStrategyProvider FrameCounterUpdateStrategyProvider { get; }
 
         protected NetworkServerConfiguration ServerConfiguration { get; }
 
@@ -56,10 +56,10 @@ namespace LoRaWan.NetworkServer.Test
 
             this.PacketForwarder = new TestPacketForwarder();
             this.LoRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            this.FrameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(ServerGatewayID, this.LoRaDeviceApi.Object);
-            this.requestHandlerImplementation = new DefaultLoRaDataRequestHandler(this.ServerConfiguration, this.FrameCounterUpdateStrategyFactory, new LoRaPayloadDecoder());
+            this.FrameCounterUpdateStrategyProvider = new LoRaDeviceFrameCounterUpdateStrategyProvider(ServerGatewayID, this.LoRaDeviceApi.Object);
+            this.requestHandlerImplementation = new DefaultLoRaDataRequestHandler(this.ServerConfiguration, this.FrameCounterUpdateStrategyProvider, new LoRaPayloadDecoder());
             this.LoRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            this.LoRaDeviceFactory = new TestLoRaDeviceFactory(this.ServerConfiguration, this.FrameCounterUpdateStrategyFactory, this.LoRaDeviceClient.Object);
+            this.LoRaDeviceFactory = new TestLoRaDeviceFactory(this.ServerConfiguration, this.FrameCounterUpdateStrategyProvider, this.LoRaDeviceClient.Object);
         }
 
         public MemoryCache NewMemoryCache() => new MemoryCache(new MemoryCacheOptions());

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
@@ -54,7 +54,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234");
@@ -106,7 +106,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends confirmed message
             var rxpk = simulatedDevice.CreateConfirmedMessageUplink("1234", fcnt: payloadFcnt).Rxpk[0];
@@ -158,7 +158,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
@@ -228,7 +228,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var payload = simulatedDevice.CreateConfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
@@ -306,7 +306,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 loRaDeviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
@@ -400,7 +400,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 loRaDeviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
@@ -500,7 +500,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 loRaDeviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
@@ -615,7 +615,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
@@ -631,7 +631,7 @@ namespace LoRaWan.NetworkServer.Test
             var actualDownlink = this.PacketForwarder.DownlinkMessages.First();
 
             var euRegion = RegionFactory.CreateEU868Region();
-            if (expectedRX == 1)
+            if (expectedRX == Constants.RECEIVE_WINDOW_1)
             {
                 // ensure response is for RX1
                 Assert.Equal(rxpk.Tmst + 1000000, actualDownlink.Txpk.Tmst);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Slow_Get_Twin_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Slow_Get_Twin_Tests.cs
@@ -70,7 +70,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // 1st join request
             // Should fail

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Slow_Get_Twin_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Slow_Get_Twin_Tests.cs
@@ -23,17 +23,15 @@ namespace LoRaWan.NetworkServer.Test
         public async Task When_Join_Fails_Due_To_Timeout_Second_Try_Should_Reuse_Cached_Device_Twin(string deviceGatewayID)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, gatewayID: deviceGatewayID));
-            var joinRequest1 = simulatedDevice.CreateJoinRequest();
+            var joinRequestPayload1 = simulatedDevice.CreateJoinRequest();
 
             // Create Rxpk
-            var joinRequestRxpk1 = joinRequest1.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
+            var joinRequestRxpk1 = joinRequestPayload1.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
 
-            var joinRequestDevNonce1 = ConversionHelper.ByteArrayToString(joinRequest1.DevNonce);
+            var joinRequestDevNonce1 = ConversionHelper.ByteArrayToString(joinRequestPayload1.DevNonce);
             var devAddr = string.Empty;
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
             var appEUI = simulatedDevice.LoRaDevice.AppEUI;
-
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
 
             // Device twin will be queried twice, 1st time will take 7 seconds, 2nd time 0.1 second
             var twin = new Twin();
@@ -42,7 +40,7 @@ namespace LoRaWan.NetworkServer.Test
             twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey;
             twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
             twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            loRaDeviceClient.Setup(x => x.GetTwinAsync())
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync())
                 .Returns(async () =>
                 {
                     await Task.Delay(TimeSpan.FromSeconds(7));
@@ -53,7 +51,7 @@ namespace LoRaWan.NetworkServer.Test
             string afterJoinAppSKey = null;
             string afterJoinNwkSKey = null;
             string afterJoinDevAddr = null;
-            loRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
                 .Callback<TwinCollection>((updatedTwin) =>
                 {
                     afterJoinAppSKey = updatedTwin[TwinProperty.AppSKey];
@@ -63,41 +61,43 @@ namespace LoRaWan.NetworkServer.Test
                 .ReturnsAsync(true);
 
             // Lora device api will be search by devices with matching deveui,
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            loRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce1))
+            this.LoRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce1))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "aabb").AsList()));
 
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
-
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // 1st join request
             // Should fail
-            var joinRequestDownlinkMessage1 = await messageProcessor.ProcessMessageAsync(joinRequestRxpk1);
-            Assert.Null(joinRequestDownlinkMessage1);
+            var joinRequest1 = this.CreateWaitableRequest(joinRequestRxpk1);
+            messageProcessor.DispatchRequest(joinRequest1);
+            Assert.True(await joinRequest1.WaitCompleteAsync());
+            Assert.True(joinRequest1.ProcessingFailed);
+            Assert.Null(joinRequest1.ResponseDownlink);
+            Assert.Equal(LoRaDeviceRequestFailedReason.ReceiveWindowMissed, joinRequest1.ProcessingFailedReason);
 
             // 2nd attempt
-            var joinRequest2 = simulatedDevice.CreateJoinRequest();
-            var joinRequestRxpk2 = joinRequest2.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
-            var joinRequestDevNonce2 = LoRaTools.Utils.ConversionHelper.ByteArrayToString(joinRequest2.DevNonce);
+            var joinRequestPayload2 = simulatedDevice.CreateJoinRequest();
+            var joinRequestRxpk2 = joinRequestPayload2.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
+            var joinRequestDevNonce2 = LoRaTools.Utils.ConversionHelper.ByteArrayToString(joinRequestPayload2.DevNonce);
 
             // setup response to this device search
-            loRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce2))
+            this.LoRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce2))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "aabb").AsList()));
 
-            var joinRequestDownlinkMessage2 = await messageProcessor.ProcessMessageAsync(joinRequestRxpk2);
-            Assert.NotNull(joinRequestDownlinkMessage2);
-            var joinAccept = new LoRaPayloadJoinAccept(Convert.FromBase64String(joinRequestDownlinkMessage2.Txpk.Data), simulatedDevice.LoRaDevice.AppKey);
+            var joinRequest2 = this.CreateWaitableRequest(joinRequestRxpk2);
+            messageProcessor.DispatchRequest(joinRequest2);
+            Assert.True(await joinRequest2.WaitCompleteAsync());
+            Assert.True(joinRequest2.ProcessingSucceeded);
+            Assert.NotNull(joinRequest2.ResponseDownlink);
+            Assert.Single(this.PacketForwarder.DownlinkMessages);
+            var joinRequestDownlinkMessage = this.PacketForwarder.DownlinkMessages[0];
+            var joinAccept = new LoRaPayloadJoinAccept(Convert.FromBase64String(joinRequestDownlinkMessage.Txpk.Data), simulatedDevice.LoRaDevice.AppKey);
             Assert.Equal(joinAccept.DevAddr.ToArray(), ConversionHelper.StringToByteArray(afterJoinDevAddr));
 
             var devicesForDevAddr = deviceRegistry.InternalGetCachedDevicesForDevAddr(afterJoinDevAddr);
@@ -120,13 +120,13 @@ namespace LoRaWan.NetworkServer.Test
             Assert.False(loRaDevice.HasFrameCountChanges);
 
             // searching the device should happen twice
-            loRaDeviceApi.Verify(x => x.SearchAndLockForJoinAsync(ServerGatewayID, devEUI, appEUI, It.IsNotNull<string>()), Times.Exactly(2));
+            this.LoRaDeviceApi.Verify(x => x.SearchAndLockForJoinAsync(ServerGatewayID, devEUI, appEUI, It.IsNotNull<string>()), Times.Exactly(2));
 
             // getting the device twin should happens once
-            loRaDeviceClient.Verify(x => x.GetTwinAsync(), Times.Once());
+            this.LoRaDeviceClient.Verify(x => x.GetTwinAsync(), Times.Once());
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
     }
 }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Slow_Twin_Update_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Slow_Twin_Update_Tests.cs
@@ -25,20 +25,18 @@ namespace LoRaWan.NetworkServer.Test
         public async Task When_First_Join_Fails_Due_To_Slow_Twin_Update_Retry_Second_Attempt_Should_Succeed(string deviceGatewayID)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, gatewayID: deviceGatewayID));
-            var joinRequest1 = simulatedDevice.CreateJoinRequest();
-            var joinRequest2 = simulatedDevice.CreateJoinRequest();
+            var joinRequestPayload1 = simulatedDevice.CreateJoinRequest();
+            var joinRequestPayload2 = simulatedDevice.CreateJoinRequest();
 
             // Create Rxpk
-            var joinRequestRxpk1 = joinRequest1.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
-            var joinRequestRxpk2 = joinRequest2.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
+            var joinRequestRxpk1 = joinRequestPayload1.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
+            var joinRequestRxpk2 = joinRequestPayload2.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
 
-            var joinRequestDevNonce1 = joinRequest1.GetDevNonceAsString();
-            var joinRequestDevNonce2 = joinRequest2.GetDevNonceAsString();
+            var joinRequestDevNonce1 = joinRequestPayload1.GetDevNonceAsString();
+            var joinRequestDevNonce2 = joinRequestPayload2.GetDevNonceAsString();
             var devAddr = string.Empty;
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
             var appEUI = simulatedDevice.LoRaDevice.AppEUI;
-
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
 
             // Device twin will be queried
             var twin = new Twin();
@@ -47,7 +45,7 @@ namespace LoRaWan.NetworkServer.Test
             twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey;
             twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
             twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            loRaDeviceClient.Setup(x => x.GetTwinAsync())
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync())
                 .ReturnsAsync(twin);
 
             // Device twin will be updated
@@ -58,7 +56,7 @@ namespace LoRaWan.NetworkServer.Test
             string afterJoin2NwkSKey = null;
             string afterJoin2DevAddr = null;
             var isFirstTwinUpdate = true;
-            loRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
                 .Callback<TwinCollection>((updatedTwin) =>
                 {
                     if (isFirstTwinUpdate)
@@ -80,36 +78,33 @@ namespace LoRaWan.NetworkServer.Test
                 .ReturnsAsync(true);
 
             // Lora device api will be search by devices with matching deveui,
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            loRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce1))
+            this.LoRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce1))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "aabb").AsList()));
 
-            loRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce2))
+            this.LoRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce2))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "aabb").AsList()));
-
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
 
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
-
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
-            var joinRequestTask1 = messageProcessor.ProcessMessageAsync(joinRequestRxpk1);
-
+            var joinRequest1 = this.CreateWaitableRequest(joinRequestRxpk1);
+            messageProcessor.DispatchRequest(joinRequest1);
             await Task.Delay(TimeSpan.FromSeconds(7));
 
-            var joinRequestTask2 = messageProcessor.ProcessMessageAsync(joinRequestRxpk2);
+            var joinRequest2 = this.CreateWaitableRequest(joinRequestRxpk2);
+            messageProcessor.DispatchRequest(joinRequest2);
 
-            await Task.WhenAll(joinRequestTask1, joinRequestTask2);
-            Assert.Null(joinRequestTask1.Result);
-            Assert.NotNull(joinRequestTask2.Result);
+            await Task.WhenAll(joinRequest1.WaitCompleteAsync(), joinRequest2.WaitCompleteAsync());
+            Assert.True(joinRequest1.ProcessingFailed);
+            Assert.Null(joinRequest1.ResponseDownlink);
+            Assert.True(joinRequest2.ProcessingSucceeded);
+            Assert.NotNull(joinRequest2.ResponseDownlink);
+            Assert.Single(this.PacketForwarder.DownlinkMessages);
 
             Assert.Empty(deviceRegistry.InternalGetCachedDevicesForDevAddr(afterJoin1DevAddr));
             var devicesInDevAddr2 = deviceRegistry.InternalGetCachedDevicesForDevAddr(afterJoin2DevAddr);
@@ -121,9 +116,9 @@ namespace LoRaWan.NetworkServer.Test
             Assert.Equal(afterJoin2AppSKey, loRaDevice.AppSKey);
 
             // get twin should happen only once
-            loRaDeviceClient.Verify(x => x.GetTwinAsync(), Times.Once());
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.Verify(x => x.GetTwinAsync(), Times.Once());
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
     }
 }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Slow_Twin_Update_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Slow_Twin_Update_Tests.cs
@@ -90,7 +90,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var joinRequest1 = this.CreateWaitableRequest(joinRequestRxpk1);
             messageProcessor.DispatchRequest(joinRequest1);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Tests.cs
@@ -36,17 +36,16 @@ namespace LoRaWan.NetworkServer.Test
         public async Task Join_And_Send_Unconfirmed_And_Confirmed_Messages(string deviceGatewayID, int initialFcntUp, int initialFcntDown, int startingPayloadFcnt, uint netId)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, gatewayID: deviceGatewayID));
-            var joinRequest = simulatedDevice.CreateJoinRequest();
+            var joinRequestPayload = simulatedDevice.CreateJoinRequest();
 
             // Create Rxpk
-            var joinRxpk = joinRequest.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
+            var joinRxpk = joinRequestPayload.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
 
-            var devNonce = LoRaTools.Utils.ConversionHelper.ByteArrayToString(joinRequest.DevNonce);
+            var devNonce = LoRaTools.Utils.ConversionHelper.ByteArrayToString(joinRequestPayload.DevNonce);
             var devAddr = string.Empty;
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
             var appEUI = simulatedDevice.LoRaDevice.AppEUI;
 
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
             this.ServerConfiguration.NetId = netId;
             // Device twin will be queried
             var twin = new Twin();
@@ -57,7 +56,7 @@ namespace LoRaWan.NetworkServer.Test
             twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
             twin.Properties.Reported[TwinProperty.FCntUp] = initialFcntUp;
             twin.Properties.Reported[TwinProperty.FCntDown] = initialFcntDown;
-            loRaDeviceClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(twin);
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(twin);
 
             // Device twin will be updated
             string afterJoinAppSKey = null;
@@ -65,7 +64,7 @@ namespace LoRaWan.NetworkServer.Test
             string afterJoinDevAddr = null;
             int afterJoinFcntDown = -1;
             int afterJoinFcntUp = -1;
-            loRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
                 .Callback<TwinCollection>((updatedTwin) =>
                 {
                     afterJoinAppSKey = updatedTwin[TwinProperty.AppSKey];
@@ -78,43 +77,42 @@ namespace LoRaWan.NetworkServer.Test
 
             // message will be sent
             var sentTelemetry = new List<LoRaDeviceTelemetry>();
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) => sentTelemetry.Add(t))
                 .ReturnsAsync(true);
 
             // C2D message will be checked
-            loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
             // Lora device api will be search by devices with matching deveui,
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            loRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, devNonce))
+            this.LoRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, devNonce))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "aabb").AsList()));
 
             // multi gateway will request a next frame count down from the lora device api, prepare it
             if (string.IsNullOrEmpty(deviceGatewayID))
             {
-                loRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, 0, startingPayloadFcnt + 1, this.ServerConfiguration.GatewayID))
+                this.LoRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, 0, startingPayloadFcnt + 1, this.ServerConfiguration.GatewayID))
                     .ReturnsAsync((ushort)1);
             }
 
             // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
-            var downlinkJoinAcceptMessage = await messageProcessor.ProcessMessageAsync(joinRxpk);
-            Assert.NotNull(downlinkJoinAcceptMessage);
+            var joinRequest = this.CreateWaitableRequest(joinRxpk);
+            messageProcessor.DispatchRequest(joinRequest);
+            Assert.True(await joinRequest.WaitCompleteAsync());
+            Assert.True(joinRequest.ProcessingSucceeded);
+            Assert.NotNull(joinRequest.ResponseDownlink);
+            Assert.Single(this.PacketForwarder.DownlinkMessages);
+            var downlinkJoinAcceptMessage = this.PacketForwarder.DownlinkMessages[0];
             var joinAccept = new LoRaPayloadJoinAccept(Convert.FromBase64String(downlinkJoinAcceptMessage.Txpk.Data), simulatedDevice.LoRaDevice.AppKey);
             Assert.Equal(joinAccept.DevAddr.ToArray(), ConversionHelper.StringToByteArray(afterJoinDevAddr));
 
@@ -145,8 +143,11 @@ namespace LoRaWan.NetworkServer.Test
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage("100", fcnt: startingPayloadFcnt);
-            var unconfirmedMessageResult = await messageProcessor.ProcessMessageAsync(unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0]);
-            Assert.Null(unconfirmedMessageResult);
+            var unconfirmedRequest = this.CreateWaitableRequest(unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0]);
+            messageProcessor.DispatchRequest(unconfirmedRequest);
+            Assert.True(await unconfirmedRequest.WaitCompleteAsync());
+            Assert.Null(unconfirmedRequest.ResponseDownlink);
+            Assert.True(unconfirmedRequest.ProcessingSucceeded);
 
             // fcnt up was updated
             Assert.Equal(startingPayloadFcnt, loRaDevice.FCntUp);
@@ -163,17 +164,22 @@ namespace LoRaWan.NetworkServer.Test
             // sends confirmed message
             var confirmedMessagePayload = simulatedDevice.CreateConfirmedDataUpMessage("200", fcnt: startingPayloadFcnt + 1);
             var confirmedMessageRxpk = confirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            var confirmedMessage = await messageProcessor.ProcessMessageAsync(confirmedMessageRxpk);
-            Assert.NotNull(confirmedMessage);
-            Assert.NotNull(confirmedMessage.Txpk);
+            var confirmedRequest = this.CreateWaitableRequest(confirmedMessageRxpk);
+            messageProcessor.DispatchRequest(confirmedRequest);
+            Assert.True(await confirmedRequest.WaitCompleteAsync());
+            Assert.True(confirmedRequest.ProcessingSucceeded);
+            Assert.NotNull(confirmedRequest.ResponseDownlink);
+            Assert.NotNull(confirmedRequest.ResponseDownlink.Txpk);
+            Assert.Equal(2, this.PacketForwarder.DownlinkMessages.Count);
             Assert.Equal(2, sentTelemetry.Count);
+            var downstreamMessage = this.PacketForwarder.DownlinkMessages[1];
 
             // validates txpk according to eu region
-            Assert.Equal(RegionFactory.CreateEU868Region().GetDownstreamChannelFrequency(confirmedMessageRxpk), confirmedMessage.Txpk.Freq);
-            Assert.Equal("4/5", confirmedMessage.Txpk.Codr);
-            Assert.False(confirmedMessage.Txpk.Imme);
-            Assert.True(confirmedMessage.Txpk.Ipol);
-            Assert.Equal("LORA", confirmedMessage.Txpk.Modu);
+            Assert.Equal(RegionFactory.CreateEU868Region().GetDownstreamChannelFrequency(confirmedMessageRxpk), downstreamMessage.Txpk.Freq);
+            Assert.Equal("4/5", downstreamMessage.Txpk.Codr);
+            Assert.False(downstreamMessage.Txpk.Imme);
+            Assert.True(downstreamMessage.Txpk.Ipol);
+            Assert.Equal("LORA", downstreamMessage.Txpk.Modu);
 
             // fcnt up was updated
             Assert.Equal(startingPayloadFcnt + 1, loRaDevice.FCntUp);
@@ -183,14 +189,14 @@ namespace LoRaWan.NetworkServer.Test
             Assert.True(loRaDevice.HasFrameCountChanges);
 
             // C2D message will be checked twice
-            loRaDeviceClient.Verify(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()), Times.Exactly(2));
+            this.LoRaDeviceClient.Verify(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()), Times.Exactly(2));
 
             // has telemetry with both fcnt
             Assert.Single(sentTelemetry, (t) => t.Fcnt == startingPayloadFcnt);
             Assert.Single(sentTelemetry, (t) => t.Fcnt == (startingPayloadFcnt + 1));
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         [Theory]
@@ -199,17 +205,15 @@ namespace LoRaWan.NetworkServer.Test
         public async Task When_Join_Fails_Due_To_GetTwin_Error_Second_Try_Should_Reload_Device_Twin(string deviceGatewayID)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, gatewayID: deviceGatewayID));
-            var joinRequest1 = simulatedDevice.CreateJoinRequest();
+            var joinRequestPayload1 = simulatedDevice.CreateJoinRequest();
 
             // Create Rxpk
-            var joinRequestRxpk1 = joinRequest1.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
+            var joinRequestRxpk1 = joinRequestPayload1.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
 
-            var joinRequestDevNonce1 = ConversionHelper.ByteArrayToString(joinRequest1.DevNonce);
+            var joinRequestDevNonce1 = ConversionHelper.ByteArrayToString(joinRequestPayload1.DevNonce);
             var devAddr = string.Empty;
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
             var appEUI = simulatedDevice.LoRaDevice.AppEUI;
-
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
 
             // Device twin will be queried
             var twin = new Twin();
@@ -218,7 +222,7 @@ namespace LoRaWan.NetworkServer.Test
             twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey;
             twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
             twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            loRaDeviceClient.SetupSequence(x => x.GetTwinAsync())
+            this.LoRaDeviceClient.SetupSequence(x => x.GetTwinAsync())
                 .ReturnsAsync((Twin)null)
                 .ReturnsAsync(twin);
 
@@ -226,7 +230,7 @@ namespace LoRaWan.NetworkServer.Test
             string afterJoinAppSKey = null;
             string afterJoinNwkSKey = null;
             string afterJoinDevAddr = null;
-            loRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
                 .Callback<TwinCollection>((updatedTwin) =>
                 {
                     afterJoinAppSKey = updatedTwin[TwinProperty.AppSKey];
@@ -236,40 +240,41 @@ namespace LoRaWan.NetworkServer.Test
                 .ReturnsAsync(true);
 
             // Lora device api will be search by devices with matching deveui,
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            loRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce1))
+            this.LoRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce1))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "aabb").AsList()));
 
             // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
-
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // 1st join request
             // Should fail
-            var joinRequestDownlinkMessage1 = await messageProcessor.ProcessMessageAsync(joinRequestRxpk1);
-            Assert.Null(joinRequestDownlinkMessage1);
+            var joinRequest1 = this.CreateWaitableRequest(joinRequestRxpk1);
+            messageProcessor.DispatchRequest(joinRequest1);
+            Assert.True(await joinRequest1.WaitCompleteAsync());
+            Assert.True(joinRequest1.ProcessingFailed);
+            Assert.Null(joinRequest1.ResponseDownlink);
 
             // 2nd attempt
-            var joinRequest2 = simulatedDevice.CreateJoinRequest();
+            var joinRequestPayload2 = simulatedDevice.CreateJoinRequest();
 
             // will reload the device matched by deveui
-            loRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, ConversionHelper.ByteArrayToString(joinRequest2.DevNonce)))
+            this.LoRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, ConversionHelper.ByteArrayToString(joinRequestPayload2.DevNonce)))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "aabb").AsList()));
 
-            var joinRequestRxpk2 = joinRequest2.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
-            var joinRequestDevNonce2 = LoRaTools.Utils.ConversionHelper.ByteArrayToString(joinRequest2.DevNonce);
-            var joinRequestDownlinkMessage2 = await messageProcessor.ProcessMessageAsync(joinRequestRxpk2);
-            Assert.NotNull(joinRequestDownlinkMessage2);
+            var joinRequestRxpk2 = joinRequestPayload2.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
+            var joinRequestDevNonce2 = LoRaTools.Utils.ConversionHelper.ByteArrayToString(joinRequestPayload2.DevNonce);
+            var joinRequest2 = this.CreateWaitableRequest(joinRequestRxpk2);
+            messageProcessor.DispatchRequest(joinRequest2);
+            Assert.NotNull(joinRequest2.ResponseDownlink);
+            Assert.True(joinRequest2.ProcessingSucceeded);
+            Assert.Single(this.PacketForwarder.DownlinkMessages);
+            var joinRequestDownlinkMessage2 = this.PacketForwarder.DownlinkMessages[0];
             var joinAccept = new LoRaPayloadJoinAccept(Convert.FromBase64String(joinRequestDownlinkMessage2.Txpk.Data), simulatedDevice.LoRaDevice.AppKey);
             Assert.Equal(joinAccept.DevAddr.ToArray(), ConversionHelper.StringToByteArray(afterJoinDevAddr));
 
@@ -293,13 +298,13 @@ namespace LoRaWan.NetworkServer.Test
             Assert.False(loRaDevice.HasFrameCountChanges);
 
             // should get twin 2x (1st failed)
-            loRaDeviceClient.Verify(x => x.GetTwinAsync(), Times.Exactly(2));
+            this.LoRaDeviceClient.Verify(x => x.GetTwinAsync(), Times.Exactly(2));
 
             // should get device for join 2x
-            loRaDeviceApi.Verify(x => x.SearchAndLockForJoinAsync(ServerGatewayID, devEUI, appEUI, It.IsAny<string>()));
+            this.LoRaDeviceApi.Verify(x => x.SearchAndLockForJoinAsync(ServerGatewayID, devEUI, appEUI, It.IsAny<string>()));
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         [Theory]
@@ -308,17 +313,15 @@ namespace LoRaWan.NetworkServer.Test
         public async Task Join_Device_Has_Mismatching_AppEUI_Should_Return_Null(string deviceGatewayID)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, gatewayID: deviceGatewayID));
-            var joinRequest = simulatedDevice.CreateJoinRequest();
+            var joinRequestPayload = simulatedDevice.CreateJoinRequest();
 
             // Create Rxpk
-            var joinRequestRxpk = joinRequest.SerializeUplink(simulatedDevice.AppKey).Rxpk[0];
+            var joinRequestRxpk = joinRequestPayload.SerializeUplink(simulatedDevice.AppKey).Rxpk[0];
 
-            var joinRequestDevNonce = ConversionHelper.ByteArrayToString(joinRequest.DevNonce);
+            var joinRequestDevNonce = ConversionHelper.ByteArrayToString(joinRequestPayload.DevNonce);
             var devAddr = string.Empty;
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
             var appEUI = simulatedDevice.LoRaDevice.AppEUI;
-
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
 
             // Device twin will be queried
             var twin = new Twin();
@@ -327,35 +330,31 @@ namespace LoRaWan.NetworkServer.Test
             twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey;
             twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
             twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            loRaDeviceClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(twin);
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(twin);
 
             // Lora device api will be search by devices with matching deveui,
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            loRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce))
+            this.LoRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "aabb").AsList()));
 
             // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
-
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // join request should fail
-            var joinRequestDownlinkMessage = await messageProcessor.ProcessMessageAsync(joinRequestRxpk);
-            Assert.Null(joinRequestDownlinkMessage);
+            var joinRequest = this.CreateWaitableRequest(joinRequestRxpk);
+            messageProcessor.DispatchRequest(joinRequest);
+            Assert.True(await joinRequest.WaitCompleteAsync());
+            Assert.Null(joinRequest.ResponseDownlink);
 
-            loRaDeviceClient.Verify(x => x.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Never);
+            this.LoRaDeviceClient.Verify(x => x.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Never);
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         [Theory]
@@ -364,17 +363,15 @@ namespace LoRaWan.NetworkServer.Test
         public async Task Join_Device_Has_Mismatching_AppKey_Should_Return_Null(string deviceGatewayID)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, gatewayID: deviceGatewayID));
-            var joinRequest = simulatedDevice.CreateJoinRequest();
+            var joinRequestPayload = simulatedDevice.CreateJoinRequest();
 
             // Create Rxpk
-            var joinRequestRxpk = joinRequest.SerializeUplink(simulatedDevice.AppKey).Rxpk[0];
+            var joinRequestRxpk = joinRequestPayload.SerializeUplink(simulatedDevice.AppKey).Rxpk[0];
 
-            var joinRequestDevNonce = ConversionHelper.ByteArrayToString(joinRequest.DevNonce);
+            var joinRequestDevNonce = ConversionHelper.ByteArrayToString(joinRequestPayload.DevNonce);
             var devAddr = string.Empty;
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
             var appEUI = simulatedDevice.LoRaDevice.AppEUI;
-
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
 
             // Device twin will be queried
             var twin = new Twin();
@@ -383,34 +380,31 @@ namespace LoRaWan.NetworkServer.Test
             twin.Properties.Desired[TwinProperty.AppKey] = "012345678901234567890123456789FF";
             twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
             twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            loRaDeviceClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(twin);
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(twin);
 
             // Lora device api will be search by devices with matching deveui,
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            loRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce))
+            this.LoRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, joinRequestDevNonce))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "aabb").AsList()));
 
             // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
-
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // join request should fail
-            var joinRequestDownlinkMessage = await messageProcessor.ProcessMessageAsync(joinRequestRxpk);
-            Assert.Null(joinRequestDownlinkMessage);
+            var joinRequest = this.CreateWaitableRequest(joinRequestRxpk);
+            messageProcessor.DispatchRequest(joinRequest);
+            Assert.True(await joinRequest.WaitCompleteAsync());
+            Assert.True(joinRequest.ProcessingFailed);
+            Assert.Null(joinRequest.ResponseDownlink);
 
-            loRaDeviceClient.Verify(x => x.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Never);
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.Verify(x => x.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Never);
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         /// <summary>
@@ -425,18 +419,16 @@ namespace LoRaWan.NetworkServer.Test
         public async Task OTAA_Join_Should_Use_Rchf_0(string deviceGatewayID, uint rfch)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, gatewayID: deviceGatewayID));
-            var joinRequest = simulatedDevice.CreateJoinRequest();
+            var joinRequestPayload = simulatedDevice.CreateJoinRequest();
 
             // Create Rxpk
-            var joinRxpk = joinRequest.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
+            var joinRxpk = joinRequestPayload.SerializeUplink(simulatedDevice.LoRaDevice.AppKey).Rxpk[0];
             joinRxpk.Rfch = rfch;
 
-            var devNonce = ConversionHelper.ByteArrayToString(joinRequest.DevNonce);
+            var devNonce = ConversionHelper.ByteArrayToString(joinRequestPayload.DevNonce);
             var devAddr = string.Empty;
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
             var appEUI = simulatedDevice.LoRaDevice.AppEUI;
-
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
 
             // Device twin will be queried
             var twin = new Twin();
@@ -445,34 +437,33 @@ namespace LoRaWan.NetworkServer.Test
             twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey;
             twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
             twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            loRaDeviceClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(twin);
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(twin);
 
             // Device twin will be updated
-            loRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
                 .ReturnsAsync(true);
 
             // Lora device api will be search by devices with matching deveui,
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            loRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, devNonce))
+            this.LoRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, devNonce))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "aabb").AsList()));
 
             // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
-            var downlinkJoinAcceptMessage = await messageProcessor.ProcessMessageAsync(joinRxpk);
-            Assert.NotNull(downlinkJoinAcceptMessage);
+            var joinRequest = this.CreateWaitableRequest(joinRxpk);
+            messageProcessor.DispatchRequest(joinRequest);
+            Assert.True(await joinRequest.WaitCompleteAsync());
+            Assert.True(joinRequest.ProcessingSucceeded);
+            Assert.NotNull(joinRequest.ResponseDownlink);
+            Assert.Single(this.PacketForwarder.DownlinkMessages);
+            var downlinkJoinAcceptMessage = this.PacketForwarder.DownlinkMessages[0];
             // validates txpk according to eu region
             Assert.Equal(0U, downlinkJoinAcceptMessage.Txpk.Rfch);
             Assert.Equal(RegionFactory.CreateEU868Region().GetDownstreamChannelFrequency(joinRxpk), downlinkJoinAcceptMessage.Txpk.Freq);
@@ -481,8 +472,8 @@ namespace LoRaWan.NetworkServer.Test
             Assert.True(downlinkJoinAcceptMessage.Txpk.Ipol);
             Assert.Equal("LORA", downlinkJoinAcceptMessage.Txpk.Modu);
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         [Theory]
@@ -496,8 +487,6 @@ namespace LoRaWan.NetworkServer.Test
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
             var appEUI = simulatedDevice.LoRaDevice.AppEUI;
 
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-
             // Device twin will be queried
             var twin = new Twin();
             twin.Properties.Desired[TwinProperty.DevEUI] = devEUI;
@@ -505,51 +494,48 @@ namespace LoRaWan.NetworkServer.Test
             twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey;
             twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
             twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            loRaDeviceClient.Setup(x => x.GetTwinAsync())
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync())
                 .ReturnsAsync(twin);
 
             // Device twin will be updated
-            loRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
                 .ReturnsAsync(true);
 
             // Lora device api will be search by devices with matching deveui
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            loRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, It.IsAny<string>()))
+            this.LoRaDeviceApi.Setup(x => x.SearchAndLockForJoinAsync(this.ServerConfiguration.GatewayID, devEUI, appEUI, It.IsAny<string>()))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "aabb").AsList()));
 
             // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
-
-            var messageProcessor = new MessageProcessor(
+            var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // 1st join request
-            var joinRequest1Response = messageProcessor.ProcessMessageAsync(simulatedDevice.CreateJoinRequest().SerializeUplink(simulatedDevice.AppKey).Rxpk[0]);
+            var joinRequest1 = this.CreateWaitableRequest(simulatedDevice.CreateJoinRequest().SerializeUplink(simulatedDevice.AppKey).Rxpk[0]);
+            messageProcessor.DispatchRequest(joinRequest1);
 
             // 2nd join request
-            var joinRequest2Response = messageProcessor.ProcessMessageAsync(simulatedDevice.CreateJoinRequest().SerializeUplink(simulatedDevice.AppKey).Rxpk[0]);
+            var joinRequest2 = this.CreateWaitableRequest(simulatedDevice.CreateJoinRequest().SerializeUplink(simulatedDevice.AppKey).Rxpk[0]);
+            messageProcessor.DispatchRequest(joinRequest2);
 
-            await Task.WhenAll(joinRequest1Response, joinRequest2Response);
+            await Task.WhenAll(joinRequest1.WaitCompleteAsync(), joinRequest2.WaitCompleteAsync());
 
-            Assert.NotNull(joinRequest1Response.Result);
-            Assert.NotNull(joinRequest2Response.Result);
+            Assert.Equal(2, this.PacketForwarder.DownlinkMessages.Count);
+            Assert.NotNull(joinRequest1.ResponseDownlink);
+            Assert.NotNull(joinRequest2.ResponseDownlink);
 
             // get twin only once called
-            loRaDeviceClient.Verify(x => x.GetTwinAsync(), Times.Once());
+            this.LoRaDeviceClient.Verify(x => x.GetTwinAsync(), Times.Once());
 
             // get device for join called x2
-            loRaDeviceApi.Verify(x => x.SearchAndLockForJoinAsync(ServerGatewayID, devEUI, appEUI, It.IsAny<string>()));
+            this.LoRaDeviceApi.Verify(x => x.SearchAndLockForJoinAsync(ServerGatewayID, devEUI, appEUI, It.IsAny<string>()), Times.Exactly(2));
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
     }
 }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Tests.cs
@@ -104,7 +104,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var joinRequest = this.CreateWaitableRequest(joinRxpk);
             messageProcessor.DispatchRequest(joinRequest);
@@ -250,7 +250,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // 1st join request
             // Should fail
@@ -343,7 +343,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // join request should fail
             var joinRequest = this.CreateWaitableRequest(joinRequestRxpk);
@@ -393,7 +393,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // join request should fail
             var joinRequest = this.CreateWaitableRequest(joinRequestRxpk);
@@ -455,7 +455,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var joinRequest = this.CreateWaitableRequest(joinRxpk);
             messageProcessor.DispatchRequest(joinRequest);
@@ -512,7 +512,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageProcessor = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // 1st join request
             var joinRequest1 = this.CreateWaitableRequest(simulatedDevice.CreateJoinRequest().SerializeUplink(simulatedDevice.AppKey).Rxpk[0]);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_MultiGateway_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_MultiGateway_Tests.cs
@@ -43,7 +43,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateConfirmedDataUpMessage("hello", fcnt: payloadFcnt);
@@ -148,7 +148,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage("hello", fcnt: payloadFcntUp);
@@ -236,7 +236,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage("hello", fcnt: payloadFcnt);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_MultiGateway_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_MultiGateway_Tests.cs
@@ -25,40 +25,33 @@ namespace LoRaWan.NetworkServer.Test
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: null));
             simulatedDevice.FrmCntDown = initialFcntDown;
             simulatedDevice.FrmCntUp = initialFcntUp;
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
 
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
             var devAddr = simulatedDevice.LoRaDevice.DevAddr;
 
-            // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            loRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, initialFcntDown, payloadFcnt, ServerGatewayID)).ReturnsAsync((ushort)0);
-
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
+            this.LoRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, initialFcntDown, payloadFcnt, ServerGatewayID)).ReturnsAsync((ushort)0);
 
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var device = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loRaDeviceClient.Object);
+            var device = this.CreateLoRaDevice(simulatedDevice);
 
             var dicForDevAddr = new DevEUIToLoRaDeviceDictionary();
             dicForDevAddr.TryAdd(devEUI, device);
             memoryCache.Set(devAddr, dicForDevAddr);
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateConfirmedDataUpMessage("hello", fcnt: payloadFcnt);
             var rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            var unconfirmedMessageResult = await messageProcessor.ProcessMessageAsync(rxpk);
-            Assert.Null(unconfirmedMessageResult);
+            var request = this.CreateWaitableRequest(rxpk);
+            messageDispatcher.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.Null(request.ResponseDownlink);
 
             // verify that the device in device registry has correct properties and frame counters
             var devicesForDevAddr = deviceRegistry.InternalGetCachedDevicesForDevAddr(devAddr);
@@ -71,8 +64,8 @@ namespace LoRaWan.NetworkServer.Test
             Assert.Equal(initialFcntDown, loRaDevice.FCntDown);
             Assert.False(loRaDevice.HasFrameCountChanges);
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         [Theory]
@@ -89,19 +82,18 @@ namespace LoRaWan.NetworkServer.Test
             int? deviceTwinFcntDown)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: null));
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
 
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
             var devAddr = simulatedDevice.LoRaDevice.DevAddr;
 
             // message will be sent
             LoRaDeviceTelemetry loRaDeviceTelemetry = null;
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) => loRaDeviceTelemetry = t)
                 .ReturnsAsync(true);
 
             // C2D message will be checked
-            loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
             // twin will be loaded
@@ -120,7 +112,7 @@ namespace LoRaWan.NetworkServer.Test
             if (deviceTwinFcntUp.HasValue)
                 initialTwin.Properties.Reported[TwinProperty.FCntUp] = deviceTwinFcntUp.Value;
 
-            loRaDeviceClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(initialTwin);
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(initialTwin);
 
             // twin will be updated with new fcnt
             int? fcntUpSavedInTwin = null;
@@ -129,7 +121,7 @@ namespace LoRaWan.NetworkServer.Test
             var shouldSaveTwin = (deviceTwinFcntDown ?? 0) != 0 || (deviceTwinFcntUp ?? 0) != 0;
             if (shouldSaveTwin)
             {
-                loRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+                this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
                     .Callback<TwinCollection>((t) =>
                     {
                         fcntUpSavedInTwin = (int)t[TwinProperty.FCntUp];
@@ -138,44 +130,36 @@ namespace LoRaWan.NetworkServer.Test
                     .ReturnsAsync(true);
             }
 
-            // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-
             // multi gateway will reset the fcnt
             if (shouldSaveTwin)
             {
-                loRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI))
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI))
                     .ReturnsAsync(true);
             }
 
             // device api will be searched for payload
-            loRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))
+            this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "abc").AsList()));
 
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage("hello", fcnt: payloadFcntUp);
             var rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            var unconfirmedMessageResult = await messageProcessor.ProcessMessageAsync(rxpk);
-            Assert.Null(unconfirmedMessageResult);
+            var request = this.CreateWaitableRequest(rxpk);
+            messageDispatcher.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.Null(request.ResponseDownlink);
 
             // Ensure that a telemetry was sent
             Assert.NotNull(loRaDeviceTelemetry);
-            // Assert.Equal(msgPayload, loRaDeviceTelemetry.data);
 
             // Ensure that the device twins were saved
             if (shouldSaveTwin)
@@ -200,14 +184,13 @@ namespace LoRaWan.NetworkServer.Test
             else
                 Assert.True(loRaDevice.HasFrameCountChanges); // should have changes!
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         /// <summary>
         /// If cannot get a fcntdown from api should drop the c2d message
         /// </summary>
-        /// <returns></returns>
         [Fact]
         public async Task When_Getting_C2D_Message_Fails_To_Resolve_Fcnt_Down_Should_Drop_Message_And_Return_Null()
         {
@@ -223,53 +206,45 @@ namespace LoRaWan.NetworkServer.Test
             var devAddr = simulatedDevice.LoRaDevice.DevAddr;
 
             // message will be sent
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
 
             var cloudToDeviceMessage = new Message();
             cloudToDeviceMessage.Properties.Add("fport", "1");
             // C2D message will be retrieved
-            loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
                 .ReturnsAsync(cloudToDeviceMessage);
 
             // C2D message will be abandonned
-            loRaDeviceClient.Setup(x => x.AbandonAsync(cloudToDeviceMessage))
+            this.LoRaDeviceClient.Setup(x => x.AbandonAsync(cloudToDeviceMessage))
                 .ReturnsAsync(true);
 
-            // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-
             // getting the fcnt down will return 0!
-            loRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, initialFcntDown, payloadFcnt, this.ServerConfiguration.GatewayID))
+            this.LoRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, initialFcntDown, payloadFcnt, this.ServerConfiguration.GatewayID))
                  .ReturnsAsync((ushort)0);
 
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var cachedDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loRaDeviceClient.Object);
+            var cachedDevice = this.CreateLoRaDevice(simulatedDevice);
 
             var devEUIDeviceDict = new DevEUIToLoRaDeviceDictionary();
             devEUIDeviceDict.TryAdd(devEUI, cachedDevice);
             memoryCache.Set(devAddr, devEUIDeviceDict);
 
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage("hello", fcnt: payloadFcnt);
             var rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            var unconfirmedMessageResult = await messageProcessor.ProcessMessageAsync(rxpk);
-            Assert.Null(unconfirmedMessageResult);
+            var unconfirmedRequest = this.CreateWaitableRequest(rxpk);
+            messageDispatcher.DispatchRequest(unconfirmedRequest);
+            Assert.True(await unconfirmedRequest.WaitCompleteAsync());
+            Assert.Null(unconfirmedRequest.ResponseDownlink);
 
             var cachedDevices = deviceRegistry.InternalGetCachedDevicesForDevAddr(simulatedDevice.DevAddr);
             Assert.True(cachedDevices.TryGetValue(devEUI, out var loRaDevice));
@@ -279,11 +254,11 @@ namespace LoRaWan.NetworkServer.Test
             // fcnt up changed
             Assert.Equal(unconfirmedMessagePayload.GetFcnt(), loRaDevice.FCntUp);
 
-            loRaDeviceClient.Verify(x => x.ReceiveAsync(It.IsAny<TimeSpan>()), Times.Once());
-            loRaDeviceClient.Verify(x => x.AbandonAsync(It.IsAny<Message>()), Times.Once());
+            this.LoRaDeviceClient.Verify(x => x.ReceiveAsync(It.IsAny<TimeSpan>()), Times.Once());
+            this.LoRaDeviceClient.Verify(x => x.AbandonAsync(It.IsAny<Message>()), Times.Once());
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
     }
 }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Parallel_Processing_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Parallel_Processing_Tests.cs
@@ -169,7 +169,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message
             var unconfirmedMessage1 = simulatedDevice.CreateUnconfirmedMessageUplink("1", fcnt: 1).Rxpk[0];
@@ -342,7 +342,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             var device1Messages = await this.SendMessages(device1, messageDispatcher, payloadInitialFcnt, delayBetweenMessages);
             var device2Messages = await this.SendMessages(device2, messageDispatcher, payloadInitialFcnt, delayBetweenMessages);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Parallel_Processing_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Parallel_Processing_Tests.cs
@@ -1,0 +1,387 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using LoRaWan.NetworkServer;
+    using LoRaWan.Test.Shared;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Caching.Memory;
+    using Moq;
+    using Xunit;
+
+    // End to end tests without external dependencies (IoT Hub, Service Facade Function)
+    // Parallel message processing
+    public class MessageProcessor_End2End_NoDep_Parallel_Processing_Tests : MessageProcessorTestBase
+    {
+        private readonly TestPacketForwarder packetForwarder;
+
+        public MessageProcessor_End2End_NoDep_Parallel_Processing_Tests()
+        {
+            this.packetForwarder = new TestPacketForwarder();
+        }
+
+        public static IEnumerable<object[]> Multiple_ABP_Messages()
+        {
+            yield return new object[]
+            {
+                    new ParallelTestConfiguration()
+                    {
+                        GatewayID = ServerGatewayID,
+                        BetweenMessageDuration = 1000,
+                        SearchByDevAddrDuration = 100,
+                        SendEventDuration = 100,
+                        ReceiveEventDuration = 100,
+                        UpdateTwinDuration = 100,
+                        LoadTwinDuration = 100,
+                    }
+            };
+
+            // Slow first calls
+            yield return new object[]
+            {
+                    new ParallelTestConfiguration()
+                    {
+                        GatewayID = ServerGatewayID,
+                        BetweenMessageDuration = 1000,
+                        SearchByDevAddrDuration = new int[] { 1000, 100 },
+                        SendEventDuration = new int[] { 1000, 100 },
+                        ReceiveEventDuration = 400,
+                        UpdateTwinDuration = new int[] { 1000, 100 },
+                        LoadTwinDuration = new int[] { 1000, 100 },
+                    }
+            };
+
+            // Very slow first calls
+            yield return new object[]
+            {
+                    new ParallelTestConfiguration()
+                    {
+                        GatewayID = ServerGatewayID,
+                        BetweenMessageDuration = 1000,
+                        SearchByDevAddrDuration = new int[] { 5000, 100 },
+                        SendEventDuration = new int[] { 1000, 100 },
+                        ReceiveEventDuration = 400,
+                        UpdateTwinDuration = new int[] { 5000, 100 },
+                        LoadTwinDuration = new int[] { 5000, 100 },
+                    }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(Multiple_ABP_Messages))]
+        public async Task ABP_Load_And_Receiving_Multiple_Unconfirmed_Should_Send_All_ToHub(ParallelTestConfiguration parallelTestConfiguration)
+        {
+            Console.WriteLine("---");
+            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: null));
+
+            var devEUI = simulatedDevice.LoRaDevice.DeviceID;
+            var devAddr = simulatedDevice.LoRaDevice.DevAddr;
+
+            // message will be sent
+            var sentTelemetry = new List<LoRaDeviceTelemetry>();
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .Returns<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) =>
+                {
+                    sentTelemetry.Add(t);
+                    var duration = parallelTestConfiguration.SendEventDuration.Next();
+                    Console.WriteLine($"{nameof(this.LoRaDeviceClient.Object.SendEventAsync)} sleeping for {duration}");
+                    return Task.Delay(duration)
+                        .ContinueWith((a) => true);
+                });
+
+            // twin will be loaded
+            var initialTwin = new Twin();
+            initialTwin.Properties.Desired[TwinProperty.DevEUI] = devEUI;
+            initialTwin.Properties.Desired[TwinProperty.AppEUI] = simulatedDevice.LoRaDevice.AppEUI;
+            initialTwin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey;
+            initialTwin.Properties.Desired[TwinProperty.NwkSKey] = simulatedDevice.LoRaDevice.NwkSKey;
+            initialTwin.Properties.Desired[TwinProperty.AppSKey] = simulatedDevice.LoRaDevice.AppSKey;
+            initialTwin.Properties.Desired[TwinProperty.DevAddr] = devAddr;
+            if (parallelTestConfiguration.GatewayID != null)
+                initialTwin.Properties.Desired[TwinProperty.GatewayID] = parallelTestConfiguration.GatewayID;
+            initialTwin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
+            if (parallelTestConfiguration.DeviceTwinFcntDown.HasValue)
+                initialTwin.Properties.Reported[TwinProperty.FCntDown] = parallelTestConfiguration.DeviceTwinFcntDown.Value;
+            if (parallelTestConfiguration.DeviceTwinFcntUp.HasValue)
+                initialTwin.Properties.Reported[TwinProperty.FCntUp] = parallelTestConfiguration.DeviceTwinFcntUp.Value;
+
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync())
+                .Returns(() =>
+                {
+                    var duration = parallelTestConfiguration.LoadTwinDuration.Next();
+                    Console.WriteLine($"{nameof(this.LoRaDeviceClient.Object.GetTwinAsync)} sleeping for {duration}");
+                    return Task.Delay(duration)
+                        .ContinueWith(_ => initialTwin);
+                });
+
+            // twin will be updated with new fcnt
+            int? fcntUpSavedInTwin = null;
+            int? fcntDownSavedInTwin = null;
+
+            var shouldSaveTwin = (parallelTestConfiguration.DeviceTwinFcntDown ?? 0) != 0 || (parallelTestConfiguration.DeviceTwinFcntUp ?? 0) != 0;
+            if (shouldSaveTwin)
+            {
+                this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+                    .Returns<TwinCollection>((t) =>
+                    {
+                        fcntUpSavedInTwin = (int)t[TwinProperty.FCntUp];
+                        fcntDownSavedInTwin = (int)t[TwinProperty.FCntDown];
+                        var duration = parallelTestConfiguration.UpdateTwinDuration.Next();
+                        Console.WriteLine($"{nameof(this.LoRaDeviceClient.Object.UpdateReportedPropertiesAsync)} sleeping for {duration}");
+                        return Task.Delay(duration)
+                            .ContinueWith((a) => true);
+                    });
+            }
+
+            // multi gateway will reset the fcnt
+            if (shouldSaveTwin)
+            {
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI))
+                    .Returns(() =>
+                    {
+                        var duration = parallelTestConfiguration.DeviceApiResetFcntDuration.Next();
+                        Console.WriteLine($"{nameof(this.LoRaDeviceApi.Object.ABPFcntCacheResetAsync)} sleeping for {duration}");
+                        return Task.Delay(duration)
+                            .ContinueWith((a) => true);
+                    });
+            }
+
+            // device api will be searched for payload
+            this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))
+                .Returns(() =>
+                {
+                    var duration = parallelTestConfiguration.SearchByDevAddrDuration.Next();
+                    Console.WriteLine($"{nameof(this.LoRaDeviceApi.Object.SearchByDevAddrAsync)} sleeping for {duration}");
+                    return Task.Delay(duration)
+                        .ContinueWith((a) => new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "abc").AsList()));
+                });
+
+            var memoryCache = new MemoryCache(new MemoryCacheOptions());
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageDispatcher = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
+
+            // sends unconfirmed message
+            var unconfirmedMessage1 = simulatedDevice.CreateUnconfirmedMessageUplink("1", fcnt: 1).Rxpk[0];
+            var unconfirmedMessage2 = simulatedDevice.CreateUnconfirmedMessageUplink("2", fcnt: 2).Rxpk[0];
+            var unconfirmedMessage3 = simulatedDevice.CreateUnconfirmedMessageUplink("3", fcnt: 3).Rxpk[0];
+
+            var packetForwarder = new TestPacketForwarder();
+
+            var req1 = new WaitableLoRaRequest(unconfirmedMessage1, this.packetForwarder);
+            messageDispatcher.DispatchRequest(req1);
+            await Task.Delay(parallelTestConfiguration.BetweenMessageDuration.Next());
+
+            var req2 = new WaitableLoRaRequest(unconfirmedMessage2, this.packetForwarder);
+            messageDispatcher.DispatchRequest(req2);
+            await Task.Delay(parallelTestConfiguration.BetweenMessageDuration.Next());
+
+            var req3 = new WaitableLoRaRequest(unconfirmedMessage3, this.packetForwarder);
+            messageDispatcher.DispatchRequest(req3);
+            await Task.Delay(parallelTestConfiguration.BetweenMessageDuration.Next());
+
+            await Task.WhenAll(req1.WaitCompleteAsync(), req2.WaitCompleteAsync(), req3.WaitCompleteAsync());
+
+            Assert.Null(req1.ResponseDownlink);
+            Assert.Null(req2.ResponseDownlink);
+            Assert.Null(req3.ResponseDownlink);
+
+            this.LoRaDeviceClient.Verify(x => x.GetTwinAsync(), Times.Exactly(1));
+            this.LoRaDeviceClient.Verify(x => x.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Exactly(1));
+            // loRaDeviceClient.Verify(x => x.ReceiveAsync(It.IsAny<TimeSpan>()), Times.Exactly(1));
+            this.LoRaDeviceApi.Verify(x => x.SearchByDevAddrAsync(devAddr), Times.Once);
+
+            // Ensure that all telemetry was sent
+            Assert.Equal(3, sentTelemetry.Count);
+
+            // Ensure data was sent in order
+            Assert.Equal(1, sentTelemetry[0].Fcnt);
+            Assert.Equal(2, sentTelemetry[1].Fcnt);
+            Assert.Equal(3, sentTelemetry[2].Fcnt);
+
+            // Ensure that the device twins were saved
+            if (shouldSaveTwin)
+            {
+                Assert.NotNull(fcntDownSavedInTwin);
+                Assert.NotNull(fcntUpSavedInTwin);
+                Assert.Equal(0, fcntDownSavedInTwin.Value);
+                Assert.Equal(0, fcntUpSavedInTwin.Value);
+            }
+
+            // verify that the device in device registry has correct properties and frame counters
+            var devicesForDevAddr = deviceRegistry.InternalGetCachedDevicesForDevAddr(devAddr);
+            Assert.Single(devicesForDevAddr);
+            Assert.True(devicesForDevAddr.TryGetValue(devEUI, out var loRaDevice));
+            Assert.Equal(devAddr, loRaDevice.DevAddr);
+            Assert.Equal(devEUI, loRaDevice.DevEUI);
+            Assert.True(loRaDevice.IsABP);
+            Assert.Equal(3, loRaDevice.FCntUp);
+            Assert.Equal(0, loRaDevice.FCntDown);
+            Assert.True(loRaDevice.HasFrameCountChanges); // should have changes!
+
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+        }
+
+        async Task<List<WaitableLoRaRequest>> SendMessages(SimulatedDevice device, MessageDispatcher dispatcher, int payloadInitialFcnt, int delayBetweenMessages = 1000)
+        {
+            var requests = new List<WaitableLoRaRequest>();
+            for (var i = 0; i < 5; ++i)
+            {
+                var rxpk = device.CreateUnconfirmedMessageUplink((i + 1).ToString(), fcnt: payloadInitialFcnt + i).Rxpk[0];
+                var req = this.CreateWaitableRequest(rxpk);
+                dispatcher.DispatchRequest(req);
+                requests.Add(req);
+
+                await Task.Delay(delayBetweenMessages);
+            }
+
+            return requests;
+        }
+
+        // 4 devices
+        // 2 sharing the same devAddr
+        // Each sending 5 messages in 1 second time
+        // Search takes 200ms
+        // Getting twin takes 300ms
+        [Theory]
+        [InlineData(200, 300, 100, 20, 1000)]
+        [InlineData(200, 300, 100, 20, 10)]
+        public async Task When_Multiple_Devices_Send_Telemetry_Queue_Sends_Messages_To_IoTHub(
+            int searchDelay,
+            int getTwinDelay,
+            int sendMessageDelay,
+            int receiveDelay,
+            int delayBetweenMessages)
+        {
+            const int payloadInitialFcnt = 2;
+
+            var device1 = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
+            var device1Twin = TestUtils.CreateABPTwin(device1);
+            var device2 = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(2));
+            device2.DevAddr = device1.DevAddr;
+            var device2Twin = TestUtils.CreateABPTwin(device2);
+            var device3 = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(3));
+            device3.SetupJoin("00000000000000000000000000000088", "00000000000000000000000000000088", "02000088");
+            var device3Twin = TestUtils.CreateOTAATwin(device3);
+            var device4 = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(4));
+            var device4Twin = TestUtils.CreateABPTwin(device4);
+
+            var device1And2Result = new IoTHubDeviceInfo[]
+            {
+                new IoTHubDeviceInfo(device1.DevAddr, device1.DevEUI, "1"),
+                new IoTHubDeviceInfo(device2.DevAddr, device2.DevEUI, "2"),
+            };
+
+            this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(device1.DevAddr))
+                .Returns(Task.Delay(searchDelay).ContinueWith((_) => new SearchDevicesResult(device1And2Result)));
+
+            this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(device3.DevAddr))
+                .Returns(Task.Delay(searchDelay).ContinueWith((_) => new SearchDevicesResult(new IoTHubDeviceInfo(device3.DevAddr, device3.DevEUI, "3").AsList())));
+
+            this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(device4.DevAddr))
+                .Returns(Task.Delay(searchDelay).ContinueWith((_) => new SearchDevicesResult(new IoTHubDeviceInfo(device4.DevAddr, device4.DevEUI, "3").AsList())));
+
+            var deviceClient1 = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
+            var deviceClient1Telemetry = new List<LoRaDeviceTelemetry>();
+            deviceClient1.Setup(x => x.GetTwinAsync())
+                .Returns(Task.Delay(getTwinDelay).ContinueWith((_) => device1Twin));
+            deviceClient1.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, d) => deviceClient1Telemetry.Add(t))
+                .Returns(Task.Delay(sendMessageDelay).ContinueWith((_) => true));
+            deviceClient1.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+                .Returns(Task.Delay(receiveDelay).ContinueWith((_) => (Message)null));
+
+            var deviceClient2 = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
+            var deviceClient2Telemetry = new List<LoRaDeviceTelemetry>();
+            deviceClient2.Setup(x => x.GetTwinAsync())
+                .Returns(Task.Delay(getTwinDelay).ContinueWith((_) => device2Twin));
+            deviceClient2.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, d) => deviceClient2Telemetry.Add(t))
+                .Returns(Task.Delay(sendMessageDelay).ContinueWith((_) => true));
+            deviceClient2.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+                .Returns(Task.Delay(receiveDelay).ContinueWith((_) => (Message)null));
+
+            var deviceClient3 = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
+            var deviceClient3Telemetry = new List<LoRaDeviceTelemetry>();
+            deviceClient3.Setup(x => x.GetTwinAsync())
+                .Returns(Task.Delay(getTwinDelay).ContinueWith((_) => device3Twin));
+            deviceClient3.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, d) => deviceClient3Telemetry.Add(t))
+                .Returns(Task.Delay(sendMessageDelay).ContinueWith((_) => true));
+            deviceClient3.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+                .Returns(Task.Delay(receiveDelay).ContinueWith((_) => (Message)null));
+
+            var deviceClient4 = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
+            var deviceClient4Telemetry = new List<LoRaDeviceTelemetry>();
+            deviceClient4.Setup(x => x.GetTwinAsync())
+                .Returns(Task.Delay(getTwinDelay).ContinueWith((_) => device4Twin));
+            deviceClient4.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, d) => deviceClient4Telemetry.Add(t))
+                .Returns(Task.Delay(sendMessageDelay).ContinueWith((_) => true));
+            deviceClient4.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+                .Returns(Task.Delay(receiveDelay).ContinueWith((_) => (Message)null));
+
+            this.LoRaDeviceFactory.SetClient(device1.DevEUI, deviceClient1.Object);
+            this.LoRaDeviceFactory.SetClient(device2.DevEUI, deviceClient2.Object);
+            this.LoRaDeviceFactory.SetClient(device3.DevEUI, deviceClient3.Object);
+            this.LoRaDeviceFactory.SetClient(device4.DevEUI, deviceClient4.Object);
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewMemoryCache(), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            var messageDispatcher = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
+
+            var device1Messages = await this.SendMessages(device1, messageDispatcher, payloadInitialFcnt, delayBetweenMessages);
+            var device2Messages = await this.SendMessages(device2, messageDispatcher, payloadInitialFcnt, delayBetweenMessages);
+            var device3Messages = await this.SendMessages(device3, messageDispatcher, payloadInitialFcnt, delayBetweenMessages);
+            var device4Messages = await this.SendMessages(device4, messageDispatcher, payloadInitialFcnt, delayBetweenMessages);
+
+            var allMessages = device1Messages
+                .Concat(device2Messages)
+                .Concat(device3Messages)
+                .Concat(device4Messages)
+                .ToList();
+
+            await Task.WhenAll(allMessages.Select(x => x.WaitCompleteAsync()));
+
+            Assert.All(allMessages, m => Assert.True(m.ProcessingSucceeded));
+
+            var telemetries = new[]
+            {
+                deviceClient1Telemetry,
+                deviceClient2Telemetry,
+                deviceClient3Telemetry,
+                deviceClient4Telemetry
+            };
+
+            foreach (var telemetry in telemetries)
+            {
+                Assert.Equal(5, telemetry.Count);
+                Assert.Equal(payloadInitialFcnt, telemetry[0].Fcnt);
+                Assert.Equal(payloadInitialFcnt + 1, telemetry[1].Fcnt);
+                Assert.Equal(payloadInitialFcnt + 2, telemetry[2].Fcnt);
+                Assert.Equal(payloadInitialFcnt + 3, telemetry[3].Fcnt);
+                Assert.Equal(payloadInitialFcnt + 4, telemetry[4].Fcnt);
+            }
+
+            deviceClient1.VerifyAll();
+            deviceClient2.VerifyAll();
+            deviceClient3.VerifyAll();
+            deviceClient4.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+        }
+    }
+}

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
@@ -96,7 +96,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage("hello", fcnt: payloadFcntUp);
@@ -176,7 +176,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload, fcnt: 1);
@@ -235,7 +235,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload, fcnt: 1);
@@ -296,7 +296,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload, fcnt: 1);
@@ -356,7 +356,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                this.ServerConfiguration,
                deviceRegistry,
-               this.FrameCounterUpdateStrategyFactory);
+               this.FrameCounterUpdateStrategyProvider);
 
             var ackMessage = simulatedDevice.CreateUnconfirmedDataUpMessage(data, fcnt: payloadFcnt, fctrl: (byte)FctrlEnum.Ack);
             var ackRxpk = ackMessage.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
@@ -411,7 +411,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends confirmed message
             var confirmedMessagePayload = simulatedDevice.CreateConfirmedDataUpMessage("repeat", fcnt: 100);
@@ -511,7 +511,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                this.ServerConfiguration,
                deviceRegistry,
-               this.FrameCounterUpdateStrategyFactory);
+               this.FrameCounterUpdateStrategyProvider);
 
             // Unconfirmed message #1 should fail
             var unconfirmedRxpk1 = simulatedDevice.CreateUnconfirmedDataUpMessage("1", fcnt: 1)
@@ -581,7 +581,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message
             var messagePayload = simulatedDevice.CreateConfirmedDataUpMessage("1234");
@@ -642,7 +642,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage("hello");
@@ -703,7 +703,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // send 1st unconfirmed message, get twin will fail
             var unconfirmedMessage1 = simulatedDevice.CreateUnconfirmedDataUpMessage("1", fcnt: 1);
@@ -787,7 +787,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // first message should fail
             const int firstMessageFcnt = 3;
@@ -854,7 +854,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // message should not be processed
             var request = this.CreateWaitableRequest(simulatedDevice.CreateUnconfirmedMessageUplink("1234").Rxpk[0]);
@@ -935,7 +935,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends confirmed message
             var firstMessagePayload = simulatedDevice.CreateConfirmedDataUpMessage("repeat", fcnt: deviceInitialFcntUp + 1);
@@ -1007,7 +1007,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message #1
             var unconfirmedMessagePayload1 = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload, fcnt: 1);
@@ -1095,7 +1095,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message #1
             var unconfirmedMessagePayload1 = simulatedDevice1.CreateUnconfirmedDataUpMessage("1", fcnt: payloadFcntUp);
@@ -1212,7 +1212,7 @@ namespace LoRaWan.NetworkServer.Test
             var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                this.FrameCounterUpdateStrategyFactory);
+                this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed message #1
             var unconfirmedMessagePayload1 = simulatedDevice1.CreateUnconfirmedDataUpMessage("1", fcnt: payloadFcntUp);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
@@ -58,13 +58,12 @@ namespace LoRaWan.NetworkServer.Test
 
             // message will be sent
             LoRaDeviceTelemetry loRaDeviceTelemetry = null;
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) => loRaDeviceTelemetry = t)
                 .ReturnsAsync(true);
 
             // C2D message will be checked
-            loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
             // twin will be updated with new fcnt
@@ -76,7 +75,7 @@ namespace LoRaWan.NetworkServer.Test
             if (shouldSaveTwin)
             {
                 // Twin will be saved
-                loRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+                this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
                     .Callback<TwinCollection>((t) =>
                     {
                         fcntUpSavedInTwin = (int)t[TwinProperty.FCntUp];
@@ -85,35 +84,27 @@ namespace LoRaWan.NetworkServer.Test
                     .ReturnsAsync(true);
             }
 
-            // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var cachedDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loRaDeviceClient.Object);
+            var cachedDevice = this.CreateLoRaDevice(simulatedDevice);
 
             var devEUIDeviceDict = new DevEUIToLoRaDeviceDictionary();
             devEUIDeviceDict.TryAdd(devEUI, cachedDevice);
             memoryCache.Set(devAddr, devEUIDeviceDict);
 
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
-
-            // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage("hello", fcnt: payloadFcntUp);
             var rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            var unconfirmedMessageResult = await messageProcessor.ProcessMessageAsync(rxpk);
-            Assert.Null(unconfirmedMessageResult);
+            var request = new WaitableLoRaRequest(rxpk, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.Null(request.ResponseDownlink);
 
             // Ensure that a telemetry was sent
             Assert.NotNull(loRaDeviceTelemetry);
@@ -145,125 +136,11 @@ namespace LoRaWan.NetworkServer.Test
             // will update api in multi gateway scenario
             if (string.IsNullOrEmpty(deviceGatewayID))
             {
-                loRaDeviceApi.Verify(x => x.ABPFcntCacheResetAsync(devEUI), Times.Exactly(1));
+                this.LoRaDeviceApi.Verify(x => x.ABPFcntCacheResetAsync(devEUI), Times.Exactly(1));
             }
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
-        }
-
-        [Theory]
-        [InlineData(0, null, null)]
-        [InlineData(0, 1, 1)]
-        [InlineData(0, 100, 20)]
-        [InlineData(1, null, null)]
-        [InlineData(1, 1, 1)]
-        [InlineData(1, 100, 20)]
-        public async Task SingleGateway_ABP_New_Loaded_Device_With_Fcnt_1_Or_0_Should_Reset_Fcnt_And_Send_To_IotHub(
-            int payloadFcntUp,
-            int? deviceTwinFcntUp,
-            int? deviceTwinFcntDown)
-        {
-            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-
-            var devEUI = simulatedDevice.LoRaDevice.DeviceID;
-            var devAddr = simulatedDevice.LoRaDevice.DevAddr;
-
-            // message will be sent
-            LoRaDeviceTelemetry loRaDeviceTelemetry = null;
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
-                .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) => loRaDeviceTelemetry = t)
-                .ReturnsAsync(true);
-
-            // C2D message will be checked
-            loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
-                .ReturnsAsync((Message)null);
-
-            // twin will be loaded
-            var initialTwin = new Twin();
-            initialTwin.Properties.Desired[TwinProperty.DevEUI] = devEUI;
-            initialTwin.Properties.Desired[TwinProperty.AppEUI] = simulatedDevice.LoRaDevice.AppEUI;
-            initialTwin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey;
-            initialTwin.Properties.Desired[TwinProperty.NwkSKey] = simulatedDevice.LoRaDevice.NwkSKey;
-            initialTwin.Properties.Desired[TwinProperty.AppSKey] = simulatedDevice.LoRaDevice.AppSKey;
-            initialTwin.Properties.Desired[TwinProperty.DevAddr] = devAddr;
-            initialTwin.Properties.Desired[TwinProperty.GatewayID] = this.ServerConfiguration.GatewayID;
-            initialTwin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            if (deviceTwinFcntDown.HasValue)
-                initialTwin.Properties.Reported[TwinProperty.FCntDown] = deviceTwinFcntDown.Value;
-            if (deviceTwinFcntUp.HasValue)
-                initialTwin.Properties.Reported[TwinProperty.FCntUp] = deviceTwinFcntUp.Value;
-
-            loRaDeviceClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(initialTwin);
-
-            // twin will be updated with new fcnt
-            int? fcntUpSavedInTwin = null;
-            int? fcntDownSavedInTwin = null;
-
-            // Twin will be save (0, 0) only if it was not 0, 0
-            loRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
-                .Callback<TwinCollection>((t) =>
-                {
-                    fcntUpSavedInTwin = (int)t[TwinProperty.FCntUp];
-                    fcntDownSavedInTwin = (int)t[TwinProperty.FCntDown];
-                })
-                .ReturnsAsync(true);
-
-            // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-
-            // device api will be searched for payload
-            loRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))
-                .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "abc").AsList()));
-
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
-            var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
-
-            // Send to message processor
-            var messageProcessor = new MessageProcessor(
-                this.ServerConfiguration,
-                deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
-
-            // sends unconfirmed message
-            var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage("hello", fcnt: payloadFcntUp);
-            var rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            var unconfirmedMessageResult = await messageProcessor.ProcessMessageAsync(rxpk);
-            Assert.Null(unconfirmedMessageResult);
-
-            // Ensure that a telemetry was sent
-            Assert.NotNull(loRaDeviceTelemetry);
-            // Assert.Equal(msgPayload, loRaDeviceTelemetry.data);
-
-            // Ensure that the device twins were saved
-            Assert.NotNull(fcntDownSavedInTwin);
-            Assert.NotNull(fcntUpSavedInTwin);
-            Assert.Equal(0, fcntDownSavedInTwin.Value);
-            Assert.Equal(0, fcntUpSavedInTwin.Value);
-
-            // verify that the device in device registry has correct properties and frame counters
-            var devicesForDevAddr = deviceRegistry.InternalGetCachedDevicesForDevAddr(devAddr);
-            Assert.Single(devicesForDevAddr);
-            Assert.True(devicesForDevAddr.TryGetValue(devEUI, out var loRaDevice));
-            Assert.Equal(devAddr, loRaDevice.DevAddr);
-            Assert.Equal(devEUI, loRaDevice.DevEUI);
-            Assert.True(loRaDevice.IsABP);
-            Assert.Equal(payloadFcntUp, loRaDevice.FCntUp);
-            Assert.Equal(0, loRaDevice.FCntDown);
-            if (payloadFcntUp == 0)
-                Assert.False(loRaDevice.HasFrameCountChanges); // no changes
-            else
-                Assert.True(loRaDevice.HasFrameCountChanges); // there are pending changes (fcntUp 0 => 1)
-
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         [Theory]
@@ -274,25 +151,18 @@ namespace LoRaWan.NetworkServer.Test
         public async Task ABP_Unconfirmed_With_No_Decoder_Sends_Raw_Payload(string deviceGatewayID, string msgPayload, string sensorDecoder)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID));
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            var loRaDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loRaDeviceClient.Object);
+            var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
             loRaDevice.SensorDecoder = sensorDecoder;
 
             // message will be sent
             LoRaDeviceTelemetry loRaDeviceTelemetry = null;
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) => loRaDeviceTelemetry = t)
                 .ReturnsAsync(true);
 
             // C2D message will be checked
-            loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
-
-            // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
 
             // add device to cache already
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
@@ -300,31 +170,29 @@ namespace LoRaWan.NetworkServer.Test
             dictionary[loRaDevice.DevEUI] = loRaDevice;
             memoryCache.Set<DevEUIToLoRaDeviceDictionary>(loRaDevice.DevAddr, dictionary);
 
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload, fcnt: 1);
             var rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-
-            var unconfirmedMessageResult = await messageProcessor.ProcessMessageAsync(rxpk);
-            Assert.Null(unconfirmedMessageResult);
+            var request = new WaitableLoRaRequest(rxpk, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.Null(request.ResponseDownlink);
 
             Assert.NotNull(loRaDeviceTelemetry);
             Assert.IsType<string>(loRaDeviceTelemetry.Data);
             var expectedPayloadContent = Convert.ToBase64String(Encoding.UTF8.GetBytes(msgPayload));
             Assert.Equal(expectedPayloadContent, loRaDeviceTelemetry.Data);
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         [Theory]
@@ -338,8 +206,7 @@ namespace LoRaWan.NetworkServer.Test
         {
             string msgPayload = "1234";
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, netId: deviceNetId));
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            var loRaDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loRaDeviceClient.Object);
+            var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
             loRaDevice.SensorDecoder = null;
 
             // message will be sent if there is a match
@@ -347,20 +214,14 @@ namespace LoRaWan.NetworkServer.Test
             LoRaDeviceTelemetry loRaDeviceTelemetry = null;
             if (netIdMatches)
             {
-                loRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                     .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) => loRaDeviceTelemetry = t)
                     .ReturnsAsync(true);
 
                 // C2D message will be checked
-                loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+                this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                     .ReturnsAsync((Message)null);
             }
-
-            // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
 
             // add device to cache already
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
@@ -368,23 +229,21 @@ namespace LoRaWan.NetworkServer.Test
             dictionary[loRaDevice.DevEUI] = loRaDevice;
             memoryCache.Set<DevEUIToLoRaDeviceDictionary>(loRaDevice.DevAddr, dictionary);
             this.ServerConfiguration.NetId = serverNetId;
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new LoRaWan.NetworkServer.MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload, fcnt: 1);
             var rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-
-            var unconfirmedMessageResult = await messageProcessor.ProcessMessageAsync(rxpk);
-            Assert.Null(unconfirmedMessageResult);
+            var request = new WaitableLoRaRequest(rxpk, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.Null(request.ResponseDownlink);
 
             if (netIdMatches)
             {
@@ -399,8 +258,8 @@ namespace LoRaWan.NetworkServer.Test
                 Assert.Equal(0, loRaDevice.FCntUp);
             }
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         [Theory]
@@ -412,25 +271,18 @@ namespace LoRaWan.NetworkServer.Test
         public async Task ABP_Unconfirmed_With_Value_Decoder_Sends_Decoded_Payload(string deviceGatewayID, string msgPayload)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID));
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            var loRaDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loRaDeviceClient.Object);
+            var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
             loRaDevice.SensorDecoder = "DecoderValueSensor";
 
             // message will be sent
             LoRaDeviceTelemetry loRaDeviceTelemetry = null;
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) => loRaDeviceTelemetry = t)
                 .ReturnsAsync(true);
 
             // C2D message will be checked
-            loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
-
-            // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
 
             // add device to cache already
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
@@ -438,31 +290,29 @@ namespace LoRaWan.NetworkServer.Test
             dictionary[loRaDevice.DevEUI] = loRaDevice;
             memoryCache.Set<DevEUIToLoRaDeviceDictionary>(loRaDevice.DevAddr, dictionary);
 
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload, fcnt: 1);
             var rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-
-            var unconfirmedMessageResult = await messageProcessor.ProcessMessageAsync(rxpk);
-            Assert.Null(unconfirmedMessageResult);
+            var request = new WaitableLoRaRequest(rxpk, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.Null(request.ResponseDownlink);
 
             Assert.NotNull(loRaDeviceTelemetry);
             Assert.IsType<JObject>(loRaDeviceTelemetry.Data);
             var telemetryData = (JObject)loRaDeviceTelemetry.Data;
             Assert.Equal(msgPayload, telemetryData["value"].ToString());
 
-            loRaDeviceApi.VerifyAll();
-            loRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
         }
 
         [Theory]
@@ -475,49 +325,45 @@ namespace LoRaWan.NetworkServer.Test
             const int payloadFcnt = 102;
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID));
             simulatedDevice.FrmCntUp = initialFcntUp;
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            var loRaDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loRaDeviceClient.Object);
+
+            var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
             if (msgId != null)
                 loRaDevice.LastConfirmedC2DMessageID = msgId;
-
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
 
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var dictionary = new DevEUIToLoRaDeviceDictionary();
             dictionary[loRaDevice.DevEUI] = loRaDevice;
             memoryCache.Set<DevEUIToLoRaDeviceDictionary>(loRaDevice.DevAddr, dictionary);
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.IsAny<LoRaDeviceTelemetry>(), It.IsAny<Dictionary<string, string>>()))
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsAny<LoRaDeviceTelemetry>(), It.IsAny<Dictionary<string, string>>()))
                 .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, d) =>
                 {
                     Assert.NotNull(d);
-                    Assert.True(d.ContainsKey(MessageProcessor.C2D_MSG_PROPERTY_VALUE_NAME));
+                    Assert.True(d.ContainsKey(Constants.C2D_MSG_PROPERTY_VALUE_NAME));
 
                     if (msgId == null)
-                        Assert.True(d.ContainsValue(MessageProcessor.C2D_MSG_ID_PLACEHOLDER));
+                        Assert.True(d.ContainsValue(Constants.C2D_MSG_ID_PLACEHOLDER));
                     else
                         Assert.True(d.ContainsValue(msgId));
                 })
                 .Returns(Task.FromResult(true));
 
             // C2D message will be checked
-            loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                this.ServerConfiguration,
                deviceRegistry,
-               frameCounterUpdateStrategyFactory,
-               new LoRaPayloadDecoder());
+               this.FrameCounterUpdateStrategyFactory);
 
             var ackMessage = simulatedDevice.CreateUnconfirmedDataUpMessage(data, fcnt: payloadFcnt, fctrl: (byte)FctrlEnum.Ack);
             var ackRxpk = ackMessage.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-
-            var ackTxpk = await messageProcessor.ProcessMessageAsync(ackRxpk);
-            Assert.Null(ackTxpk);
+            var ackRequest = new WaitableLoRaRequest(ackRxpk, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(ackRequest);
+            Assert.True(await ackRequest.WaitCompleteAsync());
+            Assert.Null(ackRequest.ResponseDownlink);
             Assert.True(deviceRegistry.InternalGetCachedDevicesForDevAddr(loRaDevice.DevAddr).TryGetValue(loRaDevice.DevEUI, out var loRaDeviceInfo));
 
             Assert.Equal(payloadFcnt, loRaDeviceInfo.FCntUp);
@@ -535,27 +381,23 @@ namespace LoRaWan.NetworkServer.Test
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID));
             simulatedDevice.FrmCntUp = initialFcntUp;
             simulatedDevice.FrmCntDown = initialFcntDown;
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            var loRaDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loRaDeviceClient.Object);
+
+            var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
 
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
 
             // C2D message will be checked
-            loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
             // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
 
             // in multigateway scenario the device api will be called to resolve fcntDown
             if (string.IsNullOrEmpty(deviceGatewayID))
             {
-                loRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, 20, 100, this.ServerConfiguration.GatewayID))
+                this.LoRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, 20, 100, this.ServerConfiguration.GatewayID))
                     .ReturnsAsync((ushort)expectedFcntDown);
             }
-
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
 
             // add device to cache already
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
@@ -563,25 +405,27 @@ namespace LoRaWan.NetworkServer.Test
             dictionary[loRaDevice.DevEUI] = loRaDevice;
             memoryCache.Set<DevEUIToLoRaDeviceDictionary>(loRaDevice.DevAddr, dictionary);
 
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // sends confirmed message
             var confirmedMessagePayload = simulatedDevice.CreateConfirmedDataUpMessage("repeat", fcnt: 100);
             var rxpk = confirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            var confirmedMessageResult = await messageProcessor.ProcessMessageAsync(rxpk);
+            var confirmedRequest = new WaitableLoRaRequest(rxpk, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(confirmedRequest);
 
             // ack should be received
-            Assert.NotNull(confirmedMessageResult);
-            Assert.NotNull(confirmedMessageResult.Txpk);
+            Assert.True(await confirmedRequest.WaitCompleteAsync());
+            Assert.NotNull(confirmedRequest.ResponseDownlink);
+            Assert.NotNull(confirmedRequest.ResponseDownlink.Txpk);
+            Assert.Single(this.PacketForwarder.DownlinkMessages);
+
+            var confirmedMessageResult = this.PacketForwarder.DownlinkMessages[0];
 
             // validates txpk according to eu region
             Assert.Equal(RegionFactory.CreateEU868Region().GetDownstreamChannelFrequency(rxpk), confirmedMessageResult.Txpk.Freq);
@@ -597,9 +441,9 @@ namespace LoRaWan.NetworkServer.Test
             Assert.True(loRaDevice.HasFrameCountChanges);
 
             // message should not be sent to iot hub
-            loRaDeviceClient.Verify(x => x.SendEventAsync(It.IsAny<LoRaDeviceTelemetry>(), It.IsAny<Dictionary<string, string>>()), Times.Never);
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.Verify(x => x.SendEventAsync(It.IsAny<LoRaDeviceTelemetry>(), It.IsAny<Dictionary<string, string>>()), Times.Never);
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         /// <summary>
@@ -632,17 +476,15 @@ namespace LoRaWan.NetworkServer.Test
                     { TwinProperty.DevNonce, "ABCD" },
                 });
 
-            var deviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-
             // Twin will be loaded once
-            deviceClient.Setup(x => x.GetTwinAsync())
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync())
                 .ReturnsAsync(updatedTwin);
 
             // Will check received messages once
-            deviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>())).ReturnsAsync((Message)null);
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>())).ReturnsAsync((Message)null);
 
             // Will send the 3 unconfirmed message
-            deviceClient.Setup(x => x.SendEventAsync(It.IsAny<LoRaDeviceTelemetry>(), It.IsAny<Dictionary<string, string>>()))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsAny<LoRaDeviceTelemetry>(), It.IsAny<Dictionary<string, string>>()))
                 .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) =>
                 {
                     Assert.NotNull(t.Data);
@@ -651,10 +493,8 @@ namespace LoRaWan.NetworkServer.Test
                 })
                 .ReturnsAsync(true);
 
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-
             // Will try to find the iot device based on dev addr
-            loRaDeviceApi.SetupSequence(x => x.SearchByDevAddrAsync(devAddr))
+            this.LoRaDeviceApi.SetupSequence(x => x.SearchByDevAddrAsync(devAddr))
                 .ReturnsAsync(new SearchDevicesResult())
                 .ReturnsAsync(new SearchDevicesResult())
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "abc").AsList()));
@@ -662,32 +502,43 @@ namespace LoRaWan.NetworkServer.Test
             var deviceRegistry = new LoRaDeviceRegistry(
                 this.ServerConfiguration,
                 new MemoryCache(new MemoryCacheOptions()),
-                loRaDeviceApi.Object,
-                new TestLoRaDeviceFactory(deviceClient.Object));
+                this.LoRaDeviceApi.Object,
+                this.LoRaDeviceFactory);
 
-            var messageProcessor = new MessageProcessor(
+            // Making the reload interval zero
+            deviceRegistry.DevAddrReloadInterval = TimeSpan.Zero;
+
+            var messageDispatcher = new MessageDispatcher(
                this.ServerConfiguration,
                deviceRegistry,
-               new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object),
-               new LoRaPayloadDecoder());
+               this.FrameCounterUpdateStrategyFactory);
 
             // Unconfirmed message #1 should fail
             var unconfirmedRxpk1 = simulatedDevice.CreateUnconfirmedDataUpMessage("1", fcnt: 1)
                 .SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            Assert.Null(await messageProcessor.ProcessMessageAsync(unconfirmedRxpk1));
+            var unconfirmedRequest1 = new WaitableLoRaRequest(unconfirmedRxpk1, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(unconfirmedRequest1);
+            Assert.True(await unconfirmedRequest1.WaitCompleteAsync());
+            Assert.Null(unconfirmedRequest1.ResponseDownlink);
 
             // Unconfirmed message #2 should fail
             var unconfirmedRxpk2 = simulatedDevice.CreateUnconfirmedDataUpMessage("2", fcnt: 2)
                 .SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            Assert.Null(await messageProcessor.ProcessMessageAsync(unconfirmedRxpk2));
+            var unconfirmedRequest2 = new WaitableLoRaRequest(unconfirmedRxpk2, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(unconfirmedRequest2);
+            Assert.True(await unconfirmedRequest2.WaitCompleteAsync());
+            Assert.Null(unconfirmedRequest2.ResponseDownlink);
 
             // Unconfirmed message #3 should succeed
             var unconfirmedRxpk3 = simulatedDevice.CreateUnconfirmedDataUpMessage("3", fcnt: 3)
                 .SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            Assert.Null(await messageProcessor.ProcessMessageAsync(unconfirmedRxpk3));
+            var unconfirmedRequest3 = new WaitableLoRaRequest(unconfirmedRxpk3, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(unconfirmedRequest3);
+            Assert.True(await unconfirmedRequest3.WaitCompleteAsync());
+            Assert.Null(unconfirmedRequest3.ResponseDownlink);
 
-            deviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         /// <summary>
@@ -708,54 +559,49 @@ namespace LoRaWan.NetworkServer.Test
 
             // message will be sent
             LoRaDeviceTelemetry loRaDeviceTelemetry = null;
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) => loRaDeviceTelemetry = t)
                 .ReturnsAsync(true);
 
             // C2D message will be checked
-            loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
-            // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var cachedDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loRaDeviceClient.Object);
+            var cachedDevice = this.CreateLoRaDevice(simulatedDevice);
 
             var devEUIDeviceDict = new DevEUIToLoRaDeviceDictionary();
             devEUIDeviceDict.TryAdd(devEUI, cachedDevice);
             memoryCache.Set(devAddr, devEUIDeviceDict);
 
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // sends unconfirmed message
-            var unconfirmedMessagePayload = simulatedDevice.CreateConfirmedDataUpMessage("1234");
-            var rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
+            var messagePayload = simulatedDevice.CreateConfirmedDataUpMessage("1234");
+            var rxpk = messagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
             rxpk.Rfch = rfch;
-            var confirmedMessageResult = await messageProcessor.ProcessMessageAsync(rxpk);
-            Assert.NotNull(confirmedMessageResult);
-            Assert.Equal(0U, confirmedMessageResult.Txpk.Rfch);
-            Assert.Equal(RegionFactory.CreateEU868Region().GetDownstreamChannelFrequency(rxpk), confirmedMessageResult.Txpk.Freq);
-            Assert.Equal("4/5", confirmedMessageResult.Txpk.Codr);
-            Assert.False(confirmedMessageResult.Txpk.Imme);
-            Assert.True(confirmedMessageResult.Txpk.Ipol);
-            Assert.Equal("LORA", confirmedMessageResult.Txpk.Modu);
+            var request = new WaitableLoRaRequest(rxpk, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.NotNull(request.ResponseDownlink);
+            Assert.Single(this.PacketForwarder.DownlinkMessages);
+            var txpk = this.PacketForwarder.DownlinkMessages[0].Txpk;
+            Assert.Equal(0U, txpk.Rfch);
+            Assert.Equal(RegionFactory.CreateEU868Region().GetDownstreamChannelFrequency(rxpk), txpk.Freq);
+            Assert.Equal("4/5", txpk.Codr);
+            Assert.False(txpk.Imme);
+            Assert.True(txpk.Ipol);
+            Assert.Equal("LORA", txpk.Modu);
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         [Theory]
@@ -775,8 +621,7 @@ namespace LoRaWan.NetworkServer.Test
             var devAddr = simulatedDevice.LoRaDevice.DevAddr;
 
             // message will be sent
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .Returns(() =>
                 {
                     var task = Task.Delay(sendMessageDelayInMs).ContinueWith((_) => true);
@@ -784,40 +629,33 @@ namespace LoRaWan.NetworkServer.Test
                     return task;
                 });
 
-            // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var cachedDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loRaDeviceClient.Object);
+            var cachedDevice = this.CreateLoRaDevice(simulatedDevice);
 
             var devEUIDeviceDict = new DevEUIToLoRaDeviceDictionary();
             devEUIDeviceDict.TryAdd(devEUI, cachedDevice);
             memoryCache.Set(devAddr, devEUIDeviceDict);
 
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // sends unconfirmed message
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage("hello");
             var rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            var unconfirmedMessageResult = await messageProcessor.ProcessMessageAsync(rxpk);
-            Assert.Null(unconfirmedMessageResult);
+            var request = new WaitableLoRaRequest(rxpk, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.Null(request.ResponseDownlink);
 
-            loRaDeviceClient.Verify(x => x.ReceiveAsync(It.IsAny<TimeSpan>()), Times.Never());
+            this.LoRaDeviceClient.Verify(x => x.ReceiveAsync(It.IsAny<TimeSpan>()), Times.Never());
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         /// <summary>
@@ -833,16 +671,14 @@ namespace LoRaWan.NetworkServer.Test
             var appEUI = simulatedDevice.LoRaDevice.AppEUI;
             var devAddr = simulatedDevice.DevAddr;
 
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-
             // Device twin will be queried
             var twin = simulatedDevice.CreateABPTwin();
-            loRaDeviceClient.SetupSequence(x => x.GetTwinAsync())
+            this.LoRaDeviceClient.SetupSequence(x => x.GetTwinAsync())
                 .ReturnsAsync((Twin)null)
                 .ReturnsAsync(twin);
 
             // 1 message will be sent
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), It.IsAny<Dictionary<string, string>>()))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), It.IsAny<Dictionary<string, string>>()))
                 .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, d) =>
                  {
                      Assert.Equal(2, t.Fcnt);
@@ -851,33 +687,32 @@ namespace LoRaWan.NetworkServer.Test
                  .ReturnsAsync(true);
 
             // will check for c2d msg
-            loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
             // Lora device api will be search by devices with matching deveui,
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            loRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))
+            this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(devAddr, devEUI, "aabb").AsList()));
 
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            // Setting the interval in which we search for devices with same devAddr on server
+            deviceRegistry.DevAddrReloadInterval = TimeSpan.Zero;
 
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // send 1st unconfirmed message, get twin will fail
             var unconfirmedMessage1 = simulatedDevice.CreateUnconfirmedDataUpMessage("1", fcnt: 1);
             var unconfirmedMessage1Rxpk = unconfirmedMessage1.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            var unconfirmedMessageResult1 = await messageProcessor.ProcessMessageAsync(unconfirmedMessage1Rxpk);
-            Assert.Null(unconfirmedMessageResult1);
+            var request1 = this.CreateWaitableRequest(unconfirmedMessage1Rxpk);
+            messageDispatcher.DispatchRequest(request1);
+            Assert.True(await request1.WaitCompleteAsync());
+            Assert.Null(request1.ResponseDownlink);
+            Assert.Empty(this.PacketForwarder.DownlinkMessages);
 
             var devicesInCache = deviceRegistry.InternalGetCachedDevicesForDevAddr(devAddr);
             Assert.Empty(devicesInCache);
@@ -885,8 +720,11 @@ namespace LoRaWan.NetworkServer.Test
             // sends 2nd unconfirmed message, now get twin will work
             var unconfirmedMessage2 = simulatedDevice.CreateUnconfirmedDataUpMessage("2", fcnt: 2);
             var unconfirmedMessage2Rxpk = unconfirmedMessage2.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            var unconfirmedMessageResult2 = await messageProcessor.ProcessMessageAsync(unconfirmedMessage2Rxpk);
-            Assert.Null(unconfirmedMessageResult2);
+            var request2 = this.CreateWaitableRequest(unconfirmedMessage2Rxpk);
+            messageDispatcher.DispatchRequest(request2);
+            Assert.True(await request2.WaitCompleteAsync());
+            Assert.Null(request2.ResponseDownlink);
+            Assert.Empty(this.PacketForwarder.DownlinkMessages);
 
             devicesInCache = deviceRegistry.InternalGetCachedDevicesForDevAddr(devAddr);
             Assert.Single(devicesInCache);
@@ -896,8 +734,8 @@ namespace LoRaWan.NetworkServer.Test
             Assert.Equal(devAddr, loRaDevice.DevAddr);
             Assert.Equal(2, loRaDevice.FCntUp);
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
         }
 
         /// <summary>
@@ -910,35 +748,29 @@ namespace LoRaWan.NetworkServer.Test
         public async Task ABP_When_First_Message_Has_Invalid_Mic_Second_Should_Send_To_Hub(bool isAlreadyInDeviceRegistryCache)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: ServerGatewayID));
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            var loRaDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loRaDeviceClient.Object);
+
+            var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
             loRaDevice.SensorDecoder = "DecoderValueSensor";
 
             // message will be sent
             LoRaDeviceTelemetry loRaDeviceTelemetry = null;
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) => loRaDeviceTelemetry = t)
                 .ReturnsAsync(true);
 
             if (!isAlreadyInDeviceRegistryCache)
             {
-                loRaDeviceClient.Setup(x => x.GetTwinAsync())
+                this.LoRaDeviceClient.Setup(x => x.GetTwinAsync())
                     .ReturnsAsync(simulatedDevice.CreateABPTwin());
             }
 
             // C2D message will be checked
-            loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
-            // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-
             // will search for the device twice
-            loRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(loRaDevice.DevAddr))
+            this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(loRaDevice.DevAddr))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(loRaDevice.DevAddr, loRaDevice.DevEUI, "aaa").AsList()));
-
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
 
             // add device to cache already
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
@@ -949,27 +781,31 @@ namespace LoRaWan.NetworkServer.Test
                 memoryCache.Set<DevEUIToLoRaDeviceDictionary>(loRaDevice.DevAddr, dictionary);
             }
 
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // first message should fail
             const int firstMessageFcnt = 3;
             const string wrongNwkSKey = "00000000000000000000000000001234";
             var unconfirmedMessageWithWrongMic = simulatedDevice.CreateUnconfirmedDataUpMessage("123", fcnt: firstMessageFcnt).SerializeUplink(simulatedDevice.AppSKey, wrongNwkSKey).Rxpk[0];
-            Assert.Null(await messageProcessor.ProcessMessageAsync(unconfirmedMessageWithWrongMic));
+            var requestWithWrongMic = this.CreateWaitableRequest(unconfirmedMessageWithWrongMic);
+            messageDispatcher.DispatchRequest(requestWithWrongMic);
+            Assert.True(await requestWithWrongMic.WaitCompleteAsync());
+            Assert.Null(requestWithWrongMic.ResponseDownlink);
+            Assert.Equal(LoRaDeviceRequestFailedReason.NotMatchingDeviceByMicCheck, requestWithWrongMic.ProcessingFailedReason);
 
             // second message should succeed
             const int secondMessageFcnt = 4;
             var unconfirmedMessageWithCorrectMic = simulatedDevice.CreateUnconfirmedDataUpMessage("456", fcnt: secondMessageFcnt).SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            Assert.Null(await messageProcessor.ProcessMessageAsync(unconfirmedMessageWithCorrectMic));
+            var requestWithCorrectMic = this.CreateWaitableRequest(unconfirmedMessageWithCorrectMic);
+            messageDispatcher.DispatchRequest(requestWithCorrectMic);
+            Assert.True(await requestWithCorrectMic.WaitCompleteAsync());
+            Assert.Null(requestWithCorrectMic.ResponseDownlink);
 
             Assert.NotNull(loRaDeviceTelemetry);
             Assert.IsType<JObject>(loRaDeviceTelemetry.Data);
@@ -982,8 +818,8 @@ namespace LoRaWan.NetworkServer.Test
             Assert.Equal(secondMessageFcnt, loRaDeviceFromRegistry.FCntUp);
             Assert.True(loRaDeviceFromRegistry.IsOurDevice);
 
-            loRaDeviceApi.VerifyAll();
-            loRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
         }
 
         /// <summary>
@@ -996,45 +832,41 @@ namespace LoRaWan.NetworkServer.Test
         public async Task ABP_When_AppSKey_Or_NwkSKey_Or_DevAddr_Is_Missing_Should_Not_Send_Message_To_Hub(string missingProperty)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: ServerGatewayID));
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
-            var loRaDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loRaDeviceClient.Object);
+
+            var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
             loRaDevice.SensorDecoder = "DecoderValueSensor";
 
             // will get the device twin without AppSKey
             var twin = TestUtils.CreateABPTwin(simulatedDevice);
             twin.Properties.Desired[missingProperty] = null;
-            loRaDeviceClient.Setup(x => x.GetTwinAsync())
+            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync())
                     .ReturnsAsync(twin);
 
             // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
 
             // will search for the device twice
-            loRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(loRaDevice.DevAddr))
+            this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(loRaDevice.DevAddr))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(loRaDevice.DevAddr, loRaDevice.DevEUI, "aaa").AsList()));
 
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
-
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, new MemoryCache(new MemoryCacheOptions()), loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, new MemoryCache(new MemoryCacheOptions()), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // message should not be processed
-            Assert.Null(await messageProcessor.ProcessMessageAsync(simulatedDevice.CreateUnconfirmedMessageUplink("1234").Rxpk[0]));
+            var request = this.CreateWaitableRequest(simulatedDevice.CreateUnconfirmedMessageUplink("1234").Rxpk[0]);
+            messageDispatcher.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.Null(request.ResponseDownlink);
 
             var devicesByDevAddr = deviceRegistry.InternalGetCachedDevicesForDevAddr(simulatedDevice.DevAddr);
             Assert.Empty(devicesByDevAddr);
 
-            loRaDeviceApi.VerifyAll();
-            loRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
         }
 
         [Theory]
@@ -1048,72 +880,62 @@ namespace LoRaWan.NetworkServer.Test
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID));
             simulatedDevice.FrmCntUp = deviceInitialFcntUp;
             simulatedDevice.FrmCntDown = deviceInitialFcntDown;
-            var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
 
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
 
             // C2D message will be checked
-            loRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
             // We will send two messages
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.Is<LoRaDeviceTelemetry>(t => t.Fcnt == deviceInitialFcntUp + 1), It.IsAny<Dictionary<string, string>>()))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.Is<LoRaDeviceTelemetry>(t => t.Fcnt == deviceInitialFcntUp + 1), It.IsAny<Dictionary<string, string>>()))
                 .ReturnsAsync(true);
 
-            loRaDeviceClient.Setup(x => x.SendEventAsync(It.Is<LoRaDeviceTelemetry>(t => t.Fcnt == deviceInitialFcntUp + 2), It.IsAny<Dictionary<string, string>>()))
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.Is<LoRaDeviceTelemetry>(t => t.Fcnt == deviceInitialFcntUp + 2), It.IsAny<Dictionary<string, string>>()))
                 .ReturnsAsync(true);
-
-            // Lora device api
-            var loRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
 
             // in multigateway scenario the device api will be called to resolve fcntDown
             if (string.IsNullOrEmpty(deviceGatewayID))
             {
-                loRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown, deviceInitialFcntUp + 1, this.ServerConfiguration.GatewayID))
+                this.LoRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown, deviceInitialFcntUp + 1, this.ServerConfiguration.GatewayID))
                     .ReturnsAsync((ushort)(deviceInitialFcntDown + 1));
 
-                loRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 1, deviceInitialFcntUp + 1, this.ServerConfiguration.GatewayID))
+                this.LoRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 1, deviceInitialFcntUp + 1, this.ServerConfiguration.GatewayID))
                     .ReturnsAsync((ushort)(deviceInitialFcntDown + 2));
 
-                loRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 2, deviceInitialFcntUp + 1, this.ServerConfiguration.GatewayID))
+                this.LoRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 2, deviceInitialFcntUp + 1, this.ServerConfiguration.GatewayID))
                     .ReturnsAsync((ushort)(deviceInitialFcntDown + 3));
 
-                loRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 3, deviceInitialFcntUp + 1, this.ServerConfiguration.GatewayID))
+                this.LoRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 3, deviceInitialFcntUp + 1, this.ServerConfiguration.GatewayID))
                     .ReturnsAsync((ushort)(deviceInitialFcntDown + 4));
 
-                loRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 4, deviceInitialFcntUp + 2, this.ServerConfiguration.GatewayID))
+                this.LoRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 4, deviceInitialFcntUp + 2, this.ServerConfiguration.GatewayID))
                     .ReturnsAsync((ushort)(deviceInitialFcntDown + 5));
 
-                loRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 5, deviceInitialFcntUp + 2, this.ServerConfiguration.GatewayID))
+                this.LoRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 5, deviceInitialFcntUp + 2, this.ServerConfiguration.GatewayID))
                     .ReturnsAsync((ushort)(deviceInitialFcntDown + 6));
 
-                loRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 6, deviceInitialFcntUp + 2, this.ServerConfiguration.GatewayID))
+                this.LoRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 6, deviceInitialFcntUp + 2, this.ServerConfiguration.GatewayID))
                     .ReturnsAsync((ushort)(deviceInitialFcntDown + 7));
 
-                loRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 7, deviceInitialFcntUp + 2, this.ServerConfiguration.GatewayID))
+                this.LoRaDeviceApi.Setup(x => x.NextFCntDownAsync(devEUI, deviceInitialFcntDown + 7, deviceInitialFcntUp + 2, this.ServerConfiguration.GatewayID))
                     .ReturnsAsync((ushort)(deviceInitialFcntDown + 8));
             }
-
-            // using factory to create mock of
-            var loRaDeviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object);
 
             // add device to cache already
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var dictionary = new DevEUIToLoRaDeviceDictionary();
-            var loRaDevice = TestUtils.CreateFromSimulatedDevice(simulatedDevice, loRaDeviceClient.Object);
+            var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
             dictionary[loRaDevice.DevEUI] = loRaDevice;
             memoryCache.Set<DevEUIToLoRaDeviceDictionary>(loRaDevice.DevAddr, dictionary);
 
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, loRaDeviceApi.Object, loRaDeviceFactory);
-
-            var frameCounterUpdateStrategyFactory = new LoRaDeviceFrameCounterUpdateStrategyFactory(this.ServerConfiguration.GatewayID, loRaDeviceApi.Object);
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, memoryCache, this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor
-            var messageProcessor = new MessageProcessor(
+            var messageDispatcher = new MessageDispatcher(
                 this.ServerConfiguration,
                 deviceRegistry,
-                frameCounterUpdateStrategyFactory,
-                new LoRaPayloadDecoder());
+                this.FrameCounterUpdateStrategyFactory);
 
             // sends confirmed message
             var firstMessagePayload = simulatedDevice.CreateConfirmedDataUpMessage("repeat", fcnt: deviceInitialFcntUp + 1);
@@ -1122,15 +944,23 @@ namespace LoRaWan.NetworkServer.Test
             // 1x as new fcntUp and 3x as resubmit
             for (var i = 0; i < 4; i++)
             {
-                var confirmedMessageResult = await messageProcessor.ProcessMessageAsync(firstMessageRxpk);
+                var firstMessageRequest = this.CreateWaitableRequest(firstMessageRxpk);
+                messageDispatcher.DispatchRequest(firstMessageRequest);
+                Assert.True(await firstMessageRequest.WaitCompleteAsync());
 
                 // ack should be received
-                Assert.NotNull(confirmedMessageResult);
-                Assert.NotNull(confirmedMessageResult.Txpk);
+                Assert.NotNull(firstMessageRequest.ResponseDownlink);
+                Assert.NotNull(firstMessageRequest.ResponseDownlink.Txpk);
+                Assert.Equal(i + 1, this.PacketForwarder.DownlinkMessages.Count);
             }
 
             // resubmitting should fail
-            Assert.Null(await messageProcessor.ProcessMessageAsync(firstMessageRxpk));
+            var fourthRequest = this.CreateWaitableRequest(firstMessageRxpk);
+            messageDispatcher.DispatchRequest(fourthRequest);
+            Assert.True(await fourthRequest.WaitCompleteAsync());
+            Assert.Null(fourthRequest.ResponseDownlink);
+            Assert.Equal(4, this.PacketForwarder.DownlinkMessages.Count);
+            Assert.Equal(LoRaDeviceRequestFailedReason.ConfirmationResubmitThresholdExceeded, fourthRequest.ProcessingFailedReason);
 
             // Sending the next fcnt with failed messages should work, including resubmit
             var secondMessagePayload = simulatedDevice.CreateConfirmedDataUpMessage("repeat", fcnt: deviceInitialFcntUp + 2);
@@ -1139,21 +969,297 @@ namespace LoRaWan.NetworkServer.Test
             // 1x as new fcntUp and 3x as resubmit
             for (var i = 0; i < 4; i++)
             {
-                var confirmedMessageResult = await messageProcessor.ProcessMessageAsync(secondMessageRxpk);
+                var request = this.CreateWaitableRequest(secondMessageRxpk);
+                messageDispatcher.DispatchRequest(request);
+                Assert.True(await request.WaitCompleteAsync());
 
                 // ack should be received
-                Assert.NotNull(confirmedMessageResult);
-                Assert.NotNull(confirmedMessageResult.Txpk);
+                Assert.NotNull(request.ResponseDownlink);
+                Assert.NotNull(request.ResponseDownlink.Txpk);
+                Assert.Equal(i + 5, this.PacketForwarder.DownlinkMessages.Count);
             }
 
             // resubmitting should fail
-            Assert.Null(await messageProcessor.ProcessMessageAsync(secondMessageRxpk));
+            var resubmitSecondRequest = this.CreateWaitableRequest(secondMessageRxpk);
+            messageDispatcher.DispatchRequest(resubmitSecondRequest);
+            Assert.True(await resubmitSecondRequest.WaitCompleteAsync());
+            Assert.Null(resubmitSecondRequest.ResponseDownlink);
+            Assert.Equal(8, this.PacketForwarder.DownlinkMessages.Count);
+            Assert.Equal(LoRaDeviceRequestFailedReason.ConfirmationResubmitThresholdExceeded, resubmitSecondRequest.ProcessingFailedReason);
 
             Assert.Equal(2 + deviceInitialFcntUp, loRaDevice.FCntUp);
             Assert.Equal(8 + deviceInitialFcntDown, loRaDevice.FCntDown);
 
-            loRaDeviceClient.VerifyAll();
-            loRaDeviceApi.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+        }
+
+        [Fact]
+        public async Task ABP_Device_With_Invalid_NetId_Should_Not_Load_Devices()
+        {
+            string msgPayload = "1234";
+            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, netId: 0));
+            var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewMemoryCache(), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageDispatcher = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
+
+            // sends unconfirmed message #1
+            var unconfirmedMessagePayload1 = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload, fcnt: 1);
+            var rxpk1 = unconfirmedMessagePayload1.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
+            var request1 = new WaitableLoRaRequest(rxpk1, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(request1);
+            Assert.True(await request1.WaitCompleteAsync());
+            Assert.Null(request1.ResponseDownlink);
+            Assert.True(request1.ProcessingFailed);
+            Assert.Equal(LoRaDeviceRequestFailedReason.InvalidNetId, request1.ProcessingFailedReason);
+
+            // sends unconfirmed message #2
+            var unconfirmedMessagePayload2 = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload, fcnt: 2);
+            var rxpk2 = unconfirmedMessagePayload2.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
+            var request2 = new WaitableLoRaRequest(rxpk2, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(request2);
+            Assert.True(await request2.WaitCompleteAsync());
+            Assert.Null(request2.ResponseDownlink);
+            Assert.True(request2.ProcessingFailed);
+            Assert.Equal(LoRaDeviceRequestFailedReason.InvalidNetId, request2.ProcessingFailedReason);
+
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+        }
+
+        [Theory]
+        [InlineData(1)] // ABP with soft reset
+        [InlineData(11)]
+        public async Task When_Loading_Multiple_Devices_With_Same_DevAddr_Should_Add_All_To_Cache_And_Process_Message(int payloadFcntUp)
+        {
+            var isResetingDevice = payloadFcntUp <= 1;
+            var simulatedDevice1 = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: ServerGatewayID));
+
+            var devAddr = simulatedDevice1.LoRaDevice.DevAddr;
+
+            var simulatedDevice2 = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(2, gatewayID: ServerGatewayID));
+            simulatedDevice2.DevAddr = devAddr;
+
+            // message will be sent
+            LoRaDeviceTelemetry loRaDeviceTelemetry = null;
+
+            // Device client 1
+            // - Get Twin
+            // - Update twin (if isResetingDevice)
+            // - Send event
+            // - Check c2d message
+            var device1SentTelemetry = new List<LoRaDeviceTelemetry>();
+            var deviceClient1 = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
+            deviceClient1.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) => device1SentTelemetry.Add(loRaDeviceTelemetry))
+                .ReturnsAsync(true);
+
+            deviceClient1.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+                .ReturnsAsync((Message)null);
+
+            deviceClient1.Setup(x => x.GetTwinAsync()).ReturnsAsync(simulatedDevice1.CreateABPTwin());
+
+            if (isResetingDevice)
+            {
+                deviceClient1.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+                    .ReturnsAsync(true);
+            }
+
+            // Device client 2
+            // - Get Twin
+            var deviceClient2 = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
+            deviceClient2.Setup(x => x.GetTwinAsync()).ReturnsAsync(simulatedDevice2.CreateABPTwin());
+
+            // device api will be searched for payload
+            var searchDevicesResult = new SearchDevicesResult(new[]
+            {
+                new IoTHubDeviceInfo(simulatedDevice1.DevAddr, simulatedDevice1.DevEUI, "device1"),
+                new IoTHubDeviceInfo(simulatedDevice2.DevAddr, simulatedDevice2.DevEUI, "device2"),
+            });
+
+            this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))
+                .ReturnsAsync(searchDevicesResult);
+
+            this.LoRaDeviceFactory.SetClient(simulatedDevice1.DevEUI, deviceClient1.Object);
+            this.LoRaDeviceFactory.SetClient(simulatedDevice2.DevEUI, deviceClient2.Object);
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewMemoryCache(), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageDispatcher = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
+
+            // sends unconfirmed message #1
+            var unconfirmedMessagePayload1 = simulatedDevice1.CreateUnconfirmedDataUpMessage("1", fcnt: payloadFcntUp);
+            var rxpk1 = unconfirmedMessagePayload1.SerializeUplink(simulatedDevice1.AppSKey, simulatedDevice1.NwkSKey).Rxpk[0];
+            var request1 = new WaitableLoRaRequest(rxpk1, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(request1);
+            Assert.True(await request1.WaitCompleteAsync());
+            Assert.Null(request1.ResponseDownlink);
+            Assert.True(request1.ProcessingSucceeded);
+            Assert.Single(device1SentTelemetry);
+
+            // sends unconfirmed message #2
+            var unconfirmedMessagePayload2 = simulatedDevice1.CreateUnconfirmedDataUpMessage("2", fcnt: payloadFcntUp + 1);
+            var rxpk2 = unconfirmedMessagePayload2.SerializeUplink(simulatedDevice1.AppSKey, simulatedDevice1.NwkSKey).Rxpk[0];
+            var request2 = new WaitableLoRaRequest(rxpk2, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(request2);
+            Assert.True(await request2.WaitCompleteAsync());
+            Assert.Null(request2.ResponseDownlink);
+            Assert.True(request2.ProcessingSucceeded);
+            Assert.Equal(2, device1SentTelemetry.Count);
+
+            // Ensure that the devices have been cached
+            var cachedDevices = deviceRegistry.InternalGetCachedDevicesForDevAddr(simulatedDevice1.DevAddr);
+            Assert.Equal(2, cachedDevices.Count);
+            Assert.True(cachedDevices.TryGetValue(simulatedDevice1.DevEUI, out var loRaDevice1));
+
+            // If the fcnt made a reset (0-1) the fcntdown is zero
+            if (isResetingDevice)
+            {
+                Assert.Equal(0, loRaDevice1.FCntDown);
+            }
+            else
+            {
+                Assert.Equal(10, loRaDevice1.FCntDown);
+            }
+
+            Assert.Equal(payloadFcntUp + 1, loRaDevice1.FCntUp);
+
+            Assert.True(cachedDevices.TryGetValue(simulatedDevice2.DevEUI, out var loRaDevice2));
+            Assert.Equal(0, loRaDevice2.FCntUp);
+            Assert.Equal(10, loRaDevice2.FCntDown);
+
+            deviceClient1.VerifyAll();
+            deviceClient2.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+
+            // devices were loaded only once
+            this.LoRaDeviceApi.Verify(x => x.SearchByDevAddrAsync(It.IsAny<string>()), Times.Once());
+            deviceClient1.Verify(x => x.GetTwinAsync(), Times.Once());
+            deviceClient2.Verify(x => x.GetTwinAsync(), Times.Once());
+        }
+
+        [Theory]
+        [InlineData(1)] // ABP with soft reset
+        [InlineData(11)]
+        public async Task When_Loading_Multiple_Devices_With_Same_DevAddr_One_Fails_Should_Add_One_To_Cache_And_Process_Message(int payloadFcntUp)
+        {
+            var isResetingDevice = payloadFcntUp <= 1;
+            var simulatedDevice1 = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: ServerGatewayID));
+
+            var devEUI = simulatedDevice1.LoRaDevice.DeviceID;
+            var devAddr = simulatedDevice1.LoRaDevice.DevAddr;
+
+            var simulatedDevice2 = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(2, gatewayID: ServerGatewayID));
+            simulatedDevice2.DevAddr = devAddr;
+
+            // message will be sent
+            LoRaDeviceTelemetry loRaDeviceTelemetry = null;
+
+            // Device client 1
+            // - Get Twin
+            // - Update twin (if isResetingDevice)
+            // - Send event
+            // - Check c2d message
+            var device1SentTelemetry = new List<LoRaDeviceTelemetry>();
+            var deviceClient1 = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
+            deviceClient1.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .Callback<LoRaDeviceTelemetry, Dictionary<string, string>>((t, _) => device1SentTelemetry.Add(loRaDeviceTelemetry))
+                .ReturnsAsync(true);
+
+            deviceClient1.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
+                .ReturnsAsync((Message)null);
+
+            deviceClient1.Setup(x => x.GetTwinAsync()).ReturnsAsync(simulatedDevice1.CreateABPTwin());
+
+            if (isResetingDevice)
+            {
+                deviceClient1.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+                    .ReturnsAsync(true);
+            }
+
+            // Device client 2
+            // - Get Twin -> throws TimeoutException
+            var deviceClient2 = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
+            deviceClient2.Setup(x => x.GetTwinAsync()).ThrowsAsync(new TimeoutException(), TimeSpan.FromMilliseconds(100));
+
+            // device api will be searched for payload
+            var searchDevicesResult = new SearchDevicesResult(new[]
+            {
+                new IoTHubDeviceInfo(simulatedDevice1.DevAddr, simulatedDevice1.DevEUI, "device1"),
+                new IoTHubDeviceInfo(simulatedDevice2.DevAddr, simulatedDevice2.DevEUI, "device2"),
+            });
+
+            this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))
+                .ReturnsAsync(searchDevicesResult);
+
+            this.LoRaDeviceFactory.SetClient(simulatedDevice1.DevEUI, deviceClient1.Object);
+            this.LoRaDeviceFactory.SetClient(simulatedDevice2.DevEUI, deviceClient2.Object);
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewMemoryCache(), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageDispatcher = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyFactory);
+
+            // sends unconfirmed message #1
+            var unconfirmedMessagePayload1 = simulatedDevice1.CreateUnconfirmedDataUpMessage("1", fcnt: payloadFcntUp);
+            var rxpk1 = unconfirmedMessagePayload1.SerializeUplink(simulatedDevice1.AppSKey, simulatedDevice1.NwkSKey).Rxpk[0];
+            var request1 = new WaitableLoRaRequest(rxpk1, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(request1);
+            Assert.True(await request1.WaitCompleteAsync());
+            Assert.Null(request1.ResponseDownlink);
+            Assert.True(request1.ProcessingSucceeded);
+            Assert.Single(device1SentTelemetry);
+
+            // sends unconfirmed message #2
+            var unconfirmedMessagePayload2 = simulatedDevice1.CreateUnconfirmedDataUpMessage("2", fcnt: payloadFcntUp + 1);
+            var rxpk2 = unconfirmedMessagePayload2.SerializeUplink(simulatedDevice1.AppSKey, simulatedDevice1.NwkSKey).Rxpk[0];
+            var request2 = new WaitableLoRaRequest(rxpk2, this.PacketForwarder);
+            messageDispatcher.DispatchRequest(request2);
+            Assert.True(await request2.WaitCompleteAsync());
+            Assert.Null(request2.ResponseDownlink);
+            Assert.True(request2.ProcessingSucceeded);
+            Assert.Equal(2, device1SentTelemetry.Count);
+
+            // Ensure that the device has been cached
+            var cachedDevices = deviceRegistry.InternalGetCachedDevicesForDevAddr(simulatedDevice1.DevAddr);
+            Assert.Single(cachedDevices);
+            Assert.True(cachedDevices.TryGetValue(simulatedDevice1.DevEUI, out var loRaDevice1));
+
+            // If the fcnt made a reset (0-1) the fcntdown is zero
+            if (isResetingDevice)
+            {
+                Assert.Equal(0, loRaDevice1.FCntDown);
+            }
+            else
+            {
+                Assert.Equal(10, loRaDevice1.FCntDown);
+            }
+
+            Assert.Equal(payloadFcntUp + 1, loRaDevice1.FCntUp);
+
+            deviceClient1.VerifyAll();
+            deviceClient2.VerifyAll();
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+
+            // devices were loaded only once
+            this.LoRaDeviceApi.Verify(x => x.SearchByDevAddrAsync(devAddr), Times.Once());
+            deviceClient1.Verify(x => x.GetTwinAsync(), Times.Once());
+            deviceClient2.Verify(x => x.GetTwinAsync(), Times.Once());
         }
     }
 }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/ParallelTestConfiguration.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/ParallelTestConfiguration.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.Test
+{
+    /// <summary>
+    /// Call durations, all in ms
+    /// </summary>
+    public class ParallelTestConfiguration
+    {
+        public string GatewayID { get; set; }
+
+        public RecordedDuration BetweenMessageDuration { get; set; }
+
+        public RecordedDuration SendEventDuration { get; set; }
+
+        public RecordedDuration ReceiveEventDuration { get; set; }
+
+        public RecordedDuration UpdateTwinDuration { get; set; }
+
+        public RecordedDuration LoadTwinDuration { get; set; }
+
+        public RecordedDuration DeviceApiResetFcntDuration { get; set; }
+
+        public RecordedDuration SearchByDevAddrDuration { get; set; }
+
+        public int? DeviceTwinFcntUp { get; set; }
+
+        public int? DeviceTwinFcntDown { get; set; }
+    }
+}

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/RecordedDuration.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/RecordedDuration.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+namespace LoRaWan.NetworkServer.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public class RecordedDuration
+    {
+        int Duration { get; set; }
+
+        IReadOnlyList<int> Sequence { get; set; }
+
+        int sequenceIndex;
+
+        public RecordedDuration(int duration)
+        {
+            this.Duration = duration;
+        }
+
+        public RecordedDuration(IReadOnlyList<int> sequence)
+        {
+            this.Sequence = sequence;
+        }
+
+        public TimeSpan Next()
+        {
+            if (this.Sequence != null && this.Sequence.Count > 0)
+            {
+                lock (this.Sequence)
+                {
+                    if (this.sequenceIndex < (this.Sequence.Count - 1))
+                    {
+                        return TimeSpan.FromMilliseconds(this.Sequence[this.sequenceIndex++]);
+                    }
+
+                    // returns the last one
+                    return TimeSpan.FromMilliseconds(this.Sequence[this.Sequence.Count - 1]);
+                }
+            }
+
+            return TimeSpan.FromMilliseconds(this.Duration);
+        }
+
+        public override string ToString()
+        {
+            if (this.Sequence == null)
+            {
+                return $"{this.Duration}ms";
+            }
+
+            return $"{string.Join(',', this.Sequence.Take(2))}ms";
+        }
+
+        public static implicit operator RecordedDuration(int value) => new RecordedDuration(value);
+
+        public static implicit operator RecordedDuration(int[] value) => new RecordedDuration(value);
+    }
+}

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/TestLoRaDeviceFactory.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/TestLoRaDeviceFactory.cs
@@ -3,23 +3,57 @@
 
 namespace LoRaWan.NetworkServer.Test
 {
+    using System;
+    using System.Collections.Generic;
     using LoRaWan.NetworkServer;
 
     internal class TestLoRaDeviceFactory : ILoRaDeviceFactory
     {
         private readonly ILoRaDeviceClient loRaDeviceClient;
+        private readonly ILoRaDataRequestHandler requestHandler;
+        private readonly Dictionary<string, ILoRaDeviceClient> deviceClientMap;
+        private readonly NetworkServerConfiguration configuration;
+        private readonly ILoRaDeviceFrameCounterUpdateStrategyFactory frameCounterUpdateStrategyFactory;
 
         public TestLoRaDeviceFactory(ILoRaDeviceClient loRaDeviceClient)
         {
             this.loRaDeviceClient = loRaDeviceClient;
+            this.deviceClientMap = new Dictionary<string, ILoRaDeviceClient>();
+        }
+
+        public TestLoRaDeviceFactory(ILoRaDeviceClient loRaDeviceClient, ILoRaDataRequestHandler requestHandler)
+        {
+            this.loRaDeviceClient = loRaDeviceClient;
+            this.requestHandler = requestHandler;
+            this.deviceClientMap = new Dictionary<string, ILoRaDeviceClient>();
+        }
+
+        public TestLoRaDeviceFactory(
+            NetworkServerConfiguration configuration,
+            ILoRaDeviceFrameCounterUpdateStrategyFactory frameCounterUpdateStrategyFactory,
+            ILoRaDeviceClient loRaDeviceClient)
+            : this(loRaDeviceClient)
+        {
+            this.configuration = configuration;
+            this.frameCounterUpdateStrategyFactory = frameCounterUpdateStrategyFactory;
         }
 
         public LoRaDevice Create(IoTHubDeviceInfo deviceInfo)
         {
-            return new LoRaDevice(
+            if (!this.deviceClientMap.TryGetValue(deviceInfo.DevEUI, out var deviceClientToAssign))
+            {
+                deviceClientToAssign = this.loRaDeviceClient;
+            }
+
+            var loRaDevice = new LoRaDevice(
                 deviceInfo.DevAddr,
                 deviceInfo.DevEUI,
-                this.loRaDeviceClient);
+                deviceClientToAssign);
+
+            loRaDevice.SetRequestHandler(this.requestHandler ?? new DefaultLoRaDataRequestHandler(this.configuration, this.frameCounterUpdateStrategyFactory, new LoRaPayloadDecoder()));
+            return loRaDevice;
         }
+
+        internal void SetClient(string devEUI, ILoRaDeviceClient deviceClient) => this.deviceClientMap[devEUI] = deviceClient;
     }
 }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/TestLoRaDeviceFactory.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/TestLoRaDeviceFactory.cs
@@ -13,7 +13,7 @@ namespace LoRaWan.NetworkServer.Test
         private readonly ILoRaDataRequestHandler requestHandler;
         private readonly Dictionary<string, ILoRaDeviceClient> deviceClientMap;
         private readonly NetworkServerConfiguration configuration;
-        private readonly ILoRaDeviceFrameCounterUpdateStrategyFactory frameCounterUpdateStrategyFactory;
+        private readonly ILoRaDeviceFrameCounterUpdateStrategyProvider frameCounterUpdateStrategyProvider;
 
         public TestLoRaDeviceFactory(ILoRaDeviceClient loRaDeviceClient)
         {
@@ -30,12 +30,12 @@ namespace LoRaWan.NetworkServer.Test
 
         public TestLoRaDeviceFactory(
             NetworkServerConfiguration configuration,
-            ILoRaDeviceFrameCounterUpdateStrategyFactory frameCounterUpdateStrategyFactory,
+            ILoRaDeviceFrameCounterUpdateStrategyProvider frameCounterUpdateStrategyProvider,
             ILoRaDeviceClient loRaDeviceClient)
             : this(loRaDeviceClient)
         {
             this.configuration = configuration;
-            this.frameCounterUpdateStrategyFactory = frameCounterUpdateStrategyFactory;
+            this.frameCounterUpdateStrategyProvider = frameCounterUpdateStrategyProvider;
         }
 
         public LoRaDevice Create(IoTHubDeviceInfo deviceInfo)
@@ -50,7 +50,7 @@ namespace LoRaWan.NetworkServer.Test
                 deviceInfo.DevEUI,
                 deviceClientToAssign);
 
-            loRaDevice.SetRequestHandler(this.requestHandler ?? new DefaultLoRaDataRequestHandler(this.configuration, this.frameCounterUpdateStrategyFactory, new LoRaPayloadDecoder()));
+            loRaDevice.SetRequestHandler(this.requestHandler ?? new DefaultLoRaDataRequestHandler(this.configuration, this.frameCounterUpdateStrategyProvider, new LoRaPayloadDecoder()));
             return loRaDevice;
         }
 

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/TestPacketForwarder.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/TestPacketForwarder.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.Test
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using LoRaTools.LoRaPhysical;
+    using LoRaWan.NetworkServer;
+
+    public class TestPacketForwarder : IPacketForwarder
+    {
+        public List<DownlinkPktFwdMessage> DownlinkMessages { get; }
+
+        public TestPacketForwarder()
+        {
+            this.DownlinkMessages = new List<DownlinkPktFwdMessage>();
+        }
+
+        public Task SendDownstreamAsync(DownlinkPktFwdMessage message)
+        {
+            this.DownlinkMessages.Add(message);
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/TestUtils.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/TestUtils.cs
@@ -14,7 +14,8 @@ namespace LoRaWan.NetworkServer.Test
     {
         internal static LoRaDevice CreateFromSimulatedDevice(
             SimulatedDevice simulatedDevice,
-            ILoRaDeviceClient loRaDeviceClient)
+            ILoRaDeviceClient loRaDeviceClient,
+            DefaultLoRaDataRequestHandler requestHandler = null)
         {
             var result = new LoRaDevice(simulatedDevice.LoRaDevice.DevAddr, simulatedDevice.LoRaDevice.DeviceID, loRaDeviceClient)
             {
@@ -28,6 +29,9 @@ namespace LoRaWan.NetworkServer.Test
             };
             result.SetFcntDown(simulatedDevice.FrmCntDown);
             result.SetFcntUp(simulatedDevice.FrmCntUp);
+
+            if (requestHandler != null)
+                result.SetRequestHandler(requestHandler);
 
             return result;
         }
@@ -75,6 +79,38 @@ namespace LoRaWan.NetworkServer.Test
 
             var reported = new Dictionary<string, object>
             {
+                { TwinProperty.FCntDown, simulatedDevice.FrmCntDown },
+                { TwinProperty.FCntUp, simulatedDevice.FrmCntUp }
+            };
+
+            return CreateTwin(desired: finalDesiredProperties, reported: reported);
+        }
+
+        internal static Twin CreateOTAATwin(this SimulatedDevice simulatedDevice, Dictionary<string, object> desiredProperties = null)
+        {
+            var finalDesiredProperties = new Dictionary<string, object>
+                {
+                    { TwinProperty.AppEUI, simulatedDevice.AppEUI },
+                    { TwinProperty.AppKey, simulatedDevice.AppKey },
+                    { TwinProperty.GatewayID, simulatedDevice.LoRaDevice.GatewayID },
+                    { TwinProperty.SensorDecoder, simulatedDevice.LoRaDevice.SensorDecoder },
+                };
+
+            if (desiredProperties != null)
+            {
+                foreach (var kv in desiredProperties)
+                {
+                    finalDesiredProperties[kv.Key] = kv.Value;
+                }
+            }
+
+            var reported = new Dictionary<string, object>
+            {
+                { TwinProperty.DevAddr, simulatedDevice.DevAddr },
+                { TwinProperty.AppSKey, simulatedDevice.AppSKey },
+                { TwinProperty.NwkSKey, simulatedDevice.NwkSKey },
+                { TwinProperty.DevNonce, simulatedDevice.DevNonce },
+                { TwinProperty.NetID, simulatedDevice.NetId },
                 { TwinProperty.FCntDown, simulatedDevice.FrmCntDown },
                 { TwinProperty.FCntUp, simulatedDevice.FrmCntUp }
             };

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/WaitableLoRaRequest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/WaitableLoRaRequest.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using LoRaTools.LoRaMessage;
+    using LoRaTools.LoRaPhysical;
+    using LoRaTools.Regions;
+    using LoRaWan.NetworkServer;
+    using LoRaWan.Test.Shared;
+    using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Caching.Memory;
+    using Moq;
+    using Xunit;
+
+    public class WaitableLoRaRequest : LoRaRequest
+    {
+        SemaphoreSlim complete;
+
+        public bool ProcessingFailed { get; private set; }
+
+        public LoRaDevice LoRaDevice { get; private set; }
+
+        public LoRaDeviceRequestFailedReason ProcessingFailedReason { get; private set; }
+
+        public DownlinkPktFwdMessage ResponseDownlink { get; private set; }
+
+        public bool ProcessingSucceeded { get; private set; }
+
+        public WaitableLoRaRequest(LoRaPayloadData payload)
+            : base(payload)
+        {
+            this.complete = new SemaphoreSlim(0);
+        }
+
+        public WaitableLoRaRequest(Rxpk rxpk, IPacketForwarder packetForwarder)
+            : base(rxpk, packetForwarder, DateTime.UtcNow)
+        {
+            this.complete = new SemaphoreSlim(0);
+        }
+
+        public override void NotifyFailed(LoRaDevice loRaDevice, LoRaDeviceRequestFailedReason reason, Exception exception = null)
+        {
+            base.NotifyFailed(loRaDevice, reason, exception);
+
+            this.ProcessingFailed = true;
+            this.LoRaDevice = loRaDevice;
+            this.ProcessingFailedReason = reason;
+            this.complete.Release();
+        }
+
+        public override void NotifySucceeded(LoRaDevice loRaDevice, DownlinkPktFwdMessage downlink)
+        {
+            base.NotifySucceeded(loRaDevice, downlink);
+
+            this.LoRaDevice = loRaDevice;
+            this.ResponseDownlink = downlink;
+            this.ProcessingSucceeded = true;
+            this.complete.Release();
+        }
+
+        internal Task<bool> WaitCompleteAsync(int timeout = 10000) => this.complete.WaitAsync(timeout);
+    }
+}


### PR DESCRIPTION
**Changes**
- Deprecated MessageProcessor. It will be removed in a future PR.
- Add task queueing to LoRaDevice class
- Moved message processing logic to DefaultLoRaDataRequestHandler
- Introduce MessageDispatcher, which internally uses the LoRaDevice queue to process data messages
- Added DeviceLoaderSynchronizer which takes care of loading devices by devAddr while queueing incoming message requests. Ensuring first-in first-out to incoming data payloads.
- Add IPacketForwarder interface that defines a contract to send data to a packet forwarder.
- UdpServer now implements IPacketForwarder, keeping also the IP address of incoming calls (in addition to udp port).
- UdpServer is using message dispatcher through a compiler directive

Fixes AB#946