### PR TITLE
fix server races

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/CheckPreferredGateway/PreferredGatewayExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/CheckPreferredGateway/PreferredGatewayExecutionItem.cs
@@ -107,7 +107,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
 
             for (var i = 0; i < MAX_ATTEMPTS_TO_RESOLVE_PREFERRED_GATEWAY; i++)
             {
-                if (await this.cacheStore.LockTakeAsync(preferredGatewayLockKey, computationId, TimeSpan.FromMilliseconds(200)))
+                if (await this.cacheStore.LockTakeAsync(preferredGatewayLockKey, computationId, TimeSpan.FromMilliseconds(200), block: false))
                 {
                     try
                     {

--- a/LoRaEngine/LoraKeysManagerFacade/CheckPreferredGateway/PreferredGatewayExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/CheckPreferredGateway/PreferredGatewayExecutionItem.cs
@@ -107,7 +107,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
 
             for (var i = 0; i < MAX_ATTEMPTS_TO_RESOLVE_PREFERRED_GATEWAY; i++)
             {
-                if (this.cacheStore.LockTake(preferredGatewayLockKey, computationId, TimeSpan.FromMilliseconds(200)))
+                if (await this.cacheStore.LockTakeAsync(preferredGatewayLockKey, computationId, TimeSpan.FromMilliseconds(200)))
                 {
                     try
                     {

--- a/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
@@ -60,7 +60,7 @@ namespace LoraKeysManagerFacade
 
             try
             {
-                var results = await this.GetDeviceList(devEUI, gatewayId, devNonce, devAddr);
+                var results = await this.GetDeviceList(devEUI, gatewayId, devNonce, devAddr, log);
                 string json = JsonConvert.SerializeObject(results);
                 return new OkObjectResult(json);
             }
@@ -68,48 +68,63 @@ namespace LoraKeysManagerFacade
             {
                 return new BadRequestObjectResult("UsedDevNonce");
             }
+            catch (JoinRefusedException ex)
+            {
+                log.LogDebug("Join refused: {msg}", ex.Message);
+                return new BadRequestObjectResult("JoinRefused: " + ex.Message);
+            }
             catch (ArgumentException ex)
             {
                 return new BadRequestObjectResult(ex.Message);
             }
         }
 
-        public async Task<List<IoTHubDeviceInfo>> GetDeviceList(string devEUI, string gatewayId, string devNonce, string devAddr)
+        public async Task<List<IoTHubDeviceInfo>> GetDeviceList(string devEUI, string gatewayId, string devNonce, string devAddr, ILogger log = null)
         {
             var results = new List<IoTHubDeviceInfo>();
 
             if (devEUI != null)
             {
                 // OTAA join
-                string cacheKey = devEUI + devNonce;
-                using (var deviceCache = new LoRaDeviceCache(this.cacheStore, devEUI, gatewayId, cacheKey))
+                using (var deviceCache = new LoRaDeviceCache(this.cacheStore, devEUI, gatewayId))
                 {
-                    if (deviceCache.HasValue())
+                    var joinInfo = await this.GetJoinInfoAsync(devEUI, gatewayId, log);
+
+                    var cacheKeyDevNonce = string.Concat(devEUI, ":", devNonce);
+                    var lockKeyDevNonce = string.Concat(cacheKeyDevNonce, ":joinlockdevnonce");
+
+                    if (await this.cacheStore.LockTakeAsync(lockKeyDevNonce, gatewayId, TimeSpan.FromSeconds(10)))
                     {
-                        throw new DeviceNonceUsedException();
-                    }
-
-                    if (deviceCache.TryToLock(cacheKey + "joinlock"))
-                    {
-                        if (deviceCache.HasValue())
+                        try
                         {
-                            throw new DeviceNonceUsedException();
-                        }
+                            var freshValue = this.cacheStore.StringSet(cacheKeyDevNonce, devNonce, TimeSpan.FromMinutes(5), onlyIfNotExists: true);
+                            if (!freshValue)
+                            {
+                                log?.LogDebug("dev nonce already used. Ignore request '{key}':{gwid}", devEUI, gatewayId);
+                                throw new DeviceNonceUsedException();
+                            }
 
-                        deviceCache.SetValue(devNonce, TimeSpan.FromMinutes(1));
-
-                        var device = await this.registryManager.GetDeviceAsync(devEUI);
-
-                        if (device != null)
-                        {
                             var iotHubDeviceInfo = new IoTHubDeviceInfo
                             {
                                 DevEUI = devEUI,
-                                PrimaryKey = device.Authentication.SymmetricKey.PrimaryKey
+                                PrimaryKey = joinInfo.PrimaryKey
                             };
+
                             results.Add(iotHubDeviceInfo);
 
-                            this.cacheStore.KeyDelete(devEUI);
+                            if (await deviceCache.TryToLockAsync())
+                            {
+                                this.cacheStore.KeyDelete(devEUI);
+                                log?.LogDebug("Removed key '{key}':{gwid}", devEUI, gatewayId);
+                            }
+                            else
+                            {
+                                log?.LogWarning("Failed to acquire lock for '{key}'", devEUI);
+                            }
+                        }
+                        finally
+                        {
+                            this.cacheStore.LockRelease(lockKeyDevNonce, gatewayId);
                         }
                     }
                     else
@@ -152,6 +167,62 @@ namespace LoraKeysManagerFacade
             }
 
             return results;
+        }
+
+        private async Task<JoinInfo> GetJoinInfoAsync(string devEUI, string gatewayId, ILogger log)
+        {
+            var cacheKeyJoinInfo = string.Concat(devEUI, ":joininfo");
+            var lockKeyJoinInfo = string.Concat(devEUI, ":joinlockjoininfo");
+            JoinInfo joinInfo = null;
+
+            if (await this.cacheStore.LockTakeAsync(lockKeyJoinInfo, gatewayId, TimeSpan.FromMinutes(5)))
+            {
+                try
+                {
+                    joinInfo = this.cacheStore.GetObject<JoinInfo>(cacheKeyJoinInfo);
+                    if (joinInfo == null)
+                    {
+                        joinInfo = new JoinInfo();
+
+                        var device = await this.registryManager.GetDeviceAsync(devEUI);
+                        if (device != null)
+                        {
+                            joinInfo.PrimaryKey = device.Authentication.SymmetricKey.PrimaryKey;
+                            var twin = await this.registryManager.GetTwinAsync(devEUI);
+                            const string GatewayIdProperty = "GatewayID";
+                            if (twin.Properties.Desired.Contains(GatewayIdProperty))
+                            {
+                                joinInfo.DesiredGateway = twin.Properties.Desired[GatewayIdProperty].Value as string;
+                            }
+                        }
+
+                        this.cacheStore.ObjectSet(cacheKeyJoinInfo, joinInfo, TimeSpan.FromMinutes(60));
+                        log?.LogDebug("updated cache with join info '{key}':{gwid}", devEUI, gatewayId);
+                    }
+
+                    if (string.IsNullOrEmpty(joinInfo.PrimaryKey))
+                    {
+                        throw new JoinRefusedException("Not in our network.");
+                    }
+
+                    if (!string.IsNullOrEmpty(joinInfo.DesiredGateway) && gatewayId != joinInfo.DesiredGateway)
+                    {
+                        throw new JoinRefusedException("Not the owning gateway");
+                    }
+
+                    log?.LogDebug("got LogInfo '{key}':{gwid} attached gw: {desiredgw}", devEUI, gatewayId, joinInfo.DesiredGateway);
+                }
+                finally
+                {
+                    var released = this.cacheStore.LockRelease(lockKeyJoinInfo, gatewayId);
+                }
+            }
+            else
+            {
+                throw new JoinRefusedException("Failed to acquire lock for joininfo");
+            }
+
+            return joinInfo;
         }
     }
 }

--- a/LoRaEngine/LoraKeysManagerFacade/FCntCacheCheck.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FCntCacheCheck.cs
@@ -57,7 +57,7 @@ namespace LoraKeysManagerFacade
                     {
                         if (deviceCache.TryGetInfo(out var deviceInfo))
                         {
-                            // only reset the cache if the current valud is larger
+                            // only reset the cache if the current value is larger
                             // than 1 otherwise we likely reset it from another device
                             // and continued processing
                             if (deviceInfo.FCntUp > 1)

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/DeduplicationExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/DeduplicationExecutionItem.cs
@@ -5,6 +5,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
 {
     using System.Threading.Tasks;
     using LoRaTools.CommonAPI;
+    using Microsoft.Extensions.Logging;
 
     public class DeduplicationExecutionItem : IFunctionBundlerExecutionItem
     {
@@ -15,10 +16,10 @@ namespace LoraKeysManagerFacade.FunctionBundler
             this.cacheStore = cacheStore;
         }
 
-        public Task<FunctionBundlerExecutionState> ExecuteAsync(IPipelineExecutionContext context)
+        public async Task<FunctionBundlerExecutionState> ExecuteAsync(IPipelineExecutionContext context)
         {
-            context.Result.DeduplicationResult = this.GetDuplicateMessageResult(context.DevEUI, context.Request.GatewayId, context.Request.ClientFCntUp, context.Request.ClientFCntDown);
-            return Task.FromResult(context.Result.DeduplicationResult.IsDuplicate ? FunctionBundlerExecutionState.Abort : FunctionBundlerExecutionState.Continue);
+            context.Result.DeduplicationResult = await this.GetDuplicateMessageResultAsync(context.DevEUI, context.Request.GatewayId, context.Request.ClientFCntUp, context.Request.ClientFCntDown, context.Logger);
+            return context.Result.DeduplicationResult.IsDuplicate ? FunctionBundlerExecutionState.Abort : FunctionBundlerExecutionState.Continue;
         }
 
         public int Priority => 1;
@@ -33,14 +34,14 @@ namespace LoraKeysManagerFacade.FunctionBundler
             return Task.CompletedTask;
         }
 
-        internal DuplicateMsgResult GetDuplicateMessageResult(string devEUI, string gatewayId, uint clientFCntUp, uint clientFCntDown)
+        internal async Task<DuplicateMsgResult> GetDuplicateMessageResultAsync(string devEUI, string gatewayId, uint clientFCntUp, uint clientFCntDown, ILogger logger = null)
         {
             var isDuplicate = true;
             string processedDevice = gatewayId;
 
             using (var deviceCache = new LoRaDeviceCache(this.cacheStore, devEUI, gatewayId))
             {
-                if (deviceCache.TryToLock())
+                if (await deviceCache.TryToLockAsync())
                 {
                     // we are owning the lock now
                     if (deviceCache.TryGetInfo(out DeviceCacheInfo cachedDeviceState))
@@ -74,7 +75,13 @@ namespace LoraKeysManagerFacade.FunctionBundler
                         // initialize
                         isDuplicate = false;
                         var state = deviceCache.Initialize(clientFCntUp, clientFCntDown);
+                        logger?.LogDebug("initialized state for {id}:{gwid} = {state}", devEUI, gatewayId, state);
                     }
+                }
+                else
+                {
+                    processedDevice = "[unknown]";
+                    logger?.LogWarning("Failed to acquire lock");
                 }
             }
 

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerPipelineExecuter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerPipelineExecuter.cs
@@ -5,7 +5,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using LoRaTools.CommonAPI;
+    using Microsoft.Extensions.Logging;
 
     public class FunctionBundlerPipelineExecuter : IPipelineExecutionContext
     {
@@ -16,6 +16,8 @@ namespace LoraKeysManagerFacade.FunctionBundler
         public FunctionBundlerRequest Request { get; private set; }
 
         public FunctionBundlerResult Result { get; private set; } = new FunctionBundlerResult();
+
+        public ILogger Logger { get; private set; }
 
         public FunctionBundlerPipelineExecuter(
                                                IFunctionBundlerExecutionItem[] registeredHandlers,

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/IPipelineExecutionContext.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/IPipelineExecutionContext.cs
@@ -5,6 +5,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
 {
     using System.Collections.Generic;
     using LoRaTools.CommonAPI;
+    using Microsoft.Extensions.Logging;
 
     public interface IPipelineExecutionContext
     {
@@ -13,5 +14,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
         FunctionBundlerRequest Request { get; }
 
         FunctionBundlerResult Result { get; }
+
+        ILogger Logger { get; }
     }
 }

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/NextFCntDownExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/NextFCntDownExecutionItem.cs
@@ -15,15 +15,15 @@ namespace LoraKeysManagerFacade.FunctionBundler
             this.fCntCacheCheck = fCntCacheCheck;
         }
 
-        public Task<FunctionBundlerExecutionState> ExecuteAsync(IPipelineExecutionContext context)
+        public async Task<FunctionBundlerExecutionState> ExecuteAsync(IPipelineExecutionContext context)
         {
             if (!context.Result.NextFCntDown.HasValue)
             {
-                var next = this.fCntCacheCheck.GetNextFCntDown(context.DevEUI, context.Request.GatewayId, context.Request.ClientFCntUp, context.Request.ClientFCntDown);
+                var next = await this.fCntCacheCheck.GetNextFCntDownAsync(context.DevEUI, context.Request.GatewayId, context.Request.ClientFCntUp, context.Request.ClientFCntDown);
                 context.Result.NextFCntDown = next > 0 ? next : (uint?)null;
             }
 
-            return Task.FromResult(FunctionBundlerExecutionState.Continue);
+            return FunctionBundlerExecutionState.Continue;
         }
 
         public int Priority => 3;

--- a/LoRaEngine/LoraKeysManagerFacade/ILoRaDeviceCacheStore.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ILoRaDeviceCacheStore.cs
@@ -17,7 +17,7 @@ namespace LoraKeysManagerFacade
         /// <param name="expiration">expiration timestamp, this specifies how long the lock will be held before automatically releasing</param>
         /// <param name="block">true to retry getting the lock in contention cases, false to try once and return the result</param>
         /// <returns>true if the lock was acquired otherwise false.</returns>
-        Task<bool> LockTakeAsync(string key, string owner, TimeSpan expiration, bool block = false);
+        Task<bool> LockTakeAsync(string key, string owner, TimeSpan expiration, bool block = true);
 
         string StringGet(string key);
 

--- a/LoRaEngine/LoraKeysManagerFacade/ILoRaDeviceCacheStore.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ILoRaDeviceCacheStore.cs
@@ -5,20 +5,35 @@ namespace LoraKeysManagerFacade
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     public interface ILoRaDeviceCacheStore
     {
-        bool LockTake(string key, string value, TimeSpan timeout);
+        /// <summary>
+        /// Tries to acquire a lock for a specific key.
+        /// </summary>
+        /// <param name="key">The lock key to try to acquire</param>
+        /// <param name="owner">The lock owner</param>
+        /// <param name="expiration">expiration timestamp, this specifies how long the lock will be held before automatically releasing</param>
+        /// <param name="block">true to retry getting the lock in contention cases, false to try once and return the result</param>
+        /// <returns>true if the lock was acquired otherwise false.</returns>
+        Task<bool> LockTakeAsync(string key, string owner, TimeSpan expiration, bool block = false);
 
         string StringGet(string key);
 
-        bool StringSet(string key, string value, TimeSpan? expiry, bool onlyIfNotExists = false);
+        T GetObject<T>(string key)
+            where T : class;
+
+        bool StringSet(string key, string value, TimeSpan? expiration, bool onlyIfNotExists = false);
+
+        bool ObjectSet<T>(string key, T value, TimeSpan? expiration, bool onlyIfNotExists = false)
+            where T : class;
 
         bool KeyDelete(string key);
 
         bool LockRelease(string key, string value);
 
-        long ListAdd(string key, string value, TimeSpan? expiry = null);
+        long ListAdd(string key, string value, TimeSpan? expiration = null);
 
         IReadOnlyList<string> ListGet(string key);
     }

--- a/LoRaEngine/LoraKeysManagerFacade/JoinInfo.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/JoinInfo.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoraKeysManagerFacade
+{
+    public class JoinInfo
+    {
+        public string PrimaryKey { get; set; }
+
+        public string DesiredGateway { get; set; }
+    }
+}

--- a/LoRaEngine/LoraKeysManagerFacade/JoinRefusedException.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/JoinRefusedException.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoraKeysManagerFacade
+{
+    using System;
+
+    public class JoinRefusedException : Exception
+    {
+        public JoinRefusedException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaADRFunction/LoRaADRServerManager.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaADRFunction/LoRaADRServerManager.cs
@@ -17,10 +17,10 @@ namespace LoraKeysManagerFacade
             this.deviceCacheStore = deviceCacheStore;
         }
 
-        public override Task<uint> NextFCntDown(string devEUI, string gatewayId, uint clientFCntUp, uint clientFCntDown)
+        public override async Task<uint> NextFCntDown(string devEUI, string gatewayId, uint clientFCntUp, uint clientFCntDown)
         {
             var fcntCheck = new FCntCacheCheck(this.deviceCacheStore);
-            return Task.FromResult(fcntCheck.GetNextFCntDown(devEUI, gatewayId, clientFCntUp, clientFCntDown));
+            return await fcntCheck.GetNextFCntDownAsync(devEUI, gatewayId, clientFCntUp, clientFCntDown);
         }
     }
 }

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCache.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCache.cs
@@ -110,6 +110,12 @@ namespace LoraKeysManagerFacade
             this.cacheStore.StringSet(this.cacheKey, value, expiry);
         }
 
+        public void ClearCache()
+        {
+            this.EnsureLockOwner();
+            this.cacheStore.KeyDelete(this.cacheKey);
+        }
+
         private void EnsureLockOwner()
         {
             if (!this.IsLockOwner)

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCache.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCache.cs
@@ -4,13 +4,14 @@
 namespace LoraKeysManagerFacade
 {
     using System;
+    using System.Threading.Tasks;
     using Microsoft.Azure.WebJobs;
     using Newtonsoft.Json;
 
     public sealed class LoRaDeviceCache : IDisposable
     {
         private const string CacheKeyLockSuffix = "msglock";
-        private static readonly TimeSpan LockWaitingTimeout = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan LockExpiry = TimeSpan.FromSeconds(10);
 
         private readonly ILoRaDeviceCacheStore cacheStore;
         private readonly string gatewayId;
@@ -21,7 +22,7 @@ namespace LoraKeysManagerFacade
 
         private string lockKey;
 
-        public LoRaDeviceCache(ILoRaDeviceCacheStore cacheStore, string devEUI, string gatewayId, string cacheKey = null)
+        public LoRaDeviceCache(ILoRaDeviceCacheStore cacheStore, string devEUI, string gatewayId)
         {
             if (string.IsNullOrEmpty(devEUI))
             {
@@ -36,27 +37,28 @@ namespace LoraKeysManagerFacade
             this.cacheStore = cacheStore;
             this.devEUI = devEUI;
             this.gatewayId = gatewayId;
-            this.cacheKey = cacheKey ?? devEUI;
+            this.cacheKey = devEUI;
         }
 
-        public bool TryToLock(string lockKey = null)
+        public async Task<bool> TryToLockAsync(string lockKey = null, bool block = true)
         {
             if (this.IsLockOwner)
             {
                 return true;
             }
 
-            this.lockKey = lockKey ?? this.devEUI + CacheKeyLockSuffix;
-            if (!this.cacheStore.LockTake(this.lockKey, this.gatewayId, LockWaitingTimeout))
+            var lk = lockKey ?? this.devEUI + CacheKeyLockSuffix;
+
+            if (this.IsLockOwner = await this.cacheStore.LockTakeAsync(lk, this.gatewayId, LockExpiry, block))
             {
-                return false;
+                // store the used key
+                this.lockKey = lk;
             }
 
-            this.IsLockOwner = true;
-            return true;
+            return this.IsLockOwner;
         }
 
-        public DeviceCacheInfo Initialize(uint fCntUp = 0, uint fCntDown = 0)
+        public bool Initialize(uint fCntUp = 0, uint fCntDown = 0)
         {
             // it is the first message from this device
             var serverStateForDeviceInfo = new DeviceCacheInfo
@@ -66,8 +68,7 @@ namespace LoraKeysManagerFacade
                 GatewayId = this.gatewayId
             };
 
-            this.StoreInfo(serverStateForDeviceInfo);
-            return serverStateForDeviceInfo;
+            return this.StoreInfo(serverStateForDeviceInfo, true);
         }
 
         public bool TryGetValue(out string value)
@@ -88,20 +89,14 @@ namespace LoraKeysManagerFacade
             info = null;
             this.EnsureLockOwner();
 
-            string cachedFCnt = this.cacheStore.StringGet(this.cacheKey);
-            if (string.IsNullOrEmpty(cachedFCnt))
-            {
-                return false;
-            }
-
-            info = JsonConvert.DeserializeObject<DeviceCacheInfo>(cachedFCnt);
+            info = this.cacheStore.GetObject<DeviceCacheInfo>(this.cacheKey);
             return info != null;
         }
 
-        public void StoreInfo(DeviceCacheInfo info)
+        public bool StoreInfo(DeviceCacheInfo info, bool initialize = false)
         {
             this.EnsureLockOwner();
-            this.cacheStore.StringSet(this.cacheKey, JsonConvert.SerializeObject(info), new TimeSpan(30, 0, 0, 0));
+            return this.cacheStore.StringSet(this.cacheKey, JsonConvert.SerializeObject(info), new TimeSpan(1, 0, 0, 0), initialize);
         }
 
         public void SetValue(string value, TimeSpan? expiry = null)

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCacheRedisStore.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCacheRedisStore.cs
@@ -6,22 +6,33 @@ namespace LoraKeysManagerFacade
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Microsoft.Azure.WebJobs;
-    using Microsoft.Extensions.Configuration;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Newtonsoft.Json;
     using StackExchange.Redis;
 
     public class LoRaDeviceCacheRedisStore : ILoRaDeviceCacheStore
     {
         private IDatabase redisCache;
+        private static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(10);
 
         public LoRaDeviceCacheRedisStore(IDatabase redisCache)
         {
             this.redisCache = redisCache;
         }
 
-        public bool LockTake(string key, string value, TimeSpan timeout)
+        public async Task<bool> LockTakeAsync(string key, string lockOwner, TimeSpan expiration, bool block = false)
         {
-            return this.redisCache.LockTake(key, value, timeout);
+            var start = DateTime.UtcNow;
+            var taken = false;
+            while (!(taken = this.redisCache.LockTake(key, lockOwner, expiration)) && block)
+            {
+                if (DateTime.UtcNow - start > LockTimeout)
+                    break;
+                await Task.Delay(100);
+            }
+
+            return taken;
         }
 
         public string StringGet(string key)
@@ -29,10 +40,41 @@ namespace LoraKeysManagerFacade
             return this.redisCache.StringGet(key, CommandFlags.DemandMaster);
         }
 
-        public bool StringSet(string key, string value, TimeSpan? expiry, bool onlyIfNotExists)
+        public T GetObject<T>(string key)
+            where T : class
+        {
+            var str = this.StringGet(key);
+            if (string.IsNullOrEmpty(str))
+            {
+                return null;
+            }
+
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(str);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public bool StringSet(string key, string value, TimeSpan? expiry, bool onlyIfNotExists = false)
         {
             var when = onlyIfNotExists ? When.NotExists : When.Always;
             return this.redisCache.StringSet(key, value, expiry, when, CommandFlags.DemandMaster);
+        }
+
+        public bool ObjectSet<T>(string key, T value, TimeSpan? expiration, bool onlyIfNotExists = false)
+            where T : class
+        {
+            var str = value != null ? JsonConvert.SerializeObject(value) : null;
+            return this.StringSet(key, str, expiration, onlyIfNotExists);
+        }
+
+        public bool KeyExists(string key)
+        {
+            return this.redisCache.KeyExists(key, CommandFlags.DemandMaster);
         }
 
         public bool KeyDelete(string key)

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCacheRedisStore.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCacheRedisStore.cs
@@ -21,7 +21,7 @@ namespace LoraKeysManagerFacade
             this.redisCache = redisCache;
         }
 
-        public async Task<bool> LockTakeAsync(string key, string lockOwner, TimeSpan expiration, bool block = false)
+        public async Task<bool> LockTakeAsync(string key, string lockOwner, TimeSpan expiration, bool block = true)
         {
             var start = DateTime.UtcNow;
             var taken = false;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApiVersion.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApiVersion.cs
@@ -25,7 +25,7 @@ namespace LoRaWan.Shared
         /// Gets the latest version released.
         /// Update this once a new API version is released
         /// </summary>
-        public static ApiVersion LatestVersion => Version_2019_03_26;
+        public static ApiVersion LatestVersion => Version_2019_04_02;
 
         /// <summary>
         /// Gets the Version from 0.1 and 0.2 had not versioning information
@@ -65,6 +65,12 @@ namespace LoRaWan.Shared
         public static ApiVersion Version_2019_03_26 { get; }
 
         /// <summary>
+        /// Gets Version_2019_04_02 version: 1.0.1
+        /// Not backward compatible
+        /// </summary>
+        public static ApiVersion Version_2019_04_02 { get; }
+
+        /// <summary>
         /// Gets the version that is assumed in case none is specified
         /// </summary>
         public static ApiVersion DefaultVersion => Version_0_2_Or_Earlier;
@@ -80,6 +86,7 @@ namespace LoRaWan.Shared
             yield return Version_2019_02_20_Preview;
             yield return Version_2019_03_08_Preview;
             yield return Version_2019_03_26;
+            yield return Version_2019_04_02;
         }
 
         /// <summary>
@@ -123,6 +130,9 @@ namespace LoRaWan.Shared
 
             Version_2019_03_26 = new ApiVersion("2019-03-26");
             Version_2019_03_26.MinCompatibleVersion = Version_2019_03_26;
+
+            Version_2019_04_02 = new ApiVersion("2019-04-02");
+            Version_2019_04_02.MinCompatibleVersion = Version_2019_04_02;
         }
 
         /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceFrameCounterUpdateStrategy.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceFrameCounterUpdateStrategy.cs
@@ -13,7 +13,7 @@ namespace LoRaWan.NetworkServer
     public interface ILoRaDeviceFrameCounterUpdateStrategy
     {
         // Resets the frame count
-        Task<bool> ResetAsync(LoRaDevice loRaDevice);
+        Task<bool> ResetAsync(LoRaDevice loRaDevice, uint fcntUp, string gatewayId);
 
         // Resolves next frame down counter
         ValueTask<uint> NextFcntDown(LoRaDevice loRaDevice, uint messageFcnt);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -55,7 +55,7 @@ namespace LoRaWan.NetworkServer
                 if (loRaDevice == null)
                 {
                     request.NotifyFailed(devEUI, LoRaDeviceRequestFailedReason.UnknownDevice);
-                    Logger.Log(devEUI, "join refused: unknown device", LogLevel.Information);
+                    Logger.Log(devEUI, "join refused", LogLevel.Information);
                     return;
                 }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -55,7 +55,7 @@ namespace LoRaWan.NetworkServer
                 if (loRaDevice == null)
                 {
                     request.NotifyFailed(devEUI, LoRaDeviceRequestFailedReason.UnknownDevice);
-                    Logger.Log(devEUI, "join refused", LogLevel.Information);
+                    // we do not log here as we assume that the deviceRegistry does a more informed logging if returning null
                     return;
                 }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIServiceBase.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIServiceBase.cs
@@ -28,7 +28,7 @@ namespace LoRaWan.NetworkServer
 
         public abstract Task<uint> NextFCntDownAsync(string devEUI, uint fcntDown, uint fcntUp, string gatewayId);
 
-        public abstract Task<bool> ABPFcntCacheResetAsync(string devEUI);
+        public abstract Task<bool> ABPFcntCacheResetAsync(string devEUI, uint fcntUp, string gatewayId);
 
         /// <summary>
         /// Searchs devices based on devAddr

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
@@ -280,7 +280,7 @@ namespace LoRaWan.NetworkServer
 
                 if (searchDeviceResult.IsDevNonceAlreadyUsed)
                 {
-                    Logger.Log(devEUI, $"join refused: DevNonce already used by this device", LogLevel.Debug);
+                    Logger.Log(devEUI, $"join refused: DevNonce already used for this device", LogLevel.Information);
                     return null;
                 }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
@@ -280,7 +280,7 @@ namespace LoRaWan.NetworkServer
 
                 if (searchDeviceResult.IsDevNonceAlreadyUsed)
                 {
-                    Logger.Log(devEUI, $"join refused: DevNonce already used for this device", LogLevel.Information);
+                    Logger.Log(devEUI, $"join refused: Join already processed by another gateway.", LogLevel.Information);
                     return null;
                 }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
@@ -286,7 +286,8 @@ namespace LoRaWan.NetworkServer
 
                 if (searchDeviceResult?.Devices == null || searchDeviceResult.Devices.Count == 0)
                 {
-                    Logger.Log(devEUI, "join refused: no devices found matching join request", LogLevel.Information);
+                    var msg = searchDeviceResult.RefusedMessage ?? "join refused: no devices found matching join request";
+                    Logger.Log(devEUI, msg, LogLevel.Information);
                     return null;
                 }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MultiGatewayFrameCounterUpdateStrategy.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MultiGatewayFrameCounterUpdateStrategy.cs
@@ -20,13 +20,13 @@ namespace LoRaWan.NetworkServer
             this.loRaDeviceAPIService = loRaDeviceAPIService;
         }
 
-        public async Task<bool> ResetAsync(LoRaDevice loRaDevice)
+        public async Task<bool> ResetAsync(LoRaDevice loRaDevice, uint fcntUp, string gatewayId)
         {
             loRaDevice.ResetFcnt();
 
             if (await this.InternalSaveChangesAsync(loRaDevice, force: true))
             {
-                return await this.loRaDeviceAPIService.ABPFcntCacheResetAsync(loRaDevice.DevEUI);
+                return await this.loRaDeviceAPIService.ABPFcntCacheResetAsync(loRaDevice.DevEUI, fcntUp, gatewayId);
             }
 
             return false;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/SearchDevicesResult.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/SearchDevicesResult.cs
@@ -20,6 +20,8 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         public bool IsDevNonceAlreadyUsed { get; set; }
 
+        public string RefusedMessage { get; set; }
+
         public SearchDevicesResult()
         {
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/SingleGatewayFrameCounterUpdateStrategy.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/SingleGatewayFrameCounterUpdateStrategy.cs
@@ -11,7 +11,7 @@ namespace LoRaWan.NetworkServer
         {
         }
 
-        public async Task<bool> ResetAsync(LoRaDevice loRaDevice)
+        public async Task<bool> ResetAsync(LoRaDevice loRaDevice, uint fcntUp, string gatewayId)
         {
             loRaDevice.ResetFcnt();
             return await this.InternalSaveChangesAsync(loRaDevice, force: true);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
@@ -11,12 +11,18 @@ namespace LoRaTools
     public class OTAAKeysGenerator
     {
         private static readonly Random RndDevAddr = new Random();
+        private static readonly object RndLock = new object();
 
         public static string GetNwkId(byte[] netId)
         {
             int nwkPart = netId[0] << 1;
             byte[] devAddr = new byte[4];
-            RndDevAddr.NextBytes(devAddr);
+
+            lock (RndLock)
+            {
+                RndDevAddr.NextBytes(devAddr);
+            }
+
             devAddr[0] = (byte)((nwkPart & 0b11111110) | (devAddr[0] & 0b00000001));
             return ConversionHelper.ByteArrayToString(devAddr);
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
@@ -10,13 +10,13 @@ namespace LoRaTools
 
     public class OTAAKeysGenerator
     {
+        private static readonly Random RndDevAddr = new Random();
+
         public static string GetNwkId(byte[] netId)
         {
             int nwkPart = netId[0] << 1;
-
             byte[] devAddr = new byte[4];
-            Random rnd = new Random();
-            rnd.NextBytes(devAddr);
+            RndDevAddr.NextBytes(devAddr);
             devAddr[0] = (byte)((nwkPart & 0b11111110) | (devAddr[0] & 0b00000001));
             return ConversionHelper.ByteArrayToString(devAddr);
         }

--- a/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
@@ -120,17 +120,20 @@ namespace LoRaWan.Test.Shared
             else
                 searchResult = await this.SearchIoTHubLogs(predicate, options);
 
-            if (this.Configuration.NetworkServerModuleLogAssertLevel == LogValidationAssertLevel.Error)
+            if (!searchResult.Found)
             {
-                var logs = string.Join("\n\t", searchResult.Logs.TakeLast(5));
-                Assert.True(searchResult.Found, $"Searching for {options?.Description ?? "??"} failed. Current log content: [{logs}]");
-            }
-            else if (this.Configuration.NetworkServerModuleLogAssertLevel == LogValidationAssertLevel.Warning)
-            {
-                if (!searchResult.Found)
+                if (this.Configuration.NetworkServerModuleLogAssertLevel == LogValidationAssertLevel.Error)
                 {
                     var logs = string.Join("\n\t", searchResult.Logs.TakeLast(5));
-                    TestLogger.Log($"[WARN] '{options?.Description ?? "??"}' found in logs? {searchResult.Found}. Logs: [{logs}]");
+                    Assert.True(searchResult.Found, $"Searching for {options?.Description ?? "??"} failed. Current log content: [{logs}]");
+                }
+                else if (this.Configuration.NetworkServerModuleLogAssertLevel == LogValidationAssertLevel.Warning)
+                {
+                    if (!searchResult.Found)
+                    {
+                        var logs = string.Join("\n\t", searchResult.Logs.TakeLast(5));
+                        TestLogger.Log($"[WARN] '{options?.Description ?? "??"}' found in logs? {searchResult.Found}. Logs: [{logs}]");
+                    }
                 }
             }
         }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/DeduplicationStrategy_End2End_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/DeduplicationStrategy_End2End_Tests.cs
@@ -59,6 +59,9 @@ namespace LoRaWan.NetworkServer.Test
                     Assert.True(mode == DeduplicationMode.None);
                 });
 
+            this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                .ReturnsAsync(true);
+
             var shouldBeMarked = false;
 
             this.LoRaDeviceClient

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/FcntLimitTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/FcntLimitTest.cs
@@ -88,7 +88,7 @@ namespace LoRaWan.NetworkServer.Test
             var shouldReset = payloadFcntUp == 0 && abpRelaxed;
             if (shouldReset)
             {
-                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI)).ReturnsAsync(true);
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI, It.IsAny<uint>(), It.IsNotNull<string>())).ReturnsAsync(true);
             }
 
             this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/FunctionBundler_End2End_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/FunctionBundler_End2End_Tests.cs
@@ -45,6 +45,9 @@ namespace LoRaWan.NetworkServer.Test
                         NextFCntDown = simulatedDevice.FrmCntDown + 1
                     });
 
+            this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                .ReturnsAsync(true);
+
             this.LoRaDeviceClient
                 .Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorMultipleGatewayTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorMultipleGatewayTest.cs
@@ -73,6 +73,11 @@ namespace LoRaWan.NetworkServer.Test
             this.SecondLoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
 
+            this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                .ReturnsAsync(true);
+            this.SecondLoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                .ReturnsAsync(true);
+
             // cloud to device messages will be checked twice
             this.LoRaDeviceClient.SetupSequence(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null)

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorSingleGatewayTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorSingleGatewayTest.cs
@@ -342,7 +342,8 @@ namespace LoRaWan.NetworkServer.Test
             this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>())).ReturnsAsync((Message)null);
 
             // Will save the fcnt up/down to zero
-            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.Is<TwinCollection>((t) => this.IsTwinFcntZero(t))));
+            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.Is<TwinCollection>((t) => this.IsTwinFcntZero(t))))
+                .ReturnsAsync(true);
 
             var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loraDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
@@ -42,6 +42,11 @@ namespace LoRaWan.NetworkServer.Test
             // message will be sent
             this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
+            if (string.IsNullOrEmpty(deviceGatewayID))
+            {
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                    .ReturnsAsync(true);
+            }
 
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var cachedDevice = this.CreateLoRaDevice(simulatedDevice);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Decoder_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Decoder_Tests.cs
@@ -74,6 +74,13 @@ namespace LoRaWan.NetworkServer.Test
             this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
+            if (string.IsNullOrEmpty(deviceGatewayID))
+            {
+                // multi GW will reset
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                    .ReturnsAsync(true);
+            }
+
             var deviceRegistry = new LoRaDeviceRegistry(this.ServerConfiguration, this.NewNonEmptyCache(loRaDevice), this.LoRaDeviceApi.Object, this.LoRaDeviceFactory);
 
             // Send to message processor

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_MultiGateway_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_MultiGateway_Tests.cs
@@ -35,6 +35,9 @@ namespace LoRaWan.NetworkServer.Test
                         NextFCntDown = 0
                     });
 
+            this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
+                    .ReturnsAsync(true);
+
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var device = this.CreateLoRaDevice(simulatedDevice);
 
@@ -134,12 +137,8 @@ namespace LoRaWan.NetworkServer.Test
                     .ReturnsAsync(true);
             }
 
-            // multi gateway will reset the fcnt
-            if (shouldSaveTwin)
-            {
-                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI))
+            this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
                     .ReturnsAsync(true);
-            }
 
             // device api will be searched for payload
             this.LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Parallel_Processing_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Parallel_Processing_Tests.cs
@@ -169,7 +169,7 @@ namespace LoRaWan.NetworkServer.Test
 
             if (expectedToSaveTwin && string.IsNullOrEmpty(parallelTestConfiguration.GatewayID))
             {
-                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI))
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
                     .Returns(() =>
                     {
                         var duration = parallelTestConfiguration.DeviceApiResetFcntDuration.Next();

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
@@ -84,6 +84,12 @@ namespace LoRaWan.NetworkServer.Test
                     .ReturnsAsync(true);
             }
 
+            if (string.IsNullOrEmpty(deviceGatewayID))
+            {
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(devEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
+                    .ReturnsAsync(true);
+            }
+
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var cachedDevice = this.CreateLoRaDevice(simulatedDevice);
 
@@ -136,7 +142,7 @@ namespace LoRaWan.NetworkServer.Test
             // will update api in multi gateway scenario
             if (string.IsNullOrEmpty(deviceGatewayID))
             {
-                this.LoRaDeviceApi.Verify(x => x.ABPFcntCacheResetAsync(devEUI), Times.Exactly(1));
+                this.LoRaDeviceApi.Verify(x => x.ABPFcntCacheResetAsync(devEUI, It.IsAny<uint>(), It.IsNotNull<string>()), Times.Exactly(1));
             }
 
             this.LoRaDeviceClient.VerifyAll();
@@ -163,6 +169,12 @@ namespace LoRaWan.NetworkServer.Test
             // C2D message will be checked
             this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
+
+            if (string.IsNullOrEmpty(deviceGatewayID))
+            {
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(loRaDevice.DevEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
+                    .ReturnsAsync(true);
+            }
 
             // add device to cache already
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
@@ -463,6 +475,9 @@ namespace LoRaWan.NetworkServer.Test
                 // C2D message will be checked
                 this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                     .ReturnsAsync((Message)null);
+
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(loRaDevice.DevEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
+                .ReturnsAsync(true);
             }
 
             // add device to cache already
@@ -832,6 +847,12 @@ namespace LoRaWan.NetworkServer.Test
             // message will be sent
             this.LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
+
+            if (string.IsNullOrEmpty(deviceGatewayID))
+            {
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(It.IsNotNull<string>(), It.IsAny<uint>(), It.IsNotNull<string>()))
+                    .ReturnsAsync(true);
+            }
 
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var cachedDevice = this.CreateLoRaDevice(simulatedDevice);
@@ -1699,7 +1720,7 @@ namespace LoRaWan.NetworkServer.Test
 
             if (string.IsNullOrEmpty(gatewayID))
             {
-                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(simDevice.DevEUI))
+                this.LoRaDeviceApi.Setup(x => x.ABPFcntCacheResetAsync(simDevice.DevEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
                     .ReturnsAsync(true);
             }
 

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MultiGatewayFrameCounterUpdateStrategyTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MultiGatewayFrameCounterUpdateStrategyTest.cs
@@ -161,10 +161,10 @@ namespace LoRaWan.NetworkServer.Test
             var device = new LoRaDevice("1", "2", new SingleDeviceConnectionManager(this.deviceClient.Object));
 
             // will reset the cloud cache
-            this.deviceApi.Setup(x => x.ABPFcntCacheResetAsync(device.DevEUI))
+            this.deviceApi.Setup(x => x.ABPFcntCacheResetAsync(device.DevEUI, It.IsAny<uint>(), It.IsNotNull<string>()))
                 .ReturnsAsync(true);
 
-            await target.ResetAsync(device);
+            await target.ResetAsync(device, 1U, this.gatewayID);
             Assert.False(device.HasFrameCountChanges);
 
             this.deviceClient.VerifyAll();

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/SingleGatewayFrameCounterUpdateStrategyTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/SingleGatewayFrameCounterUpdateStrategyTest.cs
@@ -140,7 +140,7 @@ namespace LoRaWan.NetworkServer.Test
             var target = new SingleGatewayFrameCounterUpdateStrategy();
 
             var device = new LoRaDevice("1", "2", new SingleDeviceConnectionManager(this.deviceClient.Object));
-            await target.ResetAsync(device);
+            await target.ResetAsync(device, 1, string.Empty);
             Assert.False(device.HasFrameCountChanges);
             this.deviceClient.VerifyAll();
         }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/TestMultiGatewayUpdateFrameStrategy.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/TestMultiGatewayUpdateFrameStrategy.cs
@@ -27,7 +27,7 @@ namespace LoRaWan.NetworkServer.Test
             }
         }
 
-        public Task<bool> ResetAsync(LoRaDevice loRaDevice)
+        public Task<bool> ResetAsync(LoRaDevice loRaDevice, uint fcntUp, string gatewayId)
         {
             loRaDevice.ResetFcnt();
 

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/DeviceGetterTest.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/DeviceGetterTest.cs
@@ -52,6 +52,10 @@ namespace LoraKeysManagerFacade.Test
                 .Setup(x => x.GetDeviceAsync(It.IsAny<string>()))
                 .ReturnsAsync((string deviceId) => new Device(deviceId) { Authentication = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = primaryKey } } });
 
+            mockRegistryManager
+                .Setup(x => x.GetTwinAsync(It.IsNotNull<string>()))
+                .ReturnsAsync((string deviceId) => new Twin(deviceId));
+
             const int numberOfDevices = 2;
             int deviceCount = 0;
 

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/FCntCacheCheckTest.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/FCntCacheCheckTest.cs
@@ -3,7 +3,7 @@
 
 namespace LoraKeysManagerFacade.Test
 {
-    using Microsoft.Azure.WebJobs;
+    using System.Threading.Tasks;
     using Xunit;
 
     public class FCntCacheCheckTest : FunctionTestBase
@@ -16,51 +16,51 @@ namespace LoraKeysManagerFacade.Test
         }
 
         [Fact]
-        public void FrameCounter_Down_Initial()
+        public async Task FrameCounter_Down_Initial()
         {
             var deviceEUI = NewUniqueEUI64();
             var gatewayId = NewUniqueEUI64();
 
-            var next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 1, 1);
+            var next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 1, 1);
             Assert.Equal(2U, next);
         }
 
         [Fact]
-        public void FrameCounter_Down_Update_Server()
+        public async Task FrameCounter_Down_Update_Server()
         {
             var deviceEUI = NewUniqueEUI64();
             var gatewayId = NewUniqueEUI64();
 
-            var next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 1, 1);
+            var next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 1, 1);
             Assert.Equal(2U, next);
 
-            next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 2, 1);
+            next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 2, 1);
             Assert.Equal(3U, next);
         }
 
         [Fact]
-        public void FrameCounter_Down_Update_Device()
+        public async Task FrameCounter_Down_Update_Device()
         {
             var deviceEUI = NewUniqueEUI64();
             var gatewayId = NewUniqueEUI64();
 
-            var next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 1, 1);
+            var next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 1, 1);
             Assert.Equal(2U, next);
 
-            next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 3, 10);
+            next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 3, 10);
             Assert.Equal(11U, next);
         }
 
         [Fact]
-        public void FrameCounter_Down_Retry_Increment()
+        public async Task FrameCounter_Down_Retry_Increment()
         {
             var deviceEUI = NewUniqueEUI64();
             var gatewayId = NewUniqueEUI64();
 
-            var next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 1, 1);
+            var next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 1, 1);
             Assert.Equal(2U, next);
 
-            next = this.fcntCheck.GetNextFCntDown(deviceEUI, gatewayId, 1, 1);
+            next = await this.fcntCheck.GetNextFCntDownAsync(deviceEUI, gatewayId, 1, 1);
             Assert.Equal(3U, next);
         }
     }

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/FunctionBundlerTest.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/FunctionBundlerTest.cs
@@ -221,7 +221,6 @@ namespace LoraKeysManagerFacade.Test
 
             foreach (var req in requests)
             {
-                // functionBundlerResults.Add(await ExecuteRequest(devEUI, req));
                 tasks.Add(Task.Run(async () =>
                 {
                     functionBundlerResults.Add(await this.ExecuteRequest(devEUI, req));

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/FunctionTestBase.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/FunctionTestBase.cs
@@ -14,6 +14,7 @@ namespace LoraKeysManagerFacade.Test
         private static readonly char[] ValidChars = new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'A', 'B', 'C', 'D', 'E', 'F' };
         private static readonly List<string> UsedEUI64 = new List<string>();
         private static readonly Random Rnd = new Random(Environment.TickCount);
+        private static readonly object RndLock = new object();
 
         protected static string NewUniqueEUI64()
         {
@@ -21,7 +22,13 @@ namespace LoraKeysManagerFacade.Test
 
             for (var i = 0; i < EUI64BitStringLength; i++)
             {
-                sb.Append(ValidChars[Rnd.Next(0, ValidChars.Length)]);
+                int n = 0;
+                lock (RndLock)
+                {
+                    n = Rnd.Next(0, ValidChars.Length);
+                }
+
+                sb.Append(ValidChars[n]);
             }
 
             var result = sb.ToString();

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/LoRaInMemoryDeviceStore.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/LoRaInMemoryDeviceStore.cs
@@ -128,5 +128,10 @@ namespace LoraKeysManagerFacade.Test
 
             return null;
         }
+
+        public bool KeyExists(string key)
+        {
+            return this.cache.ContainsKey(key);
+        }
     }
 }

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/LoRaInMemoryDeviceStore.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/LoRaInMemoryDeviceStore.cs
@@ -11,7 +11,7 @@ namespace LoraKeysManagerFacade.Test
 
     internal class LoRaInMemoryDeviceStore : ILoRaDeviceCacheStore
     {
-        private static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(15);
         private readonly Dictionary<string, object> cache;
         private readonly Dictionary<string, SemaphoreSlim> locks;
 

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/MessageDeduplicationTests.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/MessageDeduplicationTests.cs
@@ -3,8 +3,8 @@
 
 namespace LoraKeysManagerFacade.Test
 {
+    using System.Threading.Tasks;
     using LoraKeysManagerFacade.FunctionBundler;
-    using Microsoft.Azure.WebJobs;
     using Xunit;
 
     public class MessageDeduplicationTests : FunctionTestBase
@@ -17,57 +17,57 @@ namespace LoraKeysManagerFacade.Test
         }
 
         [Fact]
-        public void MessageDeduplication_Duplicates_Found()
+        public async Task MessageDeduplication_Duplicates_Found()
         {
             string gateway1Id = NewUniqueEUI64();
             string gateway2Id = NewUniqueEUI64();
             string dev1EUI = NewUniqueEUI64();
 
-            var result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev1EUI, gateway1Id, 1, 1);
+            var result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway1Id, 1, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway1Id, result.GatewayId);
 
-            result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev1EUI, gateway2Id, 1, 1);
+            result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway2Id, 1, 1);
             Assert.True(result.IsDuplicate);
             Assert.Equal(gateway1Id, result.GatewayId);
         }
 
         [Fact]
-        public void MessageDeduplication_Resubmit_Allowed()
+        public async Task MessageDeduplication_Resubmit_Allowed()
         {
             string gateway1Id = NewUniqueEUI64();
             string dev1EUI = NewUniqueEUI64();
 
-            var result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev1EUI, gateway1Id, 1, 1);
+            var result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway1Id, 1, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway1Id, result.GatewayId);
 
-            result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev1EUI, gateway1Id, 1, 1);
+            result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway1Id, 1, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway1Id, result.GatewayId);
         }
 
         [Fact]
-        public void MessageDeduplication_DifferentDevices_Allowed()
+        public async Task MessageDeduplication_DifferentDevices_Allowed()
         {
             string gateway1Id = NewUniqueEUI64();
             string gateway2Id = NewUniqueEUI64();
             string dev1EUI = NewUniqueEUI64();
             string dev2EUI = NewUniqueEUI64();
 
-            var result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev1EUI, gateway1Id, 1, 1);
+            var result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway1Id, 1, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway1Id, result.GatewayId);
 
-            result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev1EUI, gateway2Id, 2, 1);
+            result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway2Id, 2, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway2Id, result.GatewayId);
 
-            result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev2EUI, gateway1Id, 1, 1);
+            result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev2EUI, gateway1Id, 1, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway1Id, result.GatewayId);
 
-            result = this.deduplicationExecutionItem.GetDuplicateMessageResult(dev2EUI, gateway2Id, 2, 1);
+            result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev2EUI, gateway2Id, 2, 1);
             Assert.False(result.IsDuplicate);
             Assert.Equal(gateway2Id, result.GatewayId);
         }


### PR DESCRIPTION
fixes: 
- deduplication race with device reset (ABP relaxed mode)
- fix OTAA join when having a gateway in the twin
- add a blocking lock to the cache