### PR TITLE
fix server races in deviceache

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/CheckPreferredGateway/PreferredGatewayExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/CheckPreferredGateway/PreferredGatewayExecutionItem.cs
@@ -107,7 +107,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
 
             for (var i = 0; i < MAX_ATTEMPTS_TO_RESOLVE_PREFERRED_GATEWAY; i++)
             {
-                if (this.cacheStore.LockTake(preferredGatewayLockKey, computationId, TimeSpan.FromMilliseconds(200)))
+                if (await this.cacheStore.LockTakeAsync(preferredGatewayLockKey, computationId, TimeSpan.FromMilliseconds(200)))
                 {
                     try
                     {

--- a/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
@@ -60,7 +60,7 @@ namespace LoraKeysManagerFacade
 
             try
             {
-                var results = await this.GetDeviceList(devEUI, gatewayId, devNonce, devAddr);
+                var results = await this.GetDeviceList(devEUI, gatewayId, devNonce, devAddr, log);
                 string json = JsonConvert.SerializeObject(results);
                 return new OkObjectResult(json);
             }
@@ -68,48 +68,63 @@ namespace LoraKeysManagerFacade
             {
                 return new BadRequestObjectResult("UsedDevNonce");
             }
+            catch (JoinRefusedException ex)
+            {
+                log.LogDebug("Join refused: {msg}", ex.Message);
+                return new BadRequestObjectResult("JoinRefused: " + ex.Message);
+            }
             catch (ArgumentException ex)
             {
                 return new BadRequestObjectResult(ex.Message);
             }
         }
 
-        public async Task<List<IoTHubDeviceInfo>> GetDeviceList(string devEUI, string gatewayId, string devNonce, string devAddr)
+        public async Task<List<IoTHubDeviceInfo>> GetDeviceList(string devEUI, string gatewayId, string devNonce, string devAddr, ILogger log = null)
         {
             var results = new List<IoTHubDeviceInfo>();
 
             if (devEUI != null)
             {
                 // OTAA join
-                string cacheKey = devEUI + devNonce;
-                using (var deviceCache = new LoRaDeviceCache(this.cacheStore, devEUI, gatewayId, cacheKey))
+                using (var deviceCache = new LoRaDeviceCache(this.cacheStore, devEUI, gatewayId))
                 {
-                    if (deviceCache.HasValue())
+                    var joinInfo = await this.GetJoinInfoAsync(devEUI, gatewayId, log);
+
+                    var cacheKeyDevNonce = string.Concat(devEUI, ":", devNonce);
+                    var lockKeyDevNonce = string.Concat(cacheKeyDevNonce, ":joinlockdevnonce");
+
+                    if (await this.cacheStore.LockTakeAsync(lockKeyDevNonce, gatewayId, TimeSpan.FromSeconds(10)))
                     {
-                        throw new DeviceNonceUsedException();
-                    }
-
-                    if (deviceCache.TryToLock(cacheKey + "joinlock"))
-                    {
-                        if (deviceCache.HasValue())
+                        try
                         {
-                            throw new DeviceNonceUsedException();
-                        }
+                            var freshValue = this.cacheStore.StringSet(cacheKeyDevNonce, devNonce, TimeSpan.FromMinutes(5), onlyIfNotExists: true);
+                            if (!freshValue)
+                            {
+                                log?.LogDebug("dev nonce already used. Ignore request '{key}':{gwid}", devEUI, gatewayId);
+                                throw new DeviceNonceUsedException();
+                            }
 
-                        deviceCache.SetValue(devNonce, TimeSpan.FromMinutes(1));
-
-                        var device = await this.registryManager.GetDeviceAsync(devEUI);
-
-                        if (device != null)
-                        {
                             var iotHubDeviceInfo = new IoTHubDeviceInfo
                             {
                                 DevEUI = devEUI,
-                                PrimaryKey = device.Authentication.SymmetricKey.PrimaryKey
+                                PrimaryKey = joinInfo.PrimaryKey
                             };
+
                             results.Add(iotHubDeviceInfo);
 
-                            this.cacheStore.KeyDelete(devEUI);
+                            if (await deviceCache.TryToLockAsync())
+                            {
+                                this.cacheStore.KeyDelete(devEUI);
+                                log?.LogDebug("Removed key '{key}':{gwid}", devEUI, gatewayId);
+                            }
+                            else
+                            {
+                                log?.LogWarning("Failed to acquire lock for '{key}'", devEUI);
+                            }
+                        }
+                        finally
+                        {
+                            this.cacheStore.LockRelease(lockKeyDevNonce, gatewayId);
                         }
                     }
                     else
@@ -152,6 +167,62 @@ namespace LoraKeysManagerFacade
             }
 
             return results;
+        }
+
+        private async Task<JoinInfo> GetJoinInfoAsync(string devEUI, string gatewayId, ILogger log)
+        {
+            var cacheKeyJoinInfo = string.Concat(devEUI, ":joininfo");
+            var lockKeyJoinInfo = string.Concat(devEUI, ":joinlockjoininfo");
+            JoinInfo joinInfo = null;
+
+            if (await this.cacheStore.LockTakeAsync(lockKeyJoinInfo, gatewayId, TimeSpan.FromMinutes(5)))
+            {
+                try
+                {
+                    joinInfo = this.cacheStore.GetObject<JoinInfo>(cacheKeyJoinInfo);
+                    if (joinInfo == null)
+                    {
+                        joinInfo = new JoinInfo();
+
+                        var device = await this.registryManager.GetDeviceAsync(devEUI);
+                        if (device != null)
+                        {
+                            joinInfo.PrimaryKey = device.Authentication.SymmetricKey.PrimaryKey;
+                            var twin = await this.registryManager.GetTwinAsync(devEUI);
+                            const string GatewayIdProperty = "GatewayID";
+                            if (twin.Properties.Desired.Contains(GatewayIdProperty))
+                            {
+                                joinInfo.DesiredGateway = twin.Properties.Desired[GatewayIdProperty].Value as string;
+                            }
+                        }
+
+                        this.cacheStore.ObjectSet(cacheKeyJoinInfo, joinInfo, TimeSpan.FromMinutes(60));
+                        log?.LogDebug("updated cache with join info '{key}':{gwid}", devEUI, gatewayId);
+                    }
+
+                    if (string.IsNullOrEmpty(joinInfo.PrimaryKey))
+                    {
+                        throw new JoinRefusedException("Not in our network.");
+                    }
+
+                    if (!string.IsNullOrEmpty(joinInfo.DesiredGateway) && gatewayId != joinInfo.DesiredGateway)
+                    {
+                        throw new JoinRefusedException("Not the owning gateway");
+                    }
+
+                    log?.LogDebug("got LogInfo '{key}':{gwid} attached gw: {desiredgw}", devEUI, gatewayId, joinInfo.DesiredGateway);
+                }
+                finally
+                {
+                    var released = this.cacheStore.LockRelease(lockKeyJoinInfo, gatewayId);
+                }
+            }
+            else
+            {
+                throw new JoinRefusedException("Failed to acquire lock for joininfo");
+            }
+
+            return joinInfo;
         }
     }
 }

--- a/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
@@ -49,6 +49,7 @@ namespace LoraKeysManagerFacade
             builder.Services.AddSingleton<IFunctionBundlerExecutionItem, DeduplicationExecutionItem>();
             builder.Services.AddSingleton<IFunctionBundlerExecutionItem, ADRExecutionItem>();
             builder.Services.AddSingleton<IFunctionBundlerExecutionItem, PreferredGatewayExecutionItem>();
+            builder.Services.AddSingleton<IFunctionBundlerExecutionItem, ResetDeviceCacheExecutionItem>();
         }
 
         abstract class ConfigHandler

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/DeduplicationExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/DeduplicationExecutionItem.cs
@@ -73,7 +73,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
                     {
                         // initialize
                         isDuplicate = false;
-                        var state = deviceCache.Initialize(clientFCntUp, clientFCntDown);
+                        deviceCache.Initialize(clientFCntUp, clientFCntDown);
                     }
                 }
             }

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerFunction.cs
@@ -29,7 +29,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
         [FunctionName("FunctionBundler")]
         public async Task<IActionResult> FunctionBundlerImpl(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "FunctionBundler/{devEUI}")]HttpRequest req,
-            ILogger log,
+            ILogger logger,
             string devEUI)
         {
             try
@@ -50,14 +50,14 @@ namespace LoraKeysManagerFacade.FunctionBundler
             }
 
             var functionBundlerRequest = JsonConvert.DeserializeObject<FunctionBundlerRequest>(requestBody);
-            var result = await this.HandleFunctionBundlerInvoke(devEUI, functionBundlerRequest);
+            var result = await this.HandleFunctionBundlerInvoke(devEUI, functionBundlerRequest, logger);
 
             return new OkObjectResult(result);
         }
 
-        public async Task<FunctionBundlerResult> HandleFunctionBundlerInvoke(string devEUI, FunctionBundlerRequest request)
+        public async Task<FunctionBundlerResult> HandleFunctionBundlerInvoke(string devEUI, FunctionBundlerRequest request, ILogger logger = null)
         {
-            var pipeline = new FunctionBundlerPipelineExecuter(this.executionItems, devEUI, request);
+            var pipeline = new FunctionBundlerPipelineExecuter(this.executionItems, devEUI, request, logger);
             return await pipeline.Execute();
         }
     }

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerPipelineExecuter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerPipelineExecuter.cs
@@ -6,6 +6,8 @@ namespace LoraKeysManagerFacade.FunctionBundler
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using LoRaTools.CommonAPI;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
 
     public class FunctionBundlerPipelineExecuter : IPipelineExecutionContext
     {
@@ -17,14 +19,18 @@ namespace LoraKeysManagerFacade.FunctionBundler
 
         public FunctionBundlerResult Result { get; private set; } = new FunctionBundlerResult();
 
+        public ILogger Logger { get; private set; }
+
         public FunctionBundlerPipelineExecuter(
                                                IFunctionBundlerExecutionItem[] registeredHandlers,
                                                string devEUI,
-                                               FunctionBundlerRequest request)
+                                               FunctionBundlerRequest request,
+                                               ILogger logger = null)
         {
             this.registeredHandlers = registeredHandlers;
             this.DevEUI = devEUI;
             this.Request = request;
+            this.Logger = logger ?? NullLogger.Instance;
         }
 
         public async Task<FunctionBundlerResult> Execute()

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/IPipelineExecutionContext.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/IPipelineExecutionContext.cs
@@ -5,6 +5,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
 {
     using System.Collections.Generic;
     using LoRaTools.CommonAPI;
+    using Microsoft.Extensions.Logging;
 
     public interface IPipelineExecutionContext
     {
@@ -13,5 +14,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
         FunctionBundlerRequest Request { get; }
 
         FunctionBundlerResult Result { get; }
+
+        ILogger Logger { get; }
     }
 }

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/NextFCntDownExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/NextFCntDownExecutionItem.cs
@@ -15,15 +15,15 @@ namespace LoraKeysManagerFacade.FunctionBundler
             this.fCntCacheCheck = fCntCacheCheck;
         }
 
-        public Task<FunctionBundlerExecutionState> ExecuteAsync(IPipelineExecutionContext context)
+        public async Task<FunctionBundlerExecutionState> ExecuteAsync(IPipelineExecutionContext context)
         {
             if (!context.Result.NextFCntDown.HasValue)
             {
-                var next = this.fCntCacheCheck.GetNextFCntDown(context.DevEUI, context.Request.GatewayId, context.Request.ClientFCntUp, context.Request.ClientFCntDown);
+                var next = await this.fCntCacheCheck.GetNextFCntDownAsync(context.DevEUI, context.Request.GatewayId, context.Request.ClientFCntUp, context.Request.ClientFCntDown);
                 context.Result.NextFCntDown = next > 0 ? next : (uint?)null;
             }
 
-            return Task.FromResult(FunctionBundlerExecutionState.Continue);
+            return FunctionBundlerExecutionState.Continue;
         }
 
         public int Priority => 3;

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/ResetDeviceCacheExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/ResetDeviceCacheExecutionItem.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoraKeysManagerFacade.FunctionBundler
+{
+    using System.Threading.Tasks;
+    using LoRaTools.ADR;
+    using LoRaTools.CommonAPI;
+    using Microsoft.Extensions.Logging;
+
+    public class ResetDeviceCacheExecutionItem : IFunctionBundlerExecutionItem
+    {
+        private readonly ILoRaDeviceCacheStore deviceCacheStore;
+
+        public ResetDeviceCacheExecutionItem(ILoRaDeviceCacheStore deviceCacheStore)
+        {
+            this.deviceCacheStore = deviceCacheStore;
+        }
+
+        public Task<FunctionBundlerExecutionState> ExecuteAsync(IPipelineExecutionContext context)
+        {
+            using (var deviceCache = new LoRaDeviceCache(this.deviceCacheStore, context.DevEUI, context.Request.GatewayId))
+            {
+                if (deviceCache.TryToLock())
+                {
+                    deviceCache.ClearCache();
+                }
+                else
+                {
+                    context.Logger.LogWarning("Failed to get lock for cache reset");
+                }
+            }
+
+            return Task.FromResult(FunctionBundlerExecutionState.Continue);
+        }
+
+        public int Priority => 0;
+
+        public bool NeedsToExecute(FunctionBundlerItemType item)
+        {
+            return (item & FunctionBundlerItemType.ResetDeviceCache) == FunctionBundlerItemType.ResetDeviceCache;
+        }
+
+        public Task OnAbortExecutionAsync(IPipelineExecutionContext context)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/ResetDeviceCacheExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/ResetDeviceCacheExecutionItem.cs
@@ -17,13 +17,14 @@ namespace LoraKeysManagerFacade.FunctionBundler
             this.deviceCacheStore = deviceCacheStore;
         }
 
-        public Task<FunctionBundlerExecutionState> ExecuteAsync(IPipelineExecutionContext context)
+        public async Task<FunctionBundlerExecutionState> ExecuteAsync(IPipelineExecutionContext context)
         {
             using (var deviceCache = new LoRaDeviceCache(this.deviceCacheStore, context.DevEUI, context.Request.GatewayId))
             {
-                if (deviceCache.TryToLock())
+                if (await deviceCache.TryToLockAsync())
                 {
                     deviceCache.ClearCache();
+                    context.Logger.LogDebug("Cleared the device cache");
                 }
                 else
                 {
@@ -31,7 +32,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
                 }
             }
 
-            return Task.FromResult(FunctionBundlerExecutionState.Continue);
+            return FunctionBundlerExecutionState.Continue;
         }
 
         public int Priority => 0;

--- a/LoRaEngine/LoraKeysManagerFacade/ILoRaDeviceCacheStore.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ILoRaDeviceCacheStore.cs
@@ -16,6 +16,8 @@ namespace LoraKeysManagerFacade
 
         bool KeyDelete(string key);
 
+        bool KeyExists(string key);
+
         bool LockRelease(string key, string value);
 
         long ListAdd(string key, string value, TimeSpan? expiry = null);

--- a/LoRaEngine/LoraKeysManagerFacade/ILoRaDeviceCacheStore.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ILoRaDeviceCacheStore.cs
@@ -5,14 +5,29 @@ namespace LoraKeysManagerFacade
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     public interface ILoRaDeviceCacheStore
     {
-        bool LockTake(string key, string value, TimeSpan timeout);
+        /// <summary>
+        /// Tries to acquire a lock for a specific key.
+        /// </summary>
+        /// <param name="key">The lock key to try to acquire</param>
+        /// <param name="owner">The lock owner</param>
+        /// <param name="expiration">expiration timestamp, this specifies how long the lock will be held before automatically releasing</param>
+        /// <param name="block">true to retry getting the lock in contention cases, false to try once and return the result</param>
+        /// <returns>true if the lock was acquired otherwise false.</returns>
+        Task<bool> LockTakeAsync(string key, string owner, TimeSpan expiration, bool block = false);
 
         string StringGet(string key);
 
-        bool StringSet(string key, string value, TimeSpan? expiry, bool onlyIfNotExists = false);
+        T GetObject<T>(string key)
+            where T : class;
+
+        bool StringSet(string key, string value, TimeSpan? expiration, bool onlyIfNotExists = false);
+
+        bool ObjectSet<T>(string key, T value, TimeSpan? expiration, bool onlyIfNotExists = false)
+            where T : class;
 
         bool KeyDelete(string key);
 
@@ -20,7 +35,7 @@ namespace LoraKeysManagerFacade
 
         bool LockRelease(string key, string value);
 
-        long ListAdd(string key, string value, TimeSpan? expiry = null);
+        long ListAdd(string key, string value, TimeSpan? expiration = null);
 
         IReadOnlyList<string> ListGet(string key);
     }

--- a/LoRaEngine/LoraKeysManagerFacade/JoinInfo.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/JoinInfo.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoraKeysManagerFacade
+{
+    public class JoinInfo
+    {
+        public string PrimaryKey { get; set; }
+
+        public string DesiredGateway { get; set; }
+    }
+}

--- a/LoRaEngine/LoraKeysManagerFacade/JoinRefusedException.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/JoinRefusedException.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoraKeysManagerFacade
+{
+    using System;
+
+    public class JoinRefusedException : Exception
+    {
+        public JoinRefusedException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaADRFunction/LoRaADRServerManager.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaADRFunction/LoRaADRServerManager.cs
@@ -17,10 +17,10 @@ namespace LoraKeysManagerFacade
             this.deviceCacheStore = deviceCacheStore;
         }
 
-        public override Task<uint> NextFCntDown(string devEUI, string gatewayId, uint clientFCntUp, uint clientFCntDown)
+        public override async Task<uint> NextFCntDown(string devEUI, string gatewayId, uint clientFCntUp, uint clientFCntDown)
         {
             var fcntCheck = new FCntCacheCheck(this.deviceCacheStore);
-            return Task.FromResult(fcntCheck.GetNextFCntDown(devEUI, gatewayId, clientFCntUp, clientFCntDown));
+            return await fcntCheck.GetNextFCntDownAsync(devEUI, gatewayId, clientFCntUp, clientFCntDown);
         }
     }
 }

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCache.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCache.cs
@@ -4,7 +4,6 @@
 namespace LoraKeysManagerFacade
 {
     using System;
-    using Microsoft.Azure.WebJobs;
     using Newtonsoft.Json;
 
     public sealed class LoRaDeviceCache : IDisposable
@@ -78,6 +77,11 @@ namespace LoraKeysManagerFacade
             return value != null;
         }
 
+        public bool Exists()
+        {
+            return this.cacheStore.KeyExists(this.cacheKey);
+        }
+
         public bool HasValue()
         {
             return this.cacheStore.StringGet(this.cacheKey) != null;
@@ -98,10 +102,10 @@ namespace LoraKeysManagerFacade
             return info != null;
         }
 
-        public void StoreInfo(DeviceCacheInfo info)
+        public bool StoreInfo(DeviceCacheInfo info)
         {
             this.EnsureLockOwner();
-            this.cacheStore.StringSet(this.cacheKey, JsonConvert.SerializeObject(info), new TimeSpan(30, 0, 0, 0));
+            return this.cacheStore.StringSet(this.cacheKey, JsonConvert.SerializeObject(info), new TimeSpan(30, 0, 0, 0));
         }
 
         public void SetValue(string value, TimeSpan? expiry = null)
@@ -113,6 +117,12 @@ namespace LoraKeysManagerFacade
             }
 
             this.cacheStore.StringSet(this.cacheKey, value, expiry);
+        }
+
+        public void ClearCache()
+        {
+            this.EnsureLockOwner();
+            this.cacheStore.KeyDelete(this.cacheKey);
         }
 
         private void EnsureLockOwner()

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCache.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCache.cs
@@ -4,12 +4,13 @@
 namespace LoraKeysManagerFacade
 {
     using System;
+    using System.Threading.Tasks;
     using Newtonsoft.Json;
 
     public sealed class LoRaDeviceCache : IDisposable
     {
         private const string CacheKeyLockSuffix = "msglock";
-        private static readonly TimeSpan LockWaitingTimeout = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan LockExpiry = TimeSpan.FromSeconds(10);
 
         private readonly ILoRaDeviceCacheStore cacheStore;
         private readonly string gatewayId;
@@ -20,7 +21,7 @@ namespace LoraKeysManagerFacade
 
         private string lockKey;
 
-        public LoRaDeviceCache(ILoRaDeviceCacheStore cacheStore, string devEUI, string gatewayId, string cacheKey = null)
+        public LoRaDeviceCache(ILoRaDeviceCacheStore cacheStore, string devEUI, string gatewayId)
         {
             if (string.IsNullOrEmpty(devEUI))
             {
@@ -35,27 +36,28 @@ namespace LoraKeysManagerFacade
             this.cacheStore = cacheStore;
             this.devEUI = devEUI;
             this.gatewayId = gatewayId;
-            this.cacheKey = cacheKey ?? devEUI;
+            this.cacheKey = devEUI;
         }
 
-        public bool TryToLock(string lockKey = null)
+        public async Task<bool> TryToLockAsync(string lockKey = null, bool block = true)
         {
             if (this.IsLockOwner)
             {
                 return true;
             }
 
-            this.lockKey = lockKey ?? this.devEUI + CacheKeyLockSuffix;
-            if (!this.cacheStore.LockTake(this.lockKey, this.gatewayId, LockWaitingTimeout))
+            var lk = lockKey ?? this.devEUI + CacheKeyLockSuffix;
+
+            if (this.IsLockOwner = await this.cacheStore.LockTakeAsync(lk, this.gatewayId, LockExpiry, block))
             {
-                return false;
+                // store the used key
+                this.lockKey = lk;
             }
 
-            this.IsLockOwner = true;
-            return true;
+            return this.IsLockOwner;
         }
 
-        public DeviceCacheInfo Initialize(uint fCntUp = 0, uint fCntDown = 0)
+        public bool Initialize(uint fCntUp = 0, uint fCntDown = 0)
         {
             // it is the first message from this device
             var serverStateForDeviceInfo = new DeviceCacheInfo
@@ -65,8 +67,7 @@ namespace LoraKeysManagerFacade
                 GatewayId = this.gatewayId
             };
 
-            this.StoreInfo(serverStateForDeviceInfo);
-            return serverStateForDeviceInfo;
+            return this.StoreInfo(serverStateForDeviceInfo, true);
         }
 
         public bool TryGetValue(out string value)
@@ -92,20 +93,14 @@ namespace LoraKeysManagerFacade
             info = null;
             this.EnsureLockOwner();
 
-            string cachedFCnt = this.cacheStore.StringGet(this.cacheKey);
-            if (string.IsNullOrEmpty(cachedFCnt))
-            {
-                return false;
-            }
-
-            info = JsonConvert.DeserializeObject<DeviceCacheInfo>(cachedFCnt);
+            info = this.cacheStore.GetObject<DeviceCacheInfo>(this.cacheKey);
             return info != null;
         }
 
-        public bool StoreInfo(DeviceCacheInfo info)
+        public bool StoreInfo(DeviceCacheInfo info, bool initialize = false)
         {
             this.EnsureLockOwner();
-            return this.cacheStore.StringSet(this.cacheKey, JsonConvert.SerializeObject(info), new TimeSpan(30, 0, 0, 0));
+            return this.cacheStore.StringSet(this.cacheKey, JsonConvert.SerializeObject(info), new TimeSpan(1, 0, 0, 0), initialize);
         }
 
         public void SetValue(string value, TimeSpan? expiry = null)

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCacheRedisStore.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCacheRedisStore.cs
@@ -29,15 +29,20 @@ namespace LoraKeysManagerFacade
             return this.redisCache.StringGet(key, CommandFlags.DemandMaster);
         }
 
-        public bool StringSet(string key, string value, TimeSpan? expiry, bool onlyIfNotExists)
+        public bool StringSet(string key, string value, TimeSpan? expiry, bool onlyIfNotExists = false)
         {
             var when = onlyIfNotExists ? When.NotExists : When.Always;
             return this.redisCache.StringSet(key, value, expiry, when, CommandFlags.DemandMaster);
         }
 
+        public bool KeyExists(string key)
+        {
+            return this.redisCache.KeyExists(key, CommandFlags.DemandMaster);
+        }
+
         public bool KeyDelete(string key)
         {
-            return this.redisCache.KeyDelete(key);
+            return this.redisCache.KeyDelete(key, CommandFlags.DemandMaster);
         }
 
         public bool LockRelease(string key, string value)

--- a/LoRaEngine/deployment.test.secondary.template.json
+++ b/LoRaEngine/deployment.test.secondary.template.json
@@ -1,0 +1,175 @@
+{
+  "moduleContent": {
+    "$edgeAgent": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "runtime": {
+          "type": "docker",
+          "settings": {
+            "minDockerVersion": "v1.25",
+            "loggingOptions": "",
+            "registryCredentials": {
+              "$CONTAINER_REGISTRY_USERNAME": {
+                "username": "$CONTAINER_REGISTRY_USERNAME",
+                "password": "$CONTAINER_REGISTRY_PASSWORD",
+                "address": "$CONTAINER_REGISTRY_ADDRESS"
+              }
+            }
+          }
+        },
+        "systemModules": {
+          "edgeAgent": {
+            "type": "docker",
+            "settings": {
+              "image": "mcr.microsoft.com/azureiotedge-agent:$EDGE_AGENT_VERSION",
+              "createOptions": ""
+            }
+          },
+          "edgeHub": {
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "settings": {
+              "image": "mcr.microsoft.com/azureiotedge-hub:$EDGE_HUB_VERSION",
+              "createOptions": {
+                "HostConfig": {
+                  "PortBindings": {
+                    "8883/tcp": [
+                      {
+                        "HostPort": "8883"
+                      }
+                    ],
+                    "443/tcp": [
+                      {
+                        "HostPort": "443"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "env": {
+              "OptimizeForPerformance": {
+                "value": "$EDGEHUB_OPTIMIZEFORPERFORMANCE"
+              },
+              "mqttSettings__enabled": {
+                "value": "$EDGEHUB_MQTTSETTINGS_ENABLED"
+              },
+              "httpSettings__enabled": {
+                "value": "$EDGEHUB_HTTPSETTINGS_ENABLED"
+              },
+              "TwinManagerVersion": {
+                "value": "v2"
+              },
+              "LORA_BUILD_ID": {
+                "value": "$BUILD_BUILDID"
+              }
+            }
+          }
+        },
+        "modules": {
+          "LoRaWanNetworkSrvModule": {
+            "type": "docker",
+            "settings": {
+              "image": "${MODULES.LoRaWanNetworkSrvModule}",
+              "createOptions": {
+                "ExposedPorts": {
+                  "1680/udp": {}
+                },
+                "HostConfig": {
+                  "PortBindings": {
+                    "1680/udp": [
+                      {
+                        "HostPort": "1680",
+                        "HostIp": "172.17.0.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "version": "1.0",
+            "env": {
+              "LOG_LEVEL": {
+                "value": "$NET_SRV_LOG_LEVEL"
+              },
+              "LOG_TO_HUB": {
+                "value": "$NET_SRV_LOGTO_HUB"
+              },
+              "LOG_TO_UDP": {
+                "value": "$NET_SRV_LOGTO_UDP"
+              },
+              "IOTEDGE_TIMEOUT": {
+                "value": "$NET_SRV_IOTEDGE_TIMEOUT"
+              },
+              "LOG_TO_UDP_ADDRESS": {
+                "value": "$NET_SRV_LOG_TO_UDP_ADDRESS"
+              }
+            },
+            "status": "running",
+            "restartPolicy": "always"
+          },
+          "LoRaWanPktFwdModule": {
+            "type": "docker",
+            "settings": {
+              "image": "${MODULES.LoRaWanPktFwdModule}",
+              "createOptions": {
+                "HostConfig": {
+                  "NetworkMode": "host",
+                  "Privileged": true
+                },
+                "NetworkingConfig": {
+                  "EndpointsConfig": {
+                    "host": {}
+                  }
+                }
+              }
+            },
+            "env": {
+              "RESET_PIN": {
+                "value": "$RESET_PIN"
+              },
+              "REGION": {
+                "value": "$REGION"
+              },
+              "PKT_FWD_SPI_DEV":{
+                "value":"$SPI_DEV"
+              }
+            },
+            "version": "1.0",
+            "status": "running",
+            "restartPolicy": "always"
+          },
+          "sensordecodermodule": {
+            "type": "docker",
+            "settings": {
+              "image": "$CONTAINER_REGISTRY_ADDRESS/decodersample:2.0",
+              "createOptions": {}
+            },
+            "status": "running",
+            "restartPolicy": "always",
+            "version": "1.0"
+          }
+        }
+      }
+    },
+    "$edgeHub": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "routes": {
+          "route": "$EDGEHUB_ROUTE"
+        },
+        "storeAndForwardConfiguration": {
+          "timeToLiveSecs": 7200
+        }
+      }
+    },
+    "LoRaWanNetworkSrvModule": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "FacadeServerUrl": "$FACADE_SERVER_URL",
+        "FacadeAuthCode": "$FACADE_AUTH_CODE"
+      }
+    }
+  }
+}

--- a/LoRaEngine/deployment.test.secondary.template.json
+++ b/LoRaEngine/deployment.test.secondary.template.json
@@ -103,7 +103,7 @@
                 "value": "$NET_SRV_IOTEDGE_TIMEOUT"
               },
               "LOG_TO_UDP_ADDRESS": {
-                "value": "$NET_SRV_LOG_TO_UDP_ADDRESS"
+                "value": "$BUILD_AGENT_IP"
               }
             },
             "status": "running",

--- a/LoRaEngine/deployment.test.template.json
+++ b/LoRaEngine/deployment.test.template.json
@@ -149,7 +149,15 @@
               "image": "$DEVOPS_AGENT_IMAGE",
               "createOptions": {
                 "HostConfig": {
-                  "Privileged": true
+                  "Privileged": true,
+                  "PublishAllPorts": true,
+                  "PortBindings": {
+                    "6000/udp": [
+                      {
+                        "HostPort": "6000"
+                      }
+                    ]
+                  }
                 },
                 "ExposedPorts": {
                   "6000/udp": {}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApiVersion.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApiVersion.cs
@@ -25,7 +25,7 @@ namespace LoRaWan.Shared
         /// Gets the latest version released.
         /// Update this once a new API version is released
         /// </summary>
-        public static ApiVersion LatestVersion => Version_2019_03_26;
+        public static ApiVersion LatestVersion => Version_2019_04_02;
 
         /// <summary>
         /// Gets the Version from 0.1 and 0.2 had not versioning information
@@ -65,6 +65,12 @@ namespace LoRaWan.Shared
         public static ApiVersion Version_2019_03_26 { get; }
 
         /// <summary>
+        /// Gets Version_2019_04_02 version: 1.0.1
+        /// Not backward compatible
+        /// </summary>
+        public static ApiVersion Version_2019_04_02 { get; }
+
+        /// <summary>
         /// Gets the version that is assumed in case none is specified
         /// </summary>
         public static ApiVersion DefaultVersion => Version_0_2_Or_Earlier;
@@ -80,6 +86,7 @@ namespace LoRaWan.Shared
             yield return Version_2019_02_20_Preview;
             yield return Version_2019_03_08_Preview;
             yield return Version_2019_03_26;
+            yield return Version_2019_04_02;
         }
 
         /// <summary>
@@ -123,6 +130,9 @@ namespace LoRaWan.Shared
 
             Version_2019_03_26 = new ApiVersion("2019-03-26");
             Version_2019_03_26.MinCompatibleVersion = Version_2019_03_26;
+
+            Version_2019_04_02 = new ApiVersion("2019-04-02");
+            Version_2019_04_02.MinCompatibleVersion = Version_2019_04_02;
         }
 
         /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceFrameCounterUpdateStrategy.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceFrameCounterUpdateStrategy.cs
@@ -13,7 +13,7 @@ namespace LoRaWan.NetworkServer
     public interface ILoRaDeviceFrameCounterUpdateStrategy
     {
         // Resets the frame count
-        Task<bool> ResetAsync(LoRaDevice loRaDevice);
+        Task<bool> ResetAsync(LoRaDevice loRaDevice, uint fcntUp, string gatewayId);
 
         // Resolves next frame down counter
         ValueTask<uint> NextFcntDown(LoRaDevice loRaDevice, uint messageFcnt);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -55,7 +55,7 @@ namespace LoRaWan.NetworkServer
                 if (loRaDevice == null)
                 {
                     request.NotifyFailed(devEUI, LoRaDeviceRequestFailedReason.UnknownDevice);
-                    Logger.Log(devEUI, "join refused: unknown device", LogLevel.Information);
+                    Logger.Log(devEUI, "join refused", LogLevel.Information);
                     return;
                 }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIServiceBase.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIServiceBase.cs
@@ -28,7 +28,7 @@ namespace LoRaWan.NetworkServer
 
         public abstract Task<uint> NextFCntDownAsync(string devEUI, uint fcntDown, uint fcntUp, string gatewayId);
 
-        public abstract Task<bool> ABPFcntCacheResetAsync(string devEUI);
+        public abstract Task<bool> ABPFcntCacheResetAsync(string devEUI, uint fcntUp, string gatewayId);
 
         /// <summary>
         /// Searchs devices based on devAddr

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
@@ -286,7 +286,8 @@ namespace LoRaWan.NetworkServer
 
                 if (searchDeviceResult?.Devices == null || searchDeviceResult.Devices.Count == 0)
                 {
-                    Logger.Log(devEUI, "join refused: no devices found matching join request", LogLevel.Information);
+                    var msg = searchDeviceResult.RefusedMessage ?? "join refused: no devices found matching join request";
+                    Logger.Log(devEUI, msg, LogLevel.Information);
                     return null;
                 }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MultiGatewayFrameCounterUpdateStrategy.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MultiGatewayFrameCounterUpdateStrategy.cs
@@ -20,13 +20,13 @@ namespace LoRaWan.NetworkServer
             this.loRaDeviceAPIService = loRaDeviceAPIService;
         }
 
-        public async Task<bool> ResetAsync(LoRaDevice loRaDevice)
+        public async Task<bool> ResetAsync(LoRaDevice loRaDevice, uint fcntUp, string gatewayId)
         {
             loRaDevice.ResetFcnt();
 
             if (await this.InternalSaveChangesAsync(loRaDevice, force: true))
             {
-                return await this.loRaDeviceAPIService.ABPFcntCacheResetAsync(loRaDevice.DevEUI);
+                return await this.loRaDeviceAPIService.ABPFcntCacheResetAsync(loRaDevice.DevEUI, fcntUp, gatewayId);
             }
 
             return false;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/SearchDevicesResult.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/SearchDevicesResult.cs
@@ -20,6 +20,8 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         public bool IsDevNonceAlreadyUsed { get; set; }
 
+        public string RefusedMessage { get; set; }
+
         public SearchDevicesResult()
         {
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ServiceFacadeHttpClientHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ServiceFacadeHttpClientHandler.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace LoRaWan.NetworkServer
+namespace LoRaWan.Shared
 {
     using System;
     using System.Linq;
@@ -10,7 +10,6 @@ namespace LoRaWan.NetworkServer
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using LoRaWan.Shared;
 
     /// <summary>
     /// <see cref="HttpClientHandler"/> for service facade function API calls.

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/SingleGatewayFrameCounterUpdateStrategy.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/SingleGatewayFrameCounterUpdateStrategy.cs
@@ -11,7 +11,7 @@ namespace LoRaWan.NetworkServer
         {
         }
 
-        public async Task<bool> ResetAsync(LoRaDevice loRaDevice)
+        public async Task<bool> ResetAsync(LoRaDevice loRaDevice, uint fcntUp, string gatewayId)
         {
             loRaDevice.ResetFcnt();
             return await this.InternalSaveChangesAsync(loRaDevice, force: true);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
@@ -228,6 +228,7 @@ namespace LoRaWan.NetworkServer
                         LogToUdp = this.configuration.LogToUdp,
                         LogToUdpPort = this.configuration.LogToUdpPort,
                         LogToUdpAddress = this.configuration.LogToUdpAddress,
+                        GatewayId = this.configuration.GatewayID
                     });
 
                     if (this.configuration.IoTEdgeTimeout > 0)
@@ -278,6 +279,7 @@ namespace LoRaWan.NetworkServer
                         LogToUdp = this.configuration.LogToUdp,
                         LogToUdpPort = this.configuration.LogToUdpPort,
                         LogToUdpAddress = this.configuration.LogToUdpAddress,
+                        GatewayId = this.configuration.GatewayID
                     });
                 }
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
@@ -120,6 +120,11 @@ namespace LoRaWan
         {
             try
             {
+                if (!string.IsNullOrEmpty(configuration.GatewayId))
+                {
+                    message = string.Concat($"[{configuration.GatewayId}] ", message);
+                }
+
                 var messageInBytes = Encoding.UTF8.GetBytes(message);
                 udpClient.Send(messageInBytes, messageInBytes.Length, udpEndpoint);
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/LoggerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/LoggerConfiguration.cs
@@ -35,6 +35,11 @@ namespace LoRaWan
         // Gets/sets udp port to send logs
         public int LogToUdpPort { get; set; } = 6000;
 
+        /// <summary>
+        /// Gets or sets the id of the gateway running the logger
+        /// </summary>
+        public string GatewayId { get; set; }
+
         public static LogLevel InitLogLevel(string logLevelIn)
         {
             LogLevel logLevelOut;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/CommonAPI/FunctionBundlerItemType.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/CommonAPI/FunctionBundlerItemType.cs
@@ -11,6 +11,7 @@ namespace LoRaTools.CommonAPI
         FCntDown = 0x1,
         Deduplication = 0x2,
         ADR = 0x4,
-        PreferredGateway = 0x8
+        PreferredGateway = 0x8,
+        ResetDeviceCache = 0x10
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
@@ -10,13 +10,13 @@ namespace LoRaTools
 
     public class OTAAKeysGenerator
     {
+        private static readonly Random RndDevAddr = new Random();
+
         public static string GetNwkId(byte[] netId)
         {
             int nwkPart = netId[0] << 1;
-
             byte[] devAddr = new byte[4];
-            Random rnd = new Random();
-            rnd.NextBytes(devAddr);
+            RndDevAddr.NextBytes(devAddr);
             devAddr[0] = (byte)((nwkPart & 0b11111110) | (devAddr[0] & 0b00000001));
             return ConversionHelper.ByteArrayToString(devAddr);
         }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/DeduplicationTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/DeduplicationTest.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.IntegrationTest
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Xml;
+    using LoRaWan.Test.Shared;
+    using Newtonsoft.Json.Linq;
+    using Xunit;
+
+    // Tests OTAA requests
+    [Collection(Constants.TestCollectionName)] // run in serial
+    [Trait("Category", "SkipWhenLiveUnitTesting")]
+    public sealed class DeduplicationTest : IntegrationTestBaseCi
+    {
+        public DeduplicationTest(IntegrationTestFixtureCi testFixture)
+            : base(testFixture)
+        {
+        }
+
+        [Fact]
+        public async Task Test_Deduplication_Drop()
+        {
+            var device = this.TestFixtureCi.Device25_OTAA;
+            this.LogTestStart(device);
+
+            await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
+            await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
+            await this.ArduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, device.AppKey);
+
+            await this.ArduinoDevice.SetupLora(this.TestFixtureCi.Configuration.LoraRegion);
+
+            var joinSucceeded = await this.ArduinoDevice.setOTAAJoinAsyncWithRetry(LoRaArduinoSerial._otaa_join_cmd_t.JOIN, 20000, 5);
+
+            Assert.True(joinSucceeded, "Join failed");
+            await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_JOIN);
+
+            var joinConfirm = this.ArduinoDevice.SerialLogs.FirstOrDefault(s => s.StartsWith("+JOIN: NetID"));
+            Assert.NotNull(joinConfirm);
+
+            // validate that one GW refused the join
+            const string devNonceAlreadyUsed = "DevNonce already used by this device";
+            var joinRefused = await this.TestFixtureCi.AssertNetworkServerModuleLogExistsAsync((s) => s.IndexOf(devNonceAlreadyUsed) != -1, new SearchLogOptions(devNonceAlreadyUsed));
+            Assert.True(joinRefused.Found);
+
+            this.TestFixtureCi.ClearLogs();
+
+            var devAddr = joinConfirm.Substring(joinConfirm.LastIndexOf(' ') + 1);
+            devAddr = devAddr.Replace(":", string.Empty);
+
+            // wait for the twins to be stored and published -> all GW need the same state
+            const int DelayForJoinTwinStore = 20 * 1000;
+            const string DevAddrProperty = "DevAddr";
+            const int MaxRuns = 3;
+            bool reported = false;
+            for (var i = 0; i < MaxRuns && !reported; i++)
+            {
+                await Task.Delay(DelayForJoinTwinStore);
+
+                var twins = await this.TestFixtureCi.GetTwinAsync(device.DeviceID);
+                if (twins.Properties.Reported.Contains(DevAddrProperty))
+                {
+                    reported = devAddr.Equals(twins.Properties.Reported[DevAddrProperty].Value as string, StringComparison.InvariantCultureIgnoreCase);
+                }
+            }
+
+            Assert.True(reported);
+
+            var msg = PayloadGenerator.Next().ToString();
+            await this.ArduinoDevice.transferPacketAsync(msg, 10);
+
+            await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
+
+            // After transferPacket: Expectation from serial
+            // +MSG: Done
+            await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
+
+            var notDuplicate = "{\"isDuplicate\":false";
+            var resultProcessed = await this.TestFixtureCi.AssertNetworkServerModuleLogExistsAsync(logmsg => logmsg.IndexOf(notDuplicate) != -1, new SearchLogOptions(notDuplicate));
+            var resultDroped = await this.TestFixtureCi.SearchNetworkServerModuleAsync((s) => s.IndexOf("duplication strategy indicated to not process message") != -1);
+
+            Assert.NotEqual(resultProcessed.MatchedEvent.SourceId, resultDroped.MatchedEvent.SourceId);
+        }
+    }
+}

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
@@ -90,9 +90,14 @@ namespace LoRaWan.IntegrationTest
         public TestDeviceInfo Device26_ABP { get; private set; }
 
         /// <summary>
-        /// Gets Device24_OTAA: used for OTAA deduplication testing
+        /// Gets Device27_OTAA: used for multi GW OTAA testing
         /// </summary>
-        public TestDeviceInfo Device25_OTAA { get; private set; }
+        public TestDeviceInfo Device27_OTAA { get; private set; }
+
+        /// <summary>
+        /// Gets Device27_ABP: used for multi GW deduplication drop testing
+        /// </summary>
+        public TestDeviceInfo Device28_ABP { get; private set; }
 
         // Arduino device used for testing
         public LoRaArduinoSerial ArduinoDevice
@@ -114,6 +119,8 @@ namespace LoRaWan.IntegrationTest
             {
                 TestLogger.Log("[WARN] Not serial port defined for test");
             }
+
+            LoRaAPIHelper.Initialize(this.Configuration.FunctionAppCode, this.Configuration.FunctionAppBaseUrl);
         }
 
         public override void ClearLogs()
@@ -131,6 +138,11 @@ namespace LoRaWan.IntegrationTest
                 this.arduinoDevice?.Dispose();
                 this.arduinoDevice = null;
             }
+        }
+
+        public async Task<bool> ResetDeviceCache(string devEUI)
+        {
+            return await LoRaAPIHelper.ResetDeviceCache(devEUI);
         }
 
         public string GetKey16(int deviceId)
@@ -345,8 +357,7 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(18),
                 DevAddr = "00000018",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
+                IsIoTHubDevice = true
             };
 
             // Device19_ABP: used for C2D invalid fport testing
@@ -357,8 +368,7 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(19),
                 DevAddr = "00000019",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
+                IsIoTHubDevice = true
             };
 
             // Device20_OTAA: used for join and rejoin test
@@ -382,7 +392,6 @@ namespace LoRaWan.IntegrationTest
                 DevAddr = "00000021",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
                 PreferredWindow = 2
             };
 
@@ -428,8 +437,7 @@ namespace LoRaWan.IntegrationTest
                 DevAddr = "00000025",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
-                KeepAliveTimeout = 60,
+                KeepAliveTimeout = 60
             };
 
             // Device26_ABP: Connection timeout
@@ -440,15 +448,23 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = "00000000000000000000000000000026",
                 DevAddr = "00000026",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
+                IsIoTHubDevice = true
             };
 
-            this.Device25_OTAA = new TestDeviceInfo()
+            this.Device27_OTAA = new TestDeviceInfo()
             {
-                DeviceID = "0000000000000025",
-                AppEUI = "0000000000000025",
-                AppKey = "00000000000000000000000000000025",
+                DeviceID = "0000000000000027",
+                AppEUI = "0000000000000027",
+                AppKey = "00000000000000000000000000000027",
+                IsIoTHubDevice = true
+            };
+
+            this.Device28_ABP = new TestDeviceInfo()
+            {
+                DeviceID = "0000000000000028",
+                AppSKey = "00000000000000000000000000000028",
+                NwkSKey = "00000000000000000000000000000028",
+                DevAddr = "00000027",
                 IsIoTHubDevice = true,
                 Deduplication = "Drop"
             };

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
@@ -99,6 +99,11 @@ namespace LoRaWan.IntegrationTest
         /// </summary>
         public TestDeviceInfo Device28_ABP { get; private set; }
 
+        /// <summary>
+        /// Gets Device27_ABP: used for multi GW deduplication mark testing
+        /// </summary>
+        public TestDeviceInfo Device29_ABP { get; private set; }
+
         // Arduino device used for testing
         public LoRaArduinoSerial ArduinoDevice
         {
@@ -467,6 +472,16 @@ namespace LoRaWan.IntegrationTest
                 DevAddr = "00000027",
                 IsIoTHubDevice = true,
                 Deduplication = "Drop"
+            };
+
+            this.Device29_ABP = new TestDeviceInfo()
+            {
+                DeviceID = "0000000000000029",
+                AppSKey = "00000000000000000000000000000029",
+                NwkSKey = "00000000000000000000000000000029",
+                DevAddr = "00000029",
+                IsIoTHubDevice = true,
+                Deduplication = "Mark"
             };
         }
     }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
@@ -89,6 +89,11 @@ namespace LoRaWan.IntegrationTest
         // Device26_ABP: Connection timeout
         public TestDeviceInfo Device26_ABP { get; private set; }
 
+        /// <summary>
+        /// Gets Device24_OTAA: used for OTAA deduplication testing
+        /// </summary>
+        public TestDeviceInfo Device25_OTAA { get; private set; }
+
         // Arduino device used for testing
         public LoRaArduinoSerial ArduinoDevice
         {
@@ -171,7 +176,6 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = this.GetKey16(2),
                 AppKey = this.GetKey32(2),
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = false,
             };
 
@@ -182,7 +186,6 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = this.GetKey16(3),
                 AppKey = this.GetKey32(3),
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -193,7 +196,6 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = this.GetKey16(4),
                 AppKey = this.GetKey32(4),
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
                 RX1DROffset = 1
             };
@@ -206,7 +208,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(5),
                 DevAddr = "0028B1B0",
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -218,7 +219,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(6),
                 DevAddr = "00000006",
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = false,
             };
 
@@ -230,7 +230,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(7),
                 DevAddr = "00000007",
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -242,7 +241,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(8),
                 DevAddr = "00000008",
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -286,7 +284,6 @@ namespace LoRaWan.IntegrationTest
                 AppKey = this.GetKey32(12),
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
             };
 
             // Device13_OTAA: used for Join with wrong AppEUI
@@ -297,7 +294,6 @@ namespace LoRaWan.IntegrationTest
                 AppKey = this.GetKey32(13),
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
             };
 
             // Device14_OTAA: used for Confirmed C2D message
@@ -308,7 +304,6 @@ namespace LoRaWan.IntegrationTest
                 AppKey = this.GetKey32(14),
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
             };
 
             // Device15_OTAA: used for the Fport test
@@ -319,7 +314,6 @@ namespace LoRaWan.IntegrationTest
                 AppKey = this.GetKey32(15),
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
             };
             // Device16_ABP: used for same DevAddr test
             this.Device16_ABP = new TestDeviceInfo()
@@ -329,7 +323,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(16),
                 DevAddr = "00000016",
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -341,7 +334,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(17),
                 DevAddr = this.Device16_ABP.DevAddr, // MUST match DevAddr from Device16
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -377,7 +369,6 @@ namespace LoRaWan.IntegrationTest
                 AppKey = this.GetKey32(20),
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
                 RX2DataRate = 3,
                 PreferredWindow = 2
             };
@@ -403,7 +394,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(22),
                 DevAddr = "00000022",
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -415,7 +405,6 @@ namespace LoRaWan.IntegrationTest
                 AppKey = this.GetKey32(23),
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
             };
 
             // Device24_OTAA: used for C2D mac Command testing
@@ -427,7 +416,6 @@ namespace LoRaWan.IntegrationTest
                 DevAddr = "00000024",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
                 ClassType = 'C',
             };
 
@@ -454,6 +442,15 @@ namespace LoRaWan.IntegrationTest
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
                 SensorDecoder = "DecoderValueSensor",
+            };
+
+            this.Device25_OTAA = new TestDeviceInfo()
+            {
+                DeviceID = "0000000000000025",
+                AppEUI = "0000000000000025",
+                AppKey = "00000000000000000000000000000025",
+                IsIoTHubDevice = true,
+                Deduplication = "Drop"
             };
         }
     }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaAPIHelper.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaAPIHelper.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.IntegrationTest
+{
+    using System;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Text;
+    using System.Threading.Tasks;
+    using LoRaTools.CommonAPI;
+    using LoRaWan.Shared;
+
+    public static class LoRaAPIHelper
+    {
+        private static string authCode;
+        private static string baseUrl;
+        private static ServiceFacadeHttpClientHandler httpHandler;
+        private static Lazy<HttpClient> httpClient;
+
+        internal static void Initialize(string functionAppCode, string functionAppBaseUrl)
+        {
+            authCode = functionAppCode;
+            baseUrl = SanitizeApiURL(functionAppBaseUrl);
+            httpHandler = new ServiceFacadeHttpClientHandler(ApiVersion.LatestVersion);
+            httpClient = new Lazy<HttpClient>(CreateHttpClient);
+        }
+
+        private static HttpClient CreateHttpClient()
+        {
+            return new HttpClient(httpHandler);
+        }
+
+        public static async Task<bool> ResetDeviceCache(string devEUI)
+        {
+            var url = $"{baseUrl}FunctionBundler/{devEUI}?code={authCode}";
+            // the gateway id is only used to identify who is taking the lock when
+            // releasing the cache. Hence we do not need a real GW id
+            var payload = "{\"GatewayId\":\"integrationTesting\", \"FunctionItems\": " + (int)FunctionBundlerItemType.ResetDeviceCache + "}";
+
+            var response = await httpClient.Value.PostAsync(url, PreparePostContent(payload));
+            return response.IsSuccessStatusCode;
+        }
+
+        private static ByteArrayContent PreparePostContent(string requestBody)
+        {
+            var buffer = Encoding.UTF8.GetBytes(requestBody);
+            var byteContent = new ByteArrayContent(buffer);
+            byteContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            return byteContent;
+        }
+
+        private static string SanitizeApiURL(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return string.Empty;
+
+            value = value.Trim();
+            if (value.EndsWith('/'))
+                return value;
+
+            return string.Concat(value, "/");
+        }
+    }
+}

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaWan.IntegrationTest.csproj
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaWan.IntegrationTest.csproj
@@ -41,6 +41,10 @@
   <ItemGroup>
     <AdditionalFiles Include="../../../stylecop.json" Link="stylecop.json" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\modules\LoRaWanNetworkSrvModule\LoRaWan.NetworkServer\ApiVersion.cs" Link="ApiVersion.cs" />
+    <Compile Include="..\..\modules\LoRaWanNetworkSrvModule\LoRaWan.NetworkServer\ServiceFacadeHttpClientHandler.cs" Link="ServiceFacadeHttpClientHandler.cs" />
+  </ItemGroup>
   <PropertyGroup>
     <CodeAnalysisRuleSet>../../../stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/MultiGatewayTests.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/MultiGatewayTests.cs
@@ -16,9 +16,9 @@ namespace LoRaWan.IntegrationTest
     // Tests OTAA requests
     [Collection(Constants.TestCollectionName)] // run in serial
     [Trait("Category", "SkipWhenLiveUnitTesting")]
-    public sealed class DeduplicationTest : IntegrationTestBaseCi
+    public sealed class MultiGatewayTests : IntegrationTestBaseCi
     {
-        public DeduplicationTest(IntegrationTestFixtureCi testFixture)
+        public MultiGatewayTests(IntegrationTestFixtureCi testFixture)
             : base(testFixture)
         {
         }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/appsettings.json
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/appsettings.json
@@ -1,17 +1,19 @@
 {
-  "testConfiguration": {
-    "IoTHubEventHubConnectionString": "#{INTEGRATIONTEST_IoTHubEventHubConnectionString}#",
-    "IoTHubEventHubConsumerGroup": "#{INTEGRATIONTEST_IoTHubEventHubConsumerGroup}#",
-    "IoTHubConnectionString": "#{INTEGRATIONTEST_IoTHubConnectionString}#",
-    "EnsureHasEventDelayBetweenReadsInSeconds": "#{INTEGRATIONTEST_EnsureHasEventDelayBetweenReadsInSeconds}#",
-    "EnsureHasEventMaximumTries": "#{INTEGRATIONTEST_EnsureHasEventMaximumTries}#",
-    "LeafDeviceSerialPort": "#{INTEGRATIONTEST_LeafDeviceSerialPort}#",
-    "NetworkServerModuleLogAssertLevel": "Error",
-    "IoTHubAssertLevel": "Warning",
-    "UdpLog": "true",
-    "CreateDevices": true,
-    "LeafDeviceGatewayID": "#{INTEGRATIONTEST_LeafDeviceGatewayID}#",
-    "DevicePrefix": "#{INTEGRATIONTEST_DevicePrefix}#",
-    "DeviceKeyFormat": "00F5A90000000000"
-  }
+    "testConfiguration": {
+        "IoTHubEventHubConnectionString": "#{INTEGRATIONTEST_IoTHubEventHubConnectionString}#",
+        "IoTHubEventHubConsumerGroup": "#{INTEGRATIONTEST_IoTHubEventHubConsumerGroup}#",
+        "IoTHubConnectionString": "#{INTEGRATIONTEST_IoTHubConnectionString}#",
+        "EnsureHasEventDelayBetweenReadsInSeconds": "#{INTEGRATIONTEST_EnsureHasEventDelayBetweenReadsInSeconds}#",
+        "EnsureHasEventMaximumTries": "#{INTEGRATIONTEST_EnsureHasEventMaximumTries}#",
+        "LeafDeviceSerialPort": "#{INTEGRATIONTEST_LeafDeviceSerialPort}#",
+        "NetworkServerModuleLogAssertLevel": "Error",
+        "IoTHubAssertLevel": "Warning",
+        "UdpLog": "true",
+        "CreateDevices": true,
+        "LeafDeviceGatewayID": "#{INTEGRATIONTEST_LeafDeviceGatewayID}#",
+        "DevicePrefix": "#{INTEGRATIONTEST_DevicePrefix}#",
+        "DeviceKeyFormat": "00F5A90000000000",
+        "FunctionAppCode": "#{INTEGRATIONTEST_FunctionAppCode}#",
+        "FunctionAppBaseUrl": "#{INTEGRATIONTEST_FunctionAppBaseUrl}#"
+    }
 }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/test_runner.sh
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/test_runner.sh
@@ -41,7 +41,7 @@ declare -a testsToRun=('LoRaWan.IntegrationTest.OTAAJoinTest'
                        'LoRaWan.IntegrationTest.MacTest'
                        'LoRaWan.IntegrationTest.SensorDecodingTest'
                        'LoRaWan.IntegrationTest.ClassCTest'
-                       'LoRaWan.IntegrationTest.DeduplicationTest')
+                       'LoRaWan.IntegrationTest.MultiGatewayTests')
 
 testCount=${#testsToRun[@]}
 

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/test_runner.sh
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/test_runner.sh
@@ -40,7 +40,8 @@ declare -a testsToRun=('LoRaWan.IntegrationTest.OTAAJoinTest'
                        'LoRaWan.IntegrationTest.OTAATest'
                        'LoRaWan.IntegrationTest.MacTest'
                        'LoRaWan.IntegrationTest.SensorDecodingTest'
-                       'LoRaWan.IntegrationTest.ClassCTest')
+                       'LoRaWan.IntegrationTest.ClassCTest'
+                       'LoRaWan.IntegrationTest.DeduplicationTest')
 
 testCount=${#testsToRun[@]}
 

--- a/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
@@ -106,7 +106,7 @@ namespace LoRaWan.Test.Shared
             return searchResult;
         }
 
-        public async Task<bool> ValidateMultiGatewaySources(Func<string, bool> predicate, int maxAttempts = 2)
+        public async Task<bool> ValidateMultiGatewaySources(Func<string, bool> predicate, int maxAttempts = 5)
         {
             int numberOfGw = this.Configuration.NumberOfGateways;
             var sourceIds = new HashSet<string>(numberOfGw);

--- a/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
@@ -209,7 +209,7 @@ namespace LoRaWan.Test.Shared
                     processedEvents.Add(searchLogEvent);
                     if (predicate(searchLogEvent))
                     {
-                        return new SearchLogResult(true, processedEvents)
+                        return new SearchLogResult(true, processedEvents, item)
                         {
                             MatchedEvent = searchLogEvent
                         };
@@ -217,7 +217,7 @@ namespace LoRaWan.Test.Shared
                 }
             }
 
-            return new SearchLogResult(false, processedEvents, string.Empty);
+            return new SearchLogResult(false, processedEvents);
         }
 
         async Task<SearchLogResult> SearchUdpLogs(Func<string, bool> predicate, SearchLogOptions options = null)
@@ -258,7 +258,7 @@ namespace LoRaWan.Test.Shared
                     processedEvents.Add(searchLogEvent);
                     if (predicate(searchLogEvent))
                     {
-                        return new SearchLogResult(true, processedEvents)
+                        return new SearchLogResult(true, processedEvents, bodyText)
                         {
                             MatchedEvent = searchLogEvent
                         };
@@ -266,13 +266,7 @@ namespace LoRaWan.Test.Shared
                 }
             }
 
-            return new SearchLogResult(false, processedEvents, string.Empty);
-        }
-
-        // Searches IoT Hub for messages
-        async Task<SearchLogResult> SearchIoTHubLogs(Func<string, bool> predicate, SearchLogOptions options = null)
-        {
-            return await this.SearchIoTHubLogs(evt => predicate(evt.Message), options);
+            return new SearchLogResult(false, processedEvents);
         }
 
         // Searches IoT Hub for messages

--- a/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
@@ -8,8 +8,6 @@ namespace LoRaWan.Test.Shared
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Devices;
-    using Microsoft.Azure.Devices.Shared;
     using Microsoft.Azure.EventHubs;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
@@ -267,6 +265,12 @@ namespace LoRaWan.Test.Shared
             }
 
             return new SearchLogResult(false, processedEvents);
+        }
+
+        // Searches IoT Hub for messages
+        async Task<SearchLogResult> SearchIoTHubLogs(Func<string, bool> predicate, SearchLogOptions options = null)
+        {
+            return await this.SearchIoTHubLogs(evt => predicate(evt.Message), options);
         }
 
         // Searches IoT Hub for messages

--- a/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
@@ -79,12 +79,12 @@ namespace LoRaWan.Test.Shared
         }
 
         // Asserts network server module log contains
-        public async Task AssertNetworkServerModuleLogStartsWithAsync(string logMessageStart)
+        public async Task<SearchLogResult> AssertNetworkServerModuleLogStartsWithAsync(string logMessageStart)
         {
             if (this.Configuration.NetworkServerModuleLogAssertLevel == LogValidationAssertLevel.Ignore)
-                return;
+                return null;
 
-            await this.AssertNetworkServerModuleLogExistsAsync((input) => input.StartsWith(logMessageStart), new SearchLogOptions(logMessageStart));
+            return await this.AssertNetworkServerModuleLogExistsAsync((input) => input.StartsWith(logMessageStart), new SearchLogOptions(logMessageStart));
         }
 
         public async Task AssertNetworkServerModuleLogStartsWithAsync(string logMessageStart1, string logMessageStart2)
@@ -109,10 +109,10 @@ namespace LoRaWan.Test.Shared
         }
 
         // Asserts Network Server Module log exists. It has built-in retries and delays
-        public async Task AssertNetworkServerModuleLogExistsAsync(Func<string, bool> predicate, SearchLogOptions options)
+        public async Task<SearchLogResult> AssertNetworkServerModuleLogExistsAsync(Func<string, bool> predicate, SearchLogOptions options)
         {
             if (this.Configuration.NetworkServerModuleLogAssertLevel == LogValidationAssertLevel.Ignore)
-                return;
+                return null;
 
             SearchLogResult searchResult;
             if (this.udpLogListener != null)
@@ -133,6 +133,8 @@ namespace LoRaWan.Test.Shared
                     TestLogger.Log($"[WARN] '{options?.Description ?? "??"}' found in logs? {searchResult.Found}. Logs: [{logs}]");
                 }
             }
+
+            return searchResult;
         }
 
         /// <summary>
@@ -180,10 +182,10 @@ namespace LoRaWan.Test.Shared
             };
         }
 
-        async Task<SearchLogResult> SearchUdpLogs(Func<string, bool> predicate, SearchLogOptions options = null)
+        async Task<SearchLogResult> SearchUdpLogs(Func<SearchLogEvent, bool> predicate, SearchLogOptions options = null)
         {
             var maxAttempts = options?.MaxAttempts ?? this.Configuration.EnsureHasEventMaximumTries;
-            var processedEvents = new HashSet<string>();
+            var processedEvents = new HashSet<SearchLogEvent>();
             for (int i = 0; i < maxAttempts; i++)
             {
                 if (i > 0)
@@ -203,10 +205,14 @@ namespace LoRaWan.Test.Shared
 
                 foreach (var item in this.udpLogListener.GetEvents())
                 {
-                    processedEvents.Add(item);
-                    if (predicate(item))
+                    var searchLogEvent = new SearchLogEvent(item);
+                    processedEvents.Add(searchLogEvent);
+                    if (predicate(searchLogEvent))
                     {
-                        return new SearchLogResult(true, processedEvents, item);
+                        return new SearchLogResult(true, processedEvents)
+                        {
+                            MatchedEvent = searchLogEvent
+                        };
                     }
                 }
             }
@@ -214,11 +220,15 @@ namespace LoRaWan.Test.Shared
             return new SearchLogResult(false, processedEvents, string.Empty);
         }
 
-        // Searches IoT Hub for messages
-        async Task<SearchLogResult> SearchIoTHubLogs(Func<string, bool> predicate, SearchLogOptions options = null)
+        async Task<SearchLogResult> SearchUdpLogs(Func<string, bool> predicate, SearchLogOptions options = null)
+        {
+            return await this.SearchUdpLogs(evt => predicate(evt.Message), options);
+        }
+
+        async Task<SearchLogResult> SearchIoTHubLogs(Func<SearchLogEvent, bool> predicate, SearchLogOptions options = null)
         {
             var maxAttempts = options?.MaxAttempts ?? this.Configuration.EnsureHasEventMaximumTries;
-            var processedEvents = new HashSet<string>();
+            var processedEvents = new HashSet<SearchLogEvent>();
             for (int i = 0; i < maxAttempts; i++)
             {
                 if (i > 0)
@@ -239,10 +249,19 @@ namespace LoRaWan.Test.Shared
                 foreach (var item in this.IoTHubMessages.GetEvents())
                 {
                     var bodyText = item.Body.Count > 0 ? Encoding.UTF8.GetString(item.Body) : string.Empty;
-                    processedEvents.Add(bodyText);
-                    if (predicate(bodyText))
+                    var searchLogEvent = new SearchLogEvent
                     {
-                        return new SearchLogResult(true, processedEvents, bodyText);
+                        Message = bodyText,
+                        SourceId = item.GetDeviceId()
+                    };
+
+                    processedEvents.Add(searchLogEvent);
+                    if (predicate(searchLogEvent))
+                    {
+                        return new SearchLogResult(true, processedEvents)
+                        {
+                            MatchedEvent = searchLogEvent
+                        };
                     }
                 }
             }
@@ -251,10 +270,16 @@ namespace LoRaWan.Test.Shared
         }
 
         // Searches IoT Hub for messages
+        async Task<SearchLogResult> SearchIoTHubLogs(Func<string, bool> predicate, SearchLogOptions options = null)
+        {
+            return await this.SearchIoTHubLogs(evt => predicate(evt.Message), options);
+        }
+
+        // Searches IoT Hub for messages
         internal async Task<SearchLogResult> SearchIoTHubMessageAsync(Func<EventData, string, string, bool> predicate, SearchLogOptions options = null)
         {
             var maxAttempts = options?.MaxAttempts ?? this.Configuration.EnsureHasEventMaximumTries;
-            var processedEvents = new HashSet<string>();
+            var processedEvents = new HashSet<SearchLogEvent>();
             for (int i = 0; i < maxAttempts; i++)
             {
                 if (i > 0)
@@ -277,7 +302,14 @@ namespace LoRaWan.Test.Shared
                     try
                     {
                         var bodyText = item.Body.Count > 0 ? Encoding.UTF8.GetString(item.Body) : string.Empty;
-                        processedEvents.Add(bodyText);
+                        var searchLogEvent = new SearchLogEvent
+                        {
+                            SourceId = item.GetDeviceId(),
+                            Message = bodyText
+                        };
+
+                        processedEvents.Add(searchLogEvent);
+
                         item.SystemProperties.TryGetValue("iothub-connection-device-id", out var deviceId);
                         if (predicate(item, deviceId?.ToString() ?? string.Empty, bodyText))
                         {

--- a/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogEvent.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogEvent.cs
@@ -11,22 +11,34 @@ namespace LoRaWan.Test.Shared
 
         public SearchLogEvent(string rawMessage)
         {
+            var parsedMessage = Parse(rawMessage);
+            this.Message = parsedMessage.Message;
+            this.SourceId = parsedMessage.SourceId;
+        }
+
+        internal static (string Message, string SourceId) Parse(string rawMessage)
+        {
+            string message = null;
+            string sourceId = null;
+
             if (!string.IsNullOrEmpty(rawMessage))
             {
-                this.Message = rawMessage.Trim();
-                if (rawMessage.StartsWith('['))
+                message = rawMessage.Trim();
+                if (message.StartsWith('['))
                 {
-                    var idxEnd = rawMessage.IndexOf(']');
+                    var idxEnd = message.IndexOf(']');
                     if (idxEnd != -1)
                     {
-                        if (rawMessage.Length >= idxEnd + 1)
+                        if (message.Length >= idxEnd + 1)
                         {
-                            this.SourceId = rawMessage.Substring(1, idxEnd - 1);
-                            this.Message = rawMessage.Substring(idxEnd + 1).TrimStart();
+                            sourceId = message.Substring(1, idxEnd - 1);
+                            message = message.Substring(idxEnd + 1).TrimStart();
                         }
                     }
                 }
             }
+
+            return (message, sourceId);
         }
 
         public string Message { get; set; }

--- a/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogEvent.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogEvent.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Test.Shared
+{
+    public class SearchLogEvent
+    {
+        public SearchLogEvent()
+        {
+        }
+
+        public SearchLogEvent(string rawMessage)
+        {
+            if (!string.IsNullOrEmpty(rawMessage))
+            {
+                this.Message = rawMessage.Trim();
+                if (rawMessage.StartsWith('['))
+                {
+                    var idxEnd = rawMessage.IndexOf(']');
+                    if (idxEnd != -1)
+                    {
+                        if (rawMessage.Length >= idxEnd + 1)
+                        {
+                            this.SourceId = rawMessage.Substring(1, idxEnd - 1);
+                            this.Message = rawMessage.Substring(idxEnd + 1).TrimStart();
+                        }
+                    }
+                }
+            }
+        }
+
+        public string Message { get; set; }
+
+        public string SourceId { get; set; }
+    }
+}

--- a/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogResult.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogResult.cs
@@ -11,11 +11,13 @@ namespace LoRaWan.Test.Shared
         public bool Found { get; }
 
         // Returns the contents of the log (to diagnose problems)
-        public IReadOnlyCollection<string> Logs { get; }
+        public IReadOnlyCollection<SearchLogEvent> Logs { get; }
+
+        public SearchLogEvent MatchedEvent { get; set; }
 
         public string FoundLogResult { get; set; }
 
-        public SearchLogResult(bool found, HashSet<string> logs, string foundElement)
+        public SearchLogResult(bool found, HashSet<SearchLogEvent> logs, string foundElement = null)
         {
             this.Found = found;
             this.Logs = logs;

--- a/LoRaEngine/test/LoRaWan.Test.Shared/TestConfiguration.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/TestConfiguration.cs
@@ -67,5 +67,9 @@ namespace LoRaWan.Test.Shared
 
         // Gets/sets the network server module identifier
         public string NetworkServerModuleID { get; set; } = "LoRaWanNetworkSrvModule";
+
+        public string FunctionAppCode { get; set; }
+
+        public string FunctionAppBaseUrl { get; set; }
     }
 }

--- a/LoRaEngine/test/LoRaWan.Test.Shared/TestConfiguration.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/TestConfiguration.cs
@@ -71,5 +71,7 @@ namespace LoRaWan.Test.Shared
         public string FunctionAppCode { get; set; }
 
         public string FunctionAppBaseUrl { get; set; }
+
+        public int NumberOfGateways { get; set; } = 2;
     }
 }

--- a/LoRaEngine/test/LoRaWan.Test.Shared/TestDeviceInfo.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/TestDeviceInfo.cs
@@ -56,6 +56,8 @@ namespace LoRaWan.Test.Shared
 
         public bool Supports32BitFCnt { get; set; }
 
+        public string Deduplication { get; set; }
+
         public ushort RXDelay { get; set; } = 0;
 
         public int KeepAliveTimeout { get; set; }
@@ -100,6 +102,9 @@ namespace LoRaWan.Test.Shared
 
             if (this.KeepAliveTimeout > 0)
                 desiredProperties[nameof(this.KeepAliveTimeout)] = this.KeepAliveTimeout;
+
+            if (!string.IsNullOrEmpty(this.Deduplication))
+                desiredProperties[nameof(this.Deduplication)] = this.Deduplication;
 
             return desiredProperties;
         }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/DeduplicationStrategy_End2End_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/DeduplicationStrategy_End2End_Tests.cs
@@ -59,6 +59,9 @@ namespace LoRaWan.NetworkServer.Test
                     Assert.True(mode == DeduplicationMode.None);
                 });
 
+            this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                .ReturnsAsync(true);
+
             var shouldBeMarked = false;
 
             this.LoRaDeviceClient

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/FcntLimitTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/FcntLimitTest.cs
@@ -88,7 +88,7 @@ namespace LoRaWan.NetworkServer.Test
             var shouldReset = payloadFcntUp == 0 && abpRelaxed;
             if (shouldReset)
             {
-                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI)).ReturnsAsync(true);
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI, It.IsAny<uint>(), It.IsNotNull<string>())).ReturnsAsync(true);
             }
 
             this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/FunctionBundler_End2End_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/FunctionBundler_End2End_Tests.cs
@@ -45,6 +45,9 @@ namespace LoRaWan.NetworkServer.Test
                         NextFCntDown = simulatedDevice.FrmCntDown + 1
                     });
 
+            this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                .ReturnsAsync(true);
+
             this.LoRaDeviceClient
                 .Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorMultipleGatewayTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorMultipleGatewayTest.cs
@@ -73,6 +73,11 @@ namespace LoRaWan.NetworkServer.Test
             this.SecondLoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
 
+            this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                .ReturnsAsync(true);
+            this.SecondLoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                .ReturnsAsync(true);
+
             // cloud to device messages will be checked twice
             this.LoRaDeviceClient.SetupSequence(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null)

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorSingleGatewayTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorSingleGatewayTest.cs
@@ -342,7 +342,8 @@ namespace LoRaWan.NetworkServer.Test
             this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>())).ReturnsAsync((Message)null);
 
             // Will save the fcnt up/down to zero
-            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.Is<TwinCollection>((t) => this.IsTwinFcntZero(t))));
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.Is<TwinCollection>((t) => this.IsTwinFcntZero(t))))
+                .ReturnsAsync(true);
 
             var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
@@ -42,6 +42,11 @@ namespace LoRaWan.NetworkServer.Test
             // message will be sent
             this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
+            if (string.IsNullOrEmpty(deviceGatewayID))
+            {
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                    .ReturnsAsync(true);
+            }
 
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var cachedDevice = this.CreateLoRaDevice(simulatedDevice);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Decoder_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Decoder_Tests.cs
@@ -74,6 +74,13 @@ namespace LoRaWan.NetworkServer.Test
             this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
+            if (string.IsNullOrEmpty(deviceGatewayID))
+            {
+                // multi GW will reset
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                    .ReturnsAsync(true);
+            }
+
             var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loRaDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_MultiGateway_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_MultiGateway_Tests.cs
@@ -35,6 +35,9 @@ namespace LoRaWan.NetworkServer.Test
                         NextFCntDown = 0
                     });
 
+            this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
+                    .ReturnsAsync(true);
+
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var device = this.CreateLoRaDevice(simulatedDevice);
 
@@ -134,12 +137,8 @@ namespace LoRaWan.NetworkServer.Test
                     .ReturnsAsync(true);
             }
 
-            // multi gateway will reset the fcnt
-            if (shouldSaveTwin)
-            {
-                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI))
+            this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
                     .ReturnsAsync(true);
-            }
 
             // device api will be searched for payload
             this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Parallel_Processing_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Parallel_Processing_Tests.cs
@@ -169,7 +169,7 @@ namespace LoRaWan.NetworkServer.Test
 
             if (expectedToSaveTwin && string.IsNullOrEmpty(parallelTestConfiguration.GatewayID))
             {
-                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI))
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
                     .Returns(() =>
                     {
                         var duration = parallelTestConfiguration.DeviceApiResetFcntDuration.Next();

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
@@ -84,6 +84,12 @@ namespace LoRaWan.NetworkServer.Test
                     .ReturnsAsync(true);
             }
 
+            if (string.IsNullOrEmpty(deviceGatewayID))
+            {
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
+                    .ReturnsAsync(true);
+            }
+
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var cachedDevice = this.CreateLoRaDevice(simulatedDevice);
 
@@ -136,7 +142,7 @@ namespace LoRaWan.NetworkServer.Test
             // will update api in multi gateway scenario
             if (string.IsNullOrEmpty(deviceGatewayID))
             {
-                this.LoRaDeviceApi.Verify(x => x.ABPFcntCacheResetAsync(devEUI), Times.Exactly(1));
+                this.LoRaDeviceApi.Verify(x => x.ABPFcntCacheResetAsync(devEUI, It.IsAny<uint>(), It.IsNotNull<string>()), Times.Exactly(1));
             }
 
             this.LoRaDeviceClient.VerifyAll();
@@ -163,6 +169,12 @@ namespace LoRaWan.NetworkServer.Test
             // C2D message will be checked
             this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
+
+            if (string.IsNullOrEmpty(deviceGatewayID))
+            {
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(loRaDevice.DevEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
+                    .ReturnsAsync(true);
+            }
 
             // add device to cache already
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
@@ -463,6 +475,9 @@ namespace LoRaWan.NetworkServer.Test
                 // C2D message will be checked
                 this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                     .ReturnsAsync((Message)null);
+
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(loRaDevice.DevEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
+                .ReturnsAsync(true);
             }
 
             // add device to cache already
@@ -832,6 +847,12 @@ namespace LoRaWan.NetworkServer.Test
             // message will be sent
             this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
+
+            if (string.IsNullOrEmpty(deviceGatewayID))
+            {
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                    .ReturnsAsync(true);
+            }
 
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var cachedDevice = this.CreateLoRaDevice(simulatedDevice);
@@ -1699,7 +1720,7 @@ namespace LoRaWan.NetworkServer.Test
 
             if (string.IsNullOrEmpty(gatewayID))
             {
-                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(simDevice.DevEUI))
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(simDevice.DevEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
                     .ReturnsAsync(true);
             }
 

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MultiGatewayFrameCounterUpdateStrategyTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MultiGatewayFrameCounterUpdateStrategyTest.cs
@@ -161,10 +161,10 @@ namespace LoRaWan.NetworkServer.Test
             var device = new LoRaDevice("1", "2", new SingleDeviceConnectionManager(this.deviceClient.Object));
 
             // will reset the cloud cache
-            this.deviceApi.Setup(x => x.ABPFcntCacheResetAsync(device.DevEUI))
+            this.deviceApi.Setup(x => x.ABPFcntCacheResetAsync(device.DevEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
                 .ReturnsAsync(true);
 
-            await target.ResetAsync(device);
+            await target.ResetAsync(device, 1U, this.gatewayID);
             Assert.False(device.HasFrameCountChanges);
 
             this.deviceClient.VerifyAll();

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/SingleGatewayFrameCounterUpdateStrategyTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/SingleGatewayFrameCounterUpdateStrategyTest.cs
@@ -140,7 +140,7 @@ namespace LoRaWan.NetworkServer.Test
             var target = new SingleGatewayFrameCounterUpdateStrategy();
 
             var device = new LoRaDevice("1", "2", new SingleDeviceConnectionManager(this.deviceClient.Object));
-            await target.ResetAsync(device);
+            await target.ResetAsync(device, 1, string.Empty);
             Assert.False(device.HasFrameCountChanges);
             this.deviceClient.VerifyAll();
         }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/TestMultiGatewayUpdateFrameStrategy.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/TestMultiGatewayUpdateFrameStrategy.cs
@@ -27,7 +27,7 @@ namespace LoRaWan.NetworkServer.Test
             }
         }
 
-        public Task<bool> ResetAsync(LoRaDevice loRaDevice)
+        public Task<bool> ResetAsync(LoRaDevice loRaDevice, uint fcntUp, string gatewayId)
         {
             loRaDevice.ResetFcnt();
 

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/DeviceGetterTest.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/DeviceGetterTest.cs
@@ -52,6 +52,10 @@ namespace LoraKeysManagerFacade.Test
                 .Setup(x => x.GetDeviceAsync(It.IsAny<string>()))
                 .ReturnsAsync((string deviceId) => new Device(deviceId) { Authentication = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = primaryKey } } });
 
+            mockRegistryManager
+                .Setup(x => x.GetTwinAsync(It.IsNotNull<string>()))
+                .ReturnsAsync((string deviceId) => new Twin(deviceId));
+
             const int numberOfDevices = 2;
             int deviceCount = 0;
 

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/FCntCacheCheckTest.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/FCntCacheCheckTest.cs
@@ -3,7 +3,7 @@
 
 namespace LoraKeysManagerFacade.Test
 {
-    using Microsoft.Azure.WebJobs;
+    using System.Threading.Tasks;
     using Xunit;
 
     public class FCntCacheCheckTest : FunctionTestBase
@@ -16,51 +16,51 @@ namespace LoraKeysManagerFacade.Test
         }
 
         [Fact]
-        public void FrameCounter_Down_Initial()
+        public async Task FrameCounter_Down_Initial()
         {
             var deviceEUI = NewUniqueEUI64();
             var gatewayId = NewUniqueEUI64();
 
-            var next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 1, 1);
+            var next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 1, 1);
             Assert.Equal(2U, next);
         }
 
         [Fact]
-        public void FrameCounter_Down_Update_Server()
+        public async Task FrameCounter_Down_Update_Server()
         {
             var deviceEUI = NewUniqueEUI64();
             var gatewayId = NewUniqueEUI64();
 
-            var next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 1, 1);
+            var next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 1, 1);
             Assert.Equal(2U, next);
 
-            next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 2, 1);
+            next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 2, 1);
             Assert.Equal(3U, next);
         }
 
         [Fact]
-        public void FrameCounter_Down_Update_Device()
+        public async Task FrameCounter_Down_Update_Device()
         {
             var deviceEUI = NewUniqueEUI64();
             var gatewayId = NewUniqueEUI64();
 
-            var next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 1, 1);
+            var next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 1, 1);
             Assert.Equal(2U, next);
 
-            next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 3, 10);
+            next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 3, 10);
             Assert.Equal(11U, next);
         }
 
         [Fact]
-        public void FrameCounter_Down_Retry_Increment()
+        public async Task FrameCounter_Down_Retry_Increment()
         {
             var deviceEUI = NewUniqueEUI64();
             var gatewayId = NewUniqueEUI64();
 
-            var next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 1, 1);
+            var next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 1, 1);
             Assert.Equal(2U, next);
 
-            next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 1, 1);
+            next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 1, 1);
             Assert.Equal(3U, next);
         }
     }

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/FunctionBundlerTest.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/FunctionBundlerTest.cs
@@ -221,7 +221,6 @@ namespace LoraKeysManagerFacade.Test
 
             foreach (var req in requests)
             {
-                // functionBundlerResults.Add(await ExecuteRequest(devEUI, req));
                 tasks.Add(Task.Run(async () =>
                 {
                     functionBundlerResults.Add(await this.ExecuteRequest(devEUI, req));

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/LoRaInMemoryDeviceStore.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/LoRaInMemoryDeviceStore.cs
@@ -99,5 +99,10 @@ namespace LoraKeysManagerFacade.Test
 
             return null;
         }
+
+        public bool KeyExists(string key)
+        {
+            return this.cache.ContainsKey(key);
+        }
     }
 }

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/MessageDeduplicationTests.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/MessageDeduplicationTests.cs
@@ -3,8 +3,8 @@
 
 namespace LoraKeysManagerFacade.Test
 {
+    using System.Threading.Tasks;
     using LoraKeysManagerFacade.FunctionBundler;
-    using Microsoft.Azure.WebJobs;
     using Xunit;
 
     public class MessageDeduplicationTests : FunctionTestBase
@@ -17,57 +17,57 @@ namespace LoraKeysManagerFacade.Test
         }
 
         [Fact]
-        public void MessageDeduplication_Duplicates_Found()
+        public async Task MessageDeduplication_Duplicates_Found()
         {
             string gateway1Id = NewUniqueEUI64();
             string gateway2Id = NewUniqueEUI64();
             string dev1EUI = NewUniqueEUI64();
 
-            var result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev1EUI, gateway1Id, 1, 1);
+            var result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway1Id, 1, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway1Id, result.GatewayId);
 
-            result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev1EUI, gateway2Id, 1, 1);
+            result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway2Id, 1, 1);
             Assert.True(result.IsDuplicate);
             Assert.Equal(gateway1Id, result.GatewayId);
         }
 
         [Fact]
-        public void MessageDeduplication_Resubmit_Allowed()
+        public async Task MessageDeduplication_Resubmit_Allowed()
         {
             string gateway1Id = NewUniqueEUI64();
             string dev1EUI = NewUniqueEUI64();
 
-            var result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev1EUI, gateway1Id, 1, 1);
+            var result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway1Id, 1, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway1Id, result.GatewayId);
 
-            result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev1EUI, gateway1Id, 1, 1);
+            result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway1Id, 1, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway1Id, result.GatewayId);
         }
 
         [Fact]
-        public void MessageDeduplication_DifferentDevices_Allowed()
+        public async Task MessageDeduplication_DifferentDevices_Allowed()
         {
             string gateway1Id = NewUniqueEUI64();
             string gateway2Id = NewUniqueEUI64();
             string dev1EUI = NewUniqueEUI64();
             string dev2EUI = NewUniqueEUI64();
 
-            var result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev1EUI, gateway1Id, 1, 1);
+            var result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway1Id, 1, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway1Id, result.GatewayId);
 
-            result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev1EUI, gateway2Id, 2, 1);
+            result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway2Id, 2, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway2Id, result.GatewayId);
 
-            result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev2EUI, gateway1Id, 1, 1);
+            result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev2EUI, gateway1Id, 1, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway1Id, result.GatewayId);
 
-            result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev2EUI, gateway2Id, 2, 1);
+            result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev2EUI, gateway2Id, 2, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway2Id, result.GatewayId);
         }

--- a/Samples/DecoderSample/module.json
+++ b/Samples/DecoderSample/module.json
@@ -2,9 +2,9 @@
   "$schema-version": "0.0.1",
   "description": "",
   "image": {
-    "repository": "your.azurecr.io/sensordecodermodule",
+    "repository": "$CONTAINER_REGISTRY_ADDRESS/decodersample",
     "tag": {
-      "version": "0.0.1",
+      "version": "2.0",
       "platforms": {
         "amd64": "./Dockerfile.amd64",
         "arm32v7": "./Dockerfile.arm32v7"

--- a/Samples/DecoderSample/push_to_acr.sh
+++ b/Samples/DecoderSample/push_to_acr.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+docker push "$1.azurecr.io/decodersample:$2-amd64"
+docker push "$1.azurecr.io/decodersample:$2-arm32v7"
+
+docker manifest create "$1.azurecr.io/decodersample:$2" "$1.azurecr.io/decodersample:$2-amd64" "$1.azurecr.io/decodersample:$2-arm32v7"
+docker manifest push "$1.azurecr.io/decodersample:$2"

--- a/azure-pipelines-buildpushiotedge-templates.yaml
+++ b/azure-pipelines-buildpushiotedge-templates.yaml
@@ -3,6 +3,7 @@ parameters:
   platform: ''
   deviceID: ''
   deploymentTemplate: 'deployment.test.template.json'
+  deploymentConfigFile: 'deployment.test.json'
 
 steps:
 
@@ -52,7 +53,7 @@ steps:
     deploymentid: $(IOT_DEPLOYMENT_ID)
     azureSubscriptionEndpoint: $(AzureServiceConnectionName)
     azureContainerRegistry: '{"loginServer":"$(CONTAINER_REGISTRY_ADDRESS)", "id" : "/subscriptions/$(AZURE_SUBSCRIPTIONID)/resourceGroups/$(ACR_RG)/providers/Microsoft.ContainerRegistry/registries/$(ACR_NAME)"}'
-    templateFilePath: ./LoRaEngine/deployment.test.template.json
+    templateFilePath: ./LoRaEngine/${{parameters.deploymentTemplate}}
     defaultPlatform: ${{ parameters.platform }}
 
 # Azure IoT Edge - Deploy to test device
@@ -61,7 +62,7 @@ steps:
   inputs:
     action: 'Deploy to IoT Edge devices'
     # In Build: Path of output deployment file.
-    deploymentFilePath: $(Build.ArtifactStagingDirectory)/deployment.test.json
+    deploymentFilePath: $(Build.ArtifactStagingDirectory)/${{parameters.deploymentConfigFile}}
     azureSubscription: $(AzureServiceConnectionName)
     iothubname: $(INTEGRATIONTEST_IOTHUB_NAME)
     deploymentid: $(IOT_DEPLOYMENT_ID)

--- a/azure-pipelines-buildpushiotedge-templates.yaml
+++ b/azure-pipelines-buildpushiotedge-templates.yaml
@@ -2,6 +2,7 @@
 parameters:
   platform: ''
   deviceID: ''
+  deploymentTemplate: 'deployment.test.template.json'
 
 steps:
 
@@ -37,7 +38,7 @@ steps:
   displayName: 'Azure IoT Edge - Build module ${{ parameters.platform }} images'
   inputs:
     deploymentid: $(IOT_DEPLOYMENT_ID)
-    templateFilePath: ./LoRaEngine/deployment.test.template.json
+    templateFilePath: ./LoRaEngine/${{parameters.deploymentTemplate}}
     defaultPlatform: ${{ parameters.platform }}
 
 # Azure IoT Edge - Push images

--- a/azure-pipelines-buildpushiotedge-templates.yaml
+++ b/azure-pipelines-buildpushiotedge-templates.yaml
@@ -50,7 +50,7 @@ steps:
   inputs:
     action: 'Push module images'
     deploymentid: $(IOT_DEPLOYMENT_ID)
-    azureSubscriptionEndpoint: $(azureServiceConnectionName)
+    azureSubscriptionEndpoint: $(AzureServiceConnectionName)
     azureContainerRegistry: '{"loginServer":"$(CONTAINER_REGISTRY_ADDRESS)", "id" : "/subscriptions/$(AZURE_SUBSCRIPTIONID)/resourceGroups/$(ACR_RG)/providers/Microsoft.ContainerRegistry/registries/$(ACR_NAME)"}'
     templateFilePath: ./LoRaEngine/deployment.test.template.json
     defaultPlatform: ${{ parameters.platform }}
@@ -62,7 +62,7 @@ steps:
     action: 'Deploy to IoT Edge devices'
     # In Build: Path of output deployment file.
     deploymentFilePath: $(Build.ArtifactStagingDirectory)/deployment.test.json
-    azureSubscription: $(azureServiceConnectionName)
+    azureSubscription: $(AzureServiceConnectionName)
     iothubname: $(INTEGRATIONTEST_IOTHUB_NAME)
     deploymentid: $(IOT_DEPLOYMENT_ID)
     deviceOption: 'Single Device'
@@ -72,7 +72,7 @@ steps:
 - task: AzureCLI@1
   displayName: 'Waiting deployment $(IOT_DEPLOYMENT_ID) to be ready at ${{ parameters.deviceID }}...'
   inputs:
-    azureSubscription: $(azureServiceConnectionName)
+    azureSubscription: $(AzureServiceConnectionName)
     timeoutInMinutes: 30
     scriptLocation: inlineScript
     inlineScript: |

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -49,6 +49,7 @@ variables:
 #    - dev
 pr:
  branches:
+   include: pat-dev-multi-gw-test
    exclude:
    - master
    - dev
@@ -58,9 +59,9 @@ pr:
 trigger:
   batch: true
   branches:
+    include: pat-dev-multi-gw-test
     exclude:
-	  - pat-dev-multi-gw-test
-    - dev
+	  - dev
     - master
 
 jobs:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -152,6 +152,7 @@ jobs:
      echo "Determine ARM build agent IP address"
      BUILD_AGENT_IP_LOCAL=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
      echo "##vso[task.setvariable variable=BUILD_AGENT_IP]$BUILD_AGENT_IP_LOCAL"
+     name: Determine ARM build agent IP
 
 
 # [Job] Build, push and deploy arm32v7 IoT Edge Solution - secondary gateway

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -149,10 +149,10 @@ jobs:
     demands: Agent.OSArchitecture -equals ARM # Run on pi atm
   steps:
     - bash: |
-     echo "Determine ARM build agent IP address"
-     BUILD_AGENT_IP_LOCAL=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
-     echo "##vso[task.setvariable variable=BUILD_AGENT_IP]$BUILD_AGENT_IP_LOCAL"
-     name: Determine ARM build agent IP
+        echo "Determine ARM build agent IP address"
+        BUILD_AGENT_IP_LOCAL=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
+        echo "##vso[task.setvariable variable=BUILD_AGENT_IP]$BUILD_AGENT_IP_LOCAL"
+     displayName: Determine ARM build agent IP
 
 
 # [Job] Build, push and deploy arm32v7 IoT Edge Solution - secondary gateway

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -58,9 +58,8 @@ pr:
 trigger:
   batch: true
   branches:
-    include:
     exclude:
-	- pat-dev-multi-gw-test
+	  - pat-dev-multi-gw-test
     - dev
     - master
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -148,8 +148,6 @@ jobs:
   variables:
     IOT_DEPLOYMENT_ID: integrationtestarmsecondary
     RESET_PIN: $(RESET_PIN_SECONDARY)
-    # Defines image version to use in case in ARM architecture
-    DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-arm32v7"
     
   dependsOn:  build_and_test
   condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -147,7 +147,6 @@ jobs:
   displayName: Build, push and deploy arm32v7 IoT Edge Solution - Secondary Gateway
   variables:
     IOT_DEPLOYMENT_ID: integrationtestarmsecondary
-    VSTS_AGENT: "$(vstsAgentARM)"
     RESET_PIN: $(RESET_PIN_SECONDARY)
     # Defines image version to use in case in ARM architecture
     DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-arm32v7"

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -63,7 +63,7 @@ trigger:
     include:
     - pat-dev-multi-gw-test
     exclude:
-	  - dev
+    - dev
     - master
 
 jobs:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -141,20 +141,6 @@ jobs:
         platform: arm32v7
         deviceID: $(IoTEdgeDeviceARMPrimary)
 
-- job: full_ci_arm_secondary_prepare
-  displayName: Prepare Secondary Gateway
-  condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
-  pool:
-    name: Default
-    demands: Agent.OSArchitecture -equals ARM # Run on pi atm
-  steps:
-    - bash: |
-        echo "Determine ARM build agent IP address"
-        BUILD_AGENT_IP_LOCAL=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
-        echo "##vso[task.setvariable variable=BUILD_AGENT_IP]$BUILD_AGENT_IP_LOCAL"
-      displayName: Determine ARM build agent IP
-
-
 # [Job] Build, push and deploy arm32v7 IoT Edge Solution - secondary gateway
 - job: full_ci_deploy_arm_secondary
   displayName: Build, push and deploy arm32v7 IoT Edge Solution - Secondary Gateway
@@ -165,9 +151,7 @@ jobs:
     # Defines image version to use in case in ARM architecture
     DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-arm32v7"
     
-  dependsOn: 
-    - build_and_test
-    - full_ci_arm_secondary_prepare
+  dependsOn:  build_and_test
   condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
   pool:
     # name: docker

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -141,6 +141,19 @@ jobs:
         platform: arm32v7
         deviceID: $(IoTEdgeDeviceARMPrimary)
 
+- job: full_ci_arm_secondary_prepare
+  displayName: Prepare Secondary Gateway - Get build agent IP
+  condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
+  pool:
+    name: Default
+    demands: Agent.OSArchitecture -equals ARM # Run on pi atm
+  steps:
+    - bash: |
+     echo "Determine ARM build agent IP address"
+     BUILD_AGENT_IP_LOCAL=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
+     echo "##vso[task.setvariable variable=BUILD_AGENT_IP]$BUILD_AGENT_IP_LOCAL"
+
+
 # [Job] Build, push and deploy arm32v7 IoT Edge Solution - secondary gateway
 - job: full_ci_deploy_arm_secondary
   displayName: Build, push and deploy arm32v7 IoT Edge Solution - Secondary Gateway
@@ -151,7 +164,9 @@ jobs:
     # Defines image version to use in case in ARM architecture
     DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-arm32v7"
     
-  dependsOn: build_and_test
+  dependsOn: 
+    - build_and_test
+    - full_ci_arm_secondary_prepare
   condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
   pool:
     # name: docker

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -49,7 +49,8 @@ variables:
 #    - dev
 pr:
  branches:
-   include: pat-dev-multi-gw-test
+   include:
+    - pat-dev-multi-gw-test
    exclude:
    - master
    - dev
@@ -59,7 +60,8 @@ pr:
 trigger:
   batch: true
   branches:
-    include: pat-dev-multi-gw-test
+    include:
+    - pat-dev-multi-gw-test
     exclude:
 	  - dev
     - master

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -12,9 +12,6 @@ variables:
 
   buildConfiguration: 'Release'
 
-  # Name of service connection for resource group
-  azureServiceConnectionName: 'IntegrationTestRG'
-
   edgeAgentVersion: 1.0.6
   edgeHubVersion: 1.0.6
   edgeHubRoute: FROM /* INTO $upstream
@@ -210,7 +207,7 @@ jobs:
   - task: AzureRmWebAppDeployment@4
     displayName: 'Deploy Facade Azure Function'
     inputs:
-      azureSubscription: $(azureServiceConnectionName)
+      azureSubscription: $(AzureServiceConnectionName)
       appType: functionapp
       WebAppName: $(FACADE_WEBAPPNAME)
       packageForLinux: '$(Build.ArtifactStagingDirectory)/LoraKeysManagerFacade.zip'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -26,7 +26,23 @@ variables:
   vstsAgentAMD: myAgent-amd64
 
   # Network Server module level: 1 in order to get decoder information
-  networkServerLogLevel: 1  
+  networkServerLogLevel: 1
+
+  # IoT Edge Runtime configuration
+  EDGE_AGENT_VERSION: $(edgeAgentVersion)
+  EDGE_HUB_VERSION: $(edgeHubVersion)
+  EDGEHUB_OPTIMIZEFORPERFORMANCE: false
+  EDGEHUB_MQTTSETTINGS_ENABLED: false
+  EDGEHUB_HTTPSETTINGS_ENABLED: false
+  EDGEHUB_ROUTE: $(edgeHubRoute)
+  # LoRaWan Modules
+  NET_SRV_LOG_LEVEL: $(networkServerLogLevel)  
+  NET_SRV_LOGTO_UDP: true
+  NET_SRV_LOGTO_HUB: false
+  NET_SRV_IOTEDGE_TIMEOUT: 0
+  NET_SRV_VERSION: "" # Network Server module version
+  NET_SRV_LOG_TO_UDP_ADDRESS: AzureDevOpsAgent # Hostname of container where AzureDevOpsAgent will be running for Udp logging sink
+  PKT_FWD_VERSION: "" # Packet Forward module version
 
 # Enable PR validation on branches master and dev
 pr:
@@ -104,32 +120,18 @@ jobs:
     condition: eq(variables['Build.Reason'], 'PullRequest')
     name: checkPrCILabel
 
-# [Job] Build, push and deploy arm32v7 IoT Edge Solution
-- job: full_ci_deploy_arm
-  displayName: Build, push and deploy arm32v7 IoT Edge Solution
+# [Job] Build, push and deploy arm32v7 IoT Edge Solution - primary gateway
+- job: full_ci_deploy_arm_primary
+  displayName: Build, push and deploy arm32v7 IoT Edge Solution - Primary Gateway
   variables:
-    IOT_DEPLOYMENT_ID: integrationtestarm
-    # IoT Edge Runtime configuration
-    EDGE_AGENT_VERSION: $(edgeAgentVersion)
-    EDGE_HUB_VERSION: $(edgeHubVersion)
-    EDGEHUB_OPTIMIZEFORPERFORMANCE: false
-    EDGEHUB_MQTTSETTINGS_ENABLED: false
-    EDGEHUB_HTTPSETTINGS_ENABLED: false
-    EDGEHUB_ROUTE: $(edgeHubRoute)
-    # LoRaWan Modules
-    NET_SRV_LOG_LEVEL: $(networkServerLogLevel)  
-    NET_SRV_LOGTO_UDP: true
-    NET_SRV_LOGTO_HUB: false
-    NET_SRV_IOTEDGE_TIMEOUT: 0
-    NET_SRV_VERSION: "" # Network Server module version
-    NET_SRV_LOG_TO_UDP_ADDRESS: AzureDevOpsAgent # Hostname of container where AzureDevOpsAgent will be running for Udp logging sink
-    PKT_FWD_VERSION: "" # Packet Forward module version
+    IOT_DEPLOYMENT_ID: integrationtestarmprimary
     VSTS_AGENT: "$(vstsAgentARM)"
+    RESET_PIN: $(RESET_PIN_PRIMARY)
     # Defines image version to use in case in ARM architecture
     DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-arm32v7"
     
   dependsOn: build_and_test
-  condition: and(ne(variables['IoTEdgeDeviceARM'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
+  condition: and(ne(variables['IoTEdgeDeviceARMPrimary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
   pool:
     # name: docker
     # demands: Agent.OSArchitecture -equals X64
@@ -138,29 +140,37 @@ jobs:
     - template: azure-pipelines-buildpushiotedge-templates.yaml
       parameters:
         platform: arm32v7
-        deviceID: $(IoTEdgeDeviceARM)
+        deviceID: $(IoTEdgeDeviceARMPrimary)
+
+# [Job] Build, push and deploy arm32v7 IoT Edge Solution - secondary gateway
+- job: full_ci_deploy_arm_secondary
+  displayName: Build, push and deploy arm32v7 IoT Edge Solution - Secondary Gateway
+  variables:
+    IOT_DEPLOYMENT_ID: integrationtestarmsecondary
+    VSTS_AGENT: "$(vstsAgentARM)"
+    RESET_PIN: $(RESET_PIN_SECONDARY)
+    # Defines image version to use in case in ARM architecture
+    DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-arm32v7"
+    
+  dependsOn: build_and_test
+  condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
+  pool:
+    # name: docker
+    # demands: Agent.OSArchitecture -equals X64
+    vmImage: 'Ubuntu 16.04'   
+  steps:
+    - template: azure-pipelines-buildpushiotedge-templates.yaml
+      parameters:
+        platform: arm32v7
+        deviceID: $(IoTEdgeDeviceARMSecondary)
+        deploymentTemplate: deployment.test.secondary.template.json
+
 
 # [Job] Build, push and deploy amd64 IoT Edge Solution 
 - job: full_ci_deploy_amd
   displayName: Build, push and deploy amd64 IoT Edge Solution
   variables:
     IOT_DEPLOYMENT_ID: integrationtestamd
-    # IoT Edge Runtime configuration
-    EDGE_AGENT_VERSION: $(edgeAgentVersion)
-    EDGE_HUB_VERSION: $(edgeHubVersion)
-    EDGEHUB_OPTIMIZEFORPERFORMANCE: false
-    EDGEHUB_MQTTSETTINGS_ENABLED: false
-    EDGEHUB_HTTPSETTINGS_ENABLED: false
-    EDGEHUB_ROUTE: $(edgeHubRoute)
-    # LoRaWan Modules
-    NET_SRV_LOG_LEVEL: $(networkServerLogLevel)  
-    NET_SRV_LOGTO_UDP: true
-    NET_SRV_LOGTO_HUB: false
-    NET_SRV_IOTEDGE_TIMEOUT: 0
-    NET_SRV_VERSION: "" # Network Server module version
-    PKT_FWD_VERSION: "" # Packet Forward module version
-    NET_SRV_LOG_TO_UDP_ADDRESS: AzureDevOpsAgent # Hostname of container where AzureDevOpsAgent will be running for Udp logging sink
-
     VSTS_AGENT: "$(vstsAgentAMD)"
     # Defines image version to use in case in AMD architecture
     DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-amd64"
@@ -235,9 +245,10 @@ jobs:
 - job: test_runner_arm_eu
   displayName: Run tests in ARM device (EU)
   dependsOn: 
-    - full_ci_deploy_arm
+    - full_ci_deploy_arm_primary
+    - full_ci_deploy_arm_secondary
     - full_ci_deploy_facade_function
-  condition: and(ne(variables['IoTEdgeDeviceARM'], ''), or(succeeded(), eq(variables['RunTestsOnly'], 'true')))
+  condition: and(ne(variables['IoTEdgeDeviceARMPrimary'], ''), or(succeeded(), eq(variables['RunTestsOnly'], 'true')))
   timeoutInMinutes: 120 # Raspberry PI is slow, allow taking 120 minutes
   pool:    
     name: Default
@@ -245,7 +256,7 @@ jobs:
   variables:      
     INTEGRATIONTEST_LeafDeviceSerialPort: "/dev/ttyACM0"
     INTEGRATIONTEST_IoTHubEventHubConsumerGroup: "reserved_integrationtest" 
-    INTEGRATIONTEST_LeafDeviceGatewayID: $(IoTEdgeDeviceARM)
+    INTEGRATIONTEST_LeafDeviceGatewayID: $(IoTEdgeDeviceARMPrimary)
     INTEGRATIONTEST_DevicePrefix: '01'
   
   steps:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -161,6 +161,7 @@ jobs:
         platform: arm32v7
         deviceID: $(IoTEdgeDeviceARMSecondary)
         deploymentTemplate: deployment.test.secondary.template.json
+        deploymentConfigFile: deployment.test.secondary.json
 
 
 # [Job] Build, push and deploy amd64 IoT Edge Solution 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -42,11 +42,11 @@ variables:
   PKT_FWD_VERSION: "" # Packet Forward module version
 
 # Enable PR validation on branches master and dev
-pr:
-  branches:
-    include:
-    - master
-    - dev
+# pr:
+#  branches:
+#    include:
+#    - master
+#    - dev
 
 # Enable CI on branches master and dev
 # Batch builds
@@ -54,6 +54,8 @@ trigger:
   batch: true
   branches:
     include:
+    - pat-dev-multi-gw-test
+    exclude:
     - dev
     - master
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -51,9 +51,6 @@ pr:
  branches:
    include:
     - pat-dev-multi-gw-test
-   exclude:
-   - master
-   - dev
 
 # Enable CI on branches master and dev
 # Batch builds
@@ -62,9 +59,6 @@ trigger:
   branches:
     include:
     - pat-dev-multi-gw-test
-    exclude:
-    - dev
-    - master
 
 jobs:
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -142,7 +142,7 @@ jobs:
         deviceID: $(IoTEdgeDeviceARMPrimary)
 
 - job: full_ci_arm_secondary_prepare
-  displayName: Prepare Secondary Gateway - Get build agent IP
+  displayName: Prepare Secondary Gateway
   condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
   pool:
     name: Default
@@ -152,7 +152,7 @@ jobs:
         echo "Determine ARM build agent IP address"
         BUILD_AGENT_IP_LOCAL=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
         echo "##vso[task.setvariable variable=BUILD_AGENT_IP]$BUILD_AGENT_IP_LOCAL"
-     displayName: Determine ARM build agent IP
+      displayName: Determine ARM build agent IP
 
 
 # [Job] Build, push and deploy arm32v7 IoT Edge Solution - secondary gateway

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -47,6 +47,11 @@ variables:
 #    include:
 #    - master
 #    - dev
+pr:
+ branches:
+   exclude:
+   - master
+   - dev
 
 # Enable CI on branches master and dev
 # Batch builds
@@ -54,8 +59,8 @@ trigger:
   batch: true
   branches:
     include:
-    - pat-dev-multi-gw-test
     exclude:
+	- pat-dev-multi-gw-test
     - dev
     - master
 


### PR DESCRIPTION
This fixes several issues:
- deduplication race with device reset (ABP relaxed mode)
- fix OTAA join when having a gateway in the twin
- add a blocking lock to the cache