### PR TITLE
Implement C2D message size limit and tests

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RegionImplementationTest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RegionImplementationTest.cs
@@ -208,5 +208,37 @@ namespace LoRaWanTest
                 });
             }
         }
+
+        [Theory]
+        [InlineData("SF12BW125", 59)]
+        [InlineData("SF11BW125", 59)]
+        [InlineData("SF10BW125", 59)]
+        [InlineData("SF9BW125", 123)]
+        [InlineData("SF8BW125", 230)]
+        [InlineData("SF7BW125", 230)]
+        [InlineData("SF7BW250", 230)]
+        [InlineData("50", 230)]
+
+        public void TestMaxPayloadLengthEU(string datr, uint maxPyldSize)
+        {
+            Assert.Equal(RegionFactory.CreateEU868Region().GetMaxPayloadSize(datr), maxPyldSize);
+        }
+
+        [Theory]
+        [InlineData("SF10BW125",  19)]
+        [InlineData("SF9BW125",   61)]
+        [InlineData("SF8BW125",  133)]
+        [InlineData("SF7BW125",  250)]
+        [InlineData("SF8BW500",  250)]
+        [InlineData("SF12BW500",  61)]
+        [InlineData("SF11BW500", 137)]
+        [InlineData("SF10BW500", 250)]
+        [InlineData("SF9BW500",  250)]
+        [InlineData("SF7BW500",  250)]
+
+        public void TestMaxPayloadLengthUS(string datr, uint maxPyldSize)
+        {
+            Assert.Equal(RegionFactory.CreateUS915Region().GetMaxPayloadSize(datr), maxPyldSize);
+        }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Constants.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Constants.cs
@@ -36,5 +36,8 @@ namespace LoRaWan.NetworkServer
         /// ensure next value will be correct even if the network died before persisting it
         /// </summary>
         public const int FCNT_DOWN_INCREMENTED_ON_ABP_DEVICE_LOAD = 10;
+
+        // Cloud to device message overhead
+        public const int LORA_PROTOCOL_OVERHEAD_SIZE = 8;
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultClassCDevicesMessageSender.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultClassCDevicesMessageSender.cs
@@ -80,15 +80,23 @@ namespace LoRaWan.NetworkServer
                     return false;
                 }
 
-                var downlink = DownlinkMessageBuilder.CreateDownlinkMessage(
+                var downlinkMessageBuilderResp = DownlinkMessageBuilder.CreateDownlinkMessage(
                     this.configuration,
                     loRaDevice, // TODO resolve region from device information
                     this.loRaRegion ?? RegionFactory.CurrentRegion ?? RegionFactory.CreateEU868Region(),
                     cloudToDeviceMessage,
                     (ushort)fcntDown);
 
-                await this.packetForwarder.SendDownstreamAsync(downlink);
-                await frameCounterStrategy.SaveChangesAsync(loRaDevice);
+                if (downlinkMessageBuilderResp.AbandonOrReject)
+                {
+                    Logger.Log(loRaDevice.DevEUI, $"class C cloud to device message too large, rejecting. Id: {cloudToDeviceMessage.MessageId ?? "undefined"}", LogLevel.Information);
+                    _ = cloudToDeviceMessage.RejectAsync();
+                }
+                else
+                {
+                    await this.packetForwarder.SendDownstreamAsync(downlinkMessageBuilderResp.DownlinkPktFwdMessage);
+                    await frameCounterStrategy.SaveChangesAsync(loRaDevice);
+                }
 
                 return true;
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultClassCDevicesMessageSender.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultClassCDevicesMessageSender.cs
@@ -87,10 +87,11 @@ namespace LoRaWan.NetworkServer
                     cloudToDeviceMessage,
                     (ushort)fcntDown);
 
-                if (downlinkMessageBuilderResp.AbandonOrReject)
+                if (downlinkMessageBuilderResp.IsMessageTooLong)
                 {
                     Logger.Log(loRaDevice.DevEUI, $"class C cloud to device message too large, rejecting. Id: {cloudToDeviceMessage.MessageId ?? "undefined"}", LogLevel.Information);
-                    _ = cloudToDeviceMessage.RejectAsync();
+                    await cloudToDeviceMessage.RejectAsync();
+                    return false;
                 }
                 else
                 {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -420,26 +420,21 @@ namespace LoRaWan.NetworkServer
             var rxpk = request.Rxpk;
             var loRaRegion = request.LoRaRegion;
             uint maxPayload;
-            uint rx1MaxPayload;
-            uint rx2MaxPayload;
 
-            // Get max. payload size for RX1
-            rx1MaxPayload = loRaRegion.GetMaxPayloadSize(loRaRegion.GetDownstreamDR(rxpk));
-
-            // Get max. payload size for RX2, considering possilbe user provided Rx2DataRate
-            if (string.IsNullOrEmpty(this.configuration.Rx2DataRate))
-                rx2MaxPayload = loRaRegion.DRtoConfiguration[loRaRegion.RX2DefaultReceiveWindows.dr].maxPyldSize;
-            else
-                rx2MaxPayload = loRaRegion.GetMaxPayloadSize(this.configuration.Rx2DataRate);
-
-            // Get overall max. payload size.
+            // If preferred Window is RX2, this is the max. payload
             if (loRaDevice.PreferredWindow == Constants.RECEIVE_WINDOW_2)
             {
-                maxPayload = rx2MaxPayload;
+                // Get max. payload size for RX2, considering possilbe user provided Rx2DataRate
+                if (string.IsNullOrEmpty(this.configuration.Rx2DataRate))
+                    maxPayload = loRaRegion.DRtoConfiguration[loRaRegion.RX2DefaultReceiveWindows.dr].maxPyldSize;
+                else
+                    maxPayload = loRaRegion.GetMaxPayloadSize(this.configuration.Rx2DataRate);
             }
+
+            // Otherwise, it is RX1.
             else
             {
-                maxPayload = Math.Max(rx1MaxPayload, rx2MaxPayload);
+                maxPayload = loRaRegion.GetMaxPayloadSize(loRaRegion.GetDownstreamDR(rxpk));
             }
 
             // Deduct 8 bytes from max payload size.

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -373,7 +373,7 @@ namespace LoRaWan.NetworkServer
                         Logger.Log(loRaDevice.DevEUI, $"out of time for downstream message, will abandon c2d message id: {cloudToDeviceMessage.MessageId ?? "undefined"}", LogLevel.Information);
                         _ = cloudToDeviceMessage.AbandonAsync();
                     }
-                    else if (confirmDownlinkMessageBuilderResp.AbandonOrReject)
+                    else if (confirmDownlinkMessageBuilderResp.IsMessageTooLong)
                     {
                         Logger.Log(loRaDevice.DevEUI, $"payload will not fit in current receive window, will abandon c2d message id: {cloudToDeviceMessage.MessageId ?? "undefined"}", LogLevel.Information);
                         _ = cloudToDeviceMessage.AbandonAsync();

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -270,7 +270,7 @@ namespace LoRaWan.NetworkServer
                 // - we don't have time to check c2d and send to device we return now
                 if (requiresConfirmation && (!loRaDevice.DownlinkEnabled || timeToSecondWindow.Subtract(LoRaOperationTimeWatcher.ExpectedTimeToPackageAndSendMessage) <= LoRaOperationTimeWatcher.MinimumAvailableTimeToCheckForCloudMessage))
                 {
-                    var downlinkMessage = DownlinkMessageBuilder.CreateDownlinkMessage(
+                    var downlinkMessageBuilderResp = DownlinkMessageBuilder.CreateDownlinkMessage(
                         this.configuration,
                         loRaDevice,
                         request,
@@ -280,12 +280,12 @@ namespace LoRaWan.NetworkServer
                         (ushort)fcntDown,
                         loRaADRResult);
 
-                    if (downlinkMessage != null)
+                    if (downlinkMessageBuilderResp.DownlinkPktFwdMessage != null)
                     {
-                        _ = request.PacketForwarder.SendDownstreamAsync(downlinkMessage);
+                        _ = request.PacketForwarder.SendDownstreamAsync(downlinkMessageBuilderResp.DownlinkPktFwdMessage);
                     }
 
-                    return new LoRaDeviceRequestProcessResult(loRaDevice, request, downlinkMessage);
+                    return new LoRaDeviceRequestProcessResult(loRaDevice, request, downlinkMessageBuilderResp.DownlinkPktFwdMessage);
                 }
 
                 // Flag indicating if there is another C2D message waiting
@@ -302,9 +302,10 @@ namespace LoRaWan.NetworkServer
                     if (timeAvailableToCheckCloudToDeviceMessages >= LoRaOperationTimeWatcher.MinimumAvailableTimeToCheckForCloudMessage)
                     {
                         cloudToDeviceMessage = await this.ReceiveCloudToDeviceAsync(loRaDevice, timeAvailableToCheckCloudToDeviceMessages);
-                        if (cloudToDeviceMessage != null && !this.ValidateCloudToDeviceMessage(loRaDevice, cloudToDeviceMessage))
+                        if (cloudToDeviceMessage != null && !this.ValidateCloudToDeviceMessage(loRaDevice, request, cloudToDeviceMessage))
                         {
-                            _ = cloudToDeviceMessage.CompleteAsync();
+                            // Reject cloud to device message based on result from ValidateCloudToDeviceMessage
+                            _ = cloudToDeviceMessage.RejectAsync();
                             cloudToDeviceMessage = null;
                         }
 
@@ -355,7 +356,7 @@ namespace LoRaWan.NetworkServer
                     return new LoRaDeviceRequestProcessResult(loRaDevice, request);
                 }
 
-                var confirmDownstream = DownlinkMessageBuilder.CreateDownlinkMessage(
+                var confirmDownlinkMessageBuilderResp = DownlinkMessageBuilder.CreateDownlinkMessage(
                     this.configuration,
                     loRaDevice,
                     request,
@@ -367,9 +368,14 @@ namespace LoRaWan.NetworkServer
 
                 if (cloudToDeviceMessage != null)
                 {
-                    if (confirmDownstream == null)
+                    if (confirmDownlinkMessageBuilderResp.DownlinkPktFwdMessage == null)
                     {
                         Logger.Log(loRaDevice.DevEUI, $"out of time for downstream message, will abandon c2d message id: {cloudToDeviceMessage.MessageId ?? "undefined"}", LogLevel.Information);
+                        _ = cloudToDeviceMessage.AbandonAsync();
+                    }
+                    else if (confirmDownlinkMessageBuilderResp.AbandonOrReject)
+                    {
+                        Logger.Log(loRaDevice.DevEUI, $"payload will not fit in current receive window, will abandon c2d message id: {cloudToDeviceMessage.MessageId ?? "undefined"}", LogLevel.Information);
                         _ = cloudToDeviceMessage.AbandonAsync();
                     }
                     else
@@ -378,12 +384,12 @@ namespace LoRaWan.NetworkServer
                     }
                 }
 
-                if (confirmDownstream != null)
+                if (confirmDownlinkMessageBuilderResp.DownlinkPktFwdMessage != null)
                 {
-                    _ = request.PacketForwarder.SendDownstreamAsync(confirmDownstream);
+                    _ = request.PacketForwarder.SendDownstreamAsync(confirmDownlinkMessageBuilderResp.DownlinkPktFwdMessage);
                 }
 
-                return new LoRaDeviceRequestProcessResult(loRaDevice, request, confirmDownstream);
+                return new LoRaDeviceRequestProcessResult(loRaDevice, request, confirmDownlinkMessageBuilderResp.DownlinkPktFwdMessage);
             }
         }
 
@@ -403,11 +409,55 @@ namespace LoRaWan.NetworkServer
             return (actualMessage != null) ? new LoRaCloudToDeviceMessageWrapper(loRaDevice, actualMessage) : null;
         }
 
-        private bool ValidateCloudToDeviceMessage(LoRaDevice loRaDevice, ILoRaCloudToDeviceMessage cloudToDeviceMsg)
+        private bool ValidateCloudToDeviceMessage(LoRaDevice loRaDevice, LoRaRequest request, ILoRaCloudToDeviceMessage cloudToDeviceMsg)
         {
             if (!cloudToDeviceMsg.IsValid(out var errorMessage))
             {
                 Logger.Log(loRaDevice.DevEUI, $"Invalid cloud to device message: {errorMessage}", LogLevel.Error);
+                return false;
+            }
+
+            var rxpk = request.Rxpk;
+            var loRaRegion = request.LoRaRegion;
+            uint maxPayload;
+            uint rx2MaxPayload;
+
+            // Get max. payload size for second response window, considering possilbe user provided Rx2DataRate
+            if (string.IsNullOrEmpty(this.configuration.Rx2DataRate))
+                rx2MaxPayload = loRaRegion.DRtoConfiguration[loRaRegion.RX2DefaultReceiveWindows.dr].maxPyldSize;
+            else
+                rx2MaxPayload = loRaRegion.GetMaxPayloadSize(this.configuration.Rx2DataRate);
+
+            // Get overall max. payload size.
+            if (loRaDevice.PreferredWindow == Constants.RECEIVE_WINDOW_2)
+            {
+                maxPayload = rx2MaxPayload;
+            }
+            else
+            {
+                // Get max. payload size for first response window
+                var rx1MaxPayload = loRaRegion.GetMaxPayloadSize(loRaRegion.GetDownstreamDR(rxpk));
+                maxPayload = Math.Max(rx1MaxPayload, rx2MaxPayload);
+            }
+
+            // Deduct 8 bytes from max payload size.
+            maxPayload -= Constants.LORA_PROTOCOL_OVERHEAD_SIZE;
+
+            // Cloud to device message and optional C2D Mac commands is bigger than max. payload size: Reject.
+            // This message can never be delivered.
+            var totalPayload = cloudToDeviceMsg.GetPayload()?.Length ?? 0;
+
+            if (cloudToDeviceMsg.MacCommands?.Count > 0)
+            {
+                foreach (MacCommand macCommand in cloudToDeviceMsg.MacCommands)
+                {
+                    totalPayload += macCommand.Length;
+                }
+            }
+
+            if (totalPayload > maxPayload)
+            {
+                Logger.Log(loRaDevice.DevEUI, $"message payload size ({totalPayload}) exceeds maximum allowed payload size ({maxPayload}) in C2D message '{cloudToDeviceMsg.MessageId}'", LogLevel.Error);
                 return false;
             }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
@@ -27,7 +27,7 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Creates downlink message with ack for confirmation or cloud to device message
         /// </summary>
-        internal static DownlinkPktFwdMessage CreateDownlinkMessage(
+        internal static DownlinkMessageBuilderResponse CreateDownlinkMessage(
             NetworkServerConfiguration configuration,
             LoRaDevice loRaDevice,
             LoRaRequest request,
@@ -39,7 +39,8 @@ namespace LoRaWan.NetworkServer
         {
             var upstreamPayload = (LoRaPayloadData)request.Payload;
             var rxpk = request.Rxpk;
-            var loraRegion = request.LoRaRegion;
+            var loRaRegion = request.LoRaRegion;
+            bool abandonMessage = false;
 
             // default fport
             byte fctrl = 0;
@@ -49,47 +50,128 @@ namespace LoRaWan.NetworkServer
                 fctrl = (byte)FctrlEnum.Ack;
             }
 
-            var macCommands = PrepareMacCommandAnswer(loRaDevice.DevEUI, upstreamPayload.MacCommands, cloudToDeviceMessage?.MacCommands, rxpk, loRaADRResult);
-            byte? fport = null;
-            var requiresDeviceAcknowlegement = false;
-            var macCommandType = CidEnum.Zero;
+            // Calculate receive window
+            var receiveWindow = timeWatcher.ResolveReceiveWindowToUse(loRaDevice);
+            if (receiveWindow == Constants.INVALID_RECEIVE_WINDOW)
+            {
+                // No valid receive window. Abandon the message.
+                abandonMessage = true;
+                return new DownlinkMessageBuilderResponse(null, abandonMessage);
+            }
 
             byte[] rndToken = new byte[2];
             Random rnd = new Random();
             rnd.NextBytes(rndToken);
 
+            string datr;
+            double freq;
+            long tmst;
+
+            if (receiveWindow == Constants.RECEIVE_WINDOW_2)
+            {
+                tmst = rxpk.Tmst + timeWatcher.GetReceiveWindow2Delay(loRaDevice) * 1000000;
+
+                if (string.IsNullOrEmpty(configuration.Rx2DataRate))
+                {
+                    Logger.Log(loRaDevice.DevEUI, "using standard second receive windows", LogLevel.Information);
+                    freq = loRaRegion.RX2DefaultReceiveWindows.frequency;
+                    datr = loRaRegion.DRtoConfiguration[loRaRegion.RX2DefaultReceiveWindows.dr].configuration;
+                }
+                else
+                {
+                    // if specific twins are set, specify second channel to be as specified
+                    freq = configuration.Rx2DataFrequency;
+                    datr = configuration.Rx2DataRate;
+                    Logger.Log(loRaDevice.DevEUI, $"using custom DR second receive windows freq : {freq}, datr:{datr}", LogLevel.Information);
+                }
+            }
+            else
+            {
+                datr = loRaRegion.GetDownstreamDR(rxpk);
+                freq = loRaRegion.GetDownstreamChannelFrequency(rxpk);
+                tmst = rxpk.Tmst + timeWatcher.GetReceiveWindow1Delay(loRaDevice) * 1000000;
+            }
+
+            // get max. payload size based on data rate from LoRaRegion
+            var maxPayloadSize = loRaRegion.GetMaxPayloadSize(datr);
+            var availablePayloadSize = maxPayloadSize;
+
+            var macCommands = new List<MacCommand>();
+
+            byte? fport = null;
+            var requiresDeviceAcknowlegement = false;
+            var macCommandType = CidEnum.Zero;
+
             byte[] frmPayload = null;
 
             if (cloudToDeviceMessage != null)
             {
-                if (cloudToDeviceMessage.MacCommands != null && cloudToDeviceMessage.MacCommands.Count > 0)
+                // Get C2D Mac coomands
+                var macCommandsC2d = PrepareMacCommandAnswer(loRaDevice.DevEUI, null, cloudToDeviceMessage?.MacCommands, rxpk, loRaADRResult);
+
+                // Calculate total C2D payload size
+                var totalC2dSize = cloudToDeviceMessage.GetPayload()?.Length ?? 0;
+                totalC2dSize += macCommandsC2d?.Sum(x => x.Length) ?? 0;
+
+                // Total C2D payload will fit
+                if (availablePayloadSize >= totalC2dSize)
                 {
-                    macCommandType = cloudToDeviceMessage.MacCommands.First().Cid;
-                }
+                    // Add frmPayload
+                    frmPayload = cloudToDeviceMessage.GetPayload();
 
-                if (cloudToDeviceMessage.Confirmed)
+                    // Add C2D Mac commands
+                    if (macCommandsC2d?.Count > 0)
+                    {
+                        foreach (MacCommand macCommand in macCommandsC2d)
+                        {
+                            macCommands.Add(macCommand);
+                        }
+                    }
+
+                    // Deduct frmPayload size from available payload size, continue processing and log
+                    availablePayloadSize -= (uint)totalC2dSize;
+
+                    if (cloudToDeviceMessage.Confirmed)
+                    {
+                        requiresDeviceAcknowlegement = true;
+                        loRaDevice.LastConfirmedC2DMessageID = cloudToDeviceMessage.MessageId ?? Constants.C2D_MSG_ID_PLACEHOLDER;
+                    }
+
+                    if (cloudToDeviceMessage.Fport > 0)
+                    {
+                        fport = cloudToDeviceMessage.Fport;
+                    }
+
+                    Logger.Log(loRaDevice.DevEUI, $"C2D message: {(frmPayload?.Length == 0 ? "empty" : Encoding.UTF8.GetString(frmPayload))}, id: {cloudToDeviceMessage.MessageId ?? "undefined"}, fport: {fport ?? 0}, confirmed: {requiresDeviceAcknowlegement}, cidType: {macCommandType}, macCommand: {macCommands.Count > 0}", LogLevel.Information);
+                    Array.Reverse(frmPayload);
+                }
+                else
                 {
-                    requiresDeviceAcknowlegement = true;
-                    loRaDevice.LastConfirmedC2DMessageID = cloudToDeviceMessage.MessageId ?? Constants.C2D_MSG_ID_PLACEHOLDER;
+                    // Flag message to be abandoned and log
+                    Logger.Log(loRaDevice.DevEUI, $"C2D message: {(frmPayload?.Length == 0 ? "empty" : Encoding.UTF8.GetString(frmPayload))}, id: {cloudToDeviceMessage.MessageId ?? "undefined"}, fport: {fport ?? 0}, confirmed: {requiresDeviceAcknowlegement} too long for flagged for receive window. Abandoning.", LogLevel.Information);
+                    abandonMessage = true;
                 }
-
-                if (cloudToDeviceMessage.Fport > 0)
-                {
-                    fport = cloudToDeviceMessage.Fport;
-                }
-
-                frmPayload = cloudToDeviceMessage.GetPayload();
-
-                Logger.Log(loRaDevice.DevEUI, $"C2D message: {(frmPayload?.Length == 0 ? "empty" : Encoding.UTF8.GetString(frmPayload))}, id: {cloudToDeviceMessage.MessageId ?? "undefined"}, fport: {fport ?? 0}, confirmed: {requiresDeviceAcknowlegement}, cidType: {macCommandType}, macCommand: {macCommands.Count > 0}", LogLevel.Information);
-
-                // cut to the max payload of lora for any EU datarate
-                if (frmPayload.Length > 51)
-                    Array.Resize(ref frmPayload, 51);
-
-                Array.Reverse(frmPayload);
             }
 
-            if (fpending)
+            // Get request Mac commands
+            var macCommandsRequest = PrepareMacCommandAnswer(loRaDevice.DevEUI, upstreamPayload.MacCommands, null, rxpk, loRaADRResult);
+
+            // Calculate request Mac commands size
+            var macCommandsRequestSize = macCommandsRequest?.Sum(x => x.Length) ?? 0;
+
+            // Try adding request Mac commands
+            if (availablePayloadSize >= macCommandsRequestSize)
+            {
+                if (macCommandsRequest?.Count > 0)
+                {
+                    foreach (MacCommand macCommand in macCommandsRequest)
+                    {
+                        macCommands.Add(macCommand);
+                    }
+                }
+            }
+
+            if (fpending || abandonMessage)
             {
                 fctrl |= (int)FctrlEnum.FpendingOrClassB;
             }
@@ -117,44 +199,14 @@ namespace LoRaWan.NetworkServer
                 frmPayload,
                 1);
 
-            var receiveWindow = timeWatcher.ResolveReceiveWindowToUse(loRaDevice);
-            if (receiveWindow == Constants.INVALID_RECEIVE_WINDOW)
-                return null;
-
-            string datr;
-            double freq;
-            long tmst;
-            if (receiveWindow == Constants.RECEIVE_WINDOW_2)
-            {
-                tmst = rxpk.Tmst + timeWatcher.GetReceiveWindow2Delay(loRaDevice) * 1000000;
-
-                if (string.IsNullOrEmpty(configuration.Rx2DataRate))
-                {
-                    Logger.Log(loRaDevice.DevEUI, "using standard second receive windows", LogLevel.Information);
-                    freq = loraRegion.RX2DefaultReceiveWindows.frequency;
-                    datr = loraRegion.DRtoConfiguration[loraRegion.RX2DefaultReceiveWindows.dr].configuration;
-                }
-                else
-                {
-                    // if specific twins are set, specify second channel to be as specified
-                    freq = configuration.Rx2DataFrequency;
-                    datr = configuration.Rx2DataRate;
-                    Logger.Log(loRaDevice.DevEUI, $"using custom DR second receive windows freq : {freq}, datr:{datr}", LogLevel.Information);
-                }
-            }
-            else
-            {
-                datr = loraRegion.GetDownstreamDR(rxpk);
-                freq = loraRegion.GetDownstreamChannelFrequency(rxpk);
-                tmst = rxpk.Tmst + timeWatcher.GetReceiveWindow1Delay(loRaDevice) * 1000000;
-            }
-
             // todo: check the device twin preference if using confirmed or unconfirmed down
             Logger.Log(loRaDevice.DevEUI, $"Sending a downstream message with ID {ConversionHelper.ByteArrayToString(rndToken)}", LogLevel.Debug);
-            return ackLoRaMessage.Serialize(loRaDevice.AppSKey, loRaDevice.NwkSKey, datr, freq, tmst, loRaDevice.DevEUI);
+            return new DownlinkMessageBuilderResponse(
+                ackLoRaMessage.Serialize(loRaDevice.AppSKey, loRaDevice.NwkSKey, datr, freq, tmst, loRaDevice.DevEUI),
+                abandonMessage);
         }
 
-        internal static DownlinkPktFwdMessage CreateDownlinkMessage(
+        internal static DownlinkMessageBuilderResponse CreateDownlinkMessage(
             NetworkServerConfiguration configuration,
             LoRaDevice loRaDevice,
             Region loRaRegion,
@@ -169,12 +221,48 @@ namespace LoRaWan.NetworkServer
             Random rnd = new Random();
             rnd.NextBytes(rndToken);
 
-            PrepareMacCommandAnswer(loRaDevice.DevEUI, null, cloudToDeviceMessage.MacCommands, null, null);
+            bool rejectMessage = false;
 
-            var macCommands = cloudToDeviceMessage.MacCommands;
-            if (macCommands != null && macCommands.Count > 0)
+            // Class C uses RX2 always
+            string datr;
+            double freq;
+            var tmst = 0; // immediate mode
+
+            if (string.IsNullOrEmpty(configuration.Rx2DataRate))
             {
-                macCommandType = macCommands[0].Cid;
+                Logger.Log(loRaDevice.DevEUI, $"using standard second receive windows", LogLevel.Information);
+                freq = loRaRegion.RX2DefaultReceiveWindows.frequency;
+                datr = loRaRegion.DRtoConfiguration[loRaRegion.RX2DefaultReceiveWindows.dr].configuration;
+            }
+
+            // if specific twins are set, specify second channel to be as specified
+            else
+            {
+                freq = configuration.Rx2DataFrequency;
+                datr = configuration.Rx2DataRate;
+                Logger.Log(loRaDevice.DevEUI, $"using custom DR second receive windows freq : {freq}, datr:{datr}", LogLevel.Information);
+            }
+
+            // get max. payload size based on data rate from LoRaRegion
+            var maxPayloadSize = loRaRegion.GetMaxPayloadSize(datr);
+            var availablePayloadSize = maxPayloadSize;
+
+            var macCommands = PrepareMacCommandAnswer(loRaDevice.DevEUI, null, cloudToDeviceMessage.MacCommands, null, null);
+
+            // Calculate total C2D payload size
+            var totalC2dSize = cloudToDeviceMessage.GetPayload()?.Length ?? 0;
+            totalC2dSize += macCommands?.Sum(x => x.Length) ?? 0;
+
+            // Total C2D payload will NOT fit
+            if (availablePayloadSize < totalC2dSize)
+            {
+                rejectMessage = true;
+                return new DownlinkMessageBuilderResponse(null, rejectMessage);
+            }
+
+            if (macCommands?.Count > 0)
+            {
+                macCommandType = macCommands.First().Cid;
             }
 
             if (cloudToDeviceMessage.Confirmed)
@@ -186,11 +274,6 @@ namespace LoRaWan.NetworkServer
 
             Logger.Log(loRaDevice.DevEUI, $"Sending a downstream message with ID {ConversionHelper.ByteArrayToString(rndToken)}", LogLevel.Debug);
             Logger.Log(loRaDevice.DevEUI, $"C2D message: {Encoding.UTF8.GetString(frmPayload)}, id: {cloudToDeviceMessage.MessageId ?? "undefined"}, fport: {cloudToDeviceMessage.Fport}, confirmed: {cloudToDeviceMessage.Confirmed}, cidType: {macCommandType}", LogLevel.Information);
-
-            // cut to the max payload of lora for any EU datarate
-            if (frmPayload.Length > 51)
-                Array.Resize(ref frmPayload, 51);
-
             Array.Reverse(frmPayload);
 
             var payloadDevAddr = ConversionHelper.StringToByteArray(loRaDevice.DevAddr);
@@ -211,27 +294,9 @@ namespace LoRaWan.NetworkServer
                 frmPayload,
                 1);
 
-            // Class C uses RX2 always
-            string datr = null;
-            double freq;
-            var tmst = 0; // immediate mode
-
-            if (string.IsNullOrEmpty(configuration.Rx2DataRate))
-            {
-                Logger.Log(loRaDevice.DevEUI, $"using standard second receive windows", LogLevel.Information);
-                freq = loRaRegion.RX2DefaultReceiveWindows.frequency;
-                datr = loRaRegion.DRtoConfiguration[loRaRegion.RX2DefaultReceiveWindows.dr].configuration;
-            }
-
-            // if specific twins are set, specify second channel to be as specified
-            else
-            {
-                freq = configuration.Rx2DataFrequency;
-                datr = configuration.Rx2DataRate;
-                Logger.Log(loRaDevice.DevEUI, $"using custom DR second receive windows freq : {freq}, datr:{datr}", LogLevel.Information);
-            }
-
-            return ackLoRaMessage.Serialize(loRaDevice.AppSKey, loRaDevice.NwkSKey, datr, freq, tmst, loRaDevice.DevEUI);
+            return new DownlinkMessageBuilderResponse(
+                ackLoRaMessage.Serialize(loRaDevice.AppSKey, loRaDevice.NwkSKey, datr, freq, tmst, loRaDevice.DevEUI),
+                rejectMessage);
         }
 
         /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
@@ -111,7 +111,7 @@ namespace LoRaWan.NetworkServer
             if (cloudToDeviceMessage != null)
             {
                 // Get C2D Mac coomands
-                var macCommandsC2d = PrepareMacCommandAnswer(loRaDevice.DevEUI, null, cloudToDeviceMessage?.MacCommands, rxpk, loRaADRResult);
+                var macCommandsC2d = PrepareMacCommandAnswer(loRaDevice.DevEUI, null, cloudToDeviceMessage?.MacCommands, rxpk, null);
 
                 // Calculate total C2D payload size
                 var totalC2dSize = cloudToDeviceMessage.GetPayload()?.Length ?? 0;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilderResponse.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilderResponse.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer
+{
+    using System;
+    using LoRaTools.LoRaPhysical;
+
+    internal class DownlinkMessageBuilderResponse
+    {
+        internal DownlinkPktFwdMessage DownlinkPktFwdMessage { get; set; }
+
+        internal bool AbandonOrReject { get; set; }
+
+        internal DownlinkMessageBuilderResponse(DownlinkPktFwdMessage downlinkPktFwdMessage, bool abandonOrReject)
+        {
+            this.DownlinkPktFwdMessage = downlinkPktFwdMessage;
+            this.AbandonOrReject = abandonOrReject;
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilderResponse.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilderResponse.cs
@@ -10,12 +10,12 @@ namespace LoRaWan.NetworkServer
     {
         internal DownlinkPktFwdMessage DownlinkPktFwdMessage { get; set; }
 
-        internal bool AbandonOrReject { get; set; }
+        internal bool IsMessageTooLong { get; set; }
 
-        internal DownlinkMessageBuilderResponse(DownlinkPktFwdMessage downlinkPktFwdMessage, bool abandonOrReject)
+        internal DownlinkMessageBuilderResponse(DownlinkPktFwdMessage downlinkPktFwdMessage, bool isMessageTooLong)
         {
             this.DownlinkPktFwdMessage = downlinkPktFwdMessage;
-            this.AbandonOrReject = abandonOrReject;
+            this.IsMessageTooLong = isMessageTooLong;
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaCloudToDeviceMessage.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaCloudToDeviceMessage.cs
@@ -29,6 +29,8 @@ namespace LoRaWan.NetworkServer
 
         Task<bool> AbandonAsync();
 
+        Task<bool> RejectAsync();
+
         /// <summary>
         /// Identifies if the message is a valid LoRa downstream message
         /// </summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClient.cs
@@ -46,6 +46,11 @@ namespace LoRaWan.NetworkServer
         Task<bool> AbandonAsync(Message cloudToDeviceMessage);
 
         /// <summary>
+        /// Reject a cloud to device message
+        /// </summary>
+        Task<bool> RejectAsync(Message cloudToDeviceMessage);
+
+        /// <summary>
         /// Disconnects device client
         /// </summary>
         Task<bool> DisconnectAsync();

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaCloudToDeviceMessage.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaCloudToDeviceMessage.cs
@@ -46,6 +46,8 @@ namespace LoRaWan.NetworkServer
 
         public Task<bool> CompleteAsync() => Task.FromResult(true);
 
+        public Task<bool> RejectAsync() => Task.FromResult(true);
+
         /// <summary>
         /// Gets the payload bytes
         /// </summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaCloudToDeviceMessageWrapper.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaCloudToDeviceMessageWrapper.cs
@@ -100,6 +100,8 @@ namespace LoRaWan.NetworkServer
 
         public Task<bool> AbandonAsync() => this.loRaDevice.AbandonCloudToDeviceMessageAsync(this.message);
 
+        public Task<bool> RejectAsync() => this.loRaDevice.RejectCloudToDeviceMessageAsync(this.message);
+
         public bool IsValid(out string errorMessage)
         {
             if (this.parseCloudToDeviceMessage == null)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -503,6 +503,8 @@ namespace LoRaWan.NetworkServer
 
         public Task<bool> AbandonCloudToDeviceMessageAsync(Message cloudToDeviceMessage) => this.loRaDeviceClient.AbandonAsync(cloudToDeviceMessage);
 
+        public Task<bool> RejectCloudToDeviceMessageAsync(Message cloudToDeviceMessage) => this.loRaDeviceClient.RejectAsync(cloudToDeviceMessage);
+
         /// <summary>
         /// Updates device on the server after a join succeeded
         /// </summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
@@ -252,6 +252,34 @@ namespace LoRaWan.NetworkServer
             }
         }
 
+        public async Task<bool> RejectAsync(Message message)
+        {
+            try
+            {
+                this.deviceClient.OperationTimeoutInMilliseconds = 30000;
+
+                this.SetRetry(true);
+
+                Logger.Log(this.devEUI, $"rejecting c2d message, id: {message.MessageId ?? "undefined"}", LogLevel.Debug);
+
+                await this.deviceClient.RejectAsync(message);
+
+                Logger.Log(this.devEUI, $"done rejecting c2d message, id: {message.MessageId ?? "undefined"}", LogLevel.Debug);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(this.devEUI, $"could not reject c2d message (id: {message.MessageId ?? "undefined"}) with error: {ex.Message}", LogLevel.Error);
+                return false;
+            }
+            finally
+            {
+                // disable retry, this allows the server to close the connection if another gateway tries to open the connection for the same device
+                this.SetRetry(false);
+            }
+        }
+
         /// <summary>
         /// Disconnects device client
         /// </summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/LinkCheckAnswer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/LinkCheckAnswer.cs
@@ -35,7 +35,7 @@ namespace LoRaTools
         /// Initializes a new instance of the <see cref="LinkCheckAnswer"/> class.
         /// Test Constructor
         /// </summary>
-        public LinkCheckAnswer(Span<byte> input)
+        public LinkCheckAnswer(ReadOnlySpan<byte> input)
         {
             this.Cid = (CidEnum)input[2];
             this.Margin = (uint)input[1];

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
@@ -291,6 +291,17 @@ namespace LoRaTools.Regions
             return null;
         }
 
+        /// <summary>
+        /// Implement correct logic to get the maximum payload size based on the datr/configuration.
+        /// </summary>
+        /// <param name="datr">the datr/configuration with which the message was transmitted</param>
+        public uint GetMaxPayloadSize(string datr)
+        {
+            var maxPayloadSize = this.DRtoConfiguration.FirstOrDefault(x => x.Value.configuration == datr).Value.maxPyldSize;
+
+            return maxPayloadSize;
+        }
+
         private void EnsureValidRxpk(Rxpk rxpk)
         {
             if (this.LoRaRegion == LoRaRegion.EU868)

--- a/LoRaEngine/test/LoRaWan.Test.Shared/SimulatedDevice.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/SimulatedDevice.cs
@@ -139,7 +139,7 @@ namespace LoRaWan.Test.Shared
         /// <summary>
         /// Creates request to send unconfirmed data message
         /// </summary>
-        public LoRaPayloadData CreateConfirmedDataUpMessage(string data, int? fcnt = null, byte fport = 1)
+        public LoRaPayloadData CreateConfirmedDataUpMessage(string data, int? fcnt = null, byte fport = 1, bool isHexPayload = false)
         {
             byte[] devAddr = ConversionHelper.StringToByteArray(this.LoRaDevice.DevAddr);
             Array.Reverse(devAddr);
@@ -151,8 +151,22 @@ namespace LoRaWan.Test.Shared
             var fcntBytes = BitConverter.GetBytes((ushort)fcnt.Value);
 
             byte[] fPort = new byte[] { fport };
-            byte[] payload = Encoding.UTF8.GetBytes(data);
-            Array.Reverse(payload);
+
+            byte[] payload = null;
+
+            if (data != null)
+            {
+                if (!isHexPayload)
+                {
+                    payload = Encoding.UTF8.GetBytes(data);
+                }
+                else
+                {
+                    payload = ConversionHelper.StringToByteArray(data);
+                }
+
+                Array.Reverse(payload);
+            }
 
             // 0 = uplink, 1 = downlink
             int direction = 0;

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaWanNetworkServer.Test.csproj
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaWanNetworkServer.Test.csproj
@@ -7,12 +7,18 @@
     <CodeAnalysisRuleSet>../../../stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.2.7" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="coverlet.msbuild" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaWanNetworkServer.Test.csproj
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaWanNetworkServer.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -6,6 +6,12 @@
   <PropertyGroup>
     <CodeAnalysisRuleSet>../../../stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="MessageProcessor_End2End_NoDep_ClassC_CloudToDevice_SizeLimit_Tests - Copy.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="MessageProcessor_End2End_NoDep_ClassC_Decoder2Device_SizeLimit_Tests.cs.backup" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Moq" Version="4.10.1" />

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaWanNetworkServer.Test.csproj
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaWanNetworkServer.Test.csproj
@@ -7,19 +7,20 @@
     <CodeAnalysisRuleSet>../../../stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0"/>
-    <PackageReference Include="Moq" Version="4.10.1"/>
-    <PackageReference Include="xunit" Version="2.3.1"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1"/>
-    <PackageReference Include="coverlet.msbuild" Version="2.5.1"/>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="Xunit.Combinatorial" Version="1.2.7" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="coverlet.msbuild" Version="2.5.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\modules\LoRaWanNetworkSrvModule\LoRaWan.NetworkServer\LoRaWan.NetworkServer.csproj"/>
-    <ProjectReference Include="..\LoRaWan.Test.Shared\LoRaWan.Test.Shared.csproj"/>
+    <ProjectReference Include="..\..\modules\LoRaWanNetworkSrvModule\LoRaWan.NetworkServer\LoRaWan.NetworkServer.csproj" />
+    <ProjectReference Include="..\LoRaWan.Test.Shared\LoRaWan.Test.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <AdditionalFiles Include="../../../stylecop.json" Link="stylecop.json"/>
+    <AdditionalFiles Include="../../../stylecop.json" Link="stylecop.json" />
   </ItemGroup>
-  <Import Project="../../../stylecop.props"/>
+  <Import Project="../../../stylecop.props" />
 </Project>

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_ClassC_CloudToDeviceMessage_SizeLimit_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_ClassC_CloudToDeviceMessage_SizeLimit_Tests.cs
@@ -1,0 +1,233 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using LoRaTools;
+    using LoRaTools.LoRaMessage;
+    using LoRaTools.LoRaPhysical;
+    using LoRaTools.Regions;
+    using LoRaTools.Utils;
+    using LoRaWan.NetworkServer;
+    using LoRaWan.Test.Shared;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Caching.Memory;
+    using Moq;
+    using Xunit;
+
+    // End to end tests without external dependencies (IoT Hub, Service Facade Function)
+    // Class CCloud to device message processing max payload size tests (Join tests are handled in other class)
+    public class MessageProcessor_End2End_NoDep_ClassC_CloudToDeviceMessage_SizeLimit_Tests
+    {
+        const string ServerGatewayID = "test-gateway";
+
+        private TestPacketForwarder PacketForwarder { get; }
+
+        private readonly NetworkServerConfiguration serverConfiguration;
+        private readonly Region loRaRegion;
+        private readonly Mock<LoRaDeviceAPIServiceBase> deviceApi;
+        private readonly Mock<ILoRaDeviceClient> deviceClient;
+        private readonly TestLoRaDeviceFactory loRaDeviceFactory;
+        private readonly LoRaDeviceRegistry loRaDeviceRegistry;
+        private readonly ILoRaDeviceFrameCounterUpdateStrategyProvider frameCounterStrategyProvider;
+
+        public MessageProcessor_End2End_NoDep_ClassC_CloudToDeviceMessage_SizeLimit_Tests()
+        {
+            this.serverConfiguration = new NetworkServerConfiguration()
+            {
+                GatewayID = ServerGatewayID,
+            };
+
+            this.loRaRegion = RegionFactory.CreateEU868Region();
+            this.PacketForwarder = new TestPacketForwarder();
+            this.deviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
+            this.deviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
+            this.loRaDeviceFactory = new TestLoRaDeviceFactory(this.deviceClient.Object);
+            this.loRaDeviceRegistry = new LoRaDeviceRegistry(this.serverConfiguration, new MemoryCache(new MemoryCacheOptions()), this.deviceApi.Object, this.loRaDeviceFactory);
+            this.frameCounterStrategyProvider = new LoRaDeviceFrameCounterUpdateStrategyProvider(this.serverConfiguration.GatewayID, this.deviceApi.Object);
+        }
+
+        private void EnsureDownlinkIsCorrect(DownlinkPktFwdMessage downlink, SimulatedDevice simDevice, LoRaCloudToDeviceMessage sentMessage)
+        {
+            Assert.NotNull(downlink);
+            Assert.NotNull(downlink.Txpk);
+            Assert.True(downlink.Txpk.Imme);
+            Assert.Equal(0, downlink.Txpk.Tmst);
+            Assert.NotEmpty(downlink.Txpk.Data);
+
+            byte[] downstreamPayloadBytes = Convert.FromBase64String(downlink.Txpk.Data);
+            var downstreamPayload = new LoRaPayloadData(downstreamPayloadBytes);
+            Assert.Equal(sentMessage.Fport, downstreamPayload.GetFPort());
+            Assert.Equal(downstreamPayload.DevAddr.ToArray(), ConversionHelper.StringToByteArray(simDevice.DevAddr));
+            var decryptedPayload = downstreamPayload.GetDecryptedPayload(simDevice.AppSKey);
+            Assert.Equal(sentMessage.Payload, Encoding.UTF8.GetString(decryptedPayload));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task MessageProcessor_End2End_NoDep_ClassC_CloudToDeviceMessage_SizeLimit_Should_Accept(
+            bool hasMacInC2D)
+        {
+            var simulatedDevice = new SimulatedDevice(
+                TestDeviceInfo.CreateABPDevice(
+                    1, deviceClassType: 'c', gatewayID: this.serverConfiguration.GatewayID));
+
+            var devEUI = simulatedDevice.DevEUI;
+
+            this.deviceApi.Setup(x => x.SearchByDevEUIAsync(devEUI))
+                .ReturnsAsync(new SearchDevicesResult(
+                    new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
+
+            this.deviceClient.Setup(x => x.GetTwinAsync())
+                .ReturnsAsync(simulatedDevice.CreateABPTwin());
+
+            var c2dMessageMacCommand = new DevStatusRequest();
+            var c2dMessageMacCommandSize = hasMacInC2D ? c2dMessageMacCommand.Length : 0;
+
+            var datr = this.loRaRegion.DRtoConfiguration[this.loRaRegion.RX2DefaultReceiveWindows.dr].configuration;
+            var c2dPayloadSize = this.loRaRegion.GetMaxPayloadSize(datr)
+                - c2dMessageMacCommandSize
+                - Constants.LORA_PROTOCOL_OVERHEAD_SIZE;
+
+            var c2dMsgPayload = this.GeneratePayload("123457890", (int)c2dPayloadSize);
+            var c2d = new LoRaCloudToDeviceMessage()
+            {
+                DevEUI = devEUI,
+                Payload = c2dMsgPayload,
+                Fport = 1,
+            };
+
+            if (hasMacInC2D)
+            {
+                c2d.MacCommands = new[] { c2dMessageMacCommand };
+            }
+
+            var cloudToDeviceMessage = c2d.CreateMessage();
+
+            var target = new DefaultClassCDevicesMessageSender(
+                this.serverConfiguration,
+                this.loRaRegion,
+                this.loRaDeviceRegistry,
+                this.PacketForwarder,
+                this.frameCounterStrategyProvider);
+
+            // Expectations
+            // Verify that C2D message is sent
+            Assert.True(await target.SendAsync(c2d));
+
+            // Verify that exactly one C2D message was received
+            Assert.Single(this.PacketForwarder.DownlinkMessages);
+
+            // Verify donwlink message is correct
+            this.EnsureDownlinkIsCorrect(
+                this.PacketForwarder.DownlinkMessages.First(), simulatedDevice, c2d);
+
+            // Get C2D message payload
+            var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
+            var payloadDataDown = new LoRaPayloadData(
+                Convert.FromBase64String(downlinkMessage.Txpk.Data));
+            payloadDataDown.PerformEncryption(simulatedDevice.AppSKey);
+
+            // Verify that expected Mac commands are present
+            var expectedMacCommandsCount = 0;
+
+            if (hasMacInC2D)
+                expectedMacCommandsCount++;
+
+            if (expectedMacCommandsCount > 0)
+            {
+                var macCommands = MacCommand.CreateServerMacCommandFromBytes(
+                    simulatedDevice.DevEUI, payloadDataDown.Fopts);
+                Assert.Equal(expectedMacCommandsCount, macCommands.Count);
+            }
+            else
+            {
+                Assert.Null(payloadDataDown.MacCommands);
+            }
+
+            this.deviceApi.VerifyAll();
+            this.deviceClient.VerifyAll();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task MessageProcessor_End2End_NoDep_ClassC_CloudToDeviceMessage_SizeLimit_Should_Reject(
+            bool hasMacInC2D)
+        {
+            var simulatedDevice = new SimulatedDevice(
+                TestDeviceInfo.CreateABPDevice(
+                    1, deviceClassType: 'c', gatewayID: this.serverConfiguration.GatewayID));
+
+            var devEUI = simulatedDevice.DevEUI;
+
+            this.deviceApi.Setup(x => x.SearchByDevEUIAsync(devEUI))
+                .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
+
+            this.deviceClient.Setup(x => x.GetTwinAsync())
+                .ReturnsAsync(simulatedDevice.CreateABPTwin());
+
+            var c2dMessageMacCommand = new DevStatusRequest();
+            var c2dMessageMacCommandSize = hasMacInC2D ? c2dMessageMacCommand.Length : 0;
+
+            var datr = this.loRaRegion.DRtoConfiguration[this.loRaRegion.RX2DefaultReceiveWindows.dr].configuration;
+            var c2dPayloadSize = this.loRaRegion.GetMaxPayloadSize(datr)
+                - c2dMessageMacCommandSize
+                + 1 // make message too long on purpose
+                - Constants.LORA_PROTOCOL_OVERHEAD_SIZE;
+
+            var c2dMsgPayload = this.GeneratePayload("123457890", (int)c2dPayloadSize);
+            var c2d = new LoRaCloudToDeviceMessage()
+            {
+                DevEUI = devEUI,
+                Payload = c2dMsgPayload,
+                Fport = 1,
+            };
+
+            if (hasMacInC2D)
+            {
+                c2d.MacCommands = new[] { c2dMessageMacCommand };
+            }
+
+            var cloudToDeviceMessage = c2d.CreateMessage();
+
+            var target = new DefaultClassCDevicesMessageSender(
+                this.serverConfiguration,
+                this.loRaRegion,
+                this.loRaDeviceRegistry,
+                this.PacketForwarder,
+                this.frameCounterStrategyProvider);
+
+            // Expectations
+            // Verify that C2D message is sent
+            Assert.False(await target.SendAsync(c2d));
+
+            // Verify that exactly one C2D message was received
+            Assert.Empty(this.PacketForwarder.DownlinkMessages);
+
+            this.deviceApi.VerifyAll();
+            this.deviceClient.VerifyAll();
+        }
+
+        private string GeneratePayload(string allowedChars, int length)
+        {
+            Random random = new Random();
+
+            char[] chars = new char[length];
+            int setLength = allowedChars.Length;
+
+            for (int i = 0; i < length; ++i)
+            {
+                chars[i] = allowedChars[random.Next(setLength)];
+            }
+
+            return new string(chars, 0, length);
+        }
+    }
+}

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Tests.cs
@@ -157,7 +157,8 @@ namespace LoRaWan.NetworkServer.Test
 
             if (expectedMacCommandsCount > 0)
             {
-                var macCommands = MacCommand.CreateServerMacCommandFromBytes(simulatedDevice.DevEUI, payloadDataDown.Fopts);
+                // Possible problem: Manually casting payloadDataDown.Fopts to array and reversing it
+                var macCommands = MacCommand.CreateServerMacCommandFromBytes(simulatedDevice.DevEUI, payloadDataDown.Fopts.ToArray().Reverse().ToArray());
                 Assert.Equal(expectedMacCommandsCount, macCommands.Count);
             }
             else
@@ -384,7 +385,8 @@ namespace LoRaWan.NetworkServer.Test
             // Expected Mac command is present
             if (hasMacInUpstream)
             {
-                var frmPayload = payloadDataDown.Frmpayload.ToArray().Reverse().ToArray();
+                // Possible problem: manually casting frmPayload to array. No reversal.
+                var frmPayload = payloadDataDown.Frmpayload.ToArray();
                 var macCommands = MacCommand.CreateServerMacCommandFromBytes(simulatedDevice.DevEUI, frmPayload);
                 Assert.Single(macCommands);
                 Assert.IsType<LinkCheckAnswer>(macCommands.First());

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Tests.cs
@@ -23,7 +23,7 @@ namespace LoRaWan.NetworkServer.Test
     using Xunit;
 
     // End to end tests without external dependencies (IoT Hub, Service Facade Function)
-    // Cloud to device message processing tests (Join tests are handled in other class)
+    // Cloud to device message processing max payload size tests (Join tests are handled in other class)
     public class MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Tests : MessageProcessorTestBase
     {
         public MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Tests()
@@ -31,21 +31,15 @@ namespace LoRaWan.NetworkServer.Test
         }
 
         [Theory]
-        [InlineData("SF12BW125", "123456789012345678901234567890123456789012345678901")] // 51
-        [InlineData("SF11BW125", "123456789012345678901234567890123456789012345678901")] // 51
-        [InlineData("SF10BW125", "123456789012345678901234567890123456789012345678901")] // 51
-        [InlineData("SF9BW125", "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345")] // 115
-        [InlineData("SF8BW125", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012")] // 222
-        [InlineData("SF7BW125", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012")] // 222
-        [InlineData("SF7BW250", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012")] // 222
-
-        public async Task OTAA_Confirmed_With_Cloud_To_Device_Message_Returns_Downstream_Message_Size_OK(string customDatr, string c2dMessageContent)
+        [CombinatorialData]
+        public async Task MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Should_Reject(
+            bool isConfirmed,
+            bool hasMacInUpstream,
+            bool hasMacInC2D,
+            [CombinatorialValues("SF10BW125", "SF9BW125", "SF8BW125", "SF7BW125")] string datr)
         {
-            const int PayloadFcnt = 10;
             const int InitialDeviceFcntUp = 9;
             const int InitialDeviceFcntDown = 20;
-
-            var needsToSaveFcnt = PayloadFcnt - InitialDeviceFcntUp >= Constants.MAX_FCNT_UNSAVED_DELTA;
 
             var simulatedDevice = new SimulatedDevice(
                 TestDeviceInfo.CreateABPDevice(1, gatewayID: this.ServerConfiguration.GatewayID),
@@ -54,313 +48,44 @@ namespace LoRaWan.NetworkServer.Test
 
             var loraDevice = this.CreateLoRaDevice(simulatedDevice);
 
-            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
-                .ReturnsAsync(true);
+            Rxpk rxpk = CreateUpstreamRxpk(isConfirmed, hasMacInUpstream, datr, simulatedDevice);
 
-            if (needsToSaveFcnt)
+            if (!hasMacInUpstream)
             {
-                this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+                this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                     .ReturnsAsync(true);
             }
 
-            var cloudToDeviceMessage = new LoRaCloudToDeviceMessage() { Payload = c2dMessageContent, Fport = 1 }
-                .CreateMessage();
+            var euRegion = RegionFactory.CreateEU868Region();
+            var c2dMessageMacCommand = new DevStatusRequest();
+            var c2dMessageMacCommandSize = hasMacInC2D ? c2dMessageMacCommand.Length : 0;
+            var upstreamMessageMacCommandSize = 0;
+            string expectedDownlinkDatr;
 
-            this.LoRaDeviceClient.SetupSequence(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
-                .ReturnsAsync(cloudToDeviceMessage)
-                .ReturnsAsync((Message)null); // 2nd cloud to device message does not return anything
-
-            this.LoRaDeviceClient.Setup(x => x.CompleteAsync(cloudToDeviceMessage))
-                .ReturnsAsync(true);
-
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
-
-            // Send to message processor
-            var messageProcessor = new MessageDispatcher(
-                this.ServerConfiguration,
-                deviceRegistry,
-                this.FrameCounterUpdateStrategyProvider);
-
-            var payload = simulatedDevice.CreateConfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
-            var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            rxpk.Datr = customDatr;
-            var request = this.CreateWaitableRequest(rxpk);
-            messageProcessor.DispatchRequest(request);
-            Assert.True(await request.WaitCompleteAsync());
-
-            // Expectations
-            // 1. Message was sent to IoT Hub
-            this.LoRaDeviceClient.VerifyAll();
-            this.LoRaDeviceApi.VerifyAll();
-
-            // 2. Return is downstream message
-            Assert.NotNull(request.ResponseDownlink);
-            Assert.True(request.ProcessingSucceeded);
-            Assert.Single(this.PacketForwarder.DownlinkMessages);
-            var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
-            var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
-            payloadDataDown.PerformEncryption(loraDevice.AppSKey);
-            Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
-            Assert.False(payloadDataDown.IsConfirmed());
-            Assert.Equal(LoRaMessageType.UnconfirmedDataDown, payloadDataDown.LoRaMessageType);
-
-            // 3. Payload should not be empty
-            Assert.False(payloadDataDown.Frmpayload.IsEmpty);
-
-            // 4. Expected payload is present
-            Assert.Equal(
-                Encoding.UTF8.GetString(payloadDataDown.Frmpayload.ToArray()),
-                c2dMessageContent);
-
-            // 4. Frame counter up was updated
-            Assert.Equal(PayloadFcnt, loraDevice.FCntUp);
-
-            // 5. Frame counter down is updated
-            Assert.Equal(InitialDeviceFcntDown + 1, loraDevice.FCntDown);
-            Assert.Equal(InitialDeviceFcntDown + 1, payloadDataDown.GetFcnt());
-
-            // 6. Frame count has pending changes?
-            if (needsToSaveFcnt)
-                Assert.False(loraDevice.HasFrameCountChanges);
-            else
-                Assert.True(loraDevice.HasFrameCountChanges);
-        }
-
-        [Theory]
-        [InlineData("SF12BW125", "1234567890123456789012345678901234567890123456789012")] // 52
-        [InlineData("SF11BW125", "1234567890123456789012345678901234567890123456789012")] // 52
-        [InlineData("SF10BW125", "1234567890123456789012345678901234567890123456789012")] // 52
-        [InlineData("SF9BW125", "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456")] // 116
-        [InlineData("SF8BW125", "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123")] // 223
-        [InlineData("SF7BW125", "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123")] // 223
-        [InlineData("SF7BW250", "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123")] // 223
-
-        public async Task OTAA_Confirmed_With_Cloud_To_Device_Message_Returns_Downstream_Message_Size_Too_Long(string customDatr, string c2dMessageContent)
-        {
-            const int PayloadFcnt = 10;
-            const int InitialDeviceFcntUp = 9;
-            const int InitialDeviceFcntDown = 20;
-
-            var needsToSaveFcnt = PayloadFcnt - InitialDeviceFcntUp >= Constants.MAX_FCNT_UNSAVED_DELTA;
-
-            var simulatedDevice = new SimulatedDevice(
-                TestDeviceInfo.CreateABPDevice(1, gatewayID: this.ServerConfiguration.GatewayID),
-                frmCntUp: InitialDeviceFcntUp,
-                frmCntDown: InitialDeviceFcntDown);
-
-            var loraDevice = this.CreateLoRaDevice(simulatedDevice);
-
-            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
-                .ReturnsAsync(true);
-
-            if (needsToSaveFcnt)
+            if (hasMacInUpstream)
             {
-                this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
-                    .ReturnsAsync(true);
+                upstreamMessageMacCommandSize = new LinkCheckAnswer(1, 1).Length;
             }
 
-            var cloudToDeviceMessage = new LoRaCloudToDeviceMessage() { Payload = c2dMessageContent, Fport = 1 }
-                .CreateMessage();
+            expectedDownlinkDatr = datr;
 
-            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
-                .ReturnsAsync(cloudToDeviceMessage);
+            var c2dPayloadSize = euRegion.GetMaxPayloadSize(expectedDownlinkDatr)
+                - c2dMessageMacCommandSize
+                + 1 // make message too long on purpose
+                - Constants.LORA_PROTOCOL_OVERHEAD_SIZE;
 
-            this.LoRaDeviceClient.Setup(x => x.RejectAsync(cloudToDeviceMessage))
-                .ReturnsAsync(true);
-
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
-
-            // Send to message processor
-            var messageProcessor = new MessageDispatcher(
-                this.ServerConfiguration,
-                deviceRegistry,
-                this.FrameCounterUpdateStrategyProvider);
-
-            var payload = simulatedDevice.CreateConfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
-            var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            rxpk.Datr = customDatr;
-            var request = this.CreateWaitableRequest(rxpk);
-            messageProcessor.DispatchRequest(request);
-            Assert.True(await request.WaitCompleteAsync());
-
-            // Expectations
-            // 1. Message was sent to IoT Hub
-            this.LoRaDeviceClient.VerifyAll();
-            this.LoRaDeviceApi.VerifyAll();
-
-            // 2. Return is downstream message
-            Assert.NotNull(request.ResponseDownlink);
-            Assert.True(request.ProcessingSucceeded);
-            Assert.Single(this.PacketForwarder.DownlinkMessages);
-            var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
-            var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
-            payloadDataDown.PerformEncryption(loraDevice.AppSKey);
-
-            Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
-            Assert.False(payloadDataDown.IsConfirmed());
-            Assert.Equal(LoRaMessageType.UnconfirmedDataDown, payloadDataDown.LoRaMessageType);
-
-            // Payload should be empty
-            Assert.True(payloadDataDown.Frmpayload.IsEmpty);
-
-            // 4. Frame counter up was updated
-            Assert.Equal(PayloadFcnt, loraDevice.FCntUp);
-
-            // 5. Frame counter down is updated
-            Assert.Equal(InitialDeviceFcntDown + 1, loraDevice.FCntDown);
-            Assert.Equal(InitialDeviceFcntDown + 1, payloadDataDown.GetFcnt());
-
-            // 6. Frame count has pending changes?
-            if (needsToSaveFcnt)
-                Assert.False(loraDevice.HasFrameCountChanges);
-            else
-                Assert.True(loraDevice.HasFrameCountChanges);
-        }
-
-        [Theory]
-        [InlineData("SF12BW125", "12345678901234567890123456789012345678901234567890")] // 51 - 1 (Mac Command)
-        [InlineData("SF11BW125", "12345678901234567890123456789012345678901234567890")] // 51 - 1 (Mac Command)
-        [InlineData("SF10BW125", "12345678901234567890123456789012345678901234567890")] // 51 - 1 (Mac Command)
-        [InlineData("SF9BW125", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234")] // 115 - 1 (Mac Command)
-        [InlineData("SF8BW125", "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901")] // 222 - 1 (Mac Command)
-        [InlineData("SF7BW125", "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901")] // 222 - 1 (Mac Command)
-        [InlineData("SF7BW250", "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901")] // 222 - 1 (Mac Command)
-
-        public async Task OTAA_Confirmed_With_Cloud_To_Device_Mac_Command_Returns_Downstream_Message_Size_OK(string customDatr, string c2dMessageContent)
-        {
-            const int PayloadFcnt = 20;
-            const int InitialDeviceFcntUp = 9;
-            const int InitialDeviceFcntDown = 20;
-
-            var simulatedDevice = new SimulatedDevice(
-                TestDeviceInfo.CreateABPDevice(1, gatewayID: this.ServerConfiguration.GatewayID),
-                frmCntUp: InitialDeviceFcntUp,
-                frmCntDown: InitialDeviceFcntDown);
-
-            var loraDevice = this.CreateLoRaDevice(simulatedDevice);
-
-            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
-                .ReturnsAsync(true);
-
-            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
-                .ReturnsAsync(true);
+            var c2dMsgPayload = this.GeneratePayload("123457890", (int)c2dPayloadSize);
 
             var c2d = new LoRaCloudToDeviceMessage()
             {
-                Payload = c2dMessageContent,
-                MacCommands = new[]
-                {
-                    new DevStatusRequest(),
-                },
+                Payload = c2dMsgPayload,
                 Fport = 1,
             };
 
-            var cloudToDeviceMessage = c2d.CreateMessage();
-
-            this.LoRaDeviceClient.SetupSequence(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
-                .ReturnsAsync(cloudToDeviceMessage)
-                .ReturnsAsync((Message)null); // 2nd cloud to device message does not return anything
-
-            this.LoRaDeviceClient.Setup(x => x.CompleteAsync(cloudToDeviceMessage))
-                .ReturnsAsync(true);
-
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
-
-            // Send to message processor
-            var messageProcessor = new MessageDispatcher(
-                this.ServerConfiguration,
-                deviceRegistry,
-                this.FrameCounterUpdateStrategyProvider);
-
-            var payload = simulatedDevice.CreateConfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
-            var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            rxpk.Datr = customDatr;
-            var request = this.CreateWaitableRequest(rxpk);
-            messageProcessor.DispatchRequest(request);
-            Assert.True(await request.WaitCompleteAsync());
-
-            // Expectations
-            // 1. Message was sent to IoT Hub
-            this.LoRaDeviceClient.VerifyAll();
-            this.LoRaDeviceApi.VerifyAll();
-
-            // 2. Return is downstream message
-            Assert.NotNull(request.ResponseDownlink);
-            Assert.True(request.ProcessingSucceeded);
-            Assert.Single(this.PacketForwarder.DownlinkMessages);
-            var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
-            var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
-            payloadDataDown.PerformEncryption(loraDevice.AppSKey);
-
-            Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
-            Assert.False(payloadDataDown.IsConfirmed());
-            Assert.Equal(LoRaMessageType.UnconfirmedDataDown, payloadDataDown.LoRaMessageType);
-
-            // 3. Payload should not be empty
-            Assert.False(payloadDataDown.Frmpayload.IsEmpty);
-
-            // 4. Expected payload is present
-            Assert.Equal(
-                Encoding.UTF8.GetString(payloadDataDown.Frmpayload.ToArray()),
-                c2dMessageContent);
-
-            // 5. Frame counter up was updated
-            Assert.Equal(PayloadFcnt, loraDevice.FCntUp);
-
-            // 6. Frame counter down is updated
-            Assert.Equal(InitialDeviceFcntDown + 1, loraDevice.FCntDown);
-            Assert.Equal(InitialDeviceFcntDown + 1, payloadDataDown.GetFcnt());
-
-            // 7. Frame count has no pending changes
-            Assert.False(loraDevice.HasFrameCountChanges);
-
-            // 8. Mac commands should be present in reply
-            // mac command is in fopts if there is a c2d message
-            Assert.NotNull(payloadDataDown.Fopts.Span.ToArray());
-            Assert.Single(payloadDataDown.Fopts.Span.ToArray());
-            Assert.Equal((byte)LoRaTools.CidEnum.DevStatusCmd, payloadDataDown.Fopts.Span[0]);
-
-            this.LoRaDeviceClient.VerifyAll();
-            this.LoRaDeviceApi.VerifyAll();
-        }
-
-        [Theory]
-        [InlineData("SF12BW125", "123456789012345678901234567890123456789012345678901")] // > 51 - 1 (Mac Command)
-        [InlineData("SF11BW125", "123456789012345678901234567890123456789012345678901")] // > 51 - 1 (Mac Command)
-        [InlineData("SF10BW125", "123456789012345678901234567890123456789012345678901")] // > 51 - 1 (Mac Command)
-        [InlineData("SF9BW125", "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345")] // > 115 - 1 (Mac Command)
-        [InlineData("SF8BW125", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012")] // > 222 - 1 (Mac Command)
-        [InlineData("SF7BW125", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012")] // > 222 - 1 (Mac Command)
-        [InlineData("SF7BW250", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012")] // > 222 - 1 (Mac Command)
-
-        public async Task OTAA_Confirmed_With_Cloud_To_Device_Mac_Command_Returns_Downstream_Message_Size_Too_Long(string customDatr, string c2dMessageContent)
-        {
-            const int PayloadFcnt = 20;
-            const int InitialDeviceFcntUp = 9;
-            const int InitialDeviceFcntDown = 20;
-
-            var simulatedDevice = new SimulatedDevice(
-                TestDeviceInfo.CreateABPDevice(1, gatewayID: this.ServerConfiguration.GatewayID),
-                frmCntUp: InitialDeviceFcntUp,
-                frmCntDown: InitialDeviceFcntDown);
-
-            var loraDevice = this.CreateLoRaDevice(simulatedDevice);
-
-            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
-                .ReturnsAsync(true);
-
-            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
-                .ReturnsAsync(true);
-
-            var c2d = new LoRaCloudToDeviceMessage()
+            if (hasMacInC2D)
             {
-                Payload = c2dMessageContent,
-                MacCommands = new[]
-                {
-                    new DevStatusRequest(),
-                },
-                Fport = 1,
-            };
+                c2d.MacCommands = new[] { c2dMessageMacCommand };
+            }
 
             var cloudToDeviceMessage = c2d.CreateMessage();
 
@@ -378,46 +103,39 @@ namespace LoRaWan.NetworkServer.Test
                 deviceRegistry,
                 this.FrameCounterUpdateStrategyProvider);
 
-            var payload = simulatedDevice.CreateConfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
-            var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            rxpk.Datr = customDatr;
             var request = this.CreateWaitableRequest(rxpk);
             messageProcessor.DispatchRequest(request);
-            Assert.True(await request.WaitCompleteAsync());
 
             // Expectations
             // 1. Message was sent to IoT Hub
-            this.LoRaDeviceClient.VerifyAll();
-            this.LoRaDeviceApi.VerifyAll();
-
-            // 2. Return is downstream message
-            Assert.NotNull(request.ResponseDownlink);
+            Assert.True(await request.WaitCompleteAsync());
             Assert.True(request.ProcessingSucceeded);
-            Assert.Single(this.PacketForwarder.DownlinkMessages);
-            var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
-            var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
-            payloadDataDown.PerformEncryption(loraDevice.AppSKey);
 
-            Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
-            Assert.False(payloadDataDown.IsConfirmed());
-            Assert.Equal(LoRaMessageType.UnconfirmedDataDown, payloadDataDown.LoRaMessageType);
+            var shouldHaveADownlink = isConfirmed || hasMacInUpstream;
 
-            // 3. Payload should be empty
-            Assert.True(payloadDataDown.Frmpayload.IsEmpty);
+            if (shouldHaveADownlink)
+            {
+                // 2. Return is downstream message
+                Assert.NotNull(request.ResponseDownlink);
+                Assert.Equal(expectedDownlinkDatr, request.ResponseDownlink.Txpk.Datr);
 
-            // 4. Frame counter up was updated
-            Assert.Equal(PayloadFcnt, loraDevice.FCntUp);
+                var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
+                var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
+                payloadDataDown.PerformEncryption(loraDevice.AppSKey);
 
-            // 5. Frame counter down is updated
-            Assert.Equal(InitialDeviceFcntDown + 1, loraDevice.FCntDown);
-            Assert.Equal(InitialDeviceFcntDown + 1, payloadDataDown.GetFcnt());
+                Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
+                Assert.Equal(LoRaMessageType.UnconfirmedDataDown, payloadDataDown.LoRaMessageType);
 
-            // 6. Frame count has no pending changes
-            Assert.False(loraDevice.HasFrameCountChanges);
-
-            // 7. Mac commands should NOT be present in reply
-            // mac command is in fopts if there is a c2d message
-            Assert.True(payloadDataDown.Fopts.Span.IsEmpty);
+                if (hasMacInUpstream)
+                {
+                    Assert.Equal(new LinkCheckAnswer(1, 1).Length, payloadDataDown.Frmpayload.Length);
+                    Assert.Equal(0, payloadDataDown.GetFPort());
+                }
+            }
+            else
+            {
+                Assert.Null(request.ResponseDownlink);
+            }
 
             this.LoRaDeviceClient.VerifyAll();
             this.LoRaDeviceApi.VerifyAll();
@@ -425,25 +143,259 @@ namespace LoRaWan.NetworkServer.Test
 
         [Theory]
         [CombinatorialData]
-        public async Task Aaaaaaaaaaaaaaaargh(
+        public async Task MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Should_Accept(
             bool isConfirmed,
             bool hasMacInUpstream,
             bool hasMacInC2D,
-            MessagePayloadSize msgPayloadSize,
-            bool isTooLongForUpstreamMacCommandInAnswer, // true: drop the upstream mac answer
+            bool isTooLongForUpstreamMacCommandInAnswer,
             bool isSendingInRx2,
-            [CombinatorialValues("SF12BW125", "SF11BW125", "SF10BW125", "SF9BW125", "SF8BW125", "SF7BW125", "SF7BW250")] string datr)
+            [CombinatorialValues("SF10BW125", "SF9BW125", "SF8BW125", "SF7BW125")] string datr)
+        {
+            const int InitialDeviceFcntUp = 9;
+            const int InitialDeviceFcntDown = 20;
+
+            // This scenario makes no sense
+            if (hasMacInUpstream && isTooLongForUpstreamMacCommandInAnswer)
+                return;
+
+            var simulatedDevice = new SimulatedDevice(
+            TestDeviceInfo.CreateABPDevice(1, gatewayID: this.ServerConfiguration.GatewayID),
+            frmCntUp: InitialDeviceFcntUp,
+            frmCntDown: InitialDeviceFcntDown);
+
+            var loraDevice = this.CreateLoRaDevice(simulatedDevice);
+
+            Rxpk rxpk = CreateUpstreamRxpk(isConfirmed, hasMacInUpstream, datr, simulatedDevice);
+
+            if (!hasMacInUpstream)
+            {
+                this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                    .ReturnsAsync(true);
+            }
+
+            var euRegion = RegionFactory.CreateEU868Region();
+            var c2dMessageMacCommand = new DevStatusRequest();
+            var c2dMessageMacCommandSize = hasMacInC2D ? c2dMessageMacCommand.Length : 0;
+            var upstreamMessageMacCommandSize = 0;
+            string expectedDownlinkDatr;
+
+            if (hasMacInUpstream && !isTooLongForUpstreamMacCommandInAnswer)
+            {
+                upstreamMessageMacCommandSize = new LinkCheckAnswer(1, 1).Length;
+            }
+
+            if (isSendingInRx2)
+                expectedDownlinkDatr = euRegion.DRtoConfiguration[euRegion.RX2DefaultReceiveWindows.dr].configuration;
+            else
+                expectedDownlinkDatr = datr;
+
+            var c2dPayloadSize = euRegion.GetMaxPayloadSize(expectedDownlinkDatr)
+                - c2dMessageMacCommandSize
+                - upstreamMessageMacCommandSize
+                - Constants.LORA_PROTOCOL_OVERHEAD_SIZE;
+
+            var c2dMsgPayload = this.GeneratePayload("123457890", (int)c2dPayloadSize);
+
+            var c2d = new LoRaCloudToDeviceMessage()
+            {
+                Payload = c2dMsgPayload,
+                Fport = 1,
+            };
+
+            if (hasMacInC2D)
+            {
+                c2d.MacCommands = new[] { c2dMessageMacCommand };
+            }
+
+            var cloudToDeviceMessage = c2d.CreateMessage();
+
+            if (isSendingInRx2)
+            {
+                this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+                    .Callback<TimeSpan>((_) =>
+                    {
+                        this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+                            .ReturnsAsync((Message)null);
+                    })
+                    .ReturnsAsync(cloudToDeviceMessage, TimeSpan.FromSeconds(1));
+            }
+            else
+            {
+                this.LoRaDeviceClient.SetupSequence(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+                    .ReturnsAsync(cloudToDeviceMessage)
+                    .ReturnsAsync(null);
+            }
+
+            this.LoRaDeviceClient.Setup(x => x.CompleteAsync(cloudToDeviceMessage))
+                .ReturnsAsync(true);
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageProcessor = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyProvider);
+
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+
+            // Expectations
+            // 1. Message was sent to IoT Hub
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.True(request.ProcessingSucceeded);
+
+            // 2. Return is downstream message
+            Assert.NotNull(request.ResponseDownlink);
+            Assert.Equal(expectedDownlinkDatr, request.ResponseDownlink.Txpk.Datr);
+
+            var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
+            var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
+            payloadDataDown.PerformEncryption(loraDevice.AppSKey);
+
+            Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
+            Assert.Equal(LoRaMessageType.UnconfirmedDataDown, payloadDataDown.LoRaMessageType);
+
+            // Expected Mac commands are present
+            var expectedMacCommandsCount = 0;
+
+            if (hasMacInC2D)
+                expectedMacCommandsCount++;
+            if (hasMacInUpstream && !isTooLongForUpstreamMacCommandInAnswer)
+                expectedMacCommandsCount++;
+
+            if (expectedMacCommandsCount > 0)
+            {
+                var macCommands = MacCommand.CreateServerMacCommandFromBytes(simulatedDevice.DevEUI, payloadDataDown.Fopts);
+                Assert.Equal(expectedMacCommandsCount, macCommands.Count);
+            }
+            else
+            {
+                Assert.Null(payloadDataDown.MacCommands);
+            }
+
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Should_Abandon(
+            bool isConfirmed,
+            bool hasMacInUpstream,
+            bool hasMacInC2D,
+            [CombinatorialValues("SF9BW125", "SF8BW125", "SF7BW125")] string datr)
         {
             const int InitialDeviceFcntUp = 9;
             const int InitialDeviceFcntDown = 20;
 
             var simulatedDevice = new SimulatedDevice(
-                TestDeviceInfo.CreateABPDevice(1, gatewayID: this.ServerConfiguration.GatewayID),
-                frmCntUp: InitialDeviceFcntUp,
-                frmCntDown: InitialDeviceFcntDown);
+            TestDeviceInfo.CreateABPDevice(1, gatewayID: this.ServerConfiguration.GatewayID),
+            frmCntUp: InitialDeviceFcntUp,
+            frmCntDown: InitialDeviceFcntDown);
 
             var loraDevice = this.CreateLoRaDevice(simulatedDevice);
 
+            Rxpk rxpk = CreateUpstreamRxpk(isConfirmed, hasMacInUpstream, datr, simulatedDevice);
+
+            if (!hasMacInUpstream)
+            {
+                this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                    .ReturnsAsync(true);
+            }
+
+            var euRegion = RegionFactory.CreateEU868Region();
+            var c2dMessageMacCommand = new DevStatusRequest();
+            var c2dMessageMacCommandSize = hasMacInC2D ? c2dMessageMacCommand.Length : 0;
+            var upstreamMessageMacCommandSize = 0;
+            string expectedDownlinkDatr;
+
+            if (hasMacInUpstream)
+            {
+                upstreamMessageMacCommandSize = new LinkCheckAnswer(1, 1).Length;
+            }
+
+            expectedDownlinkDatr = euRegion.DRtoConfiguration[euRegion.RX2DefaultReceiveWindows.dr].configuration;
+
+            var c2dPayloadSize = euRegion.GetMaxPayloadSize(expectedDownlinkDatr)
+                - c2dMessageMacCommandSize
+                + 1 // make message too long on purpose
+                - Constants.LORA_PROTOCOL_OVERHEAD_SIZE;
+
+            var c2dMsgPayload = this.GeneratePayload("123457890", (int)c2dPayloadSize);
+
+            var c2d = new LoRaCloudToDeviceMessage()
+            {
+                Payload = c2dMsgPayload,
+                Fport = 1,
+            };
+
+            if (hasMacInC2D)
+            {
+                c2d.MacCommands = new[] { c2dMessageMacCommand };
+            }
+
+            var cloudToDeviceMessage = c2d.CreateMessage();
+
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+                .Callback<TimeSpan>((_) =>
+                {
+                    this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+                        .ReturnsAsync((Message)null);
+                })
+                .ReturnsAsync(cloudToDeviceMessage, TimeSpan.FromSeconds(1));
+
+            this.LoRaDeviceClient.Setup(x => x.AbandonAsync(cloudToDeviceMessage))
+                .ReturnsAsync(true);
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageProcessor = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyProvider);
+
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+
+            // Expectations
+            // 1. Message was sent to IoT Hub
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.True(request.ProcessingSucceeded);
+
+            // 2. Return is downstream message
+            Assert.NotNull(request.ResponseDownlink);
+            Assert.Equal(expectedDownlinkDatr, request.ResponseDownlink.Txpk.Datr);
+
+            var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
+            var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
+            payloadDataDown.PerformEncryption(loraDevice.AppSKey);
+
+            Assert.Equal((byte)FctrlEnum.FpendingOrClassB, payloadDataDown.Fctrl.Span[0] & (byte)FctrlEnum.FpendingOrClassB);
+
+            Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
+            Assert.Equal(LoRaMessageType.UnconfirmedDataDown, payloadDataDown.LoRaMessageType);
+
+            // Expected Mac command is present
+            if (hasMacInUpstream)
+            {
+                var frmPayload = payloadDataDown.Frmpayload.ToArray().Reverse().ToArray();
+                var macCommands = MacCommand.CreateServerMacCommandFromBytes(simulatedDevice.DevEUI, frmPayload);
+                Assert.Single(macCommands);
+                Assert.IsType<LinkCheckAnswer>(macCommands.First());
+            }
+            else
+            {
+                Assert.Null(payloadDataDown.MacCommands);
+            }
+
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+        }
+
+        private static Rxpk CreateUpstreamRxpk(bool isConfirmed, bool hasMacInUpstream, string datr, SimulatedDevice simulatedDevice)
+        {
             Rxpk rxpk = null;
             string msgPayload = null;
 
@@ -460,7 +412,7 @@ namespace LoRaWan.NetworkServer.Test
                 {
                     // Cofirmed message without Mac command in upstream
                     msgPayload = "1234567890";
-                    var confirmedMessagePayload = simulatedDevice.CreateConfirmedDataUpMessage("1234");
+                    var confirmedMessagePayload = simulatedDevice.CreateConfirmedDataUpMessage(msgPayload);
                     rxpk = confirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey, datr: datr).Rxpk[0];
                 }
             }
@@ -482,150 +434,7 @@ namespace LoRaWan.NetworkServer.Test
                 }
             }
 
-            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
-                .ReturnsAsync(true);
-
-            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
-                .ReturnsAsync(true);
-
-            var euRegion = RegionFactory.CreateEU868Region();
-            var c2dMessageMacCommand = new DevStatusRequest();
-            var c2dMessageMacCommandSize = hasMacInC2D ? c2dMessageMacCommand.Length : 0;
-            var upstreamMessageMacCommandSize = 0;
-            string expectedDownlinkDatr;
-            bool isTooLong = false;
-
-            if (hasMacInUpstream && !isTooLongForUpstreamMacCommandInAnswer)
-                upstreamMessageMacCommandSize = new LinkCheckAnswer(1, 1).Length;
-
-            if (isSendingInRx2)
-            {
-                expectedDownlinkDatr = euRegion.DRtoConfiguration[euRegion.RX2DefaultReceiveWindows.dr].configuration;
-                if (msgPayloadSize == MessagePayloadSize.TooLongForRx1 || msgPayloadSize == MessagePayloadSize.TooLongForRx2)
-                    isTooLong = true;
-            }
-            else
-            {
-                expectedDownlinkDatr = datr;
-                if (msgPayloadSize == MessagePayloadSize.TooLongForRx1)
-                    isTooLong = true;
-            }
-
-            var c2dPayloadSize = euRegion.GetMaxPayloadSize(expectedDownlinkDatr)
-                - upstreamMessageMacCommandSize
-                - c2dMessageMacCommandSize
-                + (isTooLong ? 1 : 0);
-
-            var c2dMsgPayload = this.GeneratePayload("123457890", (int)c2dPayloadSize);
-
-            var c2d = new LoRaCloudToDeviceMessage()
-            {
-                Payload = c2dMsgPayload,
-                Fport = 1,
-            };
-
-            if (hasMacInC2D)
-            {
-                c2d.MacCommands = new[] { c2dMessageMacCommand };
-            }
-
-            var cloudToDeviceMessage = c2d.CreateMessage();
-
-            if (isSendingInRx2)
-            {
-                this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
-                    .ReturnsAsync(cloudToDeviceMessage, TimeSpan.FromSeconds(1));
-            }
-            else
-            {
-                this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
-                    .ReturnsAsync(cloudToDeviceMessage);
-            }
-
-            var shouldCompleteMessage = !isTooLong;
-            var shouldAbandonMessage = isSendingInRx2 && msgPayloadSize == MessagePayloadSize.TooLongForRx2;
-
-            if (shouldCompleteMessage)
-            {
-                this.LoRaDeviceClient.Setup(x => x.CompleteAsync(cloudToDeviceMessage))
-                    .ReturnsAsync(true);
-            }
-            else if (shouldAbandonMessage)
-            {
-                this.LoRaDeviceClient.Setup(x => x.AbandonAsync(cloudToDeviceMessage))
-                    .ReturnsAsync(true);
-            }
-            else
-            {
-                this.LoRaDeviceClient.Setup(x => x.RejectAsync(cloudToDeviceMessage))
-                    .ReturnsAsync(true);
-            }
-
-            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
-
-            // Send to message processor
-            var messageProcessor = new MessageDispatcher(
-                this.ServerConfiguration,
-                deviceRegistry,
-                this.FrameCounterUpdateStrategyProvider);
-
-            var request = this.CreateWaitableRequest(rxpk);
-            messageProcessor.DispatchRequest(request);
-
-            // Expectations
-            // 1. Message was sent to IoT Hub
-            Assert.True(await request.WaitCompleteAsync());
-            Assert.True(request.ProcessingSucceeded);
-
-            var shouldHaveADownlink = isConfirmed || !isTooLong || hasMacInUpstream;
-
-            if (shouldHaveADownlink)
-            {
-                // 2. Return is downstream message
-                Assert.NotNull(request.ResponseDownlink);
-                Assert.Equal(expectedDownlinkDatr, request.ResponseDownlink.Txpk.Datr);
-
-                var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
-                var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
-                payloadDataDown.PerformEncryption(loraDevice.AppSKey);
-
-                Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
-                Assert.Equal(LoRaMessageType.UnconfirmedDataDown, payloadDataDown.LoRaMessageType);
-
-                // Confirmed or unconfirmed message
-                Assert.Equal(isConfirmed, payloadDataDown.IsConfirmed());
-
-                // Message too long, Payload should be empty
-                if (isTooLong)
-                {
-                    Assert.True(payloadDataDown.Frmpayload.IsEmpty);
-                }
-
-                // Message not too long, expected payload should be present
-                else
-                {
-                    Assert.Equal(
-                        Encoding.UTF8.GetString(payloadDataDown.Frmpayload.ToArray()),
-                        c2dMsgPayload);
-                }
-
-                // Expected Mac commands are present
-                var expectedMacCommandsCount = 0;
-
-                if (!isTooLong && hasMacInC2D)
-                    expectedMacCommandsCount++;
-                if (hasMacInUpstream && !isTooLongForUpstreamMacCommandInAnswer)
-                    expectedMacCommandsCount++;
-
-                Assert.Equal(expectedMacCommandsCount, payloadDataDown.MacCommands.Count);
-            }
-            else
-            {
-                Assert.Null(request.ResponseDownlink);
-            }
-
-            this.LoRaDeviceClient.VerifyAll();
-            this.LoRaDeviceApi.VerifyAll();
+            return rxpk;
         }
 
         private string GeneratePayload(string allowedChars, int length)
@@ -641,13 +450,6 @@ namespace LoRaWan.NetworkServer.Test
             }
 
             return new string(chars, 0, length);
-        }
-
-        public enum MessagePayloadSize
-        {
-            Ok,
-            TooLongForRx1,
-            TooLongForRx2
         }
     }
 }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Tests.cs
@@ -1,0 +1,653 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using LoRaTools;
+    using LoRaTools.LoRaMessage;
+    using LoRaTools.LoRaPhysical;
+    using LoRaTools.Regions;
+    using LoRaTools.Utils;
+    using LoRaWan.NetworkServer;
+    using LoRaWan.Test.Shared;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Caching.Memory;
+    using Moq;
+    using Xunit;
+
+    // End to end tests without external dependencies (IoT Hub, Service Facade Function)
+    // Cloud to device message processing tests (Join tests are handled in other class)
+    public class MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Tests : MessageProcessorTestBase
+    {
+        public MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Tests()
+        {
+        }
+
+        [Theory]
+        [InlineData("SF12BW125", "123456789012345678901234567890123456789012345678901")] // 51
+        [InlineData("SF11BW125", "123456789012345678901234567890123456789012345678901")] // 51
+        [InlineData("SF10BW125", "123456789012345678901234567890123456789012345678901")] // 51
+        [InlineData("SF9BW125", "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345")] // 115
+        [InlineData("SF8BW125", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012")] // 222
+        [InlineData("SF7BW125", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012")] // 222
+        [InlineData("SF7BW250", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012")] // 222
+
+        public async Task OTAA_Confirmed_With_Cloud_To_Device_Message_Returns_Downstream_Message_Size_OK(string customDatr, string c2dMessageContent)
+        {
+            const int PayloadFcnt = 10;
+            const int InitialDeviceFcntUp = 9;
+            const int InitialDeviceFcntDown = 20;
+
+            var needsToSaveFcnt = PayloadFcnt - InitialDeviceFcntUp >= Constants.MAX_FCNT_UNSAVED_DELTA;
+
+            var simulatedDevice = new SimulatedDevice(
+                TestDeviceInfo.CreateABPDevice(1, gatewayID: this.ServerConfiguration.GatewayID),
+                frmCntUp: InitialDeviceFcntUp,
+                frmCntDown: InitialDeviceFcntDown);
+
+            var loraDevice = this.CreateLoRaDevice(simulatedDevice);
+
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .ReturnsAsync(true);
+
+            if (needsToSaveFcnt)
+            {
+                this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+                    .ReturnsAsync(true);
+            }
+
+            var cloudToDeviceMessage = new LoRaCloudToDeviceMessage() { Payload = c2dMessageContent, Fport = 1 }
+                .CreateMessage();
+
+            this.LoRaDeviceClient.SetupSequence(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+                .ReturnsAsync(cloudToDeviceMessage)
+                .ReturnsAsync((Message)null); // 2nd cloud to device message does not return anything
+
+            this.LoRaDeviceClient.Setup(x => x.CompleteAsync(cloudToDeviceMessage))
+                .ReturnsAsync(true);
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageProcessor = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyProvider);
+
+            var payload = simulatedDevice.CreateConfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
+            var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
+            rxpk.Datr = customDatr;
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+
+            // Expectations
+            // 1. Message was sent to IoT Hub
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+
+            // 2. Return is downstream message
+            Assert.NotNull(request.ResponseDownlink);
+            Assert.True(request.ProcessingSucceeded);
+            Assert.Single(this.PacketForwarder.DownlinkMessages);
+            var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
+            var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
+            payloadDataDown.PerformEncryption(loraDevice.AppSKey);
+            Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
+            Assert.False(payloadDataDown.IsConfirmed());
+            Assert.Equal(LoRaMessageType.UnconfirmedDataDown, payloadDataDown.LoRaMessageType);
+
+            // 3. Payload should not be empty
+            Assert.False(payloadDataDown.Frmpayload.IsEmpty);
+
+            // 4. Expected payload is present
+            Assert.Equal(
+                Encoding.UTF8.GetString(payloadDataDown.Frmpayload.ToArray()),
+                c2dMessageContent);
+
+            // 4. Frame counter up was updated
+            Assert.Equal(PayloadFcnt, loraDevice.FCntUp);
+
+            // 5. Frame counter down is updated
+            Assert.Equal(InitialDeviceFcntDown + 1, loraDevice.FCntDown);
+            Assert.Equal(InitialDeviceFcntDown + 1, payloadDataDown.GetFcnt());
+
+            // 6. Frame count has pending changes?
+            if (needsToSaveFcnt)
+                Assert.False(loraDevice.HasFrameCountChanges);
+            else
+                Assert.True(loraDevice.HasFrameCountChanges);
+        }
+
+        [Theory]
+        [InlineData("SF12BW125", "1234567890123456789012345678901234567890123456789012")] // 52
+        [InlineData("SF11BW125", "1234567890123456789012345678901234567890123456789012")] // 52
+        [InlineData("SF10BW125", "1234567890123456789012345678901234567890123456789012")] // 52
+        [InlineData("SF9BW125", "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456")] // 116
+        [InlineData("SF8BW125", "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123")] // 223
+        [InlineData("SF7BW125", "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123")] // 223
+        [InlineData("SF7BW250", "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123")] // 223
+
+        public async Task OTAA_Confirmed_With_Cloud_To_Device_Message_Returns_Downstream_Message_Size_Too_Long(string customDatr, string c2dMessageContent)
+        {
+            const int PayloadFcnt = 10;
+            const int InitialDeviceFcntUp = 9;
+            const int InitialDeviceFcntDown = 20;
+
+            var needsToSaveFcnt = PayloadFcnt - InitialDeviceFcntUp >= Constants.MAX_FCNT_UNSAVED_DELTA;
+
+            var simulatedDevice = new SimulatedDevice(
+                TestDeviceInfo.CreateABPDevice(1, gatewayID: this.ServerConfiguration.GatewayID),
+                frmCntUp: InitialDeviceFcntUp,
+                frmCntDown: InitialDeviceFcntDown);
+
+            var loraDevice = this.CreateLoRaDevice(simulatedDevice);
+
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .ReturnsAsync(true);
+
+            if (needsToSaveFcnt)
+            {
+                this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+                    .ReturnsAsync(true);
+            }
+
+            var cloudToDeviceMessage = new LoRaCloudToDeviceMessage() { Payload = c2dMessageContent, Fport = 1 }
+                .CreateMessage();
+
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+                .ReturnsAsync(cloudToDeviceMessage);
+
+            this.LoRaDeviceClient.Setup(x => x.RejectAsync(cloudToDeviceMessage))
+                .ReturnsAsync(true);
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageProcessor = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyProvider);
+
+            var payload = simulatedDevice.CreateConfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
+            var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
+            rxpk.Datr = customDatr;
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+
+            // Expectations
+            // 1. Message was sent to IoT Hub
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+
+            // 2. Return is downstream message
+            Assert.NotNull(request.ResponseDownlink);
+            Assert.True(request.ProcessingSucceeded);
+            Assert.Single(this.PacketForwarder.DownlinkMessages);
+            var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
+            var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
+            payloadDataDown.PerformEncryption(loraDevice.AppSKey);
+
+            Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
+            Assert.False(payloadDataDown.IsConfirmed());
+            Assert.Equal(LoRaMessageType.UnconfirmedDataDown, payloadDataDown.LoRaMessageType);
+
+            // Payload should be empty
+            Assert.True(payloadDataDown.Frmpayload.IsEmpty);
+
+            // 4. Frame counter up was updated
+            Assert.Equal(PayloadFcnt, loraDevice.FCntUp);
+
+            // 5. Frame counter down is updated
+            Assert.Equal(InitialDeviceFcntDown + 1, loraDevice.FCntDown);
+            Assert.Equal(InitialDeviceFcntDown + 1, payloadDataDown.GetFcnt());
+
+            // 6. Frame count has pending changes?
+            if (needsToSaveFcnt)
+                Assert.False(loraDevice.HasFrameCountChanges);
+            else
+                Assert.True(loraDevice.HasFrameCountChanges);
+        }
+
+        [Theory]
+        [InlineData("SF12BW125", "12345678901234567890123456789012345678901234567890")] // 51 - 1 (Mac Command)
+        [InlineData("SF11BW125", "12345678901234567890123456789012345678901234567890")] // 51 - 1 (Mac Command)
+        [InlineData("SF10BW125", "12345678901234567890123456789012345678901234567890")] // 51 - 1 (Mac Command)
+        [InlineData("SF9BW125", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234")] // 115 - 1 (Mac Command)
+        [InlineData("SF8BW125", "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901")] // 222 - 1 (Mac Command)
+        [InlineData("SF7BW125", "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901")] // 222 - 1 (Mac Command)
+        [InlineData("SF7BW250", "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901")] // 222 - 1 (Mac Command)
+
+        public async Task OTAA_Confirmed_With_Cloud_To_Device_Mac_Command_Returns_Downstream_Message_Size_OK(string customDatr, string c2dMessageContent)
+        {
+            const int PayloadFcnt = 20;
+            const int InitialDeviceFcntUp = 9;
+            const int InitialDeviceFcntDown = 20;
+
+            var simulatedDevice = new SimulatedDevice(
+                TestDeviceInfo.CreateABPDevice(1, gatewayID: this.ServerConfiguration.GatewayID),
+                frmCntUp: InitialDeviceFcntUp,
+                frmCntDown: InitialDeviceFcntDown);
+
+            var loraDevice = this.CreateLoRaDevice(simulatedDevice);
+
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .ReturnsAsync(true);
+
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+                .ReturnsAsync(true);
+
+            var c2d = new LoRaCloudToDeviceMessage()
+            {
+                Payload = c2dMessageContent,
+                MacCommands = new[]
+                {
+                    new DevStatusRequest(),
+                },
+                Fport = 1,
+            };
+
+            var cloudToDeviceMessage = c2d.CreateMessage();
+
+            this.LoRaDeviceClient.SetupSequence(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+                .ReturnsAsync(cloudToDeviceMessage)
+                .ReturnsAsync((Message)null); // 2nd cloud to device message does not return anything
+
+            this.LoRaDeviceClient.Setup(x => x.CompleteAsync(cloudToDeviceMessage))
+                .ReturnsAsync(true);
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageProcessor = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyProvider);
+
+            var payload = simulatedDevice.CreateConfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
+            var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
+            rxpk.Datr = customDatr;
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+
+            // Expectations
+            // 1. Message was sent to IoT Hub
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+
+            // 2. Return is downstream message
+            Assert.NotNull(request.ResponseDownlink);
+            Assert.True(request.ProcessingSucceeded);
+            Assert.Single(this.PacketForwarder.DownlinkMessages);
+            var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
+            var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
+            payloadDataDown.PerformEncryption(loraDevice.AppSKey);
+
+            Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
+            Assert.False(payloadDataDown.IsConfirmed());
+            Assert.Equal(LoRaMessageType.UnconfirmedDataDown, payloadDataDown.LoRaMessageType);
+
+            // 3. Payload should not be empty
+            Assert.False(payloadDataDown.Frmpayload.IsEmpty);
+
+            // 4. Expected payload is present
+            Assert.Equal(
+                Encoding.UTF8.GetString(payloadDataDown.Frmpayload.ToArray()),
+                c2dMessageContent);
+
+            // 5. Frame counter up was updated
+            Assert.Equal(PayloadFcnt, loraDevice.FCntUp);
+
+            // 6. Frame counter down is updated
+            Assert.Equal(InitialDeviceFcntDown + 1, loraDevice.FCntDown);
+            Assert.Equal(InitialDeviceFcntDown + 1, payloadDataDown.GetFcnt());
+
+            // 7. Frame count has no pending changes
+            Assert.False(loraDevice.HasFrameCountChanges);
+
+            // 8. Mac commands should be present in reply
+            // mac command is in fopts if there is a c2d message
+            Assert.NotNull(payloadDataDown.Fopts.Span.ToArray());
+            Assert.Single(payloadDataDown.Fopts.Span.ToArray());
+            Assert.Equal((byte)LoRaTools.CidEnum.DevStatusCmd, payloadDataDown.Fopts.Span[0]);
+
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+        }
+
+        [Theory]
+        [InlineData("SF12BW125", "123456789012345678901234567890123456789012345678901")] // > 51 - 1 (Mac Command)
+        [InlineData("SF11BW125", "123456789012345678901234567890123456789012345678901")] // > 51 - 1 (Mac Command)
+        [InlineData("SF10BW125", "123456789012345678901234567890123456789012345678901")] // > 51 - 1 (Mac Command)
+        [InlineData("SF9BW125", "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345")] // > 115 - 1 (Mac Command)
+        [InlineData("SF8BW125", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012")] // > 222 - 1 (Mac Command)
+        [InlineData("SF7BW125", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012")] // > 222 - 1 (Mac Command)
+        [InlineData("SF7BW250", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012")] // > 222 - 1 (Mac Command)
+
+        public async Task OTAA_Confirmed_With_Cloud_To_Device_Mac_Command_Returns_Downstream_Message_Size_Too_Long(string customDatr, string c2dMessageContent)
+        {
+            const int PayloadFcnt = 20;
+            const int InitialDeviceFcntUp = 9;
+            const int InitialDeviceFcntDown = 20;
+
+            var simulatedDevice = new SimulatedDevice(
+                TestDeviceInfo.CreateABPDevice(1, gatewayID: this.ServerConfiguration.GatewayID),
+                frmCntUp: InitialDeviceFcntUp,
+                frmCntDown: InitialDeviceFcntDown);
+
+            var loraDevice = this.CreateLoRaDevice(simulatedDevice);
+
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .ReturnsAsync(true);
+
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+                .ReturnsAsync(true);
+
+            var c2d = new LoRaCloudToDeviceMessage()
+            {
+                Payload = c2dMessageContent,
+                MacCommands = new[]
+                {
+                    new DevStatusRequest(),
+                },
+                Fport = 1,
+            };
+
+            var cloudToDeviceMessage = c2d.CreateMessage();
+
+            this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+                .ReturnsAsync(cloudToDeviceMessage);
+
+            this.LoRaDeviceClient.Setup(x => x.RejectAsync(cloudToDeviceMessage))
+                .ReturnsAsync(true);
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageProcessor = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyProvider);
+
+            var payload = simulatedDevice.CreateConfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
+            var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
+            rxpk.Datr = customDatr;
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+            Assert.True(await request.WaitCompleteAsync());
+
+            // Expectations
+            // 1. Message was sent to IoT Hub
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+
+            // 2. Return is downstream message
+            Assert.NotNull(request.ResponseDownlink);
+            Assert.True(request.ProcessingSucceeded);
+            Assert.Single(this.PacketForwarder.DownlinkMessages);
+            var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
+            var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
+            payloadDataDown.PerformEncryption(loraDevice.AppSKey);
+
+            Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
+            Assert.False(payloadDataDown.IsConfirmed());
+            Assert.Equal(LoRaMessageType.UnconfirmedDataDown, payloadDataDown.LoRaMessageType);
+
+            // 3. Payload should be empty
+            Assert.True(payloadDataDown.Frmpayload.IsEmpty);
+
+            // 4. Frame counter up was updated
+            Assert.Equal(PayloadFcnt, loraDevice.FCntUp);
+
+            // 5. Frame counter down is updated
+            Assert.Equal(InitialDeviceFcntDown + 1, loraDevice.FCntDown);
+            Assert.Equal(InitialDeviceFcntDown + 1, payloadDataDown.GetFcnt());
+
+            // 6. Frame count has no pending changes
+            Assert.False(loraDevice.HasFrameCountChanges);
+
+            // 7. Mac commands should NOT be present in reply
+            // mac command is in fopts if there is a c2d message
+            Assert.True(payloadDataDown.Fopts.Span.IsEmpty);
+
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task Aaaaaaaaaaaaaaaargh(
+            bool isConfirmed,
+            bool hasMacInUpstream,
+            bool hasMacInC2D,
+            MessagePayloadSize msgPayloadSize,
+            bool isTooLongForUpstreamMacCommandInAnswer, // true: drop the upstream mac answer
+            bool isSendingInRx2,
+            [CombinatorialValues("SF12BW125", "SF11BW125", "SF10BW125", "SF9BW125", "SF8BW125", "SF7BW125", "SF7BW250")] string datr)
+        {
+            const int InitialDeviceFcntUp = 9;
+            const int InitialDeviceFcntDown = 20;
+
+            var simulatedDevice = new SimulatedDevice(
+                TestDeviceInfo.CreateABPDevice(1, gatewayID: this.ServerConfiguration.GatewayID),
+                frmCntUp: InitialDeviceFcntUp,
+                frmCntDown: InitialDeviceFcntDown);
+
+            var loraDevice = this.CreateLoRaDevice(simulatedDevice);
+
+            Rxpk rxpk = null;
+            string msgPayload = null;
+
+            if (isConfirmed)
+            {
+                if (hasMacInUpstream)
+                {
+                    // Cofirmed message with Mac command in upstream
+                    msgPayload = "02";
+                    var confirmedMessagePayload = simulatedDevice.CreateConfirmedDataUpMessage(msgPayload, isHexPayload: true, fport: 0);
+                    rxpk = confirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey, datr: datr).Rxpk[0];
+                }
+                else
+                {
+                    // Cofirmed message without Mac command in upstream
+                    msgPayload = "1234567890";
+                    var confirmedMessagePayload = simulatedDevice.CreateConfirmedDataUpMessage("1234");
+                    rxpk = confirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey, datr: datr).Rxpk[0];
+                }
+            }
+            else
+            {
+                if (hasMacInUpstream)
+                {
+                    // Uncofirmed message with Mac command in upstream
+                    msgPayload = "02";
+                    var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload, isHexPayload: true, fport: 0);
+                    rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey, datr: datr).Rxpk[0];
+                }
+                else
+                {
+                    // Uncofirmed message without Mac command in upstream
+                    msgPayload = "1234567890";
+                    var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload);
+                    rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey, datr: datr).Rxpk[0];
+                }
+            }
+
+            this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
+                .ReturnsAsync(true);
+
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
+                .ReturnsAsync(true);
+
+            var euRegion = RegionFactory.CreateEU868Region();
+            var c2dMessageMacCommand = new DevStatusRequest();
+            var c2dMessageMacCommandSize = hasMacInC2D ? c2dMessageMacCommand.Length : 0;
+            var upstreamMessageMacCommandSize = 0;
+            string expectedDownlinkDatr;
+            bool isTooLong = false;
+
+            if (hasMacInUpstream && !isTooLongForUpstreamMacCommandInAnswer)
+                upstreamMessageMacCommandSize = new LinkCheckAnswer(1, 1).Length;
+
+            if (isSendingInRx2)
+            {
+                expectedDownlinkDatr = euRegion.DRtoConfiguration[euRegion.RX2DefaultReceiveWindows.dr].configuration;
+                if (msgPayloadSize == MessagePayloadSize.TooLongForRx1 || msgPayloadSize == MessagePayloadSize.TooLongForRx2)
+                    isTooLong = true;
+            }
+            else
+            {
+                expectedDownlinkDatr = datr;
+                if (msgPayloadSize == MessagePayloadSize.TooLongForRx1)
+                    isTooLong = true;
+            }
+
+            var c2dPayloadSize = euRegion.GetMaxPayloadSize(expectedDownlinkDatr)
+                - upstreamMessageMacCommandSize
+                - c2dMessageMacCommandSize
+                + (isTooLong ? 1 : 0);
+
+            var c2dMsgPayload = this.GeneratePayload("123457890", (int)c2dPayloadSize);
+
+            var c2d = new LoRaCloudToDeviceMessage()
+            {
+                Payload = c2dMsgPayload,
+                Fport = 1,
+            };
+
+            if (hasMacInC2D)
+            {
+                c2d.MacCommands = new[] { c2dMessageMacCommand };
+            }
+
+            var cloudToDeviceMessage = c2d.CreateMessage();
+
+            if (isSendingInRx2)
+            {
+                this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+                    .ReturnsAsync(cloudToDeviceMessage, TimeSpan.FromSeconds(1));
+            }
+            else
+            {
+                this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
+                    .ReturnsAsync(cloudToDeviceMessage);
+            }
+
+            var shouldCompleteMessage = !isTooLong;
+            var shouldAbandonMessage = isSendingInRx2 && msgPayloadSize == MessagePayloadSize.TooLongForRx2;
+
+            if (shouldCompleteMessage)
+            {
+                this.LoRaDeviceClient.Setup(x => x.CompleteAsync(cloudToDeviceMessage))
+                    .ReturnsAsync(true);
+            }
+            else if (shouldAbandonMessage)
+            {
+                this.LoRaDeviceClient.Setup(x => x.AbandonAsync(cloudToDeviceMessage))
+                    .ReturnsAsync(true);
+            }
+            else
+            {
+                this.LoRaDeviceClient.Setup(x => x.RejectAsync(cloudToDeviceMessage))
+                    .ReturnsAsync(true);
+            }
+
+            var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
+
+            // Send to message processor
+            var messageProcessor = new MessageDispatcher(
+                this.ServerConfiguration,
+                deviceRegistry,
+                this.FrameCounterUpdateStrategyProvider);
+
+            var request = this.CreateWaitableRequest(rxpk);
+            messageProcessor.DispatchRequest(request);
+
+            // Expectations
+            // 1. Message was sent to IoT Hub
+            Assert.True(await request.WaitCompleteAsync());
+            Assert.True(request.ProcessingSucceeded);
+
+            var shouldHaveADownlink = isConfirmed || !isTooLong || hasMacInUpstream;
+
+            if (shouldHaveADownlink)
+            {
+                // 2. Return is downstream message
+                Assert.NotNull(request.ResponseDownlink);
+                Assert.Equal(expectedDownlinkDatr, request.ResponseDownlink.Txpk.Datr);
+
+                var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
+                var payloadDataDown = new LoRaPayloadData(Convert.FromBase64String(downlinkMessage.Txpk.Data));
+                payloadDataDown.PerformEncryption(loraDevice.AppSKey);
+
+                Assert.Equal(payloadDataDown.DevAddr.ToArray(), LoRaTools.Utils.ConversionHelper.StringToByteArray(loraDevice.DevAddr));
+                Assert.Equal(LoRaMessageType.UnconfirmedDataDown, payloadDataDown.LoRaMessageType);
+
+                // Confirmed or unconfirmed message
+                Assert.Equal(isConfirmed, payloadDataDown.IsConfirmed());
+
+                // Message too long, Payload should be empty
+                if (isTooLong)
+                {
+                    Assert.True(payloadDataDown.Frmpayload.IsEmpty);
+                }
+
+                // Message not too long, expected payload should be present
+                else
+                {
+                    Assert.Equal(
+                        Encoding.UTF8.GetString(payloadDataDown.Frmpayload.ToArray()),
+                        c2dMsgPayload);
+                }
+
+                // Expected Mac commands are present
+                var expectedMacCommandsCount = 0;
+
+                if (!isTooLong && hasMacInC2D)
+                    expectedMacCommandsCount++;
+                if (hasMacInUpstream && !isTooLongForUpstreamMacCommandInAnswer)
+                    expectedMacCommandsCount++;
+
+                Assert.Equal(expectedMacCommandsCount, payloadDataDown.MacCommands.Count);
+            }
+            else
+            {
+                Assert.Null(request.ResponseDownlink);
+            }
+
+            this.LoRaDeviceClient.VerifyAll();
+            this.LoRaDeviceApi.VerifyAll();
+        }
+
+        private string GeneratePayload(string allowedChars, int length)
+        {
+            Random random = new Random();
+
+            char[] chars = new char[length];
+            int setLength = allowedChars.Length;
+
+            for (int i = 0; i < length; ++i)
+            {
+                chars[i] = allowedChars[random.Next(setLength)];
+            }
+
+            return new string(chars, 0, length);
+        }
+
+        public enum MessagePayloadSize
+        {
+            Ok,
+            TooLongForRx1,
+            TooLongForRx2
+        }
+    }
+}

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
@@ -821,7 +821,7 @@ namespace LoRaWan.NetworkServer.Test
                 .ReturnsAsync(cloudToDeviceMessage)
                 .ReturnsAsync((Message)null); // 2nd cloud to device message does not return anything
 
-            this.LoRaDeviceClient.Setup(x => x.CompleteAsync(cloudToDeviceMessage))
+            this.LoRaDeviceClient.Setup(x => x.RejectAsync(cloudToDeviceMessage))
                 .ReturnsAsync(true);
 
             var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
@@ -11,6 +11,7 @@ namespace LoRaWan.NetworkServer.Test
     using System.Threading.Tasks;
     using LoRaTools;
     using LoRaTools.LoRaMessage;
+    using LoRaTools.LoRaPhysical;
     using LoRaTools.Regions;
     using LoRaTools.Utils;
     using LoRaWan.NetworkServer;
@@ -220,7 +221,7 @@ namespace LoRaWan.NetworkServer.Test
             Assert.Equal(InitialDeviceFcntDown + 1, loraDevice.FCntDown);
             Assert.Equal(InitialDeviceFcntDown + 1, payloadDataDown.GetFcnt());
 
-                        // 6. Frame count has pending changes?
+            // 6. Frame count has pending changes?
             if (needsToSaveFcnt)
                 Assert.False(loraDevice.HasFrameCountChanges);
             else


### PR DESCRIPTION
- Update ValidateCloudToDeviceMessage to verify if a message will fit in Rx1 or Rx2 considering possilbe user provided Rx2DataRate.
- Update DownlinkMessageBuilder.CreateDownlinkMessage to add C2D message payload and mac commands only if they fit in current receive window. If, after processing this, there is still enough space to add the uplink mac commands, they will be added as well. Fpending is set accordingly. This is done for Class A and Class C device messages.
- Update DefaultLoRaDataRequestHandler.ProcessRequestAsync to abandon or reject the message, if it is too long (for the current Rx or in general).
- Add GetMaxPayloadSize method to the LoRaRegion class.
- Add tests for all possible combinations and cases (causing success, abandon or reject for Class A devices, success or reject for Class C devices)
  - MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Tests
  - MessageProcessor_End2End_NoDep_ClassC_CloudToDeviceMessage_SizeLimit_Tests

Fixes AB#1119