### PR TITLE
Implement allowed dev addresses & resubmit decoders

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
+++ b/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Azure.Management.IotHub" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.22" />

--- a/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
+++ b/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.0" />
-    <PackageReference Include="Microsoft.Azure.Management.IotHub" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.22" />

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
@@ -99,16 +99,23 @@ namespace LoRaWan.NetworkServer
 
         bool IsValidNetId(LoRaPayloadData loRaPayload)
         {
+            // Check if the current dev addr is in our network id
+            byte devAddrNwkid = loRaPayload.GetDevAddrNetID();
+            var netIdBytes = BitConverter.GetBytes(this.configuration.NetId);
+            devAddrNwkid = (byte)(devAddrNwkid >> 1);
+            if (devAddrNwkid == (netIdBytes[0] & 0b01111111))
+            {
+                return true;
+            }
+
+            // If not, check if the devaddr is part of the allowed dev address list
             var currentDevAddr = ConversionHelper.ByteArrayToString(loRaPayload.DevAddr);
             if (this.configuration.AllowedDevAddresses != null && this.configuration.AllowedDevAddresses.Contains(currentDevAddr))
             {
                 return true;
             }
 
-            byte devAddrNwkid = loRaPayload.GetDevAddrNetID();
-            var netIdBytes = BitConverter.GetBytes(this.configuration.NetId);
-            devAddrNwkid = (byte)(devAddrNwkid >> 1);
-            return devAddrNwkid == (netIdBytes[0] & 0b01111111);
+            return false;
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.NetworkServer
 {
     using System;
+    using System.Collections.Generic;
     using LoRaTools.LoRaMessage;
     using LoRaTools.Regions;
     using LoRaTools.Utils;
@@ -86,7 +87,7 @@ namespace LoRaWan.NetworkServer
         void DispatchLoRaDataMessage(LoRaRequest request)
         {
             var loRaPayload = (LoRaPayloadData)request.Payload;
-            if (!this.IsValidNetId(loRaPayload.GetDevAddrNetID(), this.configuration.NetId))
+            if (!this.IsValidNetId(loRaPayload))
             {
                 Logger.Log(ConversionHelper.ByteArrayToString(loRaPayload.DevAddr), $"device is using another network id, ignoring this message (network: {this.configuration.NetId}, devAddr: {loRaPayload.GetDevAddrNetID()})", LogLevel.Debug);
                 request.NotifyFailed(null, LoRaDeviceRequestFailedReason.InvalidNetId);
@@ -96,9 +97,16 @@ namespace LoRaWan.NetworkServer
             this.deviceRegistry.GetLoRaRequestQueue(request).Queue(request);
         }
 
-        bool IsValidNetId(byte devAddrNwkid, uint netId)
+        bool IsValidNetId(LoRaPayloadData loRaPayload)
         {
-            var netIdBytes = BitConverter.GetBytes(netId);
+            var currentDevAddr = ConversionHelper.ByteArrayToString(loRaPayload.DevAddr);
+            if (this.configuration.AllowedDevAddresses != null && this.configuration.AllowedDevAddresses.Contains(currentDevAddr))
+            {
+                return true;
+            }
+
+            byte devAddrNwkid = loRaPayload.GetDevAddrNetID();
+            var netIdBytes = BitConverter.GetBytes(this.configuration.NetId);
             devAddrNwkid = (byte)(devAddrNwkid >> 1);
             return devAddrNwkid == (netIdBytes[0] & 0b01111111);
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -70,6 +70,11 @@ namespace LoRaWan.NetworkServer
         // Gets/sets gateway NetId
         public uint NetId { get; set; } = 1;
 
+        /// <summary>
+        /// Gets list of allowed dev addresses
+        /// </summary>
+        public HashSet<string> AllowedDevAddresses { get; internal set; }
+
         // Creates a new instance of NetworkServerConfiguration
         public NetworkServerConfiguration()
         {
@@ -101,6 +106,7 @@ namespace LoRaWan.NetworkServer
             config.LogToUdpAddress = envVars.GetEnvVar("LOG_TO_UDP_ADDRESS", string.Empty);
             config.LogToUdpPort = envVars.GetEnvVar("LOG_TO_UDP_PORT", config.LogToUdpPort);
             config.NetId = envVars.GetEnvVar("NETID", config.NetId);
+            config.AllowedDevAddresses = new HashSet<string>(envVars.GetEnvVar("AllowedDevAddresses", string.Empty).Split(";"));
 
             return config;
         }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/ConfigurationTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/ConfigurationTest.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWanNetworkServer.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using LoRaWan.NetworkServer;
+    using Xunit;
+    using Xunit.Extensions;
+
+    public class ConfigurationTest
+    {
+        [Theory]
+        [MemberData(nameof(AllowedDevAddressesInput))]
+        public void Should_Setup_Allowed_Dev_Addresses_Correctly(string inputAllowedDevAddrValues, HashSet<string> expectedAllowedDevAddrValues)
+        {
+            Environment.SetEnvironmentVariable("AllowedDevAddresses", inputAllowedDevAddrValues);
+            NetworkServerConfiguration networkServerConfiguration = NetworkServerConfiguration.CreateFromEnviromentVariables();
+            Assert.Equal(expectedAllowedDevAddrValues.Count, networkServerConfiguration.AllowedDevAddresses.Count);
+            foreach (string devAddr in expectedAllowedDevAddrValues)
+            {
+                Assert.Contains(devAddr, networkServerConfiguration.AllowedDevAddresses);
+            }
+        }
+
+        public static IEnumerable<object[]> AllowedDevAddressesInput
+        {
+            get
+            {
+                return new[]
+                {
+                    new object[]
+                    {
+                        "0228B1B1;", new HashSet<string>()
+                        {
+                            "0228B1B1", string.Empty
+                        }
+                    },
+                    new object[]
+                    {
+                        "0228B1B1;0228B1B2", new HashSet<string>()
+                        {
+                            "0228B1B1", "0228B1B2"
+                        }
+                    },
+                    new object[]
+                    {
+                        "ads;0228B1B2;", new HashSet<string>()
+                        {
+                            "ads", string.Empty, "0228B1B2"
+                        }
+                    }
+            };
+            }
+        }
+    }
+}

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
@@ -1279,8 +1279,8 @@ namespace LoRaWan.NetworkServer.Test
 
             deviceClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(simulatedDevice.CreateABPTwin());
 
-            deviceClient.Setup(x => x.DisconnectAsync())
-               .ReturnsAsync(true);
+            deviceClient.Setup(x => x.Disconnect())
+               .Returns(true);
 
             deviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                .ReturnsAsync((Message)null);


### PR DESCRIPTION
* Retransmitted messages in case of missed confirmed upstream will now correctly trigger decoder processing (fix [AB#1166](https://dev.azure.com/epicstuff/web/wi.aspx?pcguid=b4ad2b30-c669-4749-9c24-e42a8da5d35d&id=1166))
* Add possibility to specify some DevAddr to override the netId Check

This PR is ready for review, but some rebase is expected to keep up to date with dev
