### PR TITLE
Update ReadMe.md to reflect changes to the DecoderSample infrastructure

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/.vscode/launch.json
+++ b/LoRaEngine/LoraKeysManagerFacade/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Attach to C# Functions",
+      "name": "Attach to .NET Functions",
       "type": "coreclr",
       "request": "attach",
       "processId": "${command:azureFunctions.pickProcess}"

--- a/LoRaEngine/LoraKeysManagerFacade/.vscode/tasks.json
+++ b/LoRaEngine/LoraKeysManagerFacade/.vscode/tasks.json
@@ -32,13 +32,12 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "runFunctionsHost",
-      "type": "shell",
+      "type": "func",
       "dependsOn": "build",
       "options": {
         "cwd": "${workspaceFolder}/bin/Debug/netstandard2.0"
       },
-      "command": "func host start",
+      "command": "host start",
       "isBackground": true,
       "problemMatcher": "$func-watch"
     }

--- a/LoRaEngine/modules/LoRaWanPktFwdModule/global_conf.us.org.json
+++ b/LoRaEngine/modules/LoRaWanPktFwdModule/global_conf.us.org.json
@@ -1,0 +1,215 @@
+{
+    "SX1301_conf": {
+             "lorawan_public": true,
+        "clksrc": 1, /* radio_1 provides clock to concentrator */
+        "antenna_gain": 0, /* antenna gain, in dBi */
+        "radio_0": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 902700000,
+            "rssi_offset": -166.0,
+            "tx_enable": true,
+            "tx_freq_min": 902000000,
+            "tx_freq_max": 928000000
+        },
+        "radio_1": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 903400000,
+            "rssi_offset": -166.0,
+            "tx_enable": false
+        },
+        "chan_multiSF_0": {
+            /* Lora MAC channel, 125kHz, all SF, 902.3 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -400000
+        },
+        "chan_multiSF_1": {
+            /* Lora MAC channel, 125kHz, all SF, 902.5 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -200000
+        },
+        "chan_multiSF_2": {
+            /* Lora MAC channel, 125kHz, all SF, 902.7 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 0
+        },
+        "chan_multiSF_3": {
+            /* Lora MAC channel, 125kHz, all SF, 902.9 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 200000
+        },
+        "chan_multiSF_4": {
+            /* Lora MAC channel, 125kHz, all SF, 903.1 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -300000
+        },
+        "chan_multiSF_5": {
+            /* Lora MAC channel, 125kHz, all SF, 903.3 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -100000
+        },
+        "chan_multiSF_6": {
+            /* Lora MAC channel, 125kHz, all SF, 903.5 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 100000
+        },
+        "chan_multiSF_7": {
+            /* Lora MAC channel, 125kHz, all SF, 903.7 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 300000
+        },
+        "chan_Lora_std": {
+            /* Lora MAC channel, 500kHz, SF8, 903.0 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 300000,
+            "bandwidth": 500000,
+            "spread_factor": 8
+        },
+        "chan_FSK": {
+            /* FSK 100kbps channel, 903.0 MHz */
+            "enable": false,
+            "radio": 0,
+            "if": 300000,
+            "bandwidth": 250000,
+            "datarate": 100000
+        },
+                "tx_lut_0": {
+                        "desc": "TX gain table, index 0",
+                        "pa_gain": 0,
+                        "mix_gain": 8,
+                        "rf_power": -6,
+                        "dig_gain": 0
+                },
+                "tx_lut_1": {
+                        "desc": "TX gain table, index 1",
+                        "pa_gain": 0,
+                        "mix_gain": 10,
+                        "rf_power": -3,
+                        "dig_gain": 0
+                },
+                "tx_lut_2": {
+                        "desc": "TX gain table, index 2",
+                        "pa_gain": 0,
+                        "mix_gain": 12,
+                        "rf_power": 0,
+                        "dig_gain": 0
+                },
+                "tx_lut_3": {
+                        "desc": "TX gain table, index 3",
+                        "pa_gain": 1,
+                        "mix_gain": 8,
+                        "rf_power": 3,
+                        "dig_gain": 0
+                },
+                "tx_lut_4": {
+                        "desc": "TX gain table, index 4",
+                        "pa_gain": 1,
+                        "mix_gain": 10,
+                        "rf_power": 6,
+                        "dig_gain": 0
+                },
+                "tx_lut_5": {
+                        "desc": "TX gain table, index 5",
+                        "pa_gain": 1,
+                        "mix_gain": 12,
+                        "rf_power": 10,
+                        "dig_gain": 0
+                },
+                "tx_lut_6": {
+                        "desc": "TX gain table, index 6",
+                        "pa_gain": 1,
+                        "mix_gain": 13,
+                        "rf_power": 11,
+                        "dig_gain": 0
+                },
+                "tx_lut_7": {
+                        "desc": "TX gain table, index 7",
+                        "pa_gain": 2,
+                        "mix_gain": 9,
+                        "rf_power": 12,
+                        "dig_gain": 0
+                },
+                "tx_lut_8": {
+                        "desc": "TX gain table, index 8",
+                        "pa_gain": 1,
+                        "mix_gain": 15,
+                        "rf_power": 13,
+                        "dig_gain": 0
+                },
+                "tx_lut_9": {
+                        "desc": "TX gain table, index 9",
+                        "pa_gain": 2,
+                        "mix_gain": 10,
+                        "rf_power": 14,
+                        "dig_gain": 0
+                },
+                "tx_lut_10": {
+                        "desc": "TX gain table, index 10",
+                        "pa_gain": 2,
+                        "mix_gain": 11,
+                        "rf_power": 16,
+                        "dig_gain": 0
+                },
+                "tx_lut_11": {
+                        "desc": "TX gain table, index 11",
+                        "pa_gain": 3,
+                        "mix_gain": 9,
+                        "rf_power": 20,
+                        "dig_gain": 0
+                },
+                "tx_lut_12": {
+                        "desc": "TX gain table, index 12",
+                        "pa_gain": 3,
+                        "mix_gain": 10,
+                        "rf_power": 23,
+                        "dig_gain": 0
+                },
+                "tx_lut_13": {
+                        "desc": "TX gain table, index 13",
+                        "pa_gain": 3,
+                        "mix_gain": 11,
+                        "rf_power": 25,
+                        "dig_gain": 0
+                },
+                "tx_lut_14": {
+                        "desc": "TX gain table, index 14",
+                        "pa_gain": 3,
+                        "mix_gain": 12,
+                        "rf_power": 26,
+                        "dig_gain": 0
+                },
+                "tx_lut_15": {
+                        "desc": "TX gain table, index 15",
+                        "pa_gain": 3,
+                        "mix_gain": 14,
+                        "rf_power": 27,
+                        "dig_gain": 0
+                }
+    },
+
+    "gateway_conf": {
+        "gateway_ID": "AA555A0000000000",
+        /* change with default server address/ports, or overwrite in local_conf.json */
+        "server_address": "192.168.0.17",
+        "serv_port_up": 1680,
+        "serv_port_down": 1680,
+        /* adjust the following parameters for your network */
+        "keepalive_interval": 10,
+        "stat_interval": 30,
+        "push_timeout_ms": 100,
+        /* forward only valid packets */
+        "forward_crc_valid": true,
+        "forward_crc_error": false,
+        "forward_crc_disabled": false
+    }
+}

--- a/LoRaEngine/modules/LoRaWanPktFwdModule/global_conf.us.things.json
+++ b/LoRaEngine/modules/LoRaWanPktFwdModule/global_conf.us.things.json
@@ -1,0 +1,212 @@
+{
+	"SX1301_conf": {
+		"lorawan_public": true,
+		"clksrc": 1,
+		"clksrc_desc": "radio_1 provides clock to concentrator for most devices except MultiTech. For MultiTech set to 0.",
+		"antenna_gain": 0,
+		"antenna_gain_desc": "antenna gain, in dBi",
+		"radio_0": {
+			"enable": true,
+			"type": "SX1257",
+			"freq": 904300000,
+			"rssi_offset": -166.0,
+			"tx_enable": true,
+			"tx_freq_min": 923000000,
+			"tx_freq_max": 928000000
+		},
+		"radio_1": {
+			"enable": true,
+			"type": "SX1257",
+			"freq": 905000000,
+			"rssi_offset": -166.0,
+			"tx_enable": false
+		},
+		"chan_multiSF_0": {
+			"desc": "Lora MAC, 125kHz, all SF, 903.9 MHz",
+			"enable": true,
+			"radio": 0,
+			"if": -400000
+		},
+		"chan_multiSF_1": {
+			"desc": "Lora MAC, 125kHz, all SF, 904.1 MHz",
+			"enable": true,
+			"radio": 0,
+			"if": -200000
+		},
+		"chan_multiSF_2": {
+			"desc": "Lora MAC, 125kHz, all SF, 904.3 MHz",
+			"enable": true,
+			"radio": 0,
+			"if": 0
+		},
+		"chan_multiSF_3": {
+			"desc": "Lora MAC, 125kHz, all SF, 904.5 MHz",
+			"enable": true,
+			"radio": 0,
+			"if": 200000
+		},
+		"chan_multiSF_4": {
+			"desc": "Lora MAC, 125kHz, all SF, 904.7 MHz",
+			"enable": true,
+			"radio": 1,
+			"if": -300000
+		},
+		"chan_multiSF_5": {
+			"desc": "Lora MAC, 125kHz, all SF, 904.9 MHz",
+			"enable": true,
+			"radio": 1,
+			"if": -100000
+		},
+		"chan_multiSF_6": {
+			"desc": "Lora MAC, 125kHz, all SF, 905.1 MHz",
+			"enable": true,
+			"radio": 1,
+			"if": 100000
+		},
+		"chan_multiSF_7": {
+			"desc": "Lora MAC, 125kHz, all SF, 905.3 MHz",
+			"enable": true,
+			"radio": 1,
+			"if": 300000
+		},
+		"chan_Lora_std": {
+			"desc": "Lora MAC, 500kHz, SF8, 904.6 MHz",
+			"enable": true,
+			"radio": 0,
+			"if": 300000,
+			"bandwidth": 500000,
+			"spread_factor": 8
+		},
+		"chan_FSK": {
+			"desc": "disabled",
+			"enable": false
+		},
+		"tx_lut_0": {
+			"desc": "TX gain table, index 0",
+			"pa_gain": 0,
+			"mix_gain": 8,
+			"rf_power": -6,
+			"dig_gain": 0
+		},
+		"tx_lut_1": {
+			"desc": "TX gain table, index 1",
+			"pa_gain": 0,
+			"mix_gain": 10,
+			"rf_power": -3,
+			"dig_gain": 0
+		},
+		"tx_lut_2": {
+			"desc": "TX gain table, index 2",
+			"pa_gain": 0,
+			"mix_gain": 12,
+			"rf_power": 0,
+			"dig_gain": 0
+		},
+		"tx_lut_3": {
+			"desc": "TX gain table, index 3",
+			"pa_gain": 1,
+			"mix_gain": 8,
+			"rf_power": 3,
+			"dig_gain": 0
+		},
+		"tx_lut_4": {
+			"desc": "TX gain table, index 4",
+			"pa_gain": 1,
+			"mix_gain": 10,
+			"rf_power": 6,
+			"dig_gain": 0
+		},
+		"tx_lut_5": {
+			"desc": "TX gain table, index 5",
+			"pa_gain": 1,
+			"mix_gain": 12,
+			"rf_power": 10,
+			"dig_gain": 0
+		},
+		"tx_lut_6": {
+			"desc": "TX gain table, index 6",
+			"pa_gain": 1,
+			"mix_gain": 13,
+			"rf_power": 11,
+			"dig_gain": 0
+		},
+		"tx_lut_7": {
+			"desc": "TX gain table, index 7",
+			"pa_gain": 2,
+			"mix_gain": 9,
+			"rf_power": 12,
+			"dig_gain": 0
+		},
+		"tx_lut_8": {
+			"desc": "TX gain table, index 8",
+			"pa_gain": 1,
+			"mix_gain": 15,
+			"rf_power": 13,
+			"dig_gain": 0
+		},
+		"tx_lut_9": {
+			"desc": "TX gain table, index 9",
+			"pa_gain": 2,
+			"mix_gain": 10,
+			"rf_power": 14,
+			"dig_gain": 0
+		},
+		"tx_lut_10": {
+			"desc": "TX gain table, index 10",
+			"pa_gain": 2,
+			"mix_gain": 11,
+			"rf_power": 16,
+			"dig_gain": 0
+		},
+		"tx_lut_11": {
+			"desc": "TX gain table, index 11",
+			"pa_gain": 3,
+			"mix_gain": 9,
+			"rf_power": 20,
+			"dig_gain": 0
+		},
+		"tx_lut_12": {
+			"desc": "TX gain table, index 12",
+			"pa_gain": 3,
+			"mix_gain": 10,
+			"rf_power": 23,
+			"dig_gain": 0
+		},
+		"tx_lut_13": {
+			"desc": "TX gain table, index 13",
+			"pa_gain": 3,
+			"mix_gain": 11,
+			"rf_power": 25,
+			"dig_gain": 0
+		},
+		"tx_lut_14": {
+			"desc": "TX gain table, index 14",
+			"pa_gain": 3,
+			"mix_gain": 12,
+			"rf_power": 26,
+			"dig_gain": 0
+		},
+		"tx_lut_15": {
+			"desc": "TX gain table, index 15",
+			"pa_gain": 3,
+			"mix_gain": 14,
+			"rf_power": 27,
+			"dig_gain": 0
+		}
+	},
+    "gateway_conf": {
+        "gateway_ID": "AA555A0000000000",
+        /* change with default server address/ports, or overwrite in local_conf.json */
+        "server_address": "192.168.0.17",
+        "serv_port_up": 1680,
+        "serv_port_down": 1680,
+        /* adjust the following parameters for your network */
+        "keepalive_interval": 10,
+        "stat_interval": 30,
+        "push_timeout_ms": 100,
+        /* forward only valid packets */
+        "forward_crc_valid": true,
+        "forward_crc_error": false,
+        "forward_crc_disabled": false
+    }
+}

--- a/Samples/DecoderSample/Classes/LoraDecoders.cs
+++ b/Samples/DecoderSample/Classes/LoraDecoders.cs
@@ -4,6 +4,7 @@
 namespace SensorDecoderModule.Classes
 {
     using System;
+    using System.Collections.Generic;
     using System.Text;
     using Newtonsoft.Json;
 
@@ -49,6 +50,86 @@ namespace SensorDecoderModule.Classes
             // Return a JSON string containing the decoded data
             return JsonConvert.SerializeObject(resultObject);
 
+        }
+        private static readonly Dictionary<uint, string> ttnEvents_ = new Dictionary<uint, string> { {1, "setup"},  {2, "interval"}, {3, "motion"}, {4, "button"}};
+        private static string DecoderTheThingsNodeSensor(string devEUI, byte[] payload, uint fport) 
+        {
+
+            var eventName = ttnEvents_[fport];
+            var battery =  (payload[0] << 8) + payload[1];
+            var light = (payload[2] << 8) + payload[3];
+            var temperature = (payload[4] & 0x80) > 0 ?  Convert.ToDouble(((0xffff << 16) + (payload[4] << 8) + payload[5])) / 100 : Convert.ToDouble(((payload[4] << 8) + payload[5])) / 100;
+ 
+           var message =  $"{{\"event\": \"{eventName}\",\"battery\": {battery}, \"light\": {light}, \"temperature\": {temperature} }}";
+            //Logger.Log(message, Logger.LoggingLevel.Always);
+           return message;
+        }
+
+         private static string DecoderLansitecTemperatureHumiditySensor(string devEUI, byte[] payload, uint fport) 
+        {
+
+            var eventName = ttnEvents_[fport];
+            var battery =  (payload[0] << 8) + payload[1];
+            var light = (payload[2] << 8) + payload[3];
+            var temperature = (payload[4] & 0x80) > 0?  ((0xffff << 16) + (payload[4] << 8) + payload[5]) / 100 : ((payload[4] << 8) + payload[5]) / 100;
+ 
+           var message =  $"{{\"event\": \"{eventName}\",\"battery\": {battery}, \"light\": {light}, \"temperature\": {temperature} }}";
+            //Logger.Log(message, Logger.LoggingLevel.Always);
+           return message;
+        }
+
+        private static string DecoderDecentlabWaterLevelSensor(string devEUI, byte[] payload, uint fport) 
+        {
+            var bytes = payload;
+
+            var deviceId = (bytes[1] << 8) + bytes[2];
+            //var flags = ((bytes[3] << 8) + bytes[4]);
+
+            var integers = new List<int>();
+
+            // convert data to 16-bit integers
+            for (var i = 5; i < bytes.Length; i += 2)
+            {
+                integers.Add((bytes[i] << 8) + bytes[i + 1]);
+            }
+
+            var pressure = DecodePressure(integers[0]);
+            var temperature = DecodeTemperature(integers[1]);
+            var battery = DecodeBattery(integers[2]);
+
+            var message =  $"{{\"deviceId\": \"{deviceId}\",\"battery\": {battery}, \"pressure\": {pressure}, \"temperature\": {temperature} }}";
+            //Logger.Log(message, Logger.LoggingLevel.Always);
+           return message;
+        }
+
+        private static double DecodePressure(double datum)
+        {
+            return (datum - 16384) / 32768 * (1 - 0) + 0;
+        }
+
+        private static double DecodeTemperature(double datum)
+        {
+            return (datum - 384) / 64000 * 200 - 50;
+        }
+
+        private static double DecodeBattery(double datum)
+        {
+            //return datum / 1000;
+            return datum;
+        }
+  
+
+       private static string DecoderNetvoxTemperatureHumiditySensor(string devEUI, byte[] payload, uint fport) 
+        {
+             var bytes = payload;
+            
+            var hex = BitConverter.ToString(bytes);
+            var hexValues = hex.Split("-"); 
+            var battery = Convert.ToUInt16(hexValues[3], 16) * 100;
+            var temperature = Convert.ToInt16($"{hexValues[4]}{hexValues[5]}", 16) * 0.01;
+            var humidity = Convert.ToUInt16($"{hexValues[6]}{hexValues[7]}", 16) * 0.01;
+
+            return  $"{{\"battery\": {battery}, \"temperature\": {temperature}, \"humidity\": {humidity} }}";
         }
     }
 }

--- a/Samples/DecoderSample/ReadMe.md
+++ b/Samples/DecoderSample/ReadMe.md
@@ -7,17 +7,26 @@ This sample allows you to create and run your own LoRa message decoder in an ind
 
 To add a new decoder, simply copy or reuse  the sample ```DecoderValueSensor``` method from the ```LoraDecoders``` class in [LoraDecoder.cs](/Samples/DecoderSample/Classes/LoraDecoder.cs). You can name the method whatever you like and can create as many decoders as you need by adding new, individual methods to the ```LoraDecoders``` class.
 
-The payload sent to the decoder is passed as byte[] ```payload``` and uint ```fport```.
+The payload sent to the decoder is passed as string ```devEui```, byte[] ```payload``` and uint ```fport```.
 
 After writing the code that decodes your message, your method should return a **string containing valid JSON** containing the response to be sent upstream.
 
 ```cs
 internal static class LoraDecoders
 {
-    private static string DecoderValueSensor(byte[] payload, uint fport)
+    private static string DecoderValueSensor(string devEUI, byte[] payload, byte fport)
     {
-        var result = Encoding.ASCII.GetString(payload);
+        // EITHER: Convert a payload containing a string back to string format for further processing
+        var result = Encoding.UTF8.GetString(payload);
+
+        // OR: Convert a payload containing binary data to HEX string for further processing
+        var result_binary = ConversionHelper.ByteArrayToString(payload);
+
+        // Write code that decodes the payload here.
+
+        // Return a JSON string containing the decoded data
         return JsonConvert.SerializeObject(new { value = result });
+
     }
 }
 ```
@@ -38,13 +47,12 @@ For example, to test a payload of `ABCDE12345`, you:
 For the built-in sample decoder ```DecoderValueSensor``` with Visual Studio (Code)'s default settings this would be:
 
 ```
-http://localhost:5000/api/DecoderValueSensor?fport=1&payload=QUJDREUxMjM0NQ%3D%3D
+http://localhost:5000/api/DecoderValueSensor?devEui=0000000000000000&fport=1&payload=QUJDREUxMjM0NQ%3D%3D
 `````
-
 You can call your decoder at:
 
 ```
-http://localhost:yourPort/api/<decodername>?fport=<1>&payload=<QUJDREUxMjM0NQ%3D%3D>
+http://localhost:yourPort/api/<decodername>?devEui=0000000000000000&fport=<1>&payload=<QUJDREUxMjM0NQ%3D%3D>
 ```
 
 You should see the result as JSON string.
@@ -81,7 +89,7 @@ docker run --rm -it -p 8881:80 --name decodersample <container registry>/<image>
 You can then use a browser to navigate to:
 
 ```
-http://localhost:8881/api/DecoderValueSensor?fport=1&payload=QUJDREUxMjM0NQ%3D%3D
+http://localhost:8881/api/DecoderValueSensor?devEui=0000000000000000&fport=1&payload=QUJDREUxMjM0NQ%3D%3D
 ```
 
 ### Deploying to IoT Edge

--- a/Samples/DecoderSample/module.json
+++ b/Samples/DecoderSample/module.json
@@ -2,9 +2,9 @@
   "$schema-version": "0.0.1",
   "description": "",
   "image": {
-    "repository": "your.azurecr.io/sensordecodermodule",
+    "repository": "evolution.azurecr.io/sensordecodermodule",
     "tag": {
-      "version": "0.0.1",
+      "version": "1.3.2",
       "platforms": {
         "amd64": "./Dockerfile.amd64",
         "arm32v7": "./Dockerfile.arm32v7"


### PR DESCRIPTION
I updated the ReadMe file to reflect the changes made to the DecoderSample infrastructure.  Added devEui parameter and noted the change to the ```fport``` type from ```unit``` to ```byte```.  Note I was not able to replace this image to reflect the addition of the devEui parameter on the URL.

![image](https://user-images.githubusercontent.com/5280484/55267519-e6cb2100-523f-11e9-85f1-cf38b71dda09.png)

