### PR TITLE
Avoid starting other gateway device clients

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/DevAddrCacheInfo.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/DevAddrCacheInfo.cs
@@ -13,15 +13,18 @@ namespace LoraKeysManagerFacade
 
         public DateTime LastUpdatedTwins { get; set; }
 
+        public string NwkSKey { get; set; }
+
         public int CompareTo(object obj)
         {
             if (obj is DevAddrCacheInfo)
             {
                 var oldElement = (DevAddrCacheInfo)obj;
                 if (this.GatewayId == oldElement.GatewayId
-                                && this.DevAddr == oldElement.DevAddr
-                                && this.DevEUI == oldElement.DevEUI
-                                && this.LastUpdatedTwins == oldElement.LastUpdatedTwins)
+                    && this.NwkSKey == oldElement.NwkSKey
+                    && this.DevAddr == oldElement.DevAddr
+                    && this.DevEUI == oldElement.DevEUI
+                    && this.LastUpdatedTwins == oldElement.LastUpdatedTwins)
                 {
                     return 0;
                 }

--- a/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
@@ -179,9 +179,8 @@ namespace LoraKeysManagerFacade
                                                     DevAddr = devAddr,
                                                     DevEUI = twin.DeviceId,
                                                     PrimaryKey = device.Authentication.SymmetricKey.PrimaryKey,
-                                                    GatewayId = twin.Properties.Desired.Contains("GatewayId") ?
-                                                        twin.Properties.Desired["GatewayId"] as string :
-                                                        string.Empty,
+                                                    GatewayId = twin.GetGatewayID(),
+                                                    NwkSKey = twin.GetNwkSKey(),
                                                     LastUpdatedTwins = twin.Properties.Desired.GetLastUpdated()
                                                 };
                                                 results.Add(iotHubDeviceInfo);
@@ -254,10 +253,9 @@ namespace LoraKeysManagerFacade
                         {
                             joinInfo.PrimaryKey = device.Authentication.SymmetricKey.PrimaryKey;
                             var twin = await this.registryManager.GetTwinAsync(devEUI);
-                            const string GatewayIdProperty = "GatewayID";
-                            if (twin.Properties.Desired.Contains(GatewayIdProperty))
+                            if (twin.Properties.Desired.Contains(LoraKeysManagerFacadeConstants.TwinProperty_GatewayID))
                             {
-                                joinInfo.DesiredGateway = twin.Properties.Desired[GatewayIdProperty].Value as string;
+                                joinInfo.DesiredGateway = twin.Properties.Desired[LoraKeysManagerFacadeConstants.TwinProperty_GatewayID].Value as string;
                             }
                         }
 

--- a/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
@@ -253,9 +253,10 @@ namespace LoraKeysManagerFacade
                         {
                             joinInfo.PrimaryKey = device.Authentication.SymmetricKey.PrimaryKey;
                             var twin = await this.registryManager.GetTwinAsync(devEUI);
-                            if (twin.Properties.Desired.Contains(LoraKeysManagerFacadeConstants.TwinProperty_GatewayID))
+                            var deviceGatewayId = twin.GetGatewayID();
+                            if (!string.IsNullOrEmpty(deviceGatewayId))
                             {
-                                joinInfo.DesiredGateway = twin.Properties.Desired[LoraKeysManagerFacadeConstants.TwinProperty_GatewayID].Value as string;
+                                joinInfo.DesiredGateway = deviceGatewayId;
                             }
                         }
 

--- a/LoRaEngine/LoraKeysManagerFacade/Directory.Build.targets
+++ b/LoRaEngine/LoraKeysManagerFacade/Directory.Build.targets
@@ -1,9 +1,0 @@
-<Project>
-  <Target Name="CopyExtensionsJson" AfterTargets="_GenerateFunctionsAndCopyContentFiles">
-    <Message Importance="High" Text="Overwritting extensions.json file with one from build." />
-
-     <Copy SourceFiles="$(PublishDir)extensions.json"
-          DestinationFiles="$(PublishDir)bin\extensions.json"
-          OverwriteReadOnlyFiles="true" />
-  </Target>
-</Project>

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCache.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCache.cs
@@ -26,12 +26,12 @@ namespace LoraKeysManagerFacade
         {
             if (string.IsNullOrEmpty(devEUI))
             {
-                throw new ArgumentNullException("devEUI");
+                throw new ArgumentNullException(nameof(devEUI));
             }
 
             if (string.IsNullOrEmpty(gatewayId))
             {
-                throw new ArgumentNullException("gatewayId");
+                throw new ArgumentNullException(nameof(gatewayId));
             }
 
             this.cacheStore = cacheStore;

--- a/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
+++ b/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
@@ -25,9 +25,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>	      
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>	
     </None>
-    <None Include="extensions.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
   <!-- StyleCop Setup -->
   <ItemGroup>

--- a/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacadeConstants.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacadeConstants.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoraKeysManagerFacade
+{
+    internal static class LoraKeysManagerFacadeConstants
+    {
+        internal const string TwinProperty_GatewayID = "GatewayID";
+        internal const string TwinProperty_ClassType = "ClassType";
+        internal const string TwinProperty_PreferredGatewayID = "PreferredGatewayID";
+        internal const string TwinProperty_DevAddr = "DevAddr";
+        internal const string TwinProperty_NwkSKey = "NwkSKey";
+        internal const string NetworkServerModuleId = "LoRaWanNetworkSrvModule";
+        internal const string CloudToDeviceMessageMethodName = "cloudtodevicemessage";
+        public const string RoundTripDateTimeStringFormat = "o";
+    }
+}

--- a/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
@@ -26,12 +26,6 @@ namespace LoraKeysManagerFacade
     /// </summary>
     public class SendCloudToDeviceMessage
     {
-        internal const string NetworkServerModuleId = "LoRaWanNetworkSrvModule";
-        internal const string CloudToDeviceMessageMethodName = "cloudtodevicemessage";
-        internal const string TwinProperty_ClassType = "ClassType";
-        internal const string TwinProperty_PreferredGatewayID = "PreferredGatewayID";
-        internal const string TwinProperty_DevAddr = "DevAddr";
-        internal const string TwinProperty_GatewayID = "GatewayID";
         private readonly ILoRaDeviceCacheStore cacheStore;
         private readonly RegistryManager registryManager;
         private readonly IServiceClient serviceClient;
@@ -107,17 +101,17 @@ namespace LoraKeysManagerFacade
                 if (twin != null)
                 {
                     // the device must have a DevAddr
-                    if (twin.Properties?.Desired?.GetTwinPropertyStringSafe(TwinProperty_DevAddr).Length == 0 && twin.Properties?.Reported?.GetTwinPropertyStringSafe(TwinProperty_DevAddr).Length == 0)
+                    if (twin.Properties?.Desired?.GetTwinPropertyStringSafe(LoraKeysManagerFacadeConstants.TwinProperty_DevAddr).Length == 0 && twin.Properties?.Reported?.GetTwinPropertyStringSafe(LoraKeysManagerFacadeConstants.TwinProperty_DevAddr).Length == 0)
                     {
                         return new BadRequestObjectResult("Device DevAddr is unknown. Ensure the device has been correctly setup as a LoRa device and that it has connected to network at least once.");
                     }
 
-                    if (string.Equals("c", twin.Properties?.Desired?.GetTwinPropertyStringSafe(TwinProperty_ClassType), StringComparison.InvariantCultureIgnoreCase))
+                    if (string.Equals("c", twin.Properties?.Desired?.GetTwinPropertyStringSafe(LoraKeysManagerFacadeConstants.TwinProperty_ClassType), StringComparison.InvariantCultureIgnoreCase))
                     {
-                        var gatewayID = twin.Properties?.Reported?.GetTwinPropertyStringSafe(TwinProperty_PreferredGatewayID);
+                        var gatewayID = twin.Properties?.Reported?.GetTwinPropertyStringSafe(LoraKeysManagerFacadeConstants.TwinProperty_PreferredGatewayID);
                         if (string.IsNullOrEmpty(gatewayID))
                         {
-                            gatewayID = twin.Properties?.Desired?.GetTwinPropertyStringSafe(TwinProperty_GatewayID);
+                            gatewayID = twin.Properties?.Desired?.GetTwinPropertyStringSafe(LoraKeysManagerFacadeConstants.TwinProperty_GatewayID);
                         }
 
                         if (!string.IsNullOrEmpty(gatewayID))
@@ -172,10 +166,10 @@ namespace LoraKeysManagerFacade
         {
             try
             {
-                var method = new CloudToDeviceMethod(CloudToDeviceMessageMethodName, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+                var method = new CloudToDeviceMethod(LoraKeysManagerFacadeConstants.CloudToDeviceMessageMethodName, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
                 method.SetPayloadJson(JsonConvert.SerializeObject(c2dMessage));
 
-                var res = await this.serviceClient.InvokeDeviceMethodAsync(preferredGatewayID, NetworkServerModuleId, method);
+                var res = await this.serviceClient.InvokeDeviceMethodAsync(preferredGatewayID, LoraKeysManagerFacadeConstants.NetworkServerModuleId, method);
                 if (IsSuccessStatusCode(res.Status))
                 {
                     this.log.LogInformation("Direct method call to {gatewayID} and {devEUI} succeeded with {statusCode}", preferredGatewayID, devEUI, res.Status);

--- a/LoRaEngine/LoraKeysManagerFacade/TwinExtensions.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/TwinExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoraKeysManagerFacade
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using Microsoft.Azure.Devices.Shared;
+
+    internal static class TwinExtensions
+    {
+        internal static string GetGatewayID(this Twin twin)
+        {
+            return twin.Properties.Desired.Contains(LoraKeysManagerFacadeConstants.TwinProperty_GatewayID)
+                ? twin.Properties.Desired[LoraKeysManagerFacadeConstants.TwinProperty_GatewayID].Value as string
+                : string.Empty;
+        }
+
+        internal static string GetNwkSKey(this Twin twin)
+        {
+            string networkSessionKey = null;
+            if (twin.Properties.Desired.Contains(LoraKeysManagerFacadeConstants.TwinProperty_NwkSKey))
+            {
+                networkSessionKey = twin.Properties.Desired[LoraKeysManagerFacadeConstants.TwinProperty_NwkSKey].Value as string;
+            }
+            else if (twin.Properties.Reported.Contains(LoraKeysManagerFacadeConstants.TwinProperty_NwkSKey))
+            {
+                networkSessionKey = twin.Properties.Reported[LoraKeysManagerFacadeConstants.TwinProperty_NwkSKey].Value as string;
+            }
+
+            return networkSessionKey;
+        }
+    }
+}

--- a/LoRaEngine/LoraKeysManagerFacade/extensions.json
+++ b/LoRaEngine/LoraKeysManagerFacade/extensions.json
@@ -1,8 +1,0 @@
-﻿{
-  "extensions":[
-    {
-        "name": "Startup",
-        "typeName": "LoraKeysManagerFacade.FacadeStartup, LoraKeysManagerFacade, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
-    }
-  ]
-}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApiVersion.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApiVersion.cs
@@ -25,7 +25,7 @@ namespace LoRaWan.Shared
         /// Gets the latest version released.
         /// Update this once a new API version is released
         /// </summary>
-        public static ApiVersion LatestVersion => Version_2019_07_05;
+        public static ApiVersion LatestVersion => Version_2019_07_16;
 
         /// <summary>
         /// Gets the Version from 0.1 and 0.2 had not versioning information
@@ -85,6 +85,14 @@ namespace LoRaWan.Shared
         public static ApiVersion Version_2019_07_05 { get; }
 
         /// <summary>
+        /// Gets 2019_07_16 version
+        /// Fix iothub query error
+        /// Adds nwkSKey to response
+        /// not backward compatible (fixes to iothub bug)
+        /// </summary>
+        public static ApiVersion Version_2019_07_16 { get; }
+
+        /// <summary>
         /// Gets the version that is assumed in case none is specified
         /// </summary>
         public static ApiVersion DefaultVersion => Version_0_2_Or_Earlier;
@@ -103,6 +111,7 @@ namespace LoRaWan.Shared
             yield return Version_2019_04_02;
             yield return Version_2019_04_15_Preview;
             yield return Version_2019_07_05;
+            yield return Version_2019_07_16;
         }
 
         /// <summary>
@@ -155,6 +164,9 @@ namespace LoRaWan.Shared
 
             Version_2019_07_05 = new ApiVersion("2019-07-05");
             Version_2019_07_05.MinCompatibleVersion = Version_2019_04_15_Preview;
+
+            Version_2019_07_16 = new ApiVersion("2019-07-16");
+            Version_2019_07_16.MinCompatibleVersion = Version_2019_07_16;
         }
 
         /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/IoTHubDeviceInfo.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/IoTHubDeviceInfo.cs
@@ -15,6 +15,10 @@ namespace LoRaWan.NetworkServer
 
         public string PrimaryKey { get; set; }
 
+        public string GatewayId { get; set; }
+
+        public string NwkSKey { get; set; }
+
         public IoTHubDeviceInfo()
         {
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
@@ -23,14 +23,19 @@ namespace LoRaWan.NetworkServer
 
         public LoRaDevice Create(IoTHubDeviceInfo deviceInfo)
         {
-            var loraDeviceClient = this.CreateDeviceClient(deviceInfo.DevEUI, deviceInfo.PrimaryKey);
-
             var loRaDevice = new LoRaDevice(
                 deviceInfo.DevAddr,
                 deviceInfo.DevEUI,
                 this.connectionManager);
 
-            this.connectionManager.Register(loRaDevice, loraDeviceClient);
+            loRaDevice.GatewayID = deviceInfo.GatewayId;
+            loRaDevice.NwkSKey = deviceInfo.NwkSKey;
+
+            var isOurDevice = string.IsNullOrEmpty(deviceInfo.GatewayId) || string.Equals(deviceInfo.GatewayId, this.configuration.GatewayID, StringComparison.OrdinalIgnoreCase);
+            if (isOurDevice)
+            {
+                this.connectionManager.Register(loRaDevice, this.CreateDeviceClient(deviceInfo.DevEUI, deviceInfo.PrimaryKey));
+            }
 
             loRaDevice.SetRequestHandler(this.dataRequestHandler);
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/SearchDevicesResult.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/SearchDevicesResult.cs
@@ -11,12 +11,12 @@ namespace LoRaWan.NetworkServer
     public class SearchDevicesResult
     {
         /// <summary>
-        /// List of devices that match the criteria
+        /// Gets list of devices that match the criteria
         /// </summary>
         public IReadOnlyList<IoTHubDeviceInfo> Devices { get; }
 
         /// <summary>
-        /// Indicates dev nonce already used
+        /// Gets or sets a value indicating whether the dev nonce was already used
         /// </summary>
         public bool IsDevNonceAlreadyUsed { get; set; }
 

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/TestLoRaDeviceFactory.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/TestLoRaDeviceFactory.cs
@@ -75,6 +75,8 @@ namespace LoRaWan.NetworkServer.Test
                 deviceInfo.DevEUI,
                 this.connectionManager);
 
+            loRaDevice.GatewayID = deviceInfo.GatewayId;
+
             this.connectionManager.Register(loRaDevice, deviceClientToAssign);
 
             loRaDevice.SetRequestHandler(this.requestHandler ?? new DefaultLoRaDataRequestHandler(this.configuration, this.frameCounterUpdateStrategyProvider, new LoRaPayloadDecoder(), this.deduplicationFactory, this.adrStrategyProvider, this.adrManagerFactory, this.functionBundlerProvider));

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/DevAddrCacheTest.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/DevAddrCacheTest.cs
@@ -80,7 +80,7 @@ namespace LoraKeysManagerFacade.Test
                         deviceTwin.DeviceId = devaddrItem.DevEUI;
                         deviceTwin.Properties = new TwinProperties()
                         {
-                            Desired = new TwinCollection($"{{\"DevAddr\": \"{devaddrItem.DevAddr}\", \"GatewayId\": \"{devaddrItem.GatewayId}\"}}", $"{{\"$lastUpdated\": \"{devaddrItem.LastUpdatedTwins}\"}}"),
+                            Desired = new TwinCollection($"{{\"{LoraKeysManagerFacadeConstants.TwinProperty_DevAddr}\": \"{devaddrItem.DevAddr}\", \"{LoraKeysManagerFacadeConstants.TwinProperty_GatewayID}\": \"{devaddrItem.GatewayId}\"}}", $"{{\"$lastUpdated\": \"{devaddrItem.LastUpdatedTwins.ToString(LoraKeysManagerFacadeConstants.RoundTripDateTimeStringFormat)}\"}}"),
                         };
 
                         twins.Add(deviceTwin);
@@ -107,7 +107,7 @@ namespace LoraKeysManagerFacade.Test
                 });
 
             mockRegistryManager
-                .Setup(x => x.CreateQuery(It.Is<string>(z => z.Contains("SELECT * FROM c where properties.desired.$metadata.$lastUpdated >="))))
+                .Setup(x => x.CreateQuery(It.Is<string>(z => z.Contains("SELECT * FROM devices where properties.desired.$metadata.$lastUpdated >="))))
                 .Returns((string query) =>
                 {
                     currentDevAddrContext = currentDevices.Take(numberOfDeviceDeltaUpdates).ToList();
@@ -166,7 +166,7 @@ namespace LoraKeysManagerFacade.Test
             Assert.Single(queryResult);
             var resultObject = JsonConvert.DeserializeObject<DevAddrCacheInfo>(queryResult[0].Value);
             Assert.Equal(managerInput[0].DevAddr, resultObject.DevAddr);
-            Assert.Equal(managerInput[0].GatewayId, resultObject.GatewayId);
+            Assert.Equal(managerInput[0].GatewayId ?? string.Empty, resultObject.GatewayId);
             Assert.Equal(managerInput[0].DevEUI, resultObject.DevEUI);
 
             registryManagerMock.Verify(x => x.CreateQuery(It.IsAny<string>(), It.IsAny<int>()), Times.Once);
@@ -216,7 +216,7 @@ namespace LoraKeysManagerFacade.Test
             Assert.Single(queryResult);
             var resultObject = JsonConvert.DeserializeObject<DevAddrCacheInfo>(queryResult[0].Value);
             Assert.Equal(managerInput[0].DevAddr, resultObject.DevAddr);
-            Assert.Equal(managerInput[0].GatewayId, resultObject.GatewayId);
+            Assert.Equal(managerInput[0].GatewayId ?? string.Empty, resultObject.GatewayId);
             Assert.Equal(managerInput[0].DevEUI, resultObject.DevEUI);
 
             registryManagerMock.Verify(x => x.CreateQuery(It.IsAny<string>(), It.IsAny<int>()), Times.Once);

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/SendCloudToDeviceMessageTest.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/SendCloudToDeviceMessageTest.cs
@@ -93,7 +93,7 @@ namespace LoraKeysManagerFacade.Test
                 Payload = "hello",
             };
 
-            this.serviceClient.Setup(x => x.InvokeDeviceMethodAsync("gateway1", SendCloudToDeviceMessage.NetworkServerModuleId, It.IsNotNull<CloudToDeviceMethod>()))
+            this.serviceClient.Setup(x => x.InvokeDeviceMethodAsync("gateway1", LoraKeysManagerFacadeConstants.NetworkServerModuleId, It.IsNotNull<CloudToDeviceMethod>()))
                 .Callback<string, string, CloudToDeviceMethod>((device, methodName, method) =>
                 {
                     var c2dMessage = JsonConvert.DeserializeObject<LoRaCloudToDeviceMessage>(method.GetPayloadAsJson());
@@ -124,7 +124,7 @@ namespace LoraKeysManagerFacade.Test
             var preferredGateway = new LoRaDevicePreferredGateway("gateway1", 100);
             LoRaDevicePreferredGateway.SaveToCache(this.cacheStore, devEUI, preferredGateway);
 
-            this.serviceClient.Setup(x => x.InvokeDeviceMethodAsync("gateway1", SendCloudToDeviceMessage.NetworkServerModuleId, It.IsNotNull<CloudToDeviceMethod>()))
+            this.serviceClient.Setup(x => x.InvokeDeviceMethodAsync("gateway1", LoraKeysManagerFacadeConstants.NetworkServerModuleId, It.IsNotNull<CloudToDeviceMethod>()))
                 .ReturnsAsync(new CloudToDeviceMethodResult() { Status = (int)HttpStatusCode.BadRequest });
 
             var actual = await this.sendCloudToDeviceMessage.SendCloudToDeviceMessageImplementationAsync(
@@ -148,7 +148,7 @@ namespace LoraKeysManagerFacade.Test
             var preferredGateway = new LoRaDevicePreferredGateway("gateway1", 100);
             LoRaDevicePreferredGateway.SaveToCache(this.cacheStore, devEUI, preferredGateway);
 
-            this.serviceClient.Setup(x => x.InvokeDeviceMethodAsync("gateway1", SendCloudToDeviceMessage.NetworkServerModuleId, It.IsNotNull<CloudToDeviceMethod>()))
+            this.serviceClient.Setup(x => x.InvokeDeviceMethodAsync("gateway1", LoraKeysManagerFacadeConstants.NetworkServerModuleId, It.IsNotNull<CloudToDeviceMethod>()))
                 .ThrowsAsync(new TimeoutException());
 
             var actual = await this.sendCloudToDeviceMessage.SendCloudToDeviceMessageImplementationAsync(
@@ -274,7 +274,7 @@ namespace LoraKeysManagerFacade.Test
                 Payload = "hello",
             };
 
-            this.serviceClient.Setup(x => x.InvokeDeviceMethodAsync("gateway1", SendCloudToDeviceMessage.NetworkServerModuleId, It.IsNotNull<CloudToDeviceMethod>()))
+            this.serviceClient.Setup(x => x.InvokeDeviceMethodAsync("gateway1", LoraKeysManagerFacadeConstants.NetworkServerModuleId, It.IsNotNull<CloudToDeviceMethod>()))
                 .Callback<string, string, CloudToDeviceMethod>((device, methodName, method) =>
                 {
                     var c2dMessage = JsonConvert.DeserializeObject<LoRaCloudToDeviceMessage>(method.GetPayloadAsJson());
@@ -329,7 +329,7 @@ namespace LoraKeysManagerFacade.Test
                 Payload = "hello",
             };
 
-            this.serviceClient.Setup(x => x.InvokeDeviceMethodAsync("mygateway", SendCloudToDeviceMessage.NetworkServerModuleId, It.IsNotNull<CloudToDeviceMethod>()))
+            this.serviceClient.Setup(x => x.InvokeDeviceMethodAsync("mygateway", LoraKeysManagerFacadeConstants.NetworkServerModuleId, It.IsNotNull<CloudToDeviceMethod>()))
                 .Callback<string, string, CloudToDeviceMethod>((device, methodName, method) =>
                 {
                     var c2dMessage = JsonConvert.DeserializeObject<LoRaCloudToDeviceMessage>(method.GetPayloadAsJson());


### PR DESCRIPTION
**Changes**
- Avoid loading device twin knowing that it belongs to another gateway (added nwkskey to cache)
- Fix error querying iothub device for changes
- Fix date comparison in iothub query (delta reload)
- Remove unnecessary files for Azure Function DI

Fixes [AB#1382](https://dev.azure.com/epicstuff/7acd4d9f-4949-49e3-ada7-2485edc00c16/_workitems/edit/1382), [AB#1383](https://dev.azure.com/epicstuff/7acd4d9f-4949-49e3-ada7-2485edc00c16/_workitems/edit/1383)