### PR TITLE
Improvements to simulated device load tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -296,3 +296,5 @@ Doc
 appsettings.local.json
 Docs/.DS_Store
 .DS_Store
+
+Tools/Cli-LoRa-Device-Provisioning/settings\.local\.json

--- a/LoRaEngine/test/LoRaWan.SimulatedTest/IntegrationTestFixtureSim.cs
+++ b/LoRaEngine/test/LoRaWan.SimulatedTest/IntegrationTestFixtureSim.cs
@@ -27,18 +27,18 @@ namespace LoRaWan.SimulatedTest
             get { return this.deviceRange1000_ABP; }
         }
 
-        List<TestDeviceInfo> deviceRange1200_100_ABP = new List<TestDeviceInfo>();
+        List<TestDeviceInfo> deviceRange2000_500_ABP = new List<TestDeviceInfo>();
 
-        public IReadOnlyCollection<TestDeviceInfo> DeviceRange1200_100_ABP
+        public IReadOnlyCollection<TestDeviceInfo> DeviceRange2000_500_ABP
         {
-            get { return this.deviceRange1200_100_ABP; }
+            get { return this.deviceRange2000_500_ABP; }
         }
 
-        List<TestDeviceInfo> deviceRange1300_10_OTAA = new List<TestDeviceInfo>();
+        List<TestDeviceInfo> deviceRange3000_10_OTAA = new List<TestDeviceInfo>();
 
-        public IReadOnlyCollection<TestDeviceInfo> DeviceRange1300_10_OTAA
+        public IReadOnlyCollection<TestDeviceInfo> DeviceRange3000_10_OTAA
         {
-            get { return this.deviceRange1300_10_OTAA; }
+            get { return this.deviceRange3000_10_OTAA; }
         }
 
         public override void SetupTestDevices()
@@ -98,26 +98,27 @@ namespace LoRaWan.SimulatedTest
                     });
             }
 
-            // Range of 100 ABP devices from 1200 to 1299: Used for load testing
-            for (int deviceID = 1200; deviceID <= 1299; deviceID++)
+            // Range of 100 ABP devices from 2000 to 2499: Used for load testing
+            for (int deviceID = 2000; deviceID <= 2499; deviceID++)
             {
-                this.deviceRange1200_100_ABP.Add(
+                this.deviceRange2000_500_ABP.Add(
                     new TestDeviceInfo
                     {
                         DeviceID = deviceID.ToString("0000000000000000"),
                         GatewayID = gatewayID,
                         IsIoTHubDevice = true,
                         SensorDecoder = "DecoderValueSensor",
+                        KeepAliveTimeout = 60,
                         AppSKey = deviceID.ToString("00000000000000000000000000000000"),
                         NwkSKey = deviceID.ToString("00000000000000000000000000000000"),
                         DevAddr = deviceID.ToString("00000000"),
                     });
             }
 
-            // Range of 10 OTAA devices from 1300 to 1309: Used for load testing
-            for (int deviceID = 1300; deviceID <= 1309; deviceID++)
+            // Range of 10 OTAA devices from 3000 to 3009: Used for load testing
+            for (int deviceID = 3000; deviceID <= 3009; deviceID++)
             {
-                this.deviceRange1300_10_OTAA.Add(
+                this.deviceRange3000_10_OTAA.Add(
                     new TestDeviceInfo
                     {
                         DeviceID = deviceID.ToString("0000000000000000"),

--- a/LoRaEngine/test/LoRaWan.SimulatedTest/IntegrationTestFixtureSim.cs
+++ b/LoRaEngine/test/LoRaWan.SimulatedTest/IntegrationTestFixtureSim.cs
@@ -27,11 +27,11 @@ namespace LoRaWan.SimulatedTest
             get { return this.deviceRange1000_ABP; }
         }
 
-        List<TestDeviceInfo> deviceRange2000_500_ABP = new List<TestDeviceInfo>();
+        List<TestDeviceInfo> deviceRange2000_1000_ABP = new List<TestDeviceInfo>();
 
-        public IReadOnlyCollection<TestDeviceInfo> DeviceRange2000_500_ABP
+        public IReadOnlyCollection<TestDeviceInfo> DeviceRange2000_1000_ABP
         {
-            get { return this.deviceRange2000_500_ABP; }
+            get { return this.deviceRange2000_1000_ABP; }
         }
 
         List<TestDeviceInfo> deviceRange3000_10_OTAA = new List<TestDeviceInfo>();
@@ -98,17 +98,17 @@ namespace LoRaWan.SimulatedTest
                     });
             }
 
-            // Range of 100 ABP devices from 2000 to 2499: Used for load testing
-            for (int deviceID = 2000; deviceID <= 2499; deviceID++)
+            // Range of 1000 ABP devices from 2000 to 2999: Used for load testing
+            for (int deviceID = 2000; deviceID <= 2999; deviceID++)
             {
-                this.deviceRange2000_500_ABP.Add(
+                this.deviceRange2000_1000_ABP.Add(
                     new TestDeviceInfo
                     {
                         DeviceID = deviceID.ToString("0000000000000000"),
                         GatewayID = gatewayID,
                         IsIoTHubDevice = true,
                         SensorDecoder = "DecoderValueSensor",
-                        KeepAliveTimeout = 60,
+                        KeepAliveTimeout = 0,
                         AppSKey = deviceID.ToString("00000000000000000000000000000000"),
                         NwkSKey = deviceID.ToString("00000000000000000000000000000000"),
                         DevAddr = deviceID.ToString("00000000"),

--- a/LoRaEngine/test/LoRaWan.SimulatedTest/SimulatorTestCollection.cs
+++ b/LoRaEngine/test/LoRaWan.SimulatedTest/SimulatorTestCollection.cs
@@ -167,7 +167,8 @@ namespace LoRaWan.SimulatedTest
         public async Task Multiple_ABP_and_OTAA_Simulated_Devices_Unconfirmed()
         {
             // amount of devices to test with. Maximum is 89
-            int scenarioDeviceNumber = 20; // Default: 20
+            // Do go beyond 100 deviceClients in IoT Edge, use edgeHub env var 'MaxConnectedClients'
+            int scenarioDeviceNumber = 250; // Default: 20
 
             // amount of messages to send per device (without warm-up phase)
             int scenarioMessagesPerDevice = 10; // Default: 10
@@ -184,16 +185,22 @@ namespace LoRaWan.SimulatedTest
             // amount of Unconfirmed messges to send before Confirmed message is to occur
             int messagesBeforeConfirmed = 5; // Default: 5
 
+            // amount of seconds to wait between sends in warmup phase
+            int delayWarmup = 5 * 1000; // Default 5 * 1000
+
+            // amount of seconds to wait between sends in main phase
+            int delayMessageSending = 5 * 1000; // Default 5 * 1000
+
             // amount of miliseconds to wait before checking LoRaWanNetworkSrvModule
             // for successful sending of messages to IoT Hub.
             // delay for 100 devices: 2 * 60 * 1000
             // delay for 20 devices: 15 * 1000
-            int delayNetworkServerCheck = 15 * 1000;
+            int delayNetworkServerCheck = 30 * 60 * 1000;
 
             // amount of miliseconds to wait before checking of messages in IoT Hub
             // delay for 100 devices: 1 * 60 * 1000
             // delay for 20 devices: 15 * 1000
-            int delayIoTHubCheck = 15 * 1000;
+            int delayIoTHubCheck = 15 * 60 * 1000;
 
             // Get random number seed
             Random rnd = new Random();
@@ -201,9 +208,9 @@ namespace LoRaWan.SimulatedTest
 
             int count = 0;
             List<SimulatedDevice> listSimulatedDevices = new List<SimulatedDevice>();
-            foreach (TestDeviceInfo device in this.TestFixtureSim.DeviceRange1200_100_ABP)
+            foreach (TestDeviceInfo device in this.TestFixtureSim.DeviceRange2000_500_ABP)
             {
-                if (count < scenarioDeviceNumber && count < 100)
+                if (count < scenarioDeviceNumber)
                 {
                     SimulatedDevice simulatedDevice = new SimulatedDevice(device);
                     listSimulatedDevices.Add(simulatedDevice);
@@ -216,7 +223,7 @@ namespace LoRaWan.SimulatedTest
             int totalJoins = 0;
 
             List<SimulatedDevice> listSimulatedJoinDevices = new List<SimulatedDevice>();
-            foreach (TestDeviceInfo joinDevice in this.TestFixtureSim.DeviceRange1300_10_OTAA)
+            foreach (TestDeviceInfo joinDevice in this.TestFixtureSim.DeviceRange3000_10_OTAA)
             {
                 SimulatedDevice simulatedJoinDevice = new SimulatedDevice(joinDevice);
                 listSimulatedJoinDevices.Add(simulatedJoinDevice);
@@ -243,7 +250,7 @@ namespace LoRaWan.SimulatedTest
                     }
 
                     await Task.WhenAll(tasks);
-                    await Task.Delay(5000);
+                    await Task.Delay(delayWarmup);
 
                     i += warmUpDeviceStepSize;
                 }
@@ -296,7 +303,7 @@ namespace LoRaWan.SimulatedTest
                         }
 
                         await Task.WhenAll(tasks);
-                        await Task.Delay(5000);
+                        await Task.Delay(delayMessageSending);
 
                         i += scenarioDeviceStepSize;
                     }

--- a/LoRaEngine/test/LoRaWan.SimulatedTest/SimulatorTestCollection.cs
+++ b/LoRaEngine/test/LoRaWan.SimulatedTest/SimulatorTestCollection.cs
@@ -195,12 +195,12 @@ namespace LoRaWan.SimulatedTest
             // for successful sending of messages to IoT Hub.
             // delay for 100 devices: 2 * 60 * 1000
             // delay for 20 devices: 15 * 1000
-            int delayNetworkServerCheck = 30 * 60 * 1000;
+            int delayNetworkServerCheck = 15 * 60 * 1000;
 
             // amount of miliseconds to wait before checking of messages in IoT Hub
             // delay for 100 devices: 1 * 60 * 1000
             // delay for 20 devices: 15 * 1000
-            int delayIoTHubCheck = 15 * 60 * 1000;
+            int delayIoTHubCheck = 5 * 60 * 1000;
 
             // Get random number seed
             Random rnd = new Random();
@@ -208,7 +208,7 @@ namespace LoRaWan.SimulatedTest
 
             int count = 0;
             List<SimulatedDevice> listSimulatedDevices = new List<SimulatedDevice>();
-            foreach (TestDeviceInfo device in this.TestFixtureSim.DeviceRange2000_500_ABP)
+            foreach (TestDeviceInfo device in this.TestFixtureSim.DeviceRange2000_1000_ABP)
             {
                 if (count < scenarioDeviceNumber)
                 {

--- a/LoRaEngine/test/LoRaWan.Test.Shared/TestDeviceInfo.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/TestDeviceInfo.cs
@@ -98,8 +98,8 @@ namespace LoRaWan.Test.Shared
 
             desiredProperties[nameof(this.RXDelay)] = this.RXDelay;
 
-            if (this.KeepAliveTimeout > 0)
-                desiredProperties[nameof(this.KeepAliveTimeout)] = this.KeepAliveTimeout;
+            // if (this.KeepAliveTimeout > 0)
+            desiredProperties[nameof(this.KeepAliveTimeout)] = this.KeepAliveTimeout;
 
             return desiredProperties;
         }


### PR DESCRIPTION
- 500 simulated devices supported
- KeepAliveTimout property set in test clients
- Delay between message bursts is now configurable