### PR TITLE
Use absolute expiration of 2 days for devices & external package updates

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
+++ b/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
@@ -4,10 +4,10 @@
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.2" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.22" />
-    <PackageReference Include="StackExchange.Redis" Version="2.0.513" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.25" />
+    <PackageReference Include="StackExchange.Redis" Version="2.0.519" />
   </ItemGroup>
   
   <!-- Add shared files -->

--- a/LoRaEngine/deployment.test.template.json
+++ b/LoRaEngine/deployment.test.template.json
@@ -58,9 +58,6 @@
               "httpSettings__enabled": {
                 "value": "$EDGEHUB_HTTPSETTINGS_ENABLED"
               },
-              "TwinManagerVersion": {
-                "value": "v2"
-              },
               "LORA_BUILD_ID": {
                 "value": "$BUILD_BUILDID"
               }

--- a/LoRaEngine/modules/LoRaSimulator/LoRaSimulator/LoRaSimulator.csproj
+++ b/LoRaEngine/modules/LoRaSimulator/LoRaSimulator/LoRaSimulator.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/LoRaWanTest.csproj
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/LoRaWanTest.csproj
@@ -7,10 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.2.7" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Constants.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Constants.cs
@@ -36,5 +36,12 @@ namespace LoRaWan.NetworkServer
         /// ensure next value will be correct even if the network died before persisting it
         /// </summary>
         public const int FCNT_DOWN_INCREMENTED_ON_ABP_DEVICE_LOAD = 10;
+
+        /// <summary>
+        /// Amount of days a <see cref="LoRaDevice"/> is cached
+        /// This is absolute caching
+        /// For caching by devAddr and devEUI
+        /// </summary>
+        public const int DEVICE_CACHE_PERIOD_IN_DAYS = 2;
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
@@ -82,7 +82,7 @@ namespace LoRaWan.NetworkServer
             {
                 return this.cache.GetOrCreate<DevEUIToLoRaDeviceDictionary>(devAddr, (cacheEntry) =>
                 {
-                    cacheEntry.SlidingExpiration = TimeSpan.FromDays(1);
+                    cacheEntry.SetAbsoluteExpiration(TimeSpan.FromDays(Constants.DEVICE_CACHE_PERIOD_IN_DAYS));
                     cacheEntry.ExpirationTokens.Add(this.resetCacheChangeToken);
                     return new DevEUIToLoRaDeviceDictionary();
                 });
@@ -174,7 +174,10 @@ namespace LoRaWan.NetworkServer
 
             Logger.Log(loRaDevice.DevEUI, "device added to cache", LogLevel.Debug);
 
-            this.cache.Set(this.CacheKeyForDevEUIDevice(loRaDevice.DevEUI), loRaDevice, this.resetCacheChangeToken);
+            var devEUICacheOptions = new MemoryCacheEntryOptions();
+            devEUICacheOptions.SetAbsoluteExpiration(TimeSpan.FromDays(Constants.DEVICE_CACHE_PERIOD_IN_DAYS));
+            devEUICacheOptions.ExpirationTokens.Add(this.resetCacheChangeToken);
+            this.cache.Set(this.CacheKeyForDevEUIDevice(loRaDevice.DevEUI), loRaDevice, devEUICacheOptions);
         }
 
         /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaWan.NetworkServer.csproj
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaWan.NetworkServer.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.18.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.csproj
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.19.0" />
   </ItemGroup>
 
   <!-- StyleCop Setup -->

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaTools.csproj
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaTools.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.2" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>
 

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaWan.IntegrationTest.csproj
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaWan.IntegrationTest.csproj
@@ -13,18 +13,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.1" />
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.2" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="NetCoreSerial" Version="1.1.1" />
     <PackageReference Include="System.IO.Ports" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0-preview-20180924-03" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/LoRaEngine/test/LoRaWan.SimulatedTest/LoRaWan.SimulatedTest.csproj
+++ b/LoRaEngine/test/LoRaWan.SimulatedTest/LoRaWan.SimulatedTest.csproj
@@ -7,9 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/LoRaEngine/test/LoRaWan.Test.Shared/LoRaWan.Test.Shared.csproj
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/LoRaWan.Test.Shared.csproj
@@ -9,14 +9,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.1" />
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.2" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 
   <!-- StyleCop Setup -->

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaWanNetworkServer.Test.csproj
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaWanNetworkServer.Test.csproj
@@ -7,19 +7,22 @@
     <CodeAnalysisRuleSet>../../../stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0"/>
-    <PackageReference Include="Moq" Version="4.10.1"/>
-    <PackageReference Include="xunit" Version="2.3.1"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1"/>
-    <PackageReference Include="coverlet.msbuild" Version="2.5.1"/>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="2.5.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\modules\LoRaWanNetworkSrvModule\LoRaWan.NetworkServer\LoRaWan.NetworkServer.csproj"/>
-    <ProjectReference Include="..\LoRaWan.Test.Shared\LoRaWan.Test.Shared.csproj"/>
+    <ProjectReference Include="..\..\modules\LoRaWanNetworkSrvModule\LoRaWan.NetworkServer\LoRaWan.NetworkServer.csproj" />
+    <ProjectReference Include="..\LoRaWan.Test.Shared\LoRaWan.Test.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <AdditionalFiles Include="../../../stylecop.json" Link="stylecop.json"/>
+    <AdditionalFiles Include="../../../stylecop.json" Link="stylecop.json" />
   </ItemGroup>
-  <Import Project="../../../stylecop.props"/>
+  <Import Project="../../../stylecop.props" />
 </Project>

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/LoraKeysManagerFacade.Test.csproj
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/LoraKeysManagerFacade.Test.csproj
@@ -7,10 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -17,8 +17,8 @@ variables:
   # Name of service connection for resource group
   azureServiceConnectionName: 'IntegrationTestRG'
 
-  edgeAgentVersion: 1.0.6
-  edgeHubVersion: 1.0.6
+  edgeAgentVersion: 1.0.7-rc1
+  edgeHubVersion: 1.0.7-rc1
   edgeHubRoute: FROM /* INTO $upstream
 
   # Defines the name of the VSTS agent in ARM architecture


### PR DESCRIPTION
Use absolute expiration of 2 days for devices

Upgrade external dependencies
  Microsoft.Azure.Devices: 1.17.0 &rarr; 1.17.2
  Microsoft.Azure.Devices.Client: 1.18.1 &rarr; 1.19.0
  Microsoft.Extensions.Caching.Memory: 2.1.2 &rarr; 2.2.0
  Microsoft.NET.Sdk.Functions: 1.0.22 &rarr; 1.0.25
  StackExchange.Redis: 2.0.513 &rarr; 2.0.519
  Newtonsoft.Json: 11.0.2 &rarr; 12.0.1

Plus .net tests and mocks.

Fixes AB#666