### PR TITLE
Update function DI

### DIFF
--- a/Docs/devguide.md
+++ b/Docs/devguide.md
@@ -104,12 +104,6 @@ You have the option to either deploy the Azure Function code from your Visual St
 
 #### Follow these next steps in both cases
 
-- Edit the Function's `Application settings` and change the `FUNCTIONS_EXTENSION_VERSION` App setting from `~2` to `2.0.12342.0`
-
-|App Settings Name|Value|
-|-|-|
-|FUNCTIONS_EXTENSION_VERSION|**2.0.12342.0**|
-
 - Configure IoT Hub and Redis connection strings in the function:
 
 Copy your Redis Cache connection string in a connection string names `RedisConnectionString`

--- a/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-[assembly: Microsoft.Azure.WebJobs.Hosting.WebJobsStartup(typeof(LoraKeysManagerFacade.FacadeStartup))]
+[assembly: Microsoft.Azure.Functions.Extensions.DependencyInjection.FunctionsStartup(typeof(LoraKeysManagerFacade.FacadeStartup))]
 
 namespace LoraKeysManagerFacade
 {
@@ -9,16 +9,15 @@ namespace LoraKeysManagerFacade
     using LoraKeysManagerFacade.FunctionBundler;
     using LoRaTools.ADR;
     using Microsoft.Azure.Devices;
-    using Microsoft.Azure.WebJobs;
-    using Microsoft.Azure.WebJobs.Hosting;
+    using Microsoft.Azure.Functions.Extensions.DependencyInjection;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using StackExchange.Redis;
 
-    public class FacadeStartup : IWebJobsStartup
+    public class FacadeStartup : FunctionsStartup
     {
-        public void Configure(IWebJobsBuilder builder)
+        public override void Configure(IFunctionsHostBuilder builder)
         {
             var configHandler = ConfigHandler.Create(builder);
 
@@ -58,7 +57,7 @@ namespace LoraKeysManagerFacade
             internal const string IoTHubConnectionStringKey = "IoTHubConnectionString";
             internal const string RedisConnectionStringKey = "RedisConnectionString";
 
-            internal static ConfigHandler Create(IWebJobsBuilder builder)
+            internal static ConfigHandler Create(IFunctionsHostBuilder builder)
             {
                 var tempProvider = builder.Services.BuildServiceProvider();
                 var config = tempProvider.GetRequiredService<IConfiguration>();

--- a/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
+++ b/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
@@ -6,9 +6,10 @@
   <ItemGroup>
     <PackageReference Include="Docker.DotNet.X509" Version="3.125.2" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.22" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.513" />
   </ItemGroup>
   


### PR DESCRIPTION
This is updating the way we do DI initialization in our functions. The latest SDK does add a FunctionStartup type that is responsible for setting up the DI. 

The way we do IConfiguration handling has not changed yet. Looks like the PG is still working on a solution to get easier access to IConfiguration while setting up the DI.

https://github.com/MicrosoftDocs/azure-docs/issues/32962