### PR TITLE
Fix race in connection management code

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
@@ -95,29 +95,22 @@ namespace LoraKeysManagerFacade
 
                     if (this.cacheStore.StringSet(cacheKeyDevNonce, devNonce, TimeSpan.FromMinutes(5), onlyIfNotExists: true))
                     {
-                        try
+                        var iotHubDeviceInfo = new IoTHubDeviceInfo
                         {
-                            var iotHubDeviceInfo = new IoTHubDeviceInfo
-                            {
-                                DevEUI = devEUI,
-                                PrimaryKey = joinInfo.PrimaryKey
-                            };
+                            DevEUI = devEUI,
+                            PrimaryKey = joinInfo.PrimaryKey
+                        };
 
-                            results.Add(iotHubDeviceInfo);
+                        results.Add(iotHubDeviceInfo);
 
-                            if (await deviceCache.TryToLockAsync())
-                            {
-                                this.cacheStore.KeyDelete(devEUI);
-                                log?.LogDebug("Removed key '{key}':{gwid}", devEUI, gatewayId);
-                            }
-                            else
-                            {
-                                log?.LogWarning("Failed to acquire lock for '{key}'", devEUI);
-                            }
+                        if (await deviceCache.TryToLockAsync())
+                        {
+                            this.cacheStore.KeyDelete(devEUI);
+                            log?.LogDebug("Removed key '{key}':{gwid}", devEUI, gatewayId);
                         }
-                        finally
+                        else
                         {
-                            this.cacheStore.LockRelease(lockKeyDevNonce, gatewayId);
+                            log?.LogWarning("Failed to acquire lock for '{key}'", devEUI);
                         }
                     }
                     else

--- a/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
@@ -49,6 +49,7 @@ namespace LoraKeysManagerFacade
             builder.Services.AddSingleton<IFunctionBundlerExecutionItem, DeduplicationExecutionItem>();
             builder.Services.AddSingleton<IFunctionBundlerExecutionItem, ADRExecutionItem>();
             builder.Services.AddSingleton<IFunctionBundlerExecutionItem, PreferredGatewayExecutionItem>();
+            builder.Services.AddSingleton<IFunctionBundlerExecutionItem, ResetDeviceCacheExecutionItem>();
         }
 
         abstract class ConfigHandler

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerFunction.cs
@@ -29,7 +29,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
         [FunctionName("FunctionBundler")]
         public async Task<IActionResult> FunctionBundlerImpl(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "FunctionBundler/{devEUI}")]HttpRequest req,
-            ILogger log,
+            ILogger logger,
             string devEUI)
         {
             try
@@ -50,14 +50,14 @@ namespace LoraKeysManagerFacade.FunctionBundler
             }
 
             var functionBundlerRequest = JsonConvert.DeserializeObject<FunctionBundlerRequest>(requestBody);
-            var result = await this.HandleFunctionBundlerInvoke(devEUI, functionBundlerRequest);
+            var result = await this.HandleFunctionBundlerInvoke(devEUI, functionBundlerRequest, logger);
 
             return new OkObjectResult(result);
         }
 
-        public async Task<FunctionBundlerResult> HandleFunctionBundlerInvoke(string devEUI, FunctionBundlerRequest request)
+        public async Task<FunctionBundlerResult> HandleFunctionBundlerInvoke(string devEUI, FunctionBundlerRequest request, ILogger logger = null)
         {
-            var pipeline = new FunctionBundlerPipelineExecuter(this.executionItems, devEUI, request);
+            var pipeline = new FunctionBundlerPipelineExecuter(this.executionItems, devEUI, request, logger);
             return await pipeline.Execute();
         }
     }

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerPipelineExecuter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerPipelineExecuter.cs
@@ -6,6 +6,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
 
     public class FunctionBundlerPipelineExecuter : IPipelineExecutionContext
     {

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerPipelineExecuter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerPipelineExecuter.cs
@@ -22,11 +22,13 @@ namespace LoraKeysManagerFacade.FunctionBundler
         public FunctionBundlerPipelineExecuter(
                                                IFunctionBundlerExecutionItem[] registeredHandlers,
                                                string devEUI,
-                                               FunctionBundlerRequest request)
+                                               FunctionBundlerRequest request,
+                                               ILogger logger = null)
         {
             this.registeredHandlers = registeredHandlers;
             this.DevEUI = devEUI;
             this.Request = request;
+            this.Logger = logger ?? NullLogger.Instance;
         }
 
         public async Task<FunctionBundlerResult> Execute()

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/ResetDeviceCacheExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/ResetDeviceCacheExecutionItem.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoraKeysManagerFacade.FunctionBundler
+{
+    using System.Threading.Tasks;
+    using LoRaTools.ADR;
+    using LoRaTools.CommonAPI;
+    using Microsoft.Extensions.Logging;
+
+    public class ResetDeviceCacheExecutionItem : IFunctionBundlerExecutionItem
+    {
+        private readonly ILoRaDeviceCacheStore deviceCacheStore;
+
+        public ResetDeviceCacheExecutionItem(ILoRaDeviceCacheStore deviceCacheStore)
+        {
+            this.deviceCacheStore = deviceCacheStore;
+        }
+
+        public Task<FunctionBundlerExecutionState> ExecuteAsync(IPipelineExecutionContext context)
+        {
+            using (var deviceCache = new LoRaDeviceCache(this.deviceCacheStore, context.DevEUI, context.Request.GatewayId))
+            {
+                if (deviceCache.TryToLock())
+                {
+                    deviceCache.ClearCache();
+                }
+                else
+                {
+                    context.Logger.LogWarning("Failed to get lock for cache reset");
+                }
+            }
+
+            return Task.FromResult(FunctionBundlerExecutionState.Continue);
+        }
+
+        public int Priority => 0;
+
+        public bool NeedsToExecute(FunctionBundlerItemType item)
+        {
+            return (item & FunctionBundlerItemType.ResetDeviceCache) == FunctionBundlerItemType.ResetDeviceCache;
+        }
+
+        public Task OnAbortExecutionAsync(IPipelineExecutionContext context)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/ResetDeviceCacheExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/ResetDeviceCacheExecutionItem.cs
@@ -4,7 +4,6 @@
 namespace LoraKeysManagerFacade.FunctionBundler
 {
     using System.Threading.Tasks;
-    using LoRaTools.ADR;
     using LoRaTools.CommonAPI;
     using Microsoft.Extensions.Logging;
 
@@ -17,11 +16,11 @@ namespace LoraKeysManagerFacade.FunctionBundler
             this.deviceCacheStore = deviceCacheStore;
         }
 
-        public Task<FunctionBundlerExecutionState> ExecuteAsync(IPipelineExecutionContext context)
+        public async Task<FunctionBundlerExecutionState> ExecuteAsync(IPipelineExecutionContext context)
         {
             using (var deviceCache = new LoRaDeviceCache(this.deviceCacheStore, context.DevEUI, context.Request.GatewayId))
             {
-                if (deviceCache.TryToLock())
+                if (await deviceCache.TryToLockAsync())
                 {
                     deviceCache.ClearCache();
                 }
@@ -31,7 +30,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
                 }
             }
 
-            return Task.FromResult(FunctionBundlerExecutionState.Continue);
+            return FunctionBundlerExecutionState.Continue;
         }
 
         public int Priority => 0;

--- a/LoRaEngine/LoraKeysManagerFacade/ILoRaDeviceCacheStore.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ILoRaDeviceCacheStore.cs
@@ -31,6 +31,8 @@ namespace LoraKeysManagerFacade
 
         bool KeyDelete(string key);
 
+        bool KeyExists(string key);
+
         bool LockRelease(string key, string value);
 
         long ListAdd(string key, string value, TimeSpan? expiration = null);

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCache.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCache.cs
@@ -79,6 +79,11 @@ namespace LoraKeysManagerFacade
             return value != null;
         }
 
+        public bool Exists()
+        {
+            return this.cacheStore.KeyExists(this.cacheKey);
+        }
+
         public bool HasValue()
         {
             return this.cacheStore.StringGet(this.cacheKey) != null;

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCacheRedisStore.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCacheRedisStore.cs
@@ -79,7 +79,7 @@ namespace LoraKeysManagerFacade
 
         public bool KeyDelete(string key)
         {
-            return this.redisCache.KeyDelete(key);
+            return this.redisCache.KeyDelete(key, CommandFlags.DemandMaster);
         }
 
         public bool LockRelease(string key, string value)

--- a/LoRaEngine/deployment.test.secondary.template.json
+++ b/LoRaEngine/deployment.test.secondary.template.json
@@ -1,0 +1,175 @@
+{
+  "moduleContent": {
+    "$edgeAgent": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "runtime": {
+          "type": "docker",
+          "settings": {
+            "minDockerVersion": "v1.25",
+            "loggingOptions": "",
+            "registryCredentials": {
+              "$CONTAINER_REGISTRY_USERNAME": {
+                "username": "$CONTAINER_REGISTRY_USERNAME",
+                "password": "$CONTAINER_REGISTRY_PASSWORD",
+                "address": "$CONTAINER_REGISTRY_ADDRESS"
+              }
+            }
+          }
+        },
+        "systemModules": {
+          "edgeAgent": {
+            "type": "docker",
+            "settings": {
+              "image": "mcr.microsoft.com/azureiotedge-agent:$EDGE_AGENT_VERSION",
+              "createOptions": ""
+            }
+          },
+          "edgeHub": {
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "settings": {
+              "image": "mcr.microsoft.com/azureiotedge-hub:$EDGE_HUB_VERSION",
+              "createOptions": {
+                "HostConfig": {
+                  "PortBindings": {
+                    "8883/tcp": [
+                      {
+                        "HostPort": "8883"
+                      }
+                    ],
+                    "443/tcp": [
+                      {
+                        "HostPort": "443"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "env": {
+              "OptimizeForPerformance": {
+                "value": "$EDGEHUB_OPTIMIZEFORPERFORMANCE"
+              },
+              "mqttSettings__enabled": {
+                "value": "$EDGEHUB_MQTTSETTINGS_ENABLED"
+              },
+              "httpSettings__enabled": {
+                "value": "$EDGEHUB_HTTPSETTINGS_ENABLED"
+              },
+              "TwinManagerVersion": {
+                "value": "v2"
+              },
+              "LORA_BUILD_ID": {
+                "value": "$BUILD_BUILDID"
+              }
+            }
+          }
+        },
+        "modules": {
+          "LoRaWanNetworkSrvModule": {
+            "type": "docker",
+            "settings": {
+              "image": "${MODULES.LoRaWanNetworkSrvModule}",
+              "createOptions": {
+                "ExposedPorts": {
+                  "1680/udp": {}
+                },
+                "HostConfig": {
+                  "PortBindings": {
+                    "1680/udp": [
+                      {
+                        "HostPort": "1680",
+                        "HostIp": "172.17.0.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "version": "1.0",
+            "env": {
+              "LOG_LEVEL": {
+                "value": "$NET_SRV_LOG_LEVEL"
+              },
+              "LOG_TO_HUB": {
+                "value": "$NET_SRV_LOGTO_HUB"
+              },
+              "LOG_TO_UDP": {
+                "value": "$NET_SRV_LOGTO_UDP"
+              },
+              "IOTEDGE_TIMEOUT": {
+                "value": "$NET_SRV_IOTEDGE_TIMEOUT"
+              },
+              "LOG_TO_UDP_ADDRESS": {
+                "value": "$NET_SRV_LOG_TO_UDP_ADDRESS"
+              }
+            },
+            "status": "running",
+            "restartPolicy": "always"
+          },
+          "LoRaWanPktFwdModule": {
+            "type": "docker",
+            "settings": {
+              "image": "${MODULES.LoRaWanPktFwdModule}",
+              "createOptions": {
+                "HostConfig": {
+                  "NetworkMode": "host",
+                  "Privileged": true
+                },
+                "NetworkingConfig": {
+                  "EndpointsConfig": {
+                    "host": {}
+                  }
+                }
+              }
+            },
+            "env": {
+              "RESET_PIN": {
+                "value": "$RESET_PIN"
+              },
+              "REGION": {
+                "value": "$REGION"
+              },
+              "PKT_FWD_SPI_DEV":{
+                "value":"$SPI_DEV"
+              }
+            },
+            "version": "1.0",
+            "status": "running",
+            "restartPolicy": "always"
+          },
+          "sensordecodermodule": {
+            "type": "docker",
+            "settings": {
+              "image": "$CONTAINER_REGISTRY_ADDRESS/decodersample:2.0",
+              "createOptions": {}
+            },
+            "status": "running",
+            "restartPolicy": "always",
+            "version": "1.0"
+          }
+        }
+      }
+    },
+    "$edgeHub": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "routes": {
+          "route": "$EDGEHUB_ROUTE"
+        },
+        "storeAndForwardConfiguration": {
+          "timeToLiveSecs": 7200
+        }
+      }
+    },
+    "LoRaWanNetworkSrvModule": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "FacadeServerUrl": "$FACADE_SERVER_URL",
+        "FacadeAuthCode": "$FACADE_AUTH_CODE"
+      }
+    }
+  }
+}

--- a/LoRaEngine/deployment.test.secondary.template.json
+++ b/LoRaEngine/deployment.test.secondary.template.json
@@ -103,7 +103,7 @@
                 "value": "$NET_SRV_IOTEDGE_TIMEOUT"
               },
               "LOG_TO_UDP_ADDRESS": {
-                "value": "$NET_SRV_LOG_TO_UDP_ADDRESS"
+                "value": "$BUILD_AGENT_IP"
               }
             },
             "status": "running",

--- a/LoRaEngine/deployment.test.secondary.template.json
+++ b/LoRaEngine/deployment.test.secondary.template.json
@@ -103,7 +103,7 @@
                 "value": "$NET_SRV_IOTEDGE_TIMEOUT"
               },
               "LOG_TO_UDP_ADDRESS": {
-                "value": "$BUILD_AGENT_IP"
+                "value": "$BUILD_AGENT_ADDRESS"
               }
             },
             "status": "running",

--- a/LoRaEngine/deployment.test.template.json
+++ b/LoRaEngine/deployment.test.template.json
@@ -149,7 +149,15 @@
               "image": "$DEVOPS_AGENT_IMAGE",
               "createOptions": {
                 "HostConfig": {
-                  "Privileged": true
+                  "Privileged": true,
+                  "PublishAllPorts": true,
+                  "PortBindings": {
+                    "6000/udp": [
+                      {
+                        "HostPort": "6000"
+                      }
+                    ]
+                  }
                 },
                 "ExposedPorts": {
                   "6000/udp": {}

--- a/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.amd64
+++ b/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.amd64
@@ -1,6 +1,6 @@
 FROM microsoft/dotnet:2.1-sdk-stretch
 
-ENV VSTS_POOL=default VSTS_AGENT=myAgent VSTS_AGENT_VERSION=2.149.1
+ENV VSTS_POOL=default VSTS_AGENT=myAgent VSTS_AGENT_VERSION=2.149.2
 
 # Install curl, wget and git
 RUN apt-get update && apt-get install -y \

--- a/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/AzureDevOpsAgent/Dockerfile.arm32v7
@@ -1,6 +1,6 @@
 FROM microsoft/dotnet:2.1-sdk-stretch-arm32v7
 
-ENV VSTS_POOL=default VSTS_AGENT=myAgent VSTS_AGENT_VERSION=2.149.1
+ENV VSTS_POOL=default VSTS_AGENT=myAgent VSTS_AGENT_VERSION=2.149.2
 
 # Install curl, wget and git
 RUN apt-get update && apt-get install -y \

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
@@ -24,6 +24,9 @@ namespace LoRaWan.NetworkServer
     /// </summary>
     internal static class DownlinkMessageBuilder
     {
+        private static readonly Random RndDownlinkMessageBuilder = new Random();
+        private static readonly object RndLock = new object();
+
         /// <summary>
         /// Creates downlink message with ack for confirmation or cloud to device message
         /// </summary>
@@ -62,8 +65,11 @@ namespace LoRaWan.NetworkServer
             }
 
             byte[] rndToken = new byte[2];
-            Random rnd = new Random();
-            rnd.NextBytes(rndToken);
+
+            lock (RndLock)
+            {
+                RndDownlinkMessageBuilder.NextBytes(rndToken);
+            }
 
             string datr;
             double freq;
@@ -235,8 +241,11 @@ namespace LoRaWan.NetworkServer
             CidEnum macCommandType = CidEnum.Zero;
 
             byte[] rndToken = new byte[2];
-            Random rnd = new Random();
-            rnd.NextBytes(rndToken);
+
+            lock (RndLock)
+            {
+                RndDownlinkMessageBuilder.NextBytes(rndToken);
+            }
 
             bool isMessageTooLong = false;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -77,15 +77,12 @@ namespace LoRaWan.NetworkServer
         void OnScheduledDisconnect(object key, object value, EvictionReason reason, object state)
         {
             var managedConnection = (ManagedConnection)value;
-            if (managedConnection.LoRaDevice.IsProcessingRequest)
+
+            if (!managedConnection.LoRaDevice.DisconnectIfNotProcessing())
             {
                 // add item to schedule once again
                 Logger.Log(managedConnection.LoRaDevice.DevEUI, "client is processing request. Not disconnecting.", LogLevel.Debug);
                 this.SetupSchedule(managedConnection);
-            }
-            else
-            {
-                managedConnection.DeviceClient.Disconnect();
             }
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -80,6 +80,7 @@ namespace LoRaWan.NetworkServer
             if (managedConnection.LoRaDevice.IsProcessingRequest)
             {
                 // add item to schedule once again
+                Logger.Log(managedConnection.LoRaDevice.DevEUI, "client is processing request. Not disconnecting.", LogLevel.Debug);
                 this.SetupSchedule(managedConnection);
             }
             else

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ServiceFacadeHttpClientHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ServiceFacadeHttpClientHandler.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace LoRaWan.NetworkServer
+namespace LoRaWan.Shared
 {
     using System;
     using System.Linq;
@@ -10,7 +10,6 @@ namespace LoRaWan.NetworkServer
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using LoRaWan.Shared;
 
     /// <summary>
     /// <see cref="HttpClientHandler"/> for service facade function API calls.

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
@@ -228,6 +228,7 @@ namespace LoRaWan.NetworkServer
                         LogToUdp = this.configuration.LogToUdp,
                         LogToUdpPort = this.configuration.LogToUdpPort,
                         LogToUdpAddress = this.configuration.LogToUdpAddress,
+                        GatewayId = this.configuration.GatewayID
                     });
 
                     if (this.configuration.IoTEdgeTimeout > 0)
@@ -278,6 +279,7 @@ namespace LoRaWan.NetworkServer
                         LogToUdp = this.configuration.LogToUdp,
                         LogToUdpPort = this.configuration.LogToUdpPort,
                         LogToUdpAddress = this.configuration.LogToUdpAddress,
+                        GatewayId = this.configuration.GatewayID
                     });
                 }
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
@@ -120,6 +120,11 @@ namespace LoRaWan
         {
             try
             {
+                if (!string.IsNullOrEmpty(configuration.GatewayId))
+                {
+                    message = string.Concat($"[{configuration.GatewayId}] ", message);
+                }
+
                 var messageInBytes = Encoding.UTF8.GetBytes(message);
                 udpClient.Send(messageInBytes, messageInBytes.Length, udpEndpoint);
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/LoggerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/LoggerConfiguration.cs
@@ -35,6 +35,11 @@ namespace LoRaWan
         // Gets/sets udp port to send logs
         public int LogToUdpPort { get; set; } = 6000;
 
+        /// <summary>
+        /// Gets or sets the id of the gateway running the logger
+        /// </summary>
+        public string GatewayId { get; set; }
+
         public static LogLevel InitLogLevel(string logLevelIn)
         {
             LogLevel logLevelOut;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/CommonAPI/FunctionBundlerItemType.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/CommonAPI/FunctionBundlerItemType.cs
@@ -11,6 +11,7 @@ namespace LoRaTools.CommonAPI
         FCntDown = 0x1,
         Deduplication = 0x2,
         ADR = 0x4,
-        PreferredGateway = 0x8
+        PreferredGateway = 0x8,
+        ResetDeviceCache = 0x10
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
@@ -10,7 +10,7 @@ namespace LoRaTools
 
     public class OTAAKeysGenerator
     {
-        private static readonly Random RndDevAddr = new Random();
+        private static readonly Random RndKeysGenerator = new Random();
         private static readonly object RndLock = new object();
 
         public static string GetNwkId(byte[] netId)
@@ -20,7 +20,7 @@ namespace LoRaTools
 
             lock (RndLock)
             {
-                RndDevAddr.NextBytes(devAddr);
+                RndKeysGenerator.NextBytes(devAddr);
             }
 
             devAddr[0] = (byte)((nwkPart & 0b11111110) | (devAddr[0] & 0b00000001));
@@ -80,9 +80,12 @@ namespace LoRaTools
 
         public static string GetAppNonce()
         {
-            Random rnd = new Random();
             byte[] appNonce = new byte[3];
-            rnd.NextBytes(appNonce);
+            lock (RndLock)
+            {
+                RndKeysGenerator.NextBytes(appNonce);
+            }
+
             return ConversionHelper.ByteArrayToString(appNonce);
         }
     }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/ABPTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/ABPTest.cs
@@ -412,6 +412,8 @@ namespace LoRaWan.IntegrationTest
             await this.ArduinoDevice.SetupLora(this.TestFixtureCi.Configuration.LoraRegion);
             await this.ArduinoDevice.transferPacketAsync(PayloadGenerator.Next().ToString(), 10);
 
+            await this.TestFixtureCi.SearchNetworkServerModuleAsync((log) => log.StartsWith($"{device25.DeviceID}: processing time"));
+
             // wait 61 seconds
             await Task.Delay(TimeSpan.FromSeconds(61));
 

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/C2DMessageTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/C2DMessageTest.cs
@@ -30,19 +30,6 @@ namespace LoRaWan.IntegrationTest
         {
         }
 
-        private string ToHexString(string str)
-        {
-            var sb = new StringBuilder();
-
-            var bytes = Encoding.UTF8.GetBytes(str);
-            foreach (var t in bytes)
-            {
-                sb.Append(t.ToString("X2"));
-            }
-
-            return sb.ToString(); // returns: "48656C6C6F20776F726C64" for "Hello world"
-        }
-
         // Ensures that C2D messages are received when working with confirmed messages
         // RxDelay set up to be 2 seconds
         // Uses Device9_OTAA
@@ -286,10 +273,12 @@ namespace LoRaWan.IntegrationTest
 
         // Ensures that C2D messages are received when working with unconfirmed messages
         // Uses Device15_OTAA
-        [Fact]
-        public async Task Test_OTAA_Unconfirmed_Receives_Confirmed_FPort_2_Message()
+        [Theory]
+        [InlineData("Device15_OTAA")]
+        [InlineData("Device15_OTAA_MultiGw")]
+        public async Task Test_OTAA_Unconfirmed_Receives_Confirmed_FPort_2_Message(string devicePropertyName)
         {
-            var device = this.TestFixtureCi.Device15_OTAA;
+            var device = this.TestFixtureCi.GetDeviceByPropertyName(devicePropertyName);
             this.LogTestStart(device);
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
@@ -394,10 +383,12 @@ namespace LoRaWan.IntegrationTest
 
         // Ensures that C2D messages are received when working with unconfirmed messages
         // Uses Device10_OTAA
-        [Fact]
-        public async Task Test_OTAA_Unconfirmed_Receives_Confirmed_C2D_Message()
+        [Theory]
+        [InlineData("Device14_OTAA")]
+        [InlineData("Device14_OTAA_MultiGw")]
+        public async Task Test_OTAA_Unconfirmed_Receives_Confirmed_C2D_Message(string devicePropertyName)
         {
-            var device = this.TestFixtureCi.Device14_OTAA;
+            var device = this.TestFixtureCi.GetDeviceByPropertyName(devicePropertyName);
             this.LogTestStart(device);
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/C2DMessageTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/C2DMessageTest.cs
@@ -293,6 +293,11 @@ namespace LoRaWan.IntegrationTest
             // wait 1 second after joined
             await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_JOIN);
 
+            if (device.IsMultiGw)
+            {
+                await this.TestFixtureCi.AssertTwinSyncAfterJoinAsync(this.ArduinoDevice.SerialLogs, device.DeviceID);
+            }
+
             // Sends 2x unconfirmed messages
             for (var i = 1; i <= 2; ++i)
             {
@@ -325,7 +330,7 @@ namespace LoRaWan.IntegrationTest
             var expectedRxSerial = $"+MSG: PORT: 2; RX: \"{this.ToHexString(c2dMessageBody)}\"";
             this.Log($"Expected C2D start with: {expectedRxSerial}");
 
-            // Sends 8x confirmed messages, stopping if C2D message is found
+            // Sends 8x unconfirmed messages, stopping if C2D message is found
             for (var i = 3; i <= 10; ++i)
             {
                 var msg = PayloadGenerator.Next().ToString();
@@ -402,6 +407,11 @@ namespace LoRaWan.IntegrationTest
             // wait 1 second after joined
             await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_JOIN);
 
+            if (device.IsMultiGw)
+            {
+                await this.TestFixtureCi.AssertTwinSyncAfterJoinAsync(this.ArduinoDevice.SerialLogs, device.DeviceID);
+            }
+
             // Sends 2x unconfirmed messages
             for (var i = 1; i <= 2; ++i)
             {
@@ -439,14 +449,14 @@ namespace LoRaWan.IntegrationTest
             this.Log($"Expected C2D received log is: {expectedRxSerial}");
             this.Log($"Expected UDP log starting with: {expectedUDPMessageV1} or {expectedUDPMessageV2}");
 
-            // Sends 8x confirmed messages, stopping if C2D message is found
+            // Sends 8x unconfirmed messages, stopping if C2D message is found
             for (var i = 3; i <= 10; ++i)
             {
                 var msg = PayloadGenerator.Next().ToString();
                 this.Log($"{device.DeviceID}: Sending unconfirmed '{msg}' {i}/10");
                 await this.ArduinoDevice.transferPacketAsync(msg, 10);
 
-                await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
+                await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
 
                 await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
 

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/DeduplicationTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/DeduplicationTest.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.IntegrationTest
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Xml;
+    using LoRaWan.Test.Shared;
+    using Newtonsoft.Json.Linq;
+    using Xunit;
+
+    // Tests OTAA requests
+    [Collection(Constants.TestCollectionName)] // run in serial
+    [Trait("Category", "SkipWhenLiveUnitTesting")]
+    public sealed class DeduplicationTest : IntegrationTestBaseCi
+    {
+        public DeduplicationTest(IntegrationTestFixtureCi testFixture)
+            : base(testFixture)
+        {
+        }
+
+        [Fact]
+        public async Task Test_Deduplication_Drop()
+        {
+            var device = this.TestFixtureCi.Device25_OTAA;
+            this.LogTestStart(device);
+
+            await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
+            await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
+            await this.ArduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, device.AppKey);
+
+            await this.ArduinoDevice.SetupLora(this.TestFixtureCi.Configuration.LoraRegion);
+
+            var joinSucceeded = await this.ArduinoDevice.setOTAAJoinAsyncWithRetry(LoRaArduinoSerial._otaa_join_cmd_t.JOIN, 20000, 5);
+
+            Assert.True(joinSucceeded, "Join failed");
+            await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_JOIN);
+
+            var joinConfirm = this.ArduinoDevice.SerialLogs.FirstOrDefault(s => s.StartsWith("+JOIN: NetID"));
+            Assert.NotNull(joinConfirm);
+
+            // validate that one GW refused the join
+            const string devNonceAlreadyUsed = "DevNonce already used by this device";
+            var joinRefused = await this.TestFixtureCi.AssertNetworkServerModuleLogExistsAsync((s) => s.IndexOf(devNonceAlreadyUsed) != -1, new SearchLogOptions(devNonceAlreadyUsed));
+            Assert.True(joinRefused.Found);
+
+            this.TestFixtureCi.ClearLogs();
+
+            var devAddr = joinConfirm.Substring(joinConfirm.LastIndexOf(' ') + 1);
+            devAddr = devAddr.Replace(":", string.Empty);
+
+            // wait for the twins to be stored and published -> all GW need the same state
+            const int DelayForJoinTwinStore = 20 * 1000;
+            const string DevAddrProperty = "DevAddr";
+            const int MaxRuns = 3;
+            bool reported = false;
+            for (var i = 0; i < MaxRuns && !reported; i++)
+            {
+                await Task.Delay(DelayForJoinTwinStore);
+
+                var twins = await this.TestFixtureCi.GetTwinAsync(device.DeviceID);
+                if (twins.Properties.Reported.Contains(DevAddrProperty))
+                {
+                    reported = devAddr.Equals(twins.Properties.Reported[DevAddrProperty].Value as string, StringComparison.InvariantCultureIgnoreCase);
+                }
+            }
+
+            Assert.True(reported);
+
+            var msg = PayloadGenerator.Next().ToString();
+            await this.ArduinoDevice.transferPacketAsync(msg, 10);
+
+            await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
+
+            // After transferPacket: Expectation from serial
+            // +MSG: Done
+            await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
+
+            var notDuplicate = "{\"isDuplicate\":false";
+            var resultProcessed = await this.TestFixtureCi.AssertNetworkServerModuleLogExistsAsync(logmsg => logmsg.IndexOf(notDuplicate) != -1, new SearchLogOptions(notDuplicate));
+            var resultDroped = await this.TestFixtureCi.SearchNetworkServerModuleAsync((s) => s.IndexOf("duplication strategy indicated to not process message") != -1);
+
+            Assert.NotEqual(resultProcessed.MatchedEvent.SourceId, resultDroped.MatchedEvent.SourceId);
+        }
+    }
+}

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestBaseCi.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestBaseCi.cs
@@ -8,11 +8,14 @@ namespace LoRaWan.IntegrationTest
     using System.Linq;
     using System.Runtime.CompilerServices;
     using System.Text;
+    using System.Threading.Tasks;
     using LoRaWan.Test.Shared;
     using Xunit;
 
     public class IntegrationTestBaseCi : IntegrationTestBase, IClassFixture<IntegrationTestFixtureCi>, IDisposable
     {
+        private bool isDisposed; // To detect redundant calls
+
         protected IntegrationTestFixtureCi TestFixtureCi
         {
             get { return (IntegrationTestFixtureCi)this.TestFixture; }
@@ -31,23 +34,6 @@ namespace LoRaWan.IntegrationTest
             this.arduinoDevice = testFixture.ArduinoDevice;
         }
 
-        private bool disposedValue = false; // To detect redundant calls
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!this.disposedValue)
-            {
-                if (disposing)
-                {
-                    // Before starting a new test, wait 5 seconds to ensure serial port is not receiving dirty data
-                    if (this.arduinoDevice != null)
-                        this.arduinoDevice.WaitForIdleAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
-                }
-
-                this.disposedValue = true;
-            }
-        }
-
         protected string ToHexString(string str)
         {
             var sb = new StringBuilder();
@@ -59,6 +45,21 @@ namespace LoRaWan.IntegrationTest
             }
 
             return sb.ToString(); // returns: "48656C6C6F20776F726C64" for "Hello world"
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.isDisposed)
+            {
+                if (disposing)
+                {
+                    // Before starting a new test, wait 5 seconds to ensure serial port is not receiving dirty data
+                    if (this.arduinoDevice != null)
+                        this.arduinoDevice.WaitForIdleAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+                }
+
+                this.isDisposed = true;
+            }
         }
 
         // This code added to correctly implement the disposable pattern.

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestBaseCi.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestBaseCi.cs
@@ -48,6 +48,19 @@ namespace LoRaWan.IntegrationTest
             }
         }
 
+        protected string ToHexString(string str)
+        {
+            var sb = new StringBuilder();
+
+            var bytes = Encoding.UTF8.GetBytes(str);
+            foreach (var t in bytes)
+            {
+                sb.Append(t.ToString("X2"));
+            }
+
+            return sb.ToString(); // returns: "48656C6C6F20776F726C64" for "Hello world"
+        }
+
         // This code added to correctly implement the disposable pattern.
         public void Dispose()
         {

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
@@ -90,9 +90,14 @@ namespace LoRaWan.IntegrationTest
         public TestDeviceInfo Device26_ABP { get; private set; }
 
         /// <summary>
-        /// Gets Device24_OTAA: used for OTAA deduplication testing
+        /// Gets Device27_OTAA: used for multi GW OTAA testing
         /// </summary>
-        public TestDeviceInfo Device25_OTAA { get; private set; }
+        public TestDeviceInfo Device27_OTAA { get; private set; }
+
+        /// <summary>
+        /// Gets Device27_ABP: used for multi GW deduplication drop testing
+        /// </summary>
+        public TestDeviceInfo Device28_ABP { get; private set; }
 
         // Arduino device used for testing
         public LoRaArduinoSerial ArduinoDevice
@@ -114,6 +119,8 @@ namespace LoRaWan.IntegrationTest
             {
                 TestLogger.Log("[WARN] Not serial port defined for test");
             }
+
+            LoRaAPIHelper.Initialize(this.Configuration.FunctionAppCode, this.Configuration.FunctionAppBaseUrl);
         }
 
         public override void ClearLogs()
@@ -131,6 +138,11 @@ namespace LoRaWan.IntegrationTest
                 this.arduinoDevice?.Dispose();
                 this.arduinoDevice = null;
             }
+        }
+
+        public async Task<bool> ResetDeviceCache(string devEUI)
+        {
+            return await LoRaAPIHelper.ResetDeviceCache(devEUI);
         }
 
         public string GetKey16(int deviceId)
@@ -345,8 +357,7 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(18),
                 DevAddr = "00000018",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
+                IsIoTHubDevice = true
             };
 
             // Device19_ABP: used for C2D invalid fport testing
@@ -357,8 +368,7 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(19),
                 DevAddr = "00000019",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
+                IsIoTHubDevice = true
             };
 
             // Device20_OTAA: used for join and rejoin test
@@ -382,7 +392,6 @@ namespace LoRaWan.IntegrationTest
                 DevAddr = "00000021",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
                 PreferredWindow = 2
             };
 
@@ -428,8 +437,7 @@ namespace LoRaWan.IntegrationTest
                 DevAddr = "00000025",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
-                KeepAliveTimeout = 60,
+                KeepAliveTimeout = 60
             };
 
             // Device26_ABP: Connection timeout
@@ -440,15 +448,23 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = "00000000000000000000000000000026",
                 DevAddr = "00000026",
                 GatewayID = gatewayID,
-                IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
+                IsIoTHubDevice = true
             };
 
-            this.Device25_OTAA = new TestDeviceInfo()
+            this.Device27_OTAA = new TestDeviceInfo()
             {
-                DeviceID = "0000000000000025",
-                AppEUI = "0000000000000025",
-                AppKey = "00000000000000000000000000000025",
+                DeviceID = "0000000000000027",
+                AppEUI = "0000000000000027",
+                AppKey = "00000000000000000000000000000027",
+                IsIoTHubDevice = true
+            };
+
+            this.Device28_ABP = new TestDeviceInfo()
+            {
+                DeviceID = "0000000000000028",
+                AppSKey = "00000000000000000000000000000028",
+                NwkSKey = "00000000000000000000000000000028",
+                DevAddr = "00000027",
                 IsIoTHubDevice = true,
                 Deduplication = "Drop"
             };

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
@@ -104,6 +104,11 @@ namespace LoRaWan.IntegrationTest
         /// </summary>
         public TestDeviceInfo Device29_ABP { get; private set; }
 
+        /// <summary>
+        /// Gets Device30_OTAA used for C2D messages in multi gateway scenario
+        /// </summary>
+        public TestDeviceInfo Device30_OTAA { get; private set; }
+
         // Arduino device used for testing
         public LoRaArduinoSerial ArduinoDevice
         {
@@ -482,6 +487,14 @@ namespace LoRaWan.IntegrationTest
                 DevAddr = "00000029",
                 IsIoTHubDevice = true,
                 Deduplication = "Mark"
+            };
+
+            this.Device30_OTAA = new TestDeviceInfo()
+            {
+                DeviceID = this.GetKey16(10),
+                AppEUI = this.GetKey16(10),
+                AppKey = this.GetKey32(10),
+                IsIoTHubDevice = true
             };
         }
     }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
@@ -99,6 +99,11 @@ namespace LoRaWan.IntegrationTest
         /// </summary>
         public TestDeviceInfo Device28_ABP { get; private set; }
 
+        /// <summary>
+        /// Gets Device27_ABP: used for multi GW deduplication mark testing
+        /// </summary>
+        public TestDeviceInfo Device29_ABP { get; private set; }
+
         // Arduino device used for testing
         public LoRaArduinoSerial ArduinoDevice
         {
@@ -467,6 +472,16 @@ namespace LoRaWan.IntegrationTest
                 DevAddr = "00000027",
                 IsIoTHubDevice = true,
                 Deduplication = "Drop"
+            };
+
+            this.Device29_ABP = new TestDeviceInfo()
+            {
+                DeviceID = "0000000000000029",
+                AppSKey = "00000000000000000000000000000029",
+                NwkSKey = "00000000000000000000000000000029",
+                DevAddr = "00000029",
+                IsIoTHubDevice = true,
+                Deduplication = "Mark"
             };
         }
     }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
@@ -89,6 +89,11 @@ namespace LoRaWan.IntegrationTest
         // Device26_ABP: Connection timeout
         public TestDeviceInfo Device26_ABP { get; private set; }
 
+        /// <summary>
+        /// Gets Device24_OTAA: used for OTAA deduplication testing
+        /// </summary>
+        public TestDeviceInfo Device25_OTAA { get; private set; }
+
         // Arduino device used for testing
         public LoRaArduinoSerial ArduinoDevice
         {
@@ -171,7 +176,6 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = this.GetKey16(2),
                 AppKey = this.GetKey32(2),
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = false,
             };
 
@@ -182,7 +186,6 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = this.GetKey16(3),
                 AppKey = this.GetKey32(3),
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -193,7 +196,6 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = this.GetKey16(4),
                 AppKey = this.GetKey32(4),
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
                 RX1DROffset = 1
             };
@@ -206,7 +208,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(5),
                 DevAddr = "0028B1B0",
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -218,7 +219,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(6),
                 DevAddr = "00000006",
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = false,
             };
 
@@ -230,7 +230,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(7),
                 DevAddr = "00000007",
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -242,7 +241,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(8),
                 DevAddr = "00000008",
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -286,7 +284,6 @@ namespace LoRaWan.IntegrationTest
                 AppKey = this.GetKey32(12),
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
             };
 
             // Device13_OTAA: used for Join with wrong AppEUI
@@ -297,7 +294,6 @@ namespace LoRaWan.IntegrationTest
                 AppKey = this.GetKey32(13),
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
             };
 
             // Device14_OTAA: used for Confirmed C2D message
@@ -308,7 +304,6 @@ namespace LoRaWan.IntegrationTest
                 AppKey = this.GetKey32(14),
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
             };
 
             // Device15_OTAA: used for the Fport test
@@ -319,7 +314,6 @@ namespace LoRaWan.IntegrationTest
                 AppKey = this.GetKey32(15),
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
             };
             // Device16_ABP: used for same DevAddr test
             this.Device16_ABP = new TestDeviceInfo()
@@ -329,7 +323,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(16),
                 DevAddr = "00000016",
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -341,7 +334,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(17),
                 DevAddr = this.Device16_ABP.DevAddr, // MUST match DevAddr from Device16
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -377,7 +369,6 @@ namespace LoRaWan.IntegrationTest
                 AppKey = this.GetKey32(20),
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
                 RX2DataRate = 3,
                 PreferredWindow = 2
             };
@@ -403,7 +394,6 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(22),
                 DevAddr = "00000022",
                 GatewayID = gatewayID,
-                SensorDecoder = "DecoderValueSensor",
                 IsIoTHubDevice = true,
             };
 
@@ -415,7 +405,6 @@ namespace LoRaWan.IntegrationTest
                 AppKey = this.GetKey32(23),
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
             };
 
             // Device24_OTAA: used for C2D mac Command testing
@@ -427,7 +416,6 @@ namespace LoRaWan.IntegrationTest
                 DevAddr = "00000024",
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
-                SensorDecoder = "DecoderValueSensor",
                 ClassType = 'C',
             };
 
@@ -454,6 +442,15 @@ namespace LoRaWan.IntegrationTest
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
                 SensorDecoder = "DecoderValueSensor",
+            };
+
+            this.Device25_OTAA = new TestDeviceInfo()
+            {
+                DeviceID = "0000000000000025",
+                AppEUI = "0000000000000025",
+                AppKey = "00000000000000000000000000000025",
+                IsIoTHubDevice = true,
+                Deduplication = "Drop"
             };
         }
     }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/IntegrationTestFixtureCI.cs
@@ -23,8 +23,12 @@ namespace LoRaWan.IntegrationTest
         // Device4_OTAA: used for OTAA confirmed & unconfirmed messaging
         public TestDeviceInfo Device4_OTAA { get; private set; }
 
+        public TestDeviceInfo Device4_OTAA_MultiGw { get; private set; }
+
         // Device5_ABP: used for ABP confirmed & unconfirmed messaging
         public TestDeviceInfo Device5_ABP { get; private set; }
+
+        public TestDeviceInfo Device5_ABP_MultiGw { get; private set; }
 
         // Device6_ABP: used for ABP wrong devaddr
         public TestDeviceInfo Device6_ABP { get; private set; }
@@ -53,8 +57,12 @@ namespace LoRaWan.IntegrationTest
         // Device14_OTAA: used for test confirmed C2D
         public TestDeviceInfo Device14_OTAA { get; private set; }
 
+        public TestDeviceInfo Device14_OTAA_MultiGw { get; private set; }
+
         // Device15_OTAA: used for test fport C2D
         public TestDeviceInfo Device15_OTAA { get; private set; }
+
+        public TestDeviceInfo Device15_OTAA_MultiGw { get; private set; }
 
         // Device16_ABP: used for test on multiple device with same devaddr
         public TestDeviceInfo Device16_ABP { get; private set; }
@@ -71,6 +79,8 @@ namespace LoRaWan.IntegrationTest
         // Device20_OTAA: used for OTAA confirmed & unconfirmed messaging
         public TestDeviceInfo Device20_OTAA { get; private set; }
 
+        public TestDeviceInfo Device20_OTAA_MultiGw { get; private set; }
+
         // Device21_ABP: Preferred 2nd window
         public TestDeviceInfo Device21_ABP { get; private set; }
 
@@ -79,6 +89,8 @@ namespace LoRaWan.IntegrationTest
 
         // Device23_OTAA: used for OTAA C2D Mac Commands testing
         public TestDeviceInfo Device23_OTAA { get; private set; }
+
+        public TestDeviceInfo Device23_OTAA_MultiGw { get; private set; }
 
         // Device24_ABP: Class C device
         public TestDeviceInfo Device24_ABP { get; private set; }
@@ -155,9 +167,11 @@ namespace LoRaWan.IntegrationTest
             return await LoRaAPIHelper.ResetDeviceCache(devEUI);
         }
 
-        public string GetKey16(int deviceId)
+        public string GetKey16(int deviceId, bool multiGw = false)
         {
-            var format = string.IsNullOrEmpty(this.Configuration.DeviceKeyFormat) ? "0000000000000000" : this.Configuration.DeviceKeyFormat;
+            var target = multiGw ? this.Configuration.DeviceKeyFormatMultiGW : this.Configuration.DeviceKeyFormat;
+            var format = string.IsNullOrEmpty(target) ? "0000000000000000" : target;
+
             if (format.Length < 16)
             {
                 format = format.PadLeft(16, '0');
@@ -166,9 +180,10 @@ namespace LoRaWan.IntegrationTest
             return deviceId.ToString(format);
         }
 
-        public string GetKey32(int deviceId)
+        public string GetKey32(int deviceId, bool multiGw = false)
         {
-            var format = string.IsNullOrEmpty(this.Configuration.DeviceKeyFormat) ? "00000000000000000000000000000000" : this.Configuration.DeviceKeyFormat;
+            var target = multiGw ? this.Configuration.DeviceKeyFormatMultiGW : this.Configuration.DeviceKeyFormat;
+            var format = string.IsNullOrEmpty(target) ? "00000000000000000000000000000000" : target;
             if (format.Length < 32)
             {
                 format = format.PadLeft(32, '0');
@@ -222,6 +237,15 @@ namespace LoRaWan.IntegrationTest
                 RX1DROffset = 1
             };
 
+            this.Device4_OTAA_MultiGw = new TestDeviceInfo()
+            {
+                DeviceID = this.GetKey16(4, true),
+                AppEUI = this.GetKey16(4, true),
+                AppKey = this.GetKey32(4, true),
+                IsIoTHubDevice = true,
+                RX1DROffset = 1
+            };
+
             // Device5_ABP: used for ABP confirmed & unconfirmed messaging
             this.Device5_ABP = new TestDeviceInfo()
             {
@@ -230,6 +254,15 @@ namespace LoRaWan.IntegrationTest
                 NwkSKey = this.GetKey32(5),
                 DevAddr = "0028B1B0",
                 GatewayID = gatewayID,
+                IsIoTHubDevice = true,
+            };
+
+            this.Device5_ABP_MultiGw = new TestDeviceInfo()
+            {
+                DeviceID = this.GetKey16(5, true),
+                AppSKey = this.GetKey32(5, true),
+                NwkSKey = this.GetKey32(5, true),
+                DevAddr = "0028B1B0",
                 IsIoTHubDevice = true,
             };
 
@@ -328,6 +361,14 @@ namespace LoRaWan.IntegrationTest
                 IsIoTHubDevice = true,
             };
 
+            this.Device14_OTAA_MultiGw = new TestDeviceInfo()
+            {
+                DeviceID = this.GetKey16(14, true),
+                AppEUI = this.GetKey16(14, true),
+                AppKey = this.GetKey32(14, true),
+                IsIoTHubDevice = true,
+            };
+
             // Device15_OTAA: used for the Fport test
             this.Device15_OTAA = new TestDeviceInfo()
             {
@@ -335,6 +376,14 @@ namespace LoRaWan.IntegrationTest
                 AppEUI = this.GetKey16(15),
                 AppKey = this.GetKey32(15),
                 GatewayID = gatewayID,
+                IsIoTHubDevice = true,
+            };
+
+            this.Device15_OTAA_MultiGw = new TestDeviceInfo()
+            {
+                DeviceID = this.GetKey16(15, true),
+                AppEUI = this.GetKey16(15, true),
+                AppKey = this.GetKey32(15, true),
                 IsIoTHubDevice = true,
             };
             // Device16_ABP: used for same DevAddr test
@@ -393,6 +442,16 @@ namespace LoRaWan.IntegrationTest
                 PreferredWindow = 2
             };
 
+            this.Device20_OTAA_MultiGw = new TestDeviceInfo()
+            {
+                DeviceID = this.GetKey16(20, true),
+                AppEUI = this.GetKey16(20, true),
+                AppKey = this.GetKey32(20, true),
+                IsIoTHubDevice = true,
+                RX2DataRate = 3,
+                PreferredWindow = 2
+            };
+
             // Device21_ABP: Preferred 2nd window
             this.Device21_ABP = new TestDeviceInfo()
             {
@@ -424,6 +483,14 @@ namespace LoRaWan.IntegrationTest
                 AppKey = this.GetKey32(23),
                 GatewayID = gatewayID,
                 IsIoTHubDevice = true,
+            };
+
+            this.Device23_OTAA_MultiGw = new TestDeviceInfo()
+            {
+                DeviceID = this.GetKey16(23, true),
+                AppEUI = this.GetKey16(23, true),
+                AppKey = this.GetKey32(23, true),
+                IsIoTHubDevice = true
             };
 
             // Device24_OTAA: used for C2D mac Command testing
@@ -491,9 +558,9 @@ namespace LoRaWan.IntegrationTest
 
             this.Device30_OTAA = new TestDeviceInfo()
             {
-                DeviceID = this.GetKey16(10),
-                AppEUI = this.GetKey16(10),
-                AppKey = this.GetKey32(10),
+                DeviceID = this.GetKey16(30),
+                AppEUI = this.GetKey16(30),
+                AppKey = this.GetKey32(30),
                 IsIoTHubDevice = true
             };
         }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaAPIHelper.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaAPIHelper.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.IntegrationTest
+{
+    using System;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Text;
+    using System.Threading.Tasks;
+    using LoRaTools.CommonAPI;
+    using LoRaWan.Shared;
+
+    public static class LoRaAPIHelper
+    {
+        private static string authCode;
+        private static string baseUrl;
+        private static ServiceFacadeHttpClientHandler httpHandler;
+        private static Lazy<HttpClient> httpClient;
+
+        internal static void Initialize(string functionAppCode, string functionAppBaseUrl)
+        {
+            authCode = functionAppCode;
+            baseUrl = SanitizeApiURL(functionAppBaseUrl);
+            httpHandler = new ServiceFacadeHttpClientHandler(ApiVersion.LatestVersion);
+            httpClient = new Lazy<HttpClient>(CreateHttpClient);
+        }
+
+        private static HttpClient CreateHttpClient()
+        {
+            return new HttpClient(httpHandler);
+        }
+
+        public static async Task<bool> ResetDeviceCache(string devEUI)
+        {
+            var url = $"{baseUrl}FunctionBundler/{devEUI}?code={authCode}";
+            // the gateway id is only used to identify who is taking the lock when
+            // releasing the cache. Hence we do not need a real GW id
+            var payload = "{\"GatewayId\":\"integrationTesting\", \"FunctionItems\": " + (int)FunctionBundlerItemType.ResetDeviceCache + "}";
+
+            var response = await httpClient.Value.PostAsync(url, PreparePostContent(payload));
+            return response.IsSuccessStatusCode;
+        }
+
+        private static ByteArrayContent PreparePostContent(string requestBody)
+        {
+            var buffer = Encoding.UTF8.GetBytes(requestBody);
+            var byteContent = new ByteArrayContent(buffer);
+            byteContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            return byteContent;
+        }
+
+        private static string SanitizeApiURL(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return string.Empty;
+
+            value = value.Trim();
+            if (value.EndsWith('/'))
+                return value;
+
+            return string.Concat(value, "/");
+        }
+    }
+}

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaAPIHelper.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaAPIHelper.cs
@@ -42,6 +42,17 @@ namespace LoRaWan.IntegrationTest
             return response.IsSuccessStatusCode;
         }
 
+        public static async Task<bool> ResetADRCache(string devEUI)
+        {
+            var url = $"{baseUrl}FunctionBundler/{devEUI}?code={authCode}";
+            // the gateway id is only used to identify who is taking the lock when
+            // releasing the cache. Hence we do not need a real GW id
+            var payload = "{\"AdrRequest\":{\"ClearCache\": true},\"GatewayId\":\"integrationTesting\", \"FunctionItems\": " + (int)FunctionBundlerItemType.ADR + "}";
+
+            var response = await httpClient.Value.PostAsync(url, PreparePostContent(payload));
+            return response.IsSuccessStatusCode;
+        }
+
         private static ByteArrayContent PreparePostContent(string requestBody)
         {
             var buffer = Encoding.UTF8.GetBytes(requestBody);

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaWan.IntegrationTest.csproj
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaWan.IntegrationTest.csproj
@@ -41,6 +41,10 @@
   <ItemGroup>
     <AdditionalFiles Include="../../../stylecop.json" Link="stylecop.json" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\modules\LoRaWanNetworkSrvModule\LoRaWan.NetworkServer\ApiVersion.cs" Link="ApiVersion.cs" />
+    <Compile Include="..\..\modules\LoRaWanNetworkSrvModule\LoRaWan.NetworkServer\ServiceFacadeHttpClientHandler.cs" Link="ServiceFacadeHttpClientHandler.cs" />
+  </ItemGroup>
   <PropertyGroup>
     <CodeAnalysisRuleSet>../../../stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/MacTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/MacTest.cs
@@ -69,10 +69,12 @@ namespace LoRaWan.IntegrationTest
 
         // Ensures that Mac Commands C2D messages working
         // Uses Device23_OTAA
-        [Fact]
-        public async Task Test_OTAA_Unconfirmed_Send_And_Receive_C2D_Mac_Commands()
+        [Theory]
+        [InlineData("Device23_OTAA")]
+        [InlineData("Device23_OTAA_MultiGw")]
+        public async Task Test_OTAA_Unconfirmed_Send_And_Receive_C2D_Mac_Commands(string devicePropertyName)
         {
-            var device = this.TestFixtureCi.Device23_OTAA;
+            var device = this.TestFixtureCi.GetDeviceByPropertyName(devicePropertyName);
             this.LogTestStart(device);
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
@@ -192,19 +194,6 @@ namespace LoRaWan.IntegrationTest
 
             Assert.True(foundMacCommandReceivedMsg, $"Did not find in network server logs: '{macCommandReceivedMsg}'");
             Assert.True(foundDeviceMacCommandResponseMsg, $"Did not find in network server logs: '{deviceMacCommandResponseMsg}'");
-        }
-
-        private string ToHexString(string str)
-        {
-            var sb = new StringBuilder();
-
-            var bytes = Encoding.UTF8.GetBytes(str);
-            foreach (var t in bytes)
-            {
-                sb.Append(t.ToString("X2"));
-            }
-
-            return sb.ToString(); // returns: "48656C6C6F20776F726C64" for "Hello world"
         }
     }
 }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/MacTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/MacTest.cs
@@ -85,6 +85,11 @@ namespace LoRaWan.IntegrationTest
             var joinSucceeded = await this.ArduinoDevice.setOTAAJoinAsyncWithRetry(LoRaArduinoSerial._otaa_join_cmd_t.JOIN, 20000, 5);
             Assert.True(joinSucceeded, "Join failed");
 
+            if (device.IsMultiGw)
+            {
+                await this.TestFixtureCi.AssertTwinSyncAfterJoinAsync(this.ArduinoDevice.SerialLogs, device.DeviceID);
+            }
+
             // wait 1 second after joined
             await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_JOIN);
 

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/MultiGatewayTests.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/MultiGatewayTests.cs
@@ -16,9 +16,9 @@ namespace LoRaWan.IntegrationTest
     // Tests OTAA requests
     [Collection(Constants.TestCollectionName)] // run in serial
     [Trait("Category", "SkipWhenLiveUnitTesting")]
-    public sealed class DeduplicationTest : IntegrationTestBaseCi
+    public sealed class MultiGatewayTests : IntegrationTestBaseCi
     {
-        public DeduplicationTest(IntegrationTestFixtureCi testFixture)
+        public MultiGatewayTests(IntegrationTestFixtureCi testFixture)
             : base(testFixture)
         {
         }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/MultiGatewayTests.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/MultiGatewayTests.cs
@@ -44,8 +44,8 @@ namespace LoRaWan.IntegrationTest
             Assert.NotNull(joinConfirm);
 
             // validate that one GW refused the join
-            const string devNonceAlreadyUsed = "DevNonce already used by this device";
-            var joinRefused = await this.TestFixtureCi.AssertNetworkServerModuleLogExistsAsync((s) => s.IndexOf(devNonceAlreadyUsed) != -1, new SearchLogOptions(devNonceAlreadyUsed));
+            const string joinRefusedMsg = "join refused";
+            var joinRefused = await this.TestFixtureCi.AssertNetworkServerModuleLogExistsAsync((s) => s.IndexOf(joinRefusedMsg) != -1, new SearchLogOptions(joinRefusedMsg));
             Assert.True(joinRefused.Found);
         }
 

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/MultiGatewayTests.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/MultiGatewayTests.cs
@@ -131,5 +131,110 @@ namespace LoRaWan.IntegrationTest
                 this.TestFixtureCi.ClearLogs();
             }
         }
+
+        [Fact]
+        public async Task Test_OTAA_Unconfirmed_Receives_C2D_Message_Multi()
+        {
+            var device = this.TestFixtureCi.Device30_OTAA;
+            this.LogTestStart(device);
+            await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
+            await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
+            await this.ArduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, device.AppKey);
+
+            await this.ArduinoDevice.SetupLora(this.TestFixtureCi.Configuration.LoraRegion);
+
+            var joinSucceeded = await this.ArduinoDevice.setOTAAJoinAsyncWithRetry(LoRaArduinoSerial._otaa_join_cmd_t.JOIN, 20000, 5);
+            Assert.True(joinSucceeded, "Join failed");
+
+            // wait 1 second after joined
+            await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_JOIN);
+
+            // Sends 2x confirmed messages
+            for (var i = 1; i <= 2; ++i)
+            {
+                var msg = PayloadGenerator.Next().ToString();
+                this.Log($"{device.DeviceID}: Sending unconfirmed '{msg}' {i}/10");
+
+                await this.ArduinoDevice.transferPacketAsync(msg, 10);
+
+                await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
+
+                await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
+
+                this.TestFixtureCi.ClearLogs();
+            }
+
+            // sends C2D - between 10 and 99
+            var c2dMessageBody = (100 + random.Next(90)).ToString();
+            var c2dMessage = new LoRaCloudToDeviceMessage()
+            {
+                Payload = c2dMessageBody,
+                Fport = 1,
+                MessageId = Guid.NewGuid().ToString(),
+            };
+
+            await this.TestFixtureCi.SendCloudToDeviceMessageAsync(device.DeviceID, c2dMessage);
+            this.Log($"Message {c2dMessageBody} sent to device, need to check if it receives");
+
+            var foundC2DMessage = false;
+            var foundReceivePacket = false;
+            var expectedRxSerial = $"+MSG: PORT: 1; RX: \"{this.ToHexString(c2dMessageBody)}\"";
+            this.Log($"Expected C2D received log is: {expectedRxSerial}");
+
+            // Sends 8x confirmed messages, stopping if C2D message is found
+            for (var i = 3; i <= 10; ++i)
+            {
+                var msg = PayloadGenerator.Next().ToString();
+                this.Log($"{device.DeviceID}: Sending unconfirmed '{msg}' {i}/10");
+                await this.ArduinoDevice.transferPacketAsync(msg, 10);
+
+                await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
+
+                await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
+
+                // check if c2d message was found
+                // 0000000000000009: C2D message: 58
+                var c2dLogMessage = $"{device.DeviceID}: cloud to device message: {this.ToHexString(c2dMessageBody)}";
+                var searchResults = await this.TestFixtureCi.SearchNetworkServerModuleAsync(
+                    (messageBody) =>
+                    {
+                        return messageBody.StartsWith(c2dLogMessage);
+                    },
+                    new SearchLogOptions
+                    {
+                        Description = c2dLogMessage,
+                        MaxAttempts = 1
+                    });
+
+                // We should only receive the message once
+                if (searchResults.Found)
+                {
+                    this.Log($"{device.DeviceID}: Found C2D message in log (after sending {i}/10) ? {foundC2DMessage}");
+                    Assert.False(foundC2DMessage, "Cloud to Device message should have been detected in Network Service module only once");
+                    foundC2DMessage = true;
+                }
+
+                var localFoundCloudToDeviceInSerial = this.ArduinoDevice.SerialLogs.Contains(expectedRxSerial);
+                if (localFoundCloudToDeviceInSerial)
+                {
+                    Assert.False(foundReceivePacket, "Cloud to device message should have been received only once");
+                    foundReceivePacket = true;
+                }
+
+                this.TestFixtureCi.ClearLogs();
+
+                await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
+            }
+
+            Assert.True(foundC2DMessage, $"Did not find '{device.DeviceID}: C2D message: {c2dMessageBody}' in logs");
+
+            // checks if log arrived
+            if (!foundReceivePacket)
+            {
+                foundReceivePacket = this.ArduinoDevice.SerialLogs.Contains(expectedRxSerial);
+            }
+
+            Assert.True(foundReceivePacket, $"Could not find lora receiving message '{expectedRxSerial}'");
+        }
     }
 }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/MultiGatewayTests.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/MultiGatewayTests.cs
@@ -9,6 +9,7 @@ namespace LoRaWan.IntegrationTest
     using System.Text;
     using System.Threading.Tasks;
     using System.Xml;
+    using LoRaTools.CommonAPI;
     using LoRaWan.Test.Shared;
     using Newtonsoft.Json.Linq;
     using Xunit;
@@ -47,52 +48,61 @@ namespace LoRaWan.IntegrationTest
             const string joinRefusedMsg = "join refused";
             var joinRefused = await this.TestFixtureCi.AssertNetworkServerModuleLogExistsAsync((s) => s.IndexOf(joinRefusedMsg) != -1, new SearchLogOptions(joinRefusedMsg));
             Assert.True(joinRefused.Found);
-        }
 
-        [Fact]
-        public async Task Test_Deduplication_Drop()
-        {
-            var device = this.TestFixtureCi.Device28_ABP;
-            this.LogTestStart(device);
+            var devAddr = joinConfirm.Substring(joinConfirm.LastIndexOf(' ') + 1);
+            devAddr = devAddr.Replace(":", string.Empty);
 
-            await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWABP);
-            await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, null);
-            await this.ArduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, null);
-
-            await this.ArduinoDevice.SetupLora(this.TestFixtureCi.Configuration.LoraRegion);
-
-            for (int i = 0; i < 10; i++)
+            // wait for the twins to be stored and published -> all GW need the same state
+            const int DelayForJoinTwinStore = 20 * 1000;
+            const string DevAddrProperty = "DevAddr";
+            const int MaxRuns = 4;
+            bool reported = false;
+            for (var i = 0; i < MaxRuns && !reported; i++)
             {
-                var msg = PayloadGenerator.Next().ToString();
-                await this.ArduinoDevice.transferPacketAsync(msg, 10);
+                await Task.Delay(DelayForJoinTwinStore);
 
-                await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
-
-                // After transferPacket: Expectation from serial
-                // +MSG: Done
-                await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
-
-                var allGwGotIt = await this.TestFixtureCi.ValidateMultiGatewaySources((log) => log.IndexOf("deduplication Strategy: Drop", StringComparison.OrdinalIgnoreCase) != -1);
-                if (allGwGotIt)
+                var twins = await this.TestFixtureCi.GetTwinAsync(device.DeviceID);
+                if (twins.Properties.Reported.Contains(DevAddrProperty))
                 {
-                    var notDuplicate = "\"IsDuplicate\":false";
-                    var resultProcessed = await this.TestFixtureCi.AssertNetworkServerModuleLogExistsAsync(logmsg => logmsg.IndexOf(notDuplicate) != -1, new SearchLogOptions(notDuplicate));
-                    var resultDroped = await this.TestFixtureCi.SearchNetworkServerModuleAsync((s) => s.IndexOf("duplication strategy indicated to not process message") != -1);
-
-                    Assert.NotNull(resultProcessed.MatchedEvent);
-                    Assert.NotNull(resultDroped.MatchedEvent);
-
-                    Assert.NotEqual(resultProcessed.MatchedEvent.SourceId, resultDroped.MatchedEvent.SourceId);
+                    reported = devAddr.Equals(twins.Properties.Reported[DevAddrProperty].Value as string, StringComparison.InvariantCultureIgnoreCase);
                 }
-
-                this.TestFixtureCi.ClearLogs();
             }
+
+            Assert.True(reported);
+
+            // expecting both gw to start picking up messages
+            // and sending to IoT hub.
+            var bothReported = false;
+            for (var i = 0; i < 5; i++)
+            {
+                var msg = PayloadGenerator.Next().ToString();
+                await this.ArduinoDevice.transferPacketAsync(msg, 10);
+
+                await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
+
+                // After transferPacket: Expectation from serial
+                // +MSG: Done
+                await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
+
+                var expectedPayload = $"{{\"value\":{msg}}}";
+                await this.TestFixtureCi.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, expectedPayload);
+
+                bothReported = await this.TestFixtureCi.ValidateMultiGatewaySources((log) => log.StartsWith($"{device.DeviceID}: sending message", StringComparison.OrdinalIgnoreCase));
+                if (bothReported)
+                {
+                    break;
+                }
+            }
+
+            Assert.True(bothReported);
         }
 
-        [Fact]
-        public async Task Test_Deduplication_Mark()
+        [Theory]
+        [InlineData("Device29_ABP", "Mark")]
+        [InlineData("Device28_ABP", "Drop")]
+        public async Task Test_Deduplication_Strategies(string devicePropertyName, string strategy)
         {
-            var device = this.TestFixtureCi.Device29_ABP;
+            var device = this.TestFixtureCi.GetDeviceByPropertyName(devicePropertyName);
             this.LogTestStart(device);
 
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWABP);
@@ -111,7 +121,7 @@ namespace LoRaWan.IntegrationTest
                 // +MSG: Done
                 await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
 
-                var allGwGotIt = await this.TestFixtureCi.ValidateMultiGatewaySources((log) => log.IndexOf("deduplication Strategy: Mark", StringComparison.OrdinalIgnoreCase) != -1);
+                var allGwGotIt = await this.TestFixtureCi.ValidateMultiGatewaySources((log) => log.IndexOf($"deduplication Strategy: {strategy}", StringComparison.OrdinalIgnoreCase) != -1);
                 if (allGwGotIt)
                 {
                     var notDuplicate = "\"IsDuplicate\":false";
@@ -125,116 +135,24 @@ namespace LoRaWan.IntegrationTest
 
                     Assert.NotEqual(duplicateResult.MatchedEvent.SourceId, notDuplicateResult.MatchedEvent.SourceId);
 
-                    // await this.TestFixture.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, "\"dupmsg\":true");
-                }
-
-                this.TestFixtureCi.ClearLogs();
-            }
-        }
-
-        [Fact]
-        public async Task Test_OTAA_Unconfirmed_Receives_C2D_Message_Multi()
-        {
-            var device = this.TestFixtureCi.Device30_OTAA;
-            this.LogTestStart(device);
-            await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
-            await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
-            await this.ArduinoDevice.setKeyAsync(device.NwkSKey, device.AppSKey, device.AppKey);
-
-            await this.ArduinoDevice.SetupLora(this.TestFixtureCi.Configuration.LoraRegion);
-
-            var joinSucceeded = await this.ArduinoDevice.setOTAAJoinAsyncWithRetry(LoRaArduinoSerial._otaa_join_cmd_t.JOIN, 20000, 5);
-            Assert.True(joinSucceeded, "Join failed");
-
-            // wait 1 second after joined
-            await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_JOIN);
-
-            // Sends 2x confirmed messages
-            for (var i = 1; i <= 2; ++i)
-            {
-                var msg = PayloadGenerator.Next().ToString();
-                this.Log($"{device.DeviceID}: Sending unconfirmed '{msg}' {i}/10");
-
-                await this.ArduinoDevice.transferPacketAsync(msg, 10);
-
-                await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
-
-                await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
-
-                this.TestFixtureCi.ClearLogs();
-            }
-
-            // sends C2D - between 10 and 99
-            var c2dMessageBody = (100 + random.Next(90)).ToString();
-            var c2dMessage = new LoRaCloudToDeviceMessage()
-            {
-                Payload = c2dMessageBody,
-                Fport = 1,
-                MessageId = Guid.NewGuid().ToString(),
-            };
-
-            await this.TestFixtureCi.SendCloudToDeviceMessageAsync(device.DeviceID, c2dMessage);
-            this.Log($"Message {c2dMessageBody} sent to device, need to check if it receives");
-
-            var foundC2DMessage = false;
-            var foundReceivePacket = false;
-            var expectedRxSerial = $"+MSG: PORT: 1; RX: \"{this.ToHexString(c2dMessageBody)}\"";
-            this.Log($"Expected C2D received log is: {expectedRxSerial}");
-
-            // Sends 8x confirmed messages, stopping if C2D message is found
-            for (var i = 3; i <= 10; ++i)
-            {
-                var msg = PayloadGenerator.Next().ToString();
-                this.Log($"{device.DeviceID}: Sending unconfirmed '{msg}' {i}/10");
-                await this.ArduinoDevice.transferPacketAsync(msg, 10);
-
-                await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
-
-                await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", this.ArduinoDevice.SerialLogs);
-
-                // check if c2d message was found
-                // 0000000000000009: C2D message: 58
-                var c2dLogMessage = $"{device.DeviceID}: cloud to device message: {this.ToHexString(c2dMessageBody)}";
-                var searchResults = await this.TestFixtureCi.SearchNetworkServerModuleAsync(
-                    (messageBody) =>
+                    switch (strategy)
                     {
-                        return messageBody.StartsWith(c2dLogMessage);
-                    },
-                    new SearchLogOptions
-                    {
-                        Description = c2dLogMessage,
-                        MaxAttempts = 1
-                    });
+                        case "Mark":
+                            await this.TestFixture.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, "dupmsg", "true");
+                            break;
+                        case "Drop":
+                            var logMsg = $"{device.DeviceID}: duplicate message '{i + 1}' is dropped.";
+                            var droppedLog = await this.TestFixtureCi.SearchNetworkServerModuleAsync((log) => log == logMsg, new SearchLogOptions { Description = logMsg, SourceIdFilter = duplicateResult.MatchedEvent.SourceId });
+                            Assert.NotNull(droppedLog.MatchedEvent);
 
-                // We should only receive the message once
-                if (searchResults.Found)
-                {
-                    this.Log($"{device.DeviceID}: Found C2D message in log (after sending {i}/10) ? {foundC2DMessage}");
-                    Assert.False(foundC2DMessage, "Cloud to Device message should have been detected in Network Service module only once");
-                    foundC2DMessage = true;
-                }
-
-                var localFoundCloudToDeviceInSerial = this.ArduinoDevice.SerialLogs.Contains(expectedRxSerial);
-                if (localFoundCloudToDeviceInSerial)
-                {
-                    Assert.False(foundReceivePacket, "Cloud to device message should have been received only once");
-                    foundReceivePacket = true;
+                            var expectedPayload = $"{{\"value\":{msg}}}";
+                            await this.TestFixtureCi.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, expectedPayload);
+                            break;
+                    }
                 }
 
                 this.TestFixtureCi.ClearLogs();
-
-                await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
             }
-
-            Assert.True(foundC2DMessage, $"Did not find '{device.DeviceID}: C2D message: {c2dMessageBody}' in logs");
-
-            // checks if log arrived
-            if (!foundReceivePacket)
-            {
-                foundReceivePacket = this.ArduinoDevice.SerialLogs.Contains(expectedRxSerial);
-            }
-
-            Assert.True(foundReceivePacket, $"Could not find lora receiving message '{expectedRxSerial}'");
         }
     }
 }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/OTAAJoinTest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/OTAAJoinTest.cs
@@ -156,10 +156,12 @@ namespace LoRaWan.IntegrationTest
         }
 
         // Performs a OTAA join and sends 1 unconfirmed, 1 confirmed and rejoins
-        [Fact]
-        public async Task Test_OTAA_Join_Send_And_Rejoin_With_Custom_RX2_DR()
+        [Theory]
+        [InlineData("Device20_OTAA")]
+        [InlineData("Device20_OTAA_MultiGw")]
+        public async Task Test_OTAA_Join_Send_And_Rejoin_With_Custom_RX2_DR(string devicePropertyName)
         {
-            var device = this.TestFixtureCi.Device20_OTAA;
+            var device = this.TestFixtureCi.GetDeviceByPropertyName(devicePropertyName);
             this.LogTestStart(device);
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/OTAATest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/OTAATest.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.IntegrationTest
 {
     using System;
+    using System.Linq;
     using System.Threading.Tasks;
     using System.Xml;
     using LoRaWan.Test.Shared;
@@ -25,12 +26,14 @@ namespace LoRaWan.IntegrationTest
         // - device message is available on IoT Hub
         // - frame counter validation is done
         // - Message is decoded
-        [Fact]
-        public async Task Test_OTAA_Confirmed_And_Unconfirmed_Message_With_Custom_RX1_DR_Offset()
+        [Theory]
+        [InlineData("Device4_OTAA")]
+        [InlineData("Device4_OTAA_MultiGw")]
+        public async Task Test_OTAA_Confirmed_And_Unconfirmed_Message_With_Custom_RX1_DR_Offset(string devicePropertyName)
         {
+            var device = this.TestFixtureCi.GetDeviceByPropertyName(devicePropertyName);
             const int MESSAGES_COUNT = 10;
 
-            var device = this.TestFixtureCi.Device4_OTAA;
             this.LogTestStart(device);
             await this.ArduinoDevice.setDeviceModeAsync(LoRaArduinoSerial._device_mode_t.LWOTAA);
             await this.ArduinoDevice.setIdAsync(device.DevAddr, device.DeviceID, device.AppEUI);
@@ -87,9 +90,16 @@ namespace LoRaWan.IntegrationTest
 
                 await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
 
+                if (string.IsNullOrEmpty(device.GatewayID))
+                {
+                    // multi gw, make sure one ignored the message
+                    var confirmedLog = $"{device.DeviceID}: sending a downstream message";
+                    Assert.True(await this.TestFixtureCi.ValidateSingleGatewaySources(log => log.StartsWith(confirmedLog, StringComparison.OrdinalIgnoreCase)));
+                }
+
                 // After transferPacketWithConfirmed: Expectation from serial
                 // +CMSG: ACK Received
-                await AssertUtils.ContainsWithRetriesAsync("+CMSG: ACK Received", this.ArduinoDevice.SerialLogs);
+                await AssertUtils.ContainsWithRetriesAsync("+CMSG: ACK Received", this.ArduinoDevice.SerialLogs, maxAttempts: 5, interval: TimeSpan.FromSeconds(10));
 
                 // 0000000000000004: decoding with: DecoderValueSensor port: 8
                 await this.TestFixtureCi.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: decoding with: {device.SensorDecoder} port:");
@@ -97,8 +107,11 @@ namespace LoRaWan.IntegrationTest
                 // 0000000000000004: message '{"value": 51}' sent to hub
                 await this.TestFixtureCi.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: message '{{\"value\":{msg}}}' sent to hub");
 
-                // Expect that the response is done on DR4 as the RX1 offset is 1 on this device.
-                await this.TestFixtureCi.AssertNetworkServerModuleLogExistsAsync(log => log.Contains("\"datr\":\"SF8BW125\""), null);
+                if (this.ArduinoDevice.SerialLogs.Where(x => x.StartsWith("+CMSG: RXWIN1")).Count() > 0)
+                {
+                    // Expect that the response is done on DR4 as the RX1 offset is 1 on this device.
+                    await this.TestFixtureCi.AssertNetworkServerModuleLogExistsAsync(log => log.Contains("\"datr\":\"SF8BW125\""), null);
+                }
 
                 // Ensure device payload is available
                 // Data: {"value": 51}

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/OTAATest.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/OTAATest.cs
@@ -47,6 +47,11 @@ namespace LoRaWan.IntegrationTest
             // wait 1 second after joined
             await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_JOIN);
 
+            if (device.IsMultiGw)
+            {
+                await this.TestFixtureCi.AssertTwinSyncAfterJoinAsync(this.ArduinoDevice.SerialLogs, device.DeviceID);
+            }
+
             // Sends 10x unconfirmed messages
             for (var i = 0; i < MESSAGES_COUNT; ++i)
             {
@@ -90,11 +95,11 @@ namespace LoRaWan.IntegrationTest
 
                 await Task.Delay(Constants.DELAY_FOR_SERIAL_AFTER_SENDING_PACKET);
 
-                if (string.IsNullOrEmpty(device.GatewayID))
+                if (device.IsMultiGw)
                 {
                     // multi gw, make sure one ignored the message
                     var confirmedLog = $"{device.DeviceID}: sending a downstream message";
-                    Assert.True(await this.TestFixtureCi.ValidateSingleGatewaySources(log => log.StartsWith(confirmedLog, StringComparison.OrdinalIgnoreCase)));
+                    await this.TestFixtureCi.AssertSingleGatewaySource(log => log.StartsWith(confirmedLog, StringComparison.OrdinalIgnoreCase));
                 }
 
                 // After transferPacketWithConfirmed: Expectation from serial

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/appsettings.json
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/appsettings.json
@@ -1,17 +1,19 @@
 {
-  "testConfiguration": {
-    "IoTHubEventHubConnectionString": "#{INTEGRATIONTEST_IoTHubEventHubConnectionString}#",
-    "IoTHubEventHubConsumerGroup": "#{INTEGRATIONTEST_IoTHubEventHubConsumerGroup}#",
-    "IoTHubConnectionString": "#{INTEGRATIONTEST_IoTHubConnectionString}#",
-    "EnsureHasEventDelayBetweenReadsInSeconds": "#{INTEGRATIONTEST_EnsureHasEventDelayBetweenReadsInSeconds}#",
-    "EnsureHasEventMaximumTries": "#{INTEGRATIONTEST_EnsureHasEventMaximumTries}#",
-    "LeafDeviceSerialPort": "#{INTEGRATIONTEST_LeafDeviceSerialPort}#",
-    "NetworkServerModuleLogAssertLevel": "Error",
-    "IoTHubAssertLevel": "Warning",
-    "UdpLog": "true",
-    "CreateDevices": true,
-    "LeafDeviceGatewayID": "#{INTEGRATIONTEST_LeafDeviceGatewayID}#",
-    "DevicePrefix": "#{INTEGRATIONTEST_DevicePrefix}#",
-    "DeviceKeyFormat": "00F5A90000000000"
-  }
+    "testConfiguration": {
+        "IoTHubEventHubConnectionString": "#{INTEGRATIONTEST_IoTHubEventHubConnectionString}#",
+        "IoTHubEventHubConsumerGroup": "#{INTEGRATIONTEST_IoTHubEventHubConsumerGroup}#",
+        "IoTHubConnectionString": "#{INTEGRATIONTEST_IoTHubConnectionString}#",
+        "EnsureHasEventDelayBetweenReadsInSeconds": "#{INTEGRATIONTEST_EnsureHasEventDelayBetweenReadsInSeconds}#",
+        "EnsureHasEventMaximumTries": "#{INTEGRATIONTEST_EnsureHasEventMaximumTries}#",
+        "LeafDeviceSerialPort": "#{INTEGRATIONTEST_LeafDeviceSerialPort}#",
+        "NetworkServerModuleLogAssertLevel": "Error",
+        "IoTHubAssertLevel": "Warning",
+        "UdpLog": "true",
+        "CreateDevices": true,
+        "LeafDeviceGatewayID": "#{INTEGRATIONTEST_LeafDeviceGatewayID}#",
+        "DevicePrefix": "#{INTEGRATIONTEST_DevicePrefix}#",
+        "DeviceKeyFormat": "00F5A90000000000",
+        "FunctionAppCode": "#{INTEGRATIONTEST_FunctionAppCode}#",
+        "FunctionAppBaseUrl": "#{INTEGRATIONTEST_FunctionAppBaseUrl}#"
+    }
 }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/appsettings.json
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/appsettings.json
@@ -13,6 +13,7 @@
         "LeafDeviceGatewayID": "#{INTEGRATIONTEST_LeafDeviceGatewayID}#",
         "DevicePrefix": "#{INTEGRATIONTEST_DevicePrefix}#",
         "DeviceKeyFormat": "00F5A90000000000",
+        "DeviceKeyFormatMultiGW": "00F5A9FF00000000",
         "FunctionAppCode": "#{INTEGRATIONTEST_FunctionAppCode}#",
         "FunctionAppBaseUrl": "#{INTEGRATIONTEST_FunctionAppBaseUrl}#"
     }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/test_runner.sh
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/test_runner.sh
@@ -41,7 +41,7 @@ declare -a testsToRun=('LoRaWan.IntegrationTest.OTAAJoinTest'
                        'LoRaWan.IntegrationTest.MacTest'
                        'LoRaWan.IntegrationTest.SensorDecodingTest'
                        'LoRaWan.IntegrationTest.ClassCTest'
-                       'LoRaWan.IntegrationTest.DeduplicationTest')
+                       'LoRaWan.IntegrationTest.MultiGatewayTests')
 
 testCount=${#testsToRun[@]}
 

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/test_runner.sh
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/test_runner.sh
@@ -40,7 +40,8 @@ declare -a testsToRun=('LoRaWan.IntegrationTest.OTAAJoinTest'
                        'LoRaWan.IntegrationTest.OTAATest'
                        'LoRaWan.IntegrationTest.MacTest'
                        'LoRaWan.IntegrationTest.SensorDecodingTest'
-                       'LoRaWan.IntegrationTest.ClassCTest')
+                       'LoRaWan.IntegrationTest.ClassCTest'
+                       'LoRaWan.IntegrationTest.DeduplicationTest')
 
 testCount=${#testsToRun[@]}
 

--- a/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
@@ -106,7 +106,7 @@ namespace LoRaWan.Test.Shared
             return searchResult;
         }
 
-        public async Task<bool> ValidateMultiGatewaySources(Func<string, bool> predicate, int maxAttempts = 2)
+        public async Task<bool> ValidateMultiGatewaySources(Func<string, bool> predicate, int maxAttempts = 5)
         {
             int numberOfGw = this.Configuration.NumberOfGateways;
             var sourceIds = new HashSet<string>(numberOfGw);

--- a/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
@@ -212,7 +212,7 @@ namespace LoRaWan.Test.Shared
                     processedEvents.Add(searchLogEvent);
                     if (predicate(searchLogEvent))
                     {
-                        return new SearchLogResult(true, processedEvents)
+                        return new SearchLogResult(true, processedEvents, item)
                         {
                             MatchedEvent = searchLogEvent
                         };
@@ -220,7 +220,7 @@ namespace LoRaWan.Test.Shared
                 }
             }
 
-            return new SearchLogResult(false, processedEvents, string.Empty);
+            return new SearchLogResult(false, processedEvents);
         }
 
         async Task<SearchLogResult> SearchUdpLogs(Func<string, bool> predicate, SearchLogOptions options = null)
@@ -261,7 +261,7 @@ namespace LoRaWan.Test.Shared
                     processedEvents.Add(searchLogEvent);
                     if (predicate(searchLogEvent))
                     {
-                        return new SearchLogResult(true, processedEvents)
+                        return new SearchLogResult(true, processedEvents, bodyText)
                         {
                             MatchedEvent = searchLogEvent
                         };
@@ -269,13 +269,7 @@ namespace LoRaWan.Test.Shared
                 }
             }
 
-            return new SearchLogResult(false, processedEvents, string.Empty);
-        }
-
-        // Searches IoT Hub for messages
-        async Task<SearchLogResult> SearchIoTHubLogs(Func<string, bool> predicate, SearchLogOptions options = null)
-        {
-            return await this.SearchIoTHubLogs(evt => predicate(evt.Message), options);
+            return new SearchLogResult(false, processedEvents);
         }
 
         // Searches IoT Hub for messages

--- a/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/IntegrationTestFixtureBase.Asserts.cs
@@ -8,8 +8,6 @@ namespace LoRaWan.Test.Shared
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Devices;
-    using Microsoft.Azure.Devices.Shared;
     using Microsoft.Azure.EventHubs;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
@@ -270,6 +268,12 @@ namespace LoRaWan.Test.Shared
             }
 
             return new SearchLogResult(false, processedEvents);
+        }
+
+        // Searches IoT Hub for messages
+        async Task<SearchLogResult> SearchIoTHubLogs(Func<string, bool> predicate, SearchLogOptions options = null)
+        {
+            return await this.SearchIoTHubLogs(evt => predicate(evt.Message), options);
         }
 
         // Searches IoT Hub for messages

--- a/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogEvent.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogEvent.cs
@@ -11,22 +11,34 @@ namespace LoRaWan.Test.Shared
 
         public SearchLogEvent(string rawMessage)
         {
+            var parsedMessage = Parse(rawMessage);
+            this.Message = parsedMessage.Message;
+            this.SourceId = parsedMessage.SourceId;
+        }
+
+        internal static (string Message, string SourceId) Parse(string rawMessage)
+        {
+            string message = null;
+            string sourceId = null;
+
             if (!string.IsNullOrEmpty(rawMessage))
             {
-                this.Message = rawMessage.Trim();
-                if (rawMessage.StartsWith('['))
+                message = rawMessage.Trim();
+                if (message.StartsWith('['))
                 {
-                    var idxEnd = rawMessage.IndexOf(']');
+                    var idxEnd = message.IndexOf(']');
                     if (idxEnd != -1)
                     {
-                        if (rawMessage.Length >= idxEnd + 1)
+                        if (message.Length >= idxEnd + 1)
                         {
-                            this.SourceId = rawMessage.Substring(1, idxEnd - 1);
-                            this.Message = rawMessage.Substring(idxEnd + 1).TrimStart();
+                            sourceId = message.Substring(1, idxEnd - 1);
+                            message = message.Substring(idxEnd + 1).TrimStart();
                         }
                     }
                 }
             }
+
+            return (message, sourceId);
         }
 
         public string Message { get; set; }

--- a/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogEvent.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogEvent.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Test.Shared
+{
+    public class SearchLogEvent
+    {
+        public SearchLogEvent()
+        {
+        }
+
+        public SearchLogEvent(string rawMessage)
+        {
+            if (!string.IsNullOrEmpty(rawMessage))
+            {
+                this.Message = rawMessage.Trim();
+                if (rawMessage.StartsWith('['))
+                {
+                    var idxEnd = rawMessage.IndexOf(']');
+                    if (idxEnd != -1)
+                    {
+                        if (rawMessage.Length >= idxEnd + 1)
+                        {
+                            this.SourceId = rawMessage.Substring(1, idxEnd - 1);
+                            this.Message = rawMessage.Substring(idxEnd + 1).TrimStart();
+                        }
+                    }
+                }
+            }
+        }
+
+        public string Message { get; set; }
+
+        public string SourceId { get; set; }
+    }
+}

--- a/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogOptions.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogOptions.cs
@@ -13,6 +13,14 @@ namespace LoRaWan.Test.Shared
         // Defines if the not finding messages should be treated as errors
         public bool? TreatAsError { get; set; }
 
+        /// <summary>
+        /// Gets or sets the source id filter that is used to
+        /// filter for a specific source (in multi gateway scenarios).
+        /// This currently only support inclusion of the specified id and exlusion
+        /// of anything that does not match that string
+        /// </summary>
+        public string SourceIdFilter { get; set; }
+
         public SearchLogOptions()
         {
         }

--- a/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogResult.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/SearchLogResult.cs
@@ -11,11 +11,13 @@ namespace LoRaWan.Test.Shared
         public bool Found { get; }
 
         // Returns the contents of the log (to diagnose problems)
-        public IReadOnlyCollection<string> Logs { get; }
+        public IReadOnlyCollection<SearchLogEvent> Logs { get; }
+
+        public SearchLogEvent MatchedEvent { get; set; }
 
         public string FoundLogResult { get; set; }
 
-        public SearchLogResult(bool found, HashSet<string> logs, string foundElement)
+        public SearchLogResult(bool found, HashSet<SearchLogEvent> logs, string foundElement = null)
         {
             this.Found = found;
             this.Logs = logs;

--- a/LoRaEngine/test/LoRaWan.Test.Shared/TestConfiguration.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/TestConfiguration.cs
@@ -67,5 +67,9 @@ namespace LoRaWan.Test.Shared
 
         // Gets/sets the network server module identifier
         public string NetworkServerModuleID { get; set; } = "LoRaWanNetworkSrvModule";
+
+        public string FunctionAppCode { get; set; }
+
+        public string FunctionAppBaseUrl { get; set; }
     }
 }

--- a/LoRaEngine/test/LoRaWan.Test.Shared/TestConfiguration.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/TestConfiguration.cs
@@ -71,5 +71,7 @@ namespace LoRaWan.Test.Shared
         public string FunctionAppCode { get; set; }
 
         public string FunctionAppBaseUrl { get; set; }
+
+        public int NumberOfGateways { get; set; } = 2;
     }
 }

--- a/LoRaEngine/test/LoRaWan.Test.Shared/TestConfiguration.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/TestConfiguration.cs
@@ -48,6 +48,8 @@ namespace LoRaWan.Test.Shared
         // Device key format. Must be at maximum 16 character long
         public string DeviceKeyFormat { get; set; }
 
+        public string DeviceKeyFormatMultiGW { get; set; }
+
         public bool CreateDevices { get; set; } = true;
 
         public LogValidationAssertLevel NetworkServerModuleLogAssertLevel { get; set; } = LogValidationAssertLevel.Warning;

--- a/LoRaEngine/test/LoRaWan.Test.Shared/TestDeviceInfo.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/TestDeviceInfo.cs
@@ -56,6 +56,8 @@ namespace LoRaWan.Test.Shared
 
         public bool Supports32BitFCnt { get; set; }
 
+        public string Deduplication { get; set; }
+
         public ushort RXDelay { get; set; } = 0;
 
         public int KeepAliveTimeout { get; set; }
@@ -100,6 +102,9 @@ namespace LoRaWan.Test.Shared
 
             // if (this.KeepAliveTimeout > 0)
             desiredProperties[nameof(this.KeepAliveTimeout)] = this.KeepAliveTimeout;
+
+            if (!string.IsNullOrEmpty(this.Deduplication))
+                desiredProperties[nameof(this.Deduplication)] = this.Deduplication;
 
             return desiredProperties;
         }

--- a/LoRaEngine/test/LoRaWan.Test.Shared/TestDeviceInfo.cs
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/TestDeviceInfo.cs
@@ -62,6 +62,8 @@ namespace LoRaWan.Test.Shared
 
         public int KeepAliveTimeout { get; set; }
 
+        public bool IsMultiGw => string.IsNullOrEmpty(this.GatewayID);
+
         /// <summary>
         /// Gets the desired properties for the <see cref="TestDeviceInfo"/>
         /// </summary>

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/LoRaInMemoryDeviceStore.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/LoRaInMemoryDeviceStore.cs
@@ -92,6 +92,25 @@ namespace LoraKeysManagerFacade.Test
             }
         }
 
+        public T GetObject<T>(string key)
+            where T : class
+        {
+            var str = this.StringGet(key);
+            if (string.IsNullOrEmpty(str))
+            {
+                return null;
+            }
+
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(str);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
         public bool StringSet(string key, string value, TimeSpan? expiry, bool onlyIfNotExists)
         {
             if (onlyIfNotExists)

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/LoRaInMemoryDeviceStore.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/LoRaInMemoryDeviceStore.cs
@@ -92,25 +92,6 @@ namespace LoraKeysManagerFacade.Test
             }
         }
 
-        public T GetObject<T>(string key)
-            where T : class
-        {
-            var str = this.StringGet(key);
-            if (string.IsNullOrEmpty(str))
-            {
-                return null;
-            }
-
-            try
-            {
-                return JsonConvert.DeserializeObject<T>(str);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
         public bool StringSet(string key, string value, TimeSpan? expiry, bool onlyIfNotExists)
         {
             if (onlyIfNotExists)

--- a/Samples/DecoderSample/module.json
+++ b/Samples/DecoderSample/module.json
@@ -2,9 +2,9 @@
   "$schema-version": "0.0.1",
   "description": "",
   "image": {
-    "repository": "your.azurecr.io/sensordecodermodule",
+    "repository": "$CONTAINER_REGISTRY_ADDRESS/decodersample",
     "tag": {
-      "version": "0.0.1",
+      "version": "2.0",
       "platforms": {
         "amd64": "./Dockerfile.amd64",
         "arm32v7": "./Dockerfile.arm32v7"

--- a/Samples/DecoderSample/push_to_acr.sh
+++ b/Samples/DecoderSample/push_to_acr.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+docker push "$1.azurecr.io/decodersample:$2-amd64"
+docker push "$1.azurecr.io/decodersample:$2-arm32v7"
+
+docker manifest create "$1.azurecr.io/decodersample:$2" "$1.azurecr.io/decodersample:$2-amd64" "$1.azurecr.io/decodersample:$2-arm32v7"
+docker manifest push "$1.azurecr.io/decodersample:$2"

--- a/azure-pipeline-integration-test-steps-template.yaml
+++ b/azure-pipeline-integration-test-steps-template.yaml
@@ -14,7 +14,7 @@ steps:
   condition: eq(variables['AdditionalIntegrationTestArguments'], '')
   workingDirectory: ./LoRaEngine/test/LoRaWan.IntegrationTest
   failOnStderr: true
-  timeoutInMinutes: 60 # up to 1 hour, increase if we need more
+  timeoutInMinutes: 120 # up to 1 hour, increase if we need more
 
 # Run integration test with filters only, no built-in retries
 - task: DotNetCoreCLI@2

--- a/azure-pipelines-buildpushiotedge-templates.yaml
+++ b/azure-pipelines-buildpushiotedge-templates.yaml
@@ -3,6 +3,7 @@ parameters:
   platform: ''
   deviceID: ''
   deploymentTemplate: 'deployment.test.template.json'
+  deploymentConfigFile: 'deployment.test.json'
 
 steps:
 
@@ -52,7 +53,7 @@ steps:
     deploymentid: $(IOT_DEPLOYMENT_ID)
     azureSubscriptionEndpoint: $(AzureServiceConnectionName)
     azureContainerRegistry: '{"loginServer":"$(CONTAINER_REGISTRY_ADDRESS)", "id" : "/subscriptions/$(AZURE_SUBSCRIPTIONID)/resourceGroups/$(ACR_RG)/providers/Microsoft.ContainerRegistry/registries/$(ACR_NAME)"}'
-    templateFilePath: ./LoRaEngine/deployment.test.template.json
+    templateFilePath: ./LoRaEngine/${{parameters.deploymentTemplate}}
     defaultPlatform: ${{ parameters.platform }}
 
 # Azure IoT Edge - Deploy to test device
@@ -61,7 +62,7 @@ steps:
   inputs:
     action: 'Deploy to IoT Edge devices'
     # In Build: Path of output deployment file.
-    deploymentFilePath: $(Build.ArtifactStagingDirectory)/deployment.test.json
+    deploymentFilePath: $(Build.ArtifactStagingDirectory)/${{parameters.deploymentConfigFile}}
     azureSubscription: $(AzureServiceConnectionName)
     iothubname: $(INTEGRATIONTEST_IOTHUB_NAME)
     deploymentid: $(IOT_DEPLOYMENT_ID)

--- a/azure-pipelines-buildpushiotedge-templates.yaml
+++ b/azure-pipelines-buildpushiotedge-templates.yaml
@@ -2,6 +2,7 @@
 parameters:
   platform: ''
   deviceID: ''
+  deploymentTemplate: 'deployment.test.template.json'
 
 steps:
 
@@ -37,7 +38,7 @@ steps:
   displayName: 'Azure IoT Edge - Build module ${{ parameters.platform }} images'
   inputs:
     deploymentid: $(IOT_DEPLOYMENT_ID)
-    templateFilePath: ./LoRaEngine/deployment.test.template.json
+    templateFilePath: ./LoRaEngine/${{parameters.deploymentTemplate}}
     defaultPlatform: ${{ parameters.platform }}
 
 # Azure IoT Edge - Push images

--- a/azure-pipelines-buildpushiotedge-templates.yaml
+++ b/azure-pipelines-buildpushiotedge-templates.yaml
@@ -50,7 +50,7 @@ steps:
   inputs:
     action: 'Push module images'
     deploymentid: $(IOT_DEPLOYMENT_ID)
-    azureSubscriptionEndpoint: $(azureServiceConnectionName)
+    azureSubscriptionEndpoint: $(AzureServiceConnectionName)
     azureContainerRegistry: '{"loginServer":"$(CONTAINER_REGISTRY_ADDRESS)", "id" : "/subscriptions/$(AZURE_SUBSCRIPTIONID)/resourceGroups/$(ACR_RG)/providers/Microsoft.ContainerRegistry/registries/$(ACR_NAME)"}'
     templateFilePath: ./LoRaEngine/deployment.test.template.json
     defaultPlatform: ${{ parameters.platform }}
@@ -62,7 +62,7 @@ steps:
     action: 'Deploy to IoT Edge devices'
     # In Build: Path of output deployment file.
     deploymentFilePath: $(Build.ArtifactStagingDirectory)/deployment.test.json
-    azureSubscription: $(azureServiceConnectionName)
+    azureSubscription: $(AzureServiceConnectionName)
     iothubname: $(INTEGRATIONTEST_IOTHUB_NAME)
     deploymentid: $(IOT_DEPLOYMENT_ID)
     deviceOption: 'Single Device'
@@ -72,7 +72,7 @@ steps:
 - task: AzureCLI@1
   displayName: 'Waiting deployment $(IOT_DEPLOYMENT_ID) to be ready at ${{ parameters.deviceID }}...'
   inputs:
-    azureSubscription: $(azureServiceConnectionName)
+    azureSubscription: $(AzureServiceConnectionName)
     timeoutInMinutes: 30
     scriptLocation: inlineScript
     inlineScript: |

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -49,6 +49,7 @@ variables:
 #    - dev
 pr:
  branches:
+   include: pat-dev-multi-gw-test
    exclude:
    - master
    - dev
@@ -58,9 +59,9 @@ pr:
 trigger:
   batch: true
   branches:
+    include: pat-dev-multi-gw-test
     exclude:
-	  - pat-dev-multi-gw-test
-    - dev
+	  - dev
     - master
 
 jobs:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -152,6 +152,7 @@ jobs:
      echo "Determine ARM build agent IP address"
      BUILD_AGENT_IP_LOCAL=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
      echo "##vso[task.setvariable variable=BUILD_AGENT_IP]$BUILD_AGENT_IP_LOCAL"
+     name: Determine ARM build agent IP
 
 
 # [Job] Build, push and deploy arm32v7 IoT Edge Solution - secondary gateway

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -149,10 +149,10 @@ jobs:
     demands: Agent.OSArchitecture -equals ARM # Run on pi atm
   steps:
     - bash: |
-     echo "Determine ARM build agent IP address"
-     BUILD_AGENT_IP_LOCAL=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
-     echo "##vso[task.setvariable variable=BUILD_AGENT_IP]$BUILD_AGENT_IP_LOCAL"
-     name: Determine ARM build agent IP
+        echo "Determine ARM build agent IP address"
+        BUILD_AGENT_IP_LOCAL=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
+        echo "##vso[task.setvariable variable=BUILD_AGENT_IP]$BUILD_AGENT_IP_LOCAL"
+     displayName: Determine ARM build agent IP
 
 
 # [Job] Build, push and deploy arm32v7 IoT Edge Solution - secondary gateway

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -58,9 +58,8 @@ pr:
 trigger:
   batch: true
   branches:
-    include:
     exclude:
-	- pat-dev-multi-gw-test
+	  - pat-dev-multi-gw-test
     - dev
     - master
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -148,8 +148,6 @@ jobs:
   variables:
     IOT_DEPLOYMENT_ID: integrationtestarmsecondary
     RESET_PIN: $(RESET_PIN_SECONDARY)
-    # Defines image version to use in case in ARM architecture
-    DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-arm32v7"
     
   dependsOn:  build_and_test
   condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -147,7 +147,6 @@ jobs:
   displayName: Build, push and deploy arm32v7 IoT Edge Solution - Secondary Gateway
   variables:
     IOT_DEPLOYMENT_ID: integrationtestarmsecondary
-    VSTS_AGENT: "$(vstsAgentARM)"
     RESET_PIN: $(RESET_PIN_SECONDARY)
     # Defines image version to use in case in ARM architecture
     DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-arm32v7"

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -63,7 +63,7 @@ trigger:
     include:
     - pat-dev-multi-gw-test
     exclude:
-	  - dev
+    - dev
     - master
 
 jobs:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -141,20 +141,6 @@ jobs:
         platform: arm32v7
         deviceID: $(IoTEdgeDeviceARMPrimary)
 
-- job: full_ci_arm_secondary_prepare
-  displayName: Prepare Secondary Gateway
-  condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
-  pool:
-    name: Default
-    demands: Agent.OSArchitecture -equals ARM # Run on pi atm
-  steps:
-    - bash: |
-        echo "Determine ARM build agent IP address"
-        BUILD_AGENT_IP_LOCAL=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
-        echo "##vso[task.setvariable variable=BUILD_AGENT_IP]$BUILD_AGENT_IP_LOCAL"
-      displayName: Determine ARM build agent IP
-
-
 # [Job] Build, push and deploy arm32v7 IoT Edge Solution - secondary gateway
 - job: full_ci_deploy_arm_secondary
   displayName: Build, push and deploy arm32v7 IoT Edge Solution - Secondary Gateway
@@ -165,9 +151,7 @@ jobs:
     # Defines image version to use in case in ARM architecture
     DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-arm32v7"
     
-  dependsOn: 
-    - build_and_test
-    - full_ci_arm_secondary_prepare
+  dependsOn:  build_and_test
   condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
   pool:
     # name: docker

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -141,6 +141,19 @@ jobs:
         platform: arm32v7
         deviceID: $(IoTEdgeDeviceARMPrimary)
 
+- job: full_ci_arm_secondary_prepare
+  displayName: Prepare Secondary Gateway - Get build agent IP
+  condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
+  pool:
+    name: Default
+    demands: Agent.OSArchitecture -equals ARM # Run on pi atm
+  steps:
+    - bash: |
+     echo "Determine ARM build agent IP address"
+     BUILD_AGENT_IP_LOCAL=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
+     echo "##vso[task.setvariable variable=BUILD_AGENT_IP]$BUILD_AGENT_IP_LOCAL"
+
+
 # [Job] Build, push and deploy arm32v7 IoT Edge Solution - secondary gateway
 - job: full_ci_deploy_arm_secondary
   displayName: Build, push and deploy arm32v7 IoT Edge Solution - Secondary Gateway
@@ -151,7 +164,9 @@ jobs:
     # Defines image version to use in case in ARM architecture
     DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-arm32v7"
     
-  dependsOn: build_and_test
+  dependsOn: 
+    - build_and_test
+    - full_ci_arm_secondary_prepare
   condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
   pool:
     # name: docker

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -49,7 +49,8 @@ variables:
 #    - dev
 pr:
  branches:
-   include: pat-dev-multi-gw-test
+   include:
+    - pat-dev-multi-gw-test
    exclude:
    - master
    - dev
@@ -59,7 +60,8 @@ pr:
 trigger:
   batch: true
   branches:
-    include: pat-dev-multi-gw-test
+    include:
+    - pat-dev-multi-gw-test
     exclude:
 	  - dev
     - master

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -12,9 +12,6 @@ variables:
 
   buildConfiguration: 'Release'
 
-  # Name of service connection for resource group
-  azureServiceConnectionName: 'IntegrationTestRG'
-
   edgeAgentVersion: 1.0.6
   edgeHubVersion: 1.0.6
   edgeHubRoute: FROM /* INTO $upstream
@@ -210,7 +207,7 @@ jobs:
   - task: AzureRmWebAppDeployment@4
     displayName: 'Deploy Facade Azure Function'
     inputs:
-      azureSubscription: $(azureServiceConnectionName)
+      azureSubscription: $(AzureServiceConnectionName)
       appType: functionapp
       WebAppName: $(FACADE_WEBAPPNAME)
       packageForLinux: '$(Build.ArtifactStagingDirectory)/LoraKeysManagerFacade.zip'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -26,7 +26,23 @@ variables:
   vstsAgentAMD: myAgent-amd64
 
   # Network Server module level: 1 in order to get decoder information
-  networkServerLogLevel: 1  
+  networkServerLogLevel: 1
+
+  # IoT Edge Runtime configuration
+  EDGE_AGENT_VERSION: $(edgeAgentVersion)
+  EDGE_HUB_VERSION: $(edgeHubVersion)
+  EDGEHUB_OPTIMIZEFORPERFORMANCE: false
+  EDGEHUB_MQTTSETTINGS_ENABLED: false
+  EDGEHUB_HTTPSETTINGS_ENABLED: false
+  EDGEHUB_ROUTE: $(edgeHubRoute)
+  # LoRaWan Modules
+  NET_SRV_LOG_LEVEL: $(networkServerLogLevel)  
+  NET_SRV_LOGTO_UDP: true
+  NET_SRV_LOGTO_HUB: false
+  NET_SRV_IOTEDGE_TIMEOUT: 0
+  NET_SRV_VERSION: "" # Network Server module version
+  NET_SRV_LOG_TO_UDP_ADDRESS: AzureDevOpsAgent # Hostname of container where AzureDevOpsAgent will be running for Udp logging sink
+  PKT_FWD_VERSION: "" # Packet Forward module version
 
 # Enable PR validation on branches master and dev
 pr:
@@ -104,32 +120,18 @@ jobs:
     condition: eq(variables['Build.Reason'], 'PullRequest')
     name: checkPrCILabel
 
-# [Job] Build, push and deploy arm32v7 IoT Edge Solution
-- job: full_ci_deploy_arm
-  displayName: Build, push and deploy arm32v7 IoT Edge Solution
+# [Job] Build, push and deploy arm32v7 IoT Edge Solution - primary gateway
+- job: full_ci_deploy_arm_primary
+  displayName: Build, push and deploy arm32v7 IoT Edge Solution - Primary Gateway
   variables:
-    IOT_DEPLOYMENT_ID: integrationtestarm
-    # IoT Edge Runtime configuration
-    EDGE_AGENT_VERSION: $(edgeAgentVersion)
-    EDGE_HUB_VERSION: $(edgeHubVersion)
-    EDGEHUB_OPTIMIZEFORPERFORMANCE: false
-    EDGEHUB_MQTTSETTINGS_ENABLED: false
-    EDGEHUB_HTTPSETTINGS_ENABLED: false
-    EDGEHUB_ROUTE: $(edgeHubRoute)
-    # LoRaWan Modules
-    NET_SRV_LOG_LEVEL: $(networkServerLogLevel)  
-    NET_SRV_LOGTO_UDP: true
-    NET_SRV_LOGTO_HUB: false
-    NET_SRV_IOTEDGE_TIMEOUT: 0
-    NET_SRV_VERSION: "" # Network Server module version
-    NET_SRV_LOG_TO_UDP_ADDRESS: AzureDevOpsAgent # Hostname of container where AzureDevOpsAgent will be running for Udp logging sink
-    PKT_FWD_VERSION: "" # Packet Forward module version
+    IOT_DEPLOYMENT_ID: integrationtestarmprimary
     VSTS_AGENT: "$(vstsAgentARM)"
+    RESET_PIN: $(RESET_PIN_PRIMARY)
     # Defines image version to use in case in ARM architecture
     DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-arm32v7"
     
   dependsOn: build_and_test
-  condition: and(ne(variables['IoTEdgeDeviceARM'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
+  condition: and(ne(variables['IoTEdgeDeviceARMPrimary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
   pool:
     # name: docker
     # demands: Agent.OSArchitecture -equals X64
@@ -138,29 +140,37 @@ jobs:
     - template: azure-pipelines-buildpushiotedge-templates.yaml
       parameters:
         platform: arm32v7
-        deviceID: $(IoTEdgeDeviceARM)
+        deviceID: $(IoTEdgeDeviceARMPrimary)
+
+# [Job] Build, push and deploy arm32v7 IoT Edge Solution - secondary gateway
+- job: full_ci_deploy_arm_secondary
+  displayName: Build, push and deploy arm32v7 IoT Edge Solution - Secondary Gateway
+  variables:
+    IOT_DEPLOYMENT_ID: integrationtestarmsecondary
+    VSTS_AGENT: "$(vstsAgentARM)"
+    RESET_PIN: $(RESET_PIN_SECONDARY)
+    # Defines image version to use in case in ARM architecture
+    DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-arm32v7"
+    
+  dependsOn: build_and_test
+  condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
+  pool:
+    # name: docker
+    # demands: Agent.OSArchitecture -equals X64
+    vmImage: 'Ubuntu 16.04'   
+  steps:
+    - template: azure-pipelines-buildpushiotedge-templates.yaml
+      parameters:
+        platform: arm32v7
+        deviceID: $(IoTEdgeDeviceARMSecondary)
+        deploymentTemplate: deployment.test.secondary.template.json
+
 
 # [Job] Build, push and deploy amd64 IoT Edge Solution 
 - job: full_ci_deploy_amd
   displayName: Build, push and deploy amd64 IoT Edge Solution
   variables:
     IOT_DEPLOYMENT_ID: integrationtestamd
-    # IoT Edge Runtime configuration
-    EDGE_AGENT_VERSION: $(edgeAgentVersion)
-    EDGE_HUB_VERSION: $(edgeHubVersion)
-    EDGEHUB_OPTIMIZEFORPERFORMANCE: false
-    EDGEHUB_MQTTSETTINGS_ENABLED: false
-    EDGEHUB_HTTPSETTINGS_ENABLED: false
-    EDGEHUB_ROUTE: $(edgeHubRoute)
-    # LoRaWan Modules
-    NET_SRV_LOG_LEVEL: $(networkServerLogLevel)  
-    NET_SRV_LOGTO_UDP: true
-    NET_SRV_LOGTO_HUB: false
-    NET_SRV_IOTEDGE_TIMEOUT: 0
-    NET_SRV_VERSION: "" # Network Server module version
-    PKT_FWD_VERSION: "" # Packet Forward module version
-    NET_SRV_LOG_TO_UDP_ADDRESS: AzureDevOpsAgent # Hostname of container where AzureDevOpsAgent will be running for Udp logging sink
-
     VSTS_AGENT: "$(vstsAgentAMD)"
     # Defines image version to use in case in AMD architecture
     DEVOPS_AGENT_IMAGE: "$(CONTAINER_REGISTRY_ADDRESS)/azuredevopsagent:$(DEVOPS_AGENT_IMAGE_VERSION)-amd64"
@@ -235,9 +245,10 @@ jobs:
 - job: test_runner_arm_eu
   displayName: Run tests in ARM device (EU)
   dependsOn: 
-    - full_ci_deploy_arm
+    - full_ci_deploy_arm_primary
+    - full_ci_deploy_arm_secondary
     - full_ci_deploy_facade_function
-  condition: and(ne(variables['IoTEdgeDeviceARM'], ''), or(succeeded(), eq(variables['RunTestsOnly'], 'true')))
+  condition: and(ne(variables['IoTEdgeDeviceARMPrimary'], ''), or(succeeded(), eq(variables['RunTestsOnly'], 'true')))
   timeoutInMinutes: 120 # Raspberry PI is slow, allow taking 120 minutes
   pool:    
     name: Default
@@ -245,7 +256,7 @@ jobs:
   variables:      
     INTEGRATIONTEST_LeafDeviceSerialPort: "/dev/ttyACM0"
     INTEGRATIONTEST_IoTHubEventHubConsumerGroup: "reserved_integrationtest" 
-    INTEGRATIONTEST_LeafDeviceGatewayID: $(IoTEdgeDeviceARM)
+    INTEGRATIONTEST_LeafDeviceGatewayID: $(IoTEdgeDeviceARMPrimary)
     INTEGRATIONTEST_DevicePrefix: '01'
   
   steps:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -161,6 +161,7 @@ jobs:
         platform: arm32v7
         deviceID: $(IoTEdgeDeviceARMSecondary)
         deploymentTemplate: deployment.test.secondary.template.json
+        deploymentConfigFile: deployment.test.secondary.json
 
 
 # [Job] Build, push and deploy amd64 IoT Edge Solution 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -42,11 +42,11 @@ variables:
   PKT_FWD_VERSION: "" # Packet Forward module version
 
 # Enable PR validation on branches master and dev
-pr:
-  branches:
-    include:
-    - master
-    - dev
+# pr:
+#  branches:
+#    include:
+#    - master
+#    - dev
 
 # Enable CI on branches master and dev
 # Batch builds
@@ -54,6 +54,8 @@ trigger:
   batch: true
   branches:
     include:
+    - pat-dev-multi-gw-test
+    exclude:
     - dev
     - master
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -51,9 +51,6 @@ pr:
  branches:
    include:
     - pat-dev-multi-gw-test
-   exclude:
-   - master
-   - dev
 
 # Enable CI on branches master and dev
 # Batch builds
@@ -62,9 +59,6 @@ trigger:
   branches:
     include:
     - pat-dev-multi-gw-test
-    exclude:
-    - dev
-    - master
 
 jobs:
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -142,7 +142,7 @@ jobs:
         deviceID: $(IoTEdgeDeviceARMPrimary)
 
 - job: full_ci_arm_secondary_prepare
-  displayName: Prepare Secondary Gateway - Get build agent IP
+  displayName: Prepare Secondary Gateway
   condition: and(ne(variables['IoTEdgeDeviceARMSecondary'], ''), and(ne(variables['RunTestsOnly'], 'true'), and(succeeded(), or(eq(dependencies.build_and_test.outputs['checkPrCILabel.prWithCILabel'], true), or(eq(variables['FullCI'],'true'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/dev'))))))
   pool:
     name: Default
@@ -152,7 +152,7 @@ jobs:
         echo "Determine ARM build agent IP address"
         BUILD_AGENT_IP_LOCAL=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
         echo "##vso[task.setvariable variable=BUILD_AGENT_IP]$BUILD_AGENT_IP_LOCAL"
-     displayName: Determine ARM build agent IP
+      displayName: Determine ARM build agent IP
 
 
 # [Job] Build, push and deploy arm32v7 IoT Edge Solution - secondary gateway

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -47,6 +47,11 @@ variables:
 #    include:
 #    - master
 #    - dev
+pr:
+ branches:
+   exclude:
+   - master
+   - dev
 
 # Enable CI on branches master and dev
 # Batch builds
@@ -54,8 +59,8 @@ trigger:
   batch: true
   branches:
     include:
-    - pat-dev-multi-gw-test
     exclude:
+	- pat-dev-multi-gw-test
     - dev
     - master
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -233,8 +233,8 @@ jobs:
     INTEGRATIONTEST_LeafDeviceSerialPort: "/dev/ttyACM0"
     INTEGRATIONTEST_IoTHubEventHubConsumerGroup: "reserved_integrationtest_amd" 
     INTEGRATIONTEST_LeafDeviceGatewayID: $(IoTEdgeDeviceAMD)
-    INTEGRATIONTEST_FunctionAppBaseUrl: $(FunctionAppServerUrl)
-    INTEGRATIONTEST_FunctionAppCode: $(FunctionAppAuthCode)
+    INTEGRATIONTEST_FunctionAppBaseUrl: $(FACADE_SERVER_URL)
+    INTEGRATIONTEST_FunctionAppCode: $(FACADE_AUTH_CODE)
     INTEGRATIONTEST_DevicePrefix: ''
   steps:
   - template: azure-pipeline-integration-test-steps-template.yaml
@@ -258,8 +258,8 @@ jobs:
     INTEGRATIONTEST_IoTHubEventHubConsumerGroup: "reserved_integrationtest" 
     INTEGRATIONTEST_LeafDeviceGatewayID: $(IoTEdgeDeviceARMPrimary)
     INTEGRATIONTEST_DevicePrefix: '01'
-    INTEGRATIONTEST_FunctionAppBaseUrl: $(FunctionAppServerUrl)
-    INTEGRATIONTEST_FunctionAppCode: $(FunctionAppAuthCode)
+    INTEGRATIONTEST_FunctionAppBaseUrl: $(FACADE_SERVER_URL)
+    INTEGRATIONTEST_FunctionAppCode: $(FACADE_AUTH_CODE)
   
   steps:
   - template: azure-pipeline-integration-test-steps-template.yaml

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -233,6 +233,8 @@ jobs:
     INTEGRATIONTEST_LeafDeviceSerialPort: "/dev/ttyACM0"
     INTEGRATIONTEST_IoTHubEventHubConsumerGroup: "reserved_integrationtest_amd" 
     INTEGRATIONTEST_LeafDeviceGatewayID: $(IoTEdgeDeviceAMD)
+    INTEGRATIONTEST_FunctionAppBaseUrl: $(FunctionAppServerUrl)
+    INTEGRATIONTEST_FunctionAppCode: $(FunctionAppAuthCode)
     INTEGRATIONTEST_DevicePrefix: ''
   steps:
   - template: azure-pipeline-integration-test-steps-template.yaml
@@ -247,7 +249,7 @@ jobs:
     - full_ci_deploy_arm_secondary
     - full_ci_deploy_facade_function
   condition: and(ne(variables['IoTEdgeDeviceARMPrimary'], ''), or(succeeded(), eq(variables['RunTestsOnly'], 'true')))
-  timeoutInMinutes: 120 # Raspberry PI is slow, allow taking 120 minutes
+  timeoutInMinutes: 125 # Raspberry PI is slow, allow taking 125 minutes
   pool:    
     name: Default
     demands: Agent.OSArchitecture -equals ARM # Run on pi atm
@@ -256,6 +258,8 @@ jobs:
     INTEGRATIONTEST_IoTHubEventHubConsumerGroup: "reserved_integrationtest" 
     INTEGRATIONTEST_LeafDeviceGatewayID: $(IoTEdgeDeviceARMPrimary)
     INTEGRATIONTEST_DevicePrefix: '01'
+    INTEGRATIONTEST_FunctionAppBaseUrl: $(FunctionAppServerUrl)
+    INTEGRATIONTEST_FunctionAppCode: $(FunctionAppAuthCode)
   
   steps:
   - template: azure-pipeline-integration-test-steps-template.yaml

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -42,7 +42,7 @@ variables:
   PKT_FWD_VERSION: "" # Packet Forward module version
 
 # Enable PR validation on branches master and dev
- pr:
+pr:
   branches:
     include:
     - master

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -42,15 +42,11 @@ variables:
   PKT_FWD_VERSION: "" # Packet Forward module version
 
 # Enable PR validation on branches master and dev
-# pr:
-#  branches:
-#    include:
-#    - master
-#    - dev
-pr:
- branches:
-   include:
-    - pat-dev-multi-gw-test
+ pr:
+  branches:
+    include:
+    - master
+    - dev
 
 # Enable CI on branches master and dev
 # Batch builds
@@ -58,7 +54,8 @@ trigger:
   batch: true
   branches:
     include:
-    - pat-dev-multi-gw-test
+    - master
+    - dev
 
 jobs:
 


### PR DESCRIPTION
We have a race when disconnecting a device client, while we are processing a request. If a thread switch happens after we checked if there is a request processing and before we disconnect, there is a chance that we do start processing the request and pass the EnsureConnected before we get back to disconnect. In that case we pull the connection away from the processing request and it will fail.

Happend in integration testing:

[UDPLOG] [raspi] Physical dataUp {"rxpk":[{"tmst":869870396,"chan":5,"rfch":0,"freq":867.500000,"stat":1,"modu":"LORA","datr":"SF7BW125","codr":"4/5","lsnr":7.2,"rssi":-70,"size":16,"data":"QCUAAAOAAQAIvdZHErHcVQ=="}]}
[UDPLOG] [raspi] FF00000000000025: device in cache
[UDPLOG] [raspi] Got Request queue LoRaDevice. Now queueing.
[UDPLOG] [raspi] FF00000000000025: disconnecting client reason: Expired
[UDPLOG] [raspi] FF00000000000025: client connection timeout set to 60 seconds (sliding expiration)
[UDPLOG] [raspi] FF00000000000025: converted 16bit FCnt 1 to 32bit FCnt 1
[UDPLOG] [raspi2] Physical dataUp {"rxpk":[{"tmst":997389596,"chan":5,"rfch":0,"freq":867.500000,"stat":1,"modu":"LORA","datr":"SF7BW125","codr":"4/5","lsnr":7.0,"rssi":-35,"size":16,"data":"QCUAAAOAAQAIvdZHErHcVQ=="}]}
[UDPLOG] [raspi2] FF00000000000025: device in cache
[UDPLOG] [raspi2] FF00000000000025: device is not our device, ignore message
[UDPLOG] [raspi2] FF00000000000025: processing time: 00:00:00.0026848
[UDPLOG] [raspi] FF00000000000025: valid frame counter, msg: 1 server: 0
[UDPLOG] [raspi] FF00000000000025: decoding with: DecoderValueSensor port: 8
[UDPLOG] [raspi] FF00000000000025: sending message {"time":null,"tmms":0,"tmst":869870396,"freq":867.5,"chan":5,"rfch":0,"stat":1,"modu":"LORA","datr":"SF7BW125","codr":"4/5","rssi":-70,"lsnr":7.2,"size":16,"data":{"value":101},"port":8,"fcnt":1,"rawdata":"MTAx","eui":"FF00000000000025","gatewayid":"raspi","edgets":1554733220924} to hub
[UDPLOG] [raspi] FF00000000000025: device client disconnected
[UDPLOG] [raspi] FF00000000000025: could not send message to IoTHub/Edge with error: Cannot access a disposed object.
Object name: 'The object has been closed and cannot be reopened.'.
[UDPLOG] [raspi] FF00000000000025: processing time: 00:00:00.0320195