### PR TITLE
Fix non-breaking exceptions when using the network server outside of Edge

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -121,7 +121,7 @@ namespace LoRaWan.NetworkServer
                 if (twin.Properties.Desired.Contains(TwinProperty.AppSKey))
                 {
                     // ABP Case
-                    this.AppSKey = twin.Properties.Desired[TwinProperty.AppSKey];
+                    this.AppSKey = twin.Properties.Desired[TwinProperty.AppSKey].Value;
 
                     if (!twin.Properties.Desired.Contains(TwinProperty.NwkSKey))
                         throw new InvalidLoRaDeviceException("Missing NwkSKey for ABP device");
@@ -129,8 +129,8 @@ namespace LoRaWan.NetworkServer
                     if (!twin.Properties.Desired.Contains(TwinProperty.DevAddr))
                         throw new InvalidLoRaDeviceException("Missing DevAddr for ABP device");
 
-                    this.NwkSKey = twin.Properties.Desired[TwinProperty.NwkSKey];
-                    this.DevAddr = twin.Properties.Desired[TwinProperty.DevAddr];
+                    this.NwkSKey = twin.Properties.Desired[TwinProperty.NwkSKey].Value;
+                    this.DevAddr = twin.Properties.Desired[TwinProperty.DevAddr].Value;
 
                     if (string.IsNullOrEmpty(this.NwkSKey))
                         throw new InvalidLoRaDeviceException("NwkSKey is empty");
@@ -151,36 +151,36 @@ namespace LoRaWan.NetworkServer
                         throw new InvalidLoRaDeviceException("Missing AppKey for OTAA device");
                     }
 
-                    this.AppKey = twin.Properties.Desired[TwinProperty.AppKey];
+                    this.AppKey = twin.Properties.Desired[TwinProperty.AppKey].Value;
 
                     if (!twin.Properties.Desired.Contains(TwinProperty.AppEUI))
                     {
                         throw new InvalidLoRaDeviceException("Missing AppEUI for OTAA device");
                     }
 
-                    this.AppEUI = twin.Properties.Desired[TwinProperty.AppEUI];
+                    this.AppEUI = twin.Properties.Desired[TwinProperty.AppEUI].Value;
 
                     // Check for already joined OTAA device properties
                     if (twin.Properties.Reported.Contains(TwinProperty.DevAddr))
-                        this.DevAddr = twin.Properties.Reported[TwinProperty.DevAddr];
+                        this.DevAddr = twin.Properties.Reported[TwinProperty.DevAddr].Value;
 
                     if (twin.Properties.Reported.Contains(TwinProperty.AppSKey))
-                        this.AppSKey = twin.Properties.Reported[TwinProperty.AppSKey];
+                        this.AppSKey = twin.Properties.Reported[TwinProperty.AppSKey].Value;
 
                     if (twin.Properties.Reported.Contains(TwinProperty.NwkSKey))
-                        this.NwkSKey = twin.Properties.Reported[TwinProperty.NwkSKey];
+                        this.NwkSKey = twin.Properties.Reported[TwinProperty.NwkSKey].Value;
 
                     if (twin.Properties.Reported.Contains(TwinProperty.NetID))
-                        this.NetID = twin.Properties.Reported[TwinProperty.NetID];
+                        this.NetID = twin.Properties.Reported[TwinProperty.NetID].Value;
 
                     if (twin.Properties.Reported.Contains(TwinProperty.DevNonce))
-                        this.DevNonce = twin.Properties.Reported[TwinProperty.DevNonce];
+                        this.DevNonce = twin.Properties.Reported[TwinProperty.DevNonce].Value;
                 }
 
                 if (twin.Properties.Desired.Contains(TwinProperty.GatewayID))
-                    this.GatewayID = twin.Properties.Desired[TwinProperty.GatewayID];
+                    this.GatewayID = twin.Properties.Desired[TwinProperty.GatewayID].Value;
                 if (twin.Properties.Desired.Contains(TwinProperty.SensorDecoder))
-                    this.SensorDecoder = twin.Properties.Desired[TwinProperty.SensorDecoder];
+                    this.SensorDecoder = twin.Properties.Desired[TwinProperty.SensorDecoder].Value;
                 if (twin.Properties.Reported.Contains(TwinProperty.FCntUp))
                     this.fcntUp = this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntUp].Value);
                 if (twin.Properties.Reported.Contains(TwinProperty.FCntDown))

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -188,7 +188,7 @@ namespace LoRaWan.NetworkServer
 
                 if (twin.Properties.Desired.Contains(TwinProperty.DownlinkEnabled))
                 {
-                    this.DownlinkEnabled = this.GetTwinPropertyBoolValue(twin.Properties.Desired[TwinProperty.DownlinkEnabled]);
+                    this.DownlinkEnabled = this.GetTwinPropertyBoolValue(twin.Properties.Desired[TwinProperty.DownlinkEnabled].Value);
                 }
 
                 if (twin.Properties.Desired.Contains(TwinProperty.PreferredWindow))

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -121,7 +121,7 @@ namespace LoRaWan.NetworkServer
                 if (twin.Properties.Desired.Contains(TwinProperty.AppSKey))
                 {
                     // ABP Case
-                    this.AppSKey = twin.Properties.Desired[TwinProperty.AppSKey] as string;
+                    this.AppSKey = twin.Properties.Desired[TwinProperty.AppSKey].Value as string;
 
                     if (!twin.Properties.Desired.Contains(TwinProperty.NwkSKey))
                         throw new InvalidLoRaDeviceException("Missing NwkSKey for ABP device");
@@ -129,8 +129,8 @@ namespace LoRaWan.NetworkServer
                     if (!twin.Properties.Desired.Contains(TwinProperty.DevAddr))
                         throw new InvalidLoRaDeviceException("Missing DevAddr for ABP device");
 
-                    this.NwkSKey = twin.Properties.Desired[TwinProperty.NwkSKey] as string;
-                    this.DevAddr = twin.Properties.Desired[TwinProperty.DevAddr] as string;
+                    this.NwkSKey = twin.Properties.Desired[TwinProperty.NwkSKey].Value as string;
+                    this.DevAddr = twin.Properties.Desired[TwinProperty.DevAddr].Value as string;
 
                     if (string.IsNullOrEmpty(this.NwkSKey))
                         throw new InvalidLoRaDeviceException("NwkSKey is empty");

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -121,7 +121,7 @@ namespace LoRaWan.NetworkServer
                 if (twin.Properties.Desired.Contains(TwinProperty.AppSKey))
                 {
                     // ABP Case
-                    this.AppSKey = twin.Properties.Desired[TwinProperty.AppSKey].Value;
+                    this.AppSKey = (string)twin.Properties.Desired[TwinProperty.AppSKey];
 
                     if (!twin.Properties.Desired.Contains(TwinProperty.NwkSKey))
                         throw new InvalidLoRaDeviceException("Missing NwkSKey for ABP device");
@@ -129,8 +129,8 @@ namespace LoRaWan.NetworkServer
                     if (!twin.Properties.Desired.Contains(TwinProperty.DevAddr))
                         throw new InvalidLoRaDeviceException("Missing DevAddr for ABP device");
 
-                    this.NwkSKey = twin.Properties.Desired[TwinProperty.NwkSKey].Value;
-                    this.DevAddr = twin.Properties.Desired[TwinProperty.DevAddr].Value;
+                    this.NwkSKey = twin.Properties.Desired[TwinProperty.NwkSKey];
+                    this.DevAddr = (string)twin.Properties.Desired[TwinProperty.DevAddr];
 
                     if (string.IsNullOrEmpty(this.NwkSKey))
                         throw new InvalidLoRaDeviceException("NwkSKey is empty");
@@ -151,49 +151,49 @@ namespace LoRaWan.NetworkServer
                         throw new InvalidLoRaDeviceException("Missing AppKey for OTAA device");
                     }
 
-                    this.AppKey = twin.Properties.Desired[TwinProperty.AppKey].Value;
+                    this.AppKey = (string)twin.Properties.Desired[TwinProperty.AppKey];
 
                     if (!twin.Properties.Desired.Contains(TwinProperty.AppEUI))
                     {
                         throw new InvalidLoRaDeviceException("Missing AppEUI for OTAA device");
                     }
 
-                    this.AppEUI = twin.Properties.Desired[TwinProperty.AppEUI].Value;
+                    this.AppEUI = (string)twin.Properties.Desired[TwinProperty.AppEUI];
 
                     // Check for already joined OTAA device properties
                     if (twin.Properties.Reported.Contains(TwinProperty.DevAddr))
-                        this.DevAddr = twin.Properties.Reported[TwinProperty.DevAddr].Value;
+                        this.DevAddr = (string)twin.Properties.Reported[TwinProperty.DevAddr];
 
                     if (twin.Properties.Reported.Contains(TwinProperty.AppSKey))
-                        this.AppSKey = twin.Properties.Reported[TwinProperty.AppSKey].Value;
+                        this.AppSKey = (string)twin.Properties.Reported[TwinProperty.AppSKey];
 
                     if (twin.Properties.Reported.Contains(TwinProperty.NwkSKey))
-                        this.NwkSKey = twin.Properties.Reported[TwinProperty.NwkSKey].Value;
+                        this.NwkSKey = (string)twin.Properties.Reported[TwinProperty.NwkSKey];
 
                     if (twin.Properties.Reported.Contains(TwinProperty.NetID))
-                        this.NetID = twin.Properties.Reported[TwinProperty.NetID].Value;
+                        this.NetID = (string)twin.Properties.Reported[TwinProperty.NetID];
 
                     if (twin.Properties.Reported.Contains(TwinProperty.DevNonce))
-                        this.DevNonce = twin.Properties.Reported[TwinProperty.DevNonce].Value;
+                        this.DevNonce = (string)twin.Properties.Reported[TwinProperty.DevNonce];
                 }
 
                 if (twin.Properties.Desired.Contains(TwinProperty.GatewayID))
-                    this.GatewayID = twin.Properties.Desired[TwinProperty.GatewayID].Value;
+                    this.GatewayID = (string)twin.Properties.Desired[TwinProperty.GatewayID];
                 if (twin.Properties.Desired.Contains(TwinProperty.SensorDecoder))
-                    this.SensorDecoder = twin.Properties.Desired[TwinProperty.SensorDecoder].Value;
+                    this.SensorDecoder = (string)twin.Properties.Desired[TwinProperty.SensorDecoder];
                 if (twin.Properties.Reported.Contains(TwinProperty.FCntUp))
-                    this.fcntUp = this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntUp].Value);
+                    this.fcntUp = (int)this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntUp]);
                 if (twin.Properties.Reported.Contains(TwinProperty.FCntDown))
-                    this.fcntDown = this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntDown].Value);
+                    this.fcntDown = (int)this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntDown]);
 
                 if (twin.Properties.Desired.Contains(TwinProperty.DownlinkEnabled))
                 {
-                    this.DownlinkEnabled = this.GetTwinPropertyBoolValue(twin.Properties.Desired[TwinProperty.DownlinkEnabled].Value);
+                    this.DownlinkEnabled = (bool)this.GetTwinPropertyBoolValue(twin.Properties.Desired[TwinProperty.DownlinkEnabled]);
                 }
 
                 if (twin.Properties.Desired.Contains(TwinProperty.PreferredWindow))
                 {
-                    var preferredWindowTwinValue = this.GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.PreferredWindow].Value);
+                    var preferredWindowTwinValue = this.GetTwinPropertyIntValue((int)twin.Properties.Desired[TwinProperty.PreferredWindow]);
                     if (preferredWindowTwinValue == Constants.RECEIVE_WINDOW_2)
                         this.PreferredWindow = preferredWindowTwinValue;
                 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -182,9 +182,9 @@ namespace LoRaWan.NetworkServer
                 if (twin.Properties.Desired.Contains(TwinProperty.SensorDecoder))
                     this.SensorDecoder = twin.Properties.Desired[TwinProperty.SensorDecoder].Value as string;
                 if (twin.Properties.Reported.Contains(TwinProperty.FCntUp))
-                    this.fcntUp = this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntUp]);
+                    this.fcntUp = this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntUp].Value);
                 if (twin.Properties.Reported.Contains(TwinProperty.FCntDown))
-                    this.fcntDown = this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntDown]);
+                    this.fcntDown = this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntDown].Value);
 
                 if (twin.Properties.Desired.Contains(TwinProperty.DownlinkEnabled))
                 {
@@ -193,7 +193,7 @@ namespace LoRaWan.NetworkServer
 
                 if (twin.Properties.Desired.Contains(TwinProperty.PreferredWindow))
                 {
-                    var preferredWindowTwinValue = this.GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.PreferredWindow]);
+                    var preferredWindowTwinValue = this.GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.PreferredWindow].Value);
                     if (preferredWindowTwinValue == Constants.RECEIVE_WINDOW_2)
                         this.PreferredWindow = preferredWindowTwinValue;
                 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -182,18 +182,18 @@ namespace LoRaWan.NetworkServer
                 if (twin.Properties.Desired.Contains(TwinProperty.SensorDecoder))
                     this.SensorDecoder = (string)twin.Properties.Desired[TwinProperty.SensorDecoder];
                 if (twin.Properties.Reported.Contains(TwinProperty.FCntUp))
-                    this.fcntUp = (int)this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntUp]);
+                    this.fcntUp = this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntUp].Value);
                 if (twin.Properties.Reported.Contains(TwinProperty.FCntDown))
-                    this.fcntDown = (int)this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntDown]);
+                    this.fcntDown = this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntDown].Value);
 
                 if (twin.Properties.Desired.Contains(TwinProperty.DownlinkEnabled))
                 {
-                    this.DownlinkEnabled = (bool)this.GetTwinPropertyBoolValue(twin.Properties.Desired[TwinProperty.DownlinkEnabled]);
+                    this.DownlinkEnabled = this.GetTwinPropertyBoolValue(twin.Properties.Desired[TwinProperty.DownlinkEnabled].Value);
                 }
 
                 if (twin.Properties.Desired.Contains(TwinProperty.PreferredWindow))
                 {
-                    var preferredWindowTwinValue = this.GetTwinPropertyIntValue((int)twin.Properties.Desired[TwinProperty.PreferredWindow]);
+                    var preferredWindowTwinValue = this.GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.PreferredWindow].Value);
                     if (preferredWindowTwinValue == Constants.RECEIVE_WINDOW_2)
                         this.PreferredWindow = preferredWindowTwinValue;
                 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -121,7 +121,7 @@ namespace LoRaWan.NetworkServer
                 if (twin.Properties.Desired.Contains(TwinProperty.AppSKey))
                 {
                     // ABP Case
-                    this.AppSKey = (string)twin.Properties.Desired[TwinProperty.AppSKey];
+                    this.AppSKey = twin.Properties.Desired[TwinProperty.AppSKey] as string;
 
                     if (!twin.Properties.Desired.Contains(TwinProperty.NwkSKey))
                         throw new InvalidLoRaDeviceException("Missing NwkSKey for ABP device");
@@ -129,8 +129,8 @@ namespace LoRaWan.NetworkServer
                     if (!twin.Properties.Desired.Contains(TwinProperty.DevAddr))
                         throw new InvalidLoRaDeviceException("Missing DevAddr for ABP device");
 
-                    this.NwkSKey = twin.Properties.Desired[TwinProperty.NwkSKey];
-                    this.DevAddr = (string)twin.Properties.Desired[TwinProperty.DevAddr];
+                    this.NwkSKey = twin.Properties.Desired[TwinProperty.NwkSKey] as string;
+                    this.DevAddr = twin.Properties.Desired[TwinProperty.DevAddr] as string;
 
                     if (string.IsNullOrEmpty(this.NwkSKey))
                         throw new InvalidLoRaDeviceException("NwkSKey is empty");
@@ -151,49 +151,49 @@ namespace LoRaWan.NetworkServer
                         throw new InvalidLoRaDeviceException("Missing AppKey for OTAA device");
                     }
 
-                    this.AppKey = (string)twin.Properties.Desired[TwinProperty.AppKey];
+                    this.AppKey = twin.Properties.Desired[TwinProperty.AppKey].Value as string;
 
                     if (!twin.Properties.Desired.Contains(TwinProperty.AppEUI))
                     {
                         throw new InvalidLoRaDeviceException("Missing AppEUI for OTAA device");
                     }
 
-                    this.AppEUI = (string)twin.Properties.Desired[TwinProperty.AppEUI];
+                    this.AppEUI = twin.Properties.Desired[TwinProperty.AppEUI].Value as string;
 
                     // Check for already joined OTAA device properties
                     if (twin.Properties.Reported.Contains(TwinProperty.DevAddr))
-                        this.DevAddr = (string)twin.Properties.Reported[TwinProperty.DevAddr];
+                        this.DevAddr = twin.Properties.Reported[TwinProperty.DevAddr].Value as string;
 
                     if (twin.Properties.Reported.Contains(TwinProperty.AppSKey))
-                        this.AppSKey = (string)twin.Properties.Reported[TwinProperty.AppSKey];
+                        this.AppSKey = twin.Properties.Reported[TwinProperty.AppSKey].Value as string;
 
                     if (twin.Properties.Reported.Contains(TwinProperty.NwkSKey))
-                        this.NwkSKey = (string)twin.Properties.Reported[TwinProperty.NwkSKey];
+                        this.NwkSKey = twin.Properties.Reported[TwinProperty.NwkSKey].Value as string;
 
                     if (twin.Properties.Reported.Contains(TwinProperty.NetID))
-                        this.NetID = (string)twin.Properties.Reported[TwinProperty.NetID];
+                        this.NetID = twin.Properties.Reported[TwinProperty.NetID].Value as string;
 
                     if (twin.Properties.Reported.Contains(TwinProperty.DevNonce))
-                        this.DevNonce = (string)twin.Properties.Reported[TwinProperty.DevNonce];
+                        this.DevNonce = twin.Properties.Reported[TwinProperty.DevNonce].Value as string;
                 }
 
                 if (twin.Properties.Desired.Contains(TwinProperty.GatewayID))
-                    this.GatewayID = (string)twin.Properties.Desired[TwinProperty.GatewayID];
+                    this.GatewayID = twin.Properties.Desired[TwinProperty.GatewayID].Value as string;
                 if (twin.Properties.Desired.Contains(TwinProperty.SensorDecoder))
-                    this.SensorDecoder = (string)twin.Properties.Desired[TwinProperty.SensorDecoder];
+                    this.SensorDecoder = twin.Properties.Desired[TwinProperty.SensorDecoder].Value as string;
                 if (twin.Properties.Reported.Contains(TwinProperty.FCntUp))
-                    this.fcntUp = this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntUp].Value);
+                    this.fcntUp = this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntUp]);
                 if (twin.Properties.Reported.Contains(TwinProperty.FCntDown))
-                    this.fcntDown = this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntDown].Value);
+                    this.fcntDown = this.GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntDown]);
 
                 if (twin.Properties.Desired.Contains(TwinProperty.DownlinkEnabled))
                 {
-                    this.DownlinkEnabled = this.GetTwinPropertyBoolValue(twin.Properties.Desired[TwinProperty.DownlinkEnabled].Value);
+                    this.DownlinkEnabled = this.GetTwinPropertyBoolValue(twin.Properties.Desired[TwinProperty.DownlinkEnabled]);
                 }
 
                 if (twin.Properties.Desired.Contains(TwinProperty.PreferredWindow))
                 {
-                    var preferredWindowTwinValue = this.GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.PreferredWindow].Value);
+                    var preferredWindowTwinValue = this.GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.PreferredWindow]);
                     if (preferredWindowTwinValue == Constants.RECEIVE_WINDOW_2)
                         this.PreferredWindow = preferredWindowTwinValue;
                 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
@@ -294,7 +294,7 @@ namespace LoRaWan.NetworkServer
                 return null;
             }
 
-            Logger.Log(devEUI, "querying the registry for OTTA device", LogLevel.Information);
+            Logger.Log(devEUI, "querying the registry for OTAA device", LogLevel.Information);
 
             try
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
@@ -409,7 +409,7 @@ namespace LoRaWan.NetworkServer
                     var moduleTwinCollection = moduleTwin.Properties.Desired;
                     try
                     {
-                        this.loRaDeviceAPIService.SetURL(moduleTwinCollection["FacadeServerUrl"] as string);
+                        this.loRaDeviceAPIService.SetURL(moduleTwinCollection["FacadeServerUrl"].Value as string);
                         Logger.LogAlways($"Facade function url: {this.loRaDeviceAPIService.URL}");
                     }
                     catch (ArgumentOutOfRangeException e)
@@ -420,7 +420,7 @@ namespace LoRaWan.NetworkServer
 
                     try
                     {
-                        this.loRaDeviceAPIService.SetAuthCode(moduleTwinCollection["FacadeAuthCode"] as string);
+                        this.loRaDeviceAPIService.SetAuthCode(moduleTwinCollection["FacadeAuthCode"].Value as string);
                     }
                     catch (ArgumentOutOfRangeException e)
                     {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
@@ -407,10 +407,9 @@ namespace LoRaWan.NetworkServer
 
                     var moduleTwin = await this.ioTHubModuleClient.GetTwinAsync();
                     var moduleTwinCollection = moduleTwin.Properties.Desired;
-
                     try
                     {
-                        this.loRaDeviceAPIService.SetURL((string)moduleTwinCollection["FacadeServerUrl"]);
+                        this.loRaDeviceAPIService.SetURL(moduleTwinCollection["FacadeServerUrl"] as string);
                         Logger.LogAlways($"Facade function url: {this.loRaDeviceAPIService.URL}");
                     }
                     catch (ArgumentOutOfRangeException e)
@@ -421,7 +420,7 @@ namespace LoRaWan.NetworkServer
 
                     try
                     {
-                        this.loRaDeviceAPIService.SetAuthCode((string)moduleTwinCollection["FacadeAuthCode"]);
+                        this.loRaDeviceAPIService.SetAuthCode(moduleTwinCollection["FacadeAuthCode"] as string);
                     }
                     catch (ArgumentOutOfRangeException e)
                     {

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/OTAATest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/OTAATest.cs
@@ -80,7 +80,7 @@ namespace LoRaWan.IntegrationTest
             // Sends 10x confirmed messages
             for (var i = 0; i < MESSAGES_COUNT; ++i)
             {
-                Console.WriteLine($"Starting sending OTTA confirmed message {i + 1}/{MESSAGES_COUNT}");
+                Console.WriteLine($"Starting sending OTAA confirmed message {i + 1}/{MESSAGES_COUNT}");
                 this.TestFixtureCi.ClearLogs();
 
                 var msg = PayloadGenerator.Next().ToString();


### PR DESCRIPTION
When running the solution outside of IoT Edge, in Visual Studio directly on my machine, the exception log windows is literally swamped by the following exception:

```
Exception thrown: 'Microsoft.CSharp.RuntimeBinder.RuntimeBinderException' in Microsoft.CSharp.dll ("Cannot implicitly convert type 'Newtonsoft.Json.Linq.JValue' to 'string'. An explicit conversion exists (are you missing a cast?)") Exception thrown: 'Microsoft.CSharp.RuntimeBinder.RuntimeBinderException' in Microsoft.CSharp.dll ("Cannot implicitly convert type 'Newtonsoft.Json.Linq.JValue' to 'string'. An explicit conversion exists (are you missing a cast?)") 
```
This makes it impossible to break on exception when developing :( and definitely impact my dev cycle.

After some investigation I found out that adding the .Value (as it was already done some times) fixed the issue.

Do you want me to run a FULL CI for this?
