### PR TITLE
Fix RX2 implementation in twin

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RegionImplementationTest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RegionImplementationTest.cs
@@ -156,20 +156,20 @@ namespace LoRaWanTest
         {
             string jsonUplink =
                 @"{ ""rxpk"":[
- 	            {
-		            ""time"":""2013-03-31T16:21:17.528002Z"",
- 		            ""tmst"":3512348611,
- 		            ""chan"":2,
- 		            ""rfch"":0,
- 		            ""freq"":" + freq + @",
- 		            ""stat"":1,
- 		            ""modu"":""LORA"",
- 		            ""datr"":""" + datr + @""",
- 		            ""codr"":""4/6"",
- 		            ""rssi"":-35,
- 		            ""lsnr"":5.1,
- 		            ""size"":32,
- 		            ""data"":""AAQDAgEEAwIBBQQDAgUEAwItEGqZDhI=""
+                {
+                    ""time"":""2013-03-31T16:21:17.528002Z"",
+                    ""tmst"":3512348611,
+                    ""chan"":2,
+                    ""rfch"":0,
+                    ""freq"":" + freq + @",
+                    ""stat"":1,
+                    ""modu"":""LORA"",
+                    ""datr"":""" + datr + @""",
+                    ""codr"":""4/6"",
+                    ""rssi"":-35,
+                    ""lsnr"":5.1,
+                    ""size"":32,
+                    ""data"":""AAQDAgEEAwIBBQQDAgUEAwItEGqZDhI=""
                 }]}";
 
             var multiRxpkInput = Encoding.Default.GetBytes(jsonUplink);
@@ -236,6 +236,24 @@ namespace LoRaWanTest
         public void TestMaxPayloadLengthUS(string datr, uint maxPyldSize)
         {
             Assert.Equal(RegionManager.US915.GetMaxPayloadSize(datr), maxPyldSize);
+        }
+
+        [Theory]
+        [InlineData(LoRaRegionType.EU868, "", null, null, 869.525, "SF12BW125")] // Standard EU.
+        [InlineData(LoRaRegionType.EU868, "SF9BW125", null, null, 869.525, "SF9BW125")] // nwksrvDR is correctly applied if no device twins.
+        [InlineData(LoRaRegionType.EU868, "SF9BW125", 868.250, (ushort)6, 868.250, "SF7BW250")] // device twins are applied in priority.
+        [InlineData(LoRaRegionType.US915, "", null, null, 923.3, "SF12BW500")] // Standard US.
+        [InlineData(LoRaRegionType.US915, "SF9BW500", null, null, 923.3, "SF9BW500")] // Standard EU.
+        [InlineData(LoRaRegionType.US915, "SF9BW500", 920.0, (ushort)12, 920.0, "SF8BW500")] // Standard EU.
+
+        public void GetDownStreamRx2(LoRaRegionType loRaRegion, string nwksrvrx2dr, double? nwksrvrx2freq, ushort? rx2drfromtwins, double expectedFreq, string expectedDr)
+        {
+            var devEui = "testDevice";
+            RegionManager.TryTranslateToRegion(loRaRegion, out Region region);
+            var datr = region.GetDownstreamRX2Datarate(devEui, nwksrvrx2dr, rx2drfromtwins);
+            var freq = region.GetDownstreamRX2Freq(devEui, nwksrvrx2freq);
+            Assert.Equal(expectedFreq, freq);
+            Assert.Equal(expectedDr, datr);
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RxpkTest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RxpkTest.cs
@@ -17,20 +17,20 @@ namespace LoRaWanTest
         public void When_Creating_From_Json_Has_Correct_Value()
         {
             string jsonUplink = @"{ ""rxpk"":[
- 	            {
-		            ""time"":""2013-03-31T16:21:17.528002Z"",
- 		            ""tmst"":3512348611,
- 		            ""chan"":2,
- 		            ""rfch"":0,
- 		            ""freq"":866.349812,
- 		            ""stat"":1,
- 		            ""modu"":""LORA"",
- 		            ""datr"":""SF7BW125"",
- 		            ""codr"":""4/6"",
- 		            ""rssi"":-35,
- 		            ""lsnr"":5.1,
- 		            ""size"":32,
- 		            ""data"":""AAQDAgEEAwIBBQQDAgUEAwItEGqZDhI=""
+                {
+                    ""time"":""2013-03-31T16:21:17.528002Z"",
+                    ""tmst"":3512348611,
+                    ""chan"":2,
+                    ""rfch"":0,
+                    ""freq"":866.349812,
+                    ""stat"":1,
+                    ""modu"":""LORA"",
+                    ""datr"":""SF7BW125"",
+                    ""codr"":""4/6"",
+                    ""rssi"":-35,
+                    ""lsnr"":5.1,
+                    ""size"":32,
+                    ""data"":""AAQDAgEEAwIBBQQDAgUEAwItEGqZDhI=""
                 }]}";
 
             byte[] physicalUpstreamPyld = new byte[12];
@@ -45,21 +45,21 @@ namespace LoRaWanTest
         public void When_Creating_From_Json_With_Custom_Elements_Has_Correct_Value()
         {
             string jsonUplink = @"{ ""rxpk"":[
- 	            {
-		            ""time"":""2013-03-31T16:21:17.528002Z"",
- 		            ""tmst"":3512348611,
- 		            ""chan"":2,
- 		            ""rfch"":0,
- 		            ""freq"":866.349812,
- 		            ""stat"":1,
- 		            ""modu"":""LORA"",
- 		            ""datr"":""SF7BW125"",
- 		            ""codr"":""4/6"",
- 		            ""rssi"":-35,
- 		            ""lsnr"":5.1,
- 		            ""size"":32,
- 		            ""data"":""AAQDAgEEAwIBBQQDAgUEAwItEGqZDhI="",
- 		            ""custom_prop_a"":""a"",
+                {
+                    ""time"":""2013-03-31T16:21:17.528002Z"",
+                    ""tmst"":3512348611,
+                    ""chan"":2,
+                    ""rfch"":0,
+                    ""freq"":866.349812,
+                    ""stat"":1,
+                    ""modu"":""LORA"",
+                    ""datr"":""SF7BW125"",
+                    ""codr"":""4/6"",
+                    ""rssi"":-35,
+                    ""lsnr"":5.1,
+                    ""size"":32,
+                    ""data"":""AAQDAgEEAwIBBQQDAgUEAwItEGqZDhI="",
+                    ""custom_prop_a"":""a"",
                     ""custom_prop_b"":10
                 }]}";
 
@@ -73,6 +73,17 @@ namespace LoRaWanTest
             Assert.Contains("custom_prop_b", rxpks[0].ExtraData.Keys);
             Assert.Equal("a", rxpks[0].ExtraData["custom_prop_a"]);
             Assert.Equal(10L, rxpks[0].ExtraData["custom_prop_b"]);
+        }
+
+        [Fact]
+        public void Multiple_Rxpk_Are_Detected_Correctly()
+        {
+            string jsonUplink = @"{""rxpk"":[{""tmst"":373051724,""time"":""2020-02-19T04:08:57.265951Z"",""chan"":0,""rfch"":0,""freq"":923.200000,""stat"":1,""modu"":""LORA"",""datr"":""SF9BW125"",""codr"":""4/5"",""lsnr"":12.5,""rssi"":-47,""size"":21,""data"":""gAMAABKgmAAIAvEgIbhjS0LBeM/d""},{""tmst"":373053772,""time"":""2020-02-19T04:08:57.265951Z"",""chan"":6,""rfch"":0,""freq"":923.000000,""stat"":-1,""modu"":""LORA"",""datr"":""SF9BW125"",""codr"":""4/5"",""lsnr"":-13.0,""rssi"":-97,""size"":21,""data"":""gJni7n4+wQBUl/E0sO4vB4gFePx7""}]}";
+            byte[] physicalUpstreamPyld = new byte[12];
+            physicalUpstreamPyld[0] = 2;
+            var request = Encoding.Default.GetBytes(jsonUplink);
+            var rxpks = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(request).ToArray());
+            Assert.Equal(2, rxpks.Count);
         }
 
         [Theory]
@@ -151,7 +162,7 @@ namespace LoRaWanTest
         [InlineData(LoRaRegionType.US915, 2)]
         [InlineData(LoRaRegionType.US915, 13, false)]
         [InlineData(LoRaRegionType.US915, 10, false)]
-        public void Check_Correct_RXPK_Datr_Are_Accepted(LoRaRegionType loRaRegionType, uint datrIndex, bool upstream = true)
+        public void Check_Correct_RXPK_Datr_Are_Accepted(LoRaRegionType loRaRegionType, ushort datrIndex, bool upstream = true)
         {
             if (loRaRegionType == LoRaRegionType.EU868)
             {
@@ -188,7 +199,7 @@ namespace LoRaWanTest
         [InlineData(LoRaRegionType.US915, 10)]
         [InlineData(LoRaRegionType.US915, 2, false)]
         [InlineData(LoRaRegionType.US915, 12)]
-        public void Check_incorrect_RXPK_Datr_Are_Refused(LoRaRegionType loRaRegionType, uint datrIndex, bool upstream = true)
+        public void Check_incorrect_RXPK_Datr_Are_Refused(LoRaRegionType loRaRegionType, ushort datrIndex, bool upstream = true)
         {
             if (loRaRegionType == LoRaRegionType.EU868)
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/CaseInsensitiveEnvironmentVariables.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/CaseInsensitiveEnvironmentVariables.cs
@@ -49,7 +49,7 @@ namespace LoRaWan.NetworkServer
             return value;
         }
 
-        public double GetEnvVar(string key, double defaultValue)
+        public double? GetEnvVar(string key, double? defaultValue)
         {
             var value = defaultValue;
             if (this.envVars.TryGetValue(key, out var envValue))

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/CaseInsensitiveEnvironmentVariables.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/CaseInsensitiveEnvironmentVariables.cs
@@ -49,7 +49,7 @@ namespace LoRaWan.NetworkServer
             return value;
         }
 
-        public double? GetEnvVar(string key, double? defaultValue)
+        public double? GetEnvVar(string key, double? defaultValue = null)
         {
             var value = defaultValue;
             if (this.envVars.TryGetValue(key, out var envValue))

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
@@ -78,7 +78,8 @@ namespace LoRaWan.NetworkServer
             if (receiveWindow == Constants.RECEIVE_WINDOW_2)
             {
                 tmst = rxpk.Tmst + CalculateTime(timeWatcher.GetReceiveWindow2Delay(loRaDevice), loRaDevice.ReportedRXDelay);
-                (freq, datr) = loRaRegion.GetDownstreamRX2DRAndFreq(loRaDevice.DevEUI, configuration.Rx2DataRate, configuration.Rx2DataFrequency, loRaDevice.ReportedRX2DataRate);
+                freq = loRaRegion.GetDownstreamRX2Freq(loRaDevice.DevEUI, configuration.Rx2Frequency);
+                datr = loRaRegion.GetDownstreamRX2Datarate(loRaDevice.DevEUI, configuration.Rx2DataRate, loRaDevice.ReportedRX2DataRate);
             }
             else
             {
@@ -255,7 +256,8 @@ namespace LoRaWan.NetworkServer
             var tmst = 0; // immediate mode
 
             // Class C always use RX2
-            (freq, datr) = loRaRegion.GetDownstreamRX2DRAndFreq(loRaDevice.DevEUI, configuration.Rx2DataRate, configuration.Rx2DataFrequency, loRaDevice.ReportedRX2DataRate);
+            freq = loRaRegion.GetDownstreamRX2Freq(loRaDevice.DevEUI, configuration.Rx2Frequency);
+            datr = loRaRegion.GetDownstreamRX2Datarate(loRaDevice.DevEUI, configuration.Rx2DataRate, loRaDevice.ReportedRX2DataRate);
 
             // get max. payload size based on data rate from LoRaRegion
             var maxPayloadSize = loRaRegion.GetMaxPayloadSize(datr);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -187,7 +187,8 @@ namespace LoRaWan.NetworkServer
                     Logger.Log(devEUI, $"processing of the join request took too long, using second join accept receive window", LogLevel.Debug);
                     tmst = request.Rxpk.Tmst + loraRegion.Join_accept_delay2 * 1000000;
 
-                    (freq, datr) = loraRegion.GetDownstreamRX2DRAndFreq(devEUI, this.configuration.Rx2DataRate, this.configuration.Rx2DataFrequency, null);
+                    freq = loraRegion.GetDownstreamRX2Freq(devEUI, this.configuration.Rx2Frequency);
+                    datr = loraRegion.GetDownstreamRX2Datarate(devEUI, this.configuration.Rx2DataRate, null);
                 }
 
                 loRaDevice.IsOurDevice = true;
@@ -200,14 +201,17 @@ namespace LoRaWan.NetworkServer
                 // Build the DlSettings fields that is a superposition of RX2DR and RX1DROffset field
                 byte[] dlSettings = new byte[1];
 
-                if (request.Region.DRtoConfiguration.ContainsKey(loRaDevice.DesiredRX2DataRate))
+                if (loRaDevice.DesiredRX2DataRate.HasValue)
                 {
-                    dlSettings[0] =
-                        (byte)(loRaDevice.DesiredRX2DataRate & 0b00001111);
-                }
-                else
-                {
-                    Logger.Log(devEUI, $"twin RX2 DR value is not within acceptable values", LogLevel.Error);
+                    if (request.Region.DRtoConfiguration.ContainsKey(loRaDevice.DesiredRX2DataRate.Value))
+                    {
+                        dlSettings[0] =
+                            (byte)(loRaDevice.DesiredRX2DataRate & 0b00001111);
+                    }
+                    else
+                    {
+                        Logger.Log(devEUI, $"twin RX2 DR value is not within acceptable values", LogLevel.Error);
+                    }
                 }
 
                 if (request.Region.IsValidRX1DROffset(loRaDevice.DesiredRX1DROffset))

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -142,11 +142,11 @@ namespace LoRaWan.NetworkServer
         private readonly object processingSyncLock = new object();
         private readonly Queue<LoRaRequest> queuedRequests = new Queue<LoRaRequest>();
 
-        public ushort DesiredRX2DataRate { get; set; }
+        public ushort? DesiredRX2DataRate { get; set; }
 
         public ushort DesiredRX1DROffset { get; set; }
 
-        public ushort ReportedRX2DataRate { get; set; }
+        public ushort? ReportedRX2DataRate { get; set; }
 
         public ushort ReportedRX1DROffset { get; set; }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -129,11 +129,7 @@ namespace LoRaWan.NetworkServer
             config.GatewayID = envVars.GetEnvVar("IOTEDGE_DEVICEID", string.Empty);
             config.HttpsProxy = envVars.GetEnvVar("HTTPS_PROXY", string.Empty);
             config.Rx2DataRate = envVars.GetEnvVar("RX2_DATR", string.Empty);
-            if (config.Rx2Frequency.HasValue)
-            {
-                config.Rx2Frequency = envVars.GetEnvVar("RX2_FREQ", config.Rx2Frequency.Value);
-            }
-
+            config.Rx2Frequency = envVars.GetEnvVar("RX2_FREQ", (double?)null);
             config.IoTEdgeTimeout = envVars.GetEnvVar("IOTEDGE_TIMEOUT", config.IoTEdgeTimeout);
             config.FacadeServerUrl = envVars.GetEnvVar("FACADE_SERVER_URL", string.Empty);
             config.FacadeAuthCode = envVars.GetEnvVar("FACADE_AUTH_CODE", string.Empty);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -129,7 +129,7 @@ namespace LoRaWan.NetworkServer
             config.GatewayID = envVars.GetEnvVar("IOTEDGE_DEVICEID", string.Empty);
             config.HttpsProxy = envVars.GetEnvVar("HTTPS_PROXY", string.Empty);
             config.Rx2DataRate = envVars.GetEnvVar("RX2_DATR", string.Empty);
-            config.Rx2Frequency = envVars.GetEnvVar("RX2_FREQ", (double?)null);
+            config.Rx2Frequency = envVars.GetEnvVar("RX2_FREQ");
             config.IoTEdgeTimeout = envVars.GetEnvVar("IOTEDGE_TIMEOUT", config.IoTEdgeTimeout);
             config.FacadeServerUrl = envVars.GetEnvVar("FACADE_SERVER_URL", string.Empty);
             config.FacadeAuthCode = envVars.GetEnvVar("FACADE_AUTH_CODE", string.Empty);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -11,63 +11,97 @@ namespace LoRaWan.NetworkServer
     // Network server configuration
     public class NetworkServerConfiguration
     {
-        // Gets/sets if the server is running as an IoT Edge module
+        /// <summary>
+        /// Gets or sets a value indicating whether the server is running as an IoT Edge module.
+        /// </summary>
         public bool RunningAsIoTEdgeModule { get; set; }
 
-        // Gets/sets the iot hub host name
+        /// <summary>
+        /// Gets or sets the iot hub host name.
+        /// </summary>
         public string IoTHubHostName { get; set; }
 
-        // Gets/sets the gateway host name
+        /// <summary>
+        /// Gets or sets the gateway host name.
+        /// </summary>
         public string GatewayHostName { get; set; }
 
-        // Gets/sets if the gateway (edgeHub) is enabled
+        /// <summary>
+        /// Gets or sets a value indicating whether the gateway (edgeHub) is enabled.
+        /// </summary>
         public bool EnableGateway { get; set; } = true;
 
-        // Gets/sets the gateway identifier
+        /// <summary>
+        /// Gets or sets the gateway identifier.
+        /// </summary>
         public string GatewayID { get; set; }
 
-        // Gets/sets the Http proxy URL
+        /// <summary>
+        /// Gets or sets the HTTP proxy url.
+        /// </summary>
         public string HttpsProxy { get; set; }
 
-        // Gets/sets the 2nd receive windows data rate
-        // TODO: better documentation and property name
+        /// <summary>
+        /// Gets or sets the 2nd receive windows datarate.
+        /// </summary>
         public string Rx2DataRate { get; set; }
 
-        // Gets/sets the 2nd receive windows data frequency
-        public double Rx2DataFrequency { get; set; }
+        /// <summary>
+        /// Gets or sets the 2nd receive windows data frequency.
+        /// </summary>
+        public double? Rx2Frequency { get; set; }
 
-        // Gets/sets a IoT edge timeout, 0 keeps the default value
+        /// <summary>
+        /// Gets or sets the IoT Edge timeout, 0 keeps default value,
+        /// </summary>
         public uint IoTEdgeTimeout { get; set; }
 
-        // Gets/sets the Azure Facade Function URL
+        /// <summary>
+        /// Gets or sets the Azure Facade function URL.
+        /// </summary>
         public string FacadeServerUrl { get; set; }
 
-        // Gets/sets the Azure Facade Function auth code
+        /// <summary>
+        /// Gets or sets the Azure Facade Function auth code.
+        /// </summary>
         public string FacadeAuthCode { get; set; }
 
-        // Gets/sets if logging to console is enabled
-        // Default: true
+        /// <summary>
+        /// Gets or sets a value indicating whether logging to console is enabled
+        /// </summary>
         public bool LogToConsole { get; set; } = true;
 
-        // Gets/sets the logging level
-        // Default: 4 (Log Errors)
+        /// <summary>
+        /// Gets or sets  the logging level.
+        /// Default: 4 (Log level: Error)
+        /// </summary>
         public string LogLevel { get; set; } = "4";
 
-        // Gets/sets if logging to IoT Hub is enabled
-        // Default: false
+        /// <summary>
+        /// Gets or sets a value indicating whether logging to IoT Hub is enabled.
+        /// Default is false.
+        /// </summary>
         public bool LogToHub { get; set; }
 
-        // Gets/sets if logging to udp is enabled (used for integration tests mainly)
-        // Default: false
+        /// <summary>
+        /// Gets or sets a value indicating whether logging to udp is enabled (used for integration tests mainly).
+        /// Default is false.
+        /// </summary>
         public bool LogToUdp { get; set; }
 
-        // Gets/sets udp address to send log
+        /// <summary>
+        /// Gets or sets udp address to send log to.
+        /// </summary>
         public string LogToUdpAddress { get; set; }
 
-        // Gets/sets udp port to send logs
+        /// <summary>
+        /// Gets or sets udp port to send logs to.
+        /// </summary>
         public int LogToUdpPort { get; set; } = 6000;
 
-        // Gets/sets gateway NetId
+        /// <summary>
+        /// Gets or sets the gateway netword id.
+        /// </summary>
         public uint NetId { get; set; } = 1;
 
         /// <summary>
@@ -95,7 +129,11 @@ namespace LoRaWan.NetworkServer
             config.GatewayID = envVars.GetEnvVar("IOTEDGE_DEVICEID", string.Empty);
             config.HttpsProxy = envVars.GetEnvVar("HTTPS_PROXY", string.Empty);
             config.Rx2DataRate = envVars.GetEnvVar("RX2_DATR", string.Empty);
-            config.Rx2DataFrequency = envVars.GetEnvVar("RX2_FREQ", config.Rx2DataFrequency);
+            if (config.Rx2Frequency.HasValue)
+            {
+                config.Rx2Frequency = envVars.GetEnvVar("RX2_FREQ", config.Rx2Frequency.Value);
+            }
+
             config.IoTEdgeTimeout = envVars.GetEnvVar("IOTEDGE_TIMEOUT", config.IoTEdgeTimeout);
             config.FacadeServerUrl = envVars.GetEnvVar("FACADE_SERVER_URL", string.Empty);
             config.FacadeAuthCode = envVars.GetEnvVar("FACADE_AUTH_CODE", string.Empty);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
@@ -198,28 +198,24 @@ namespace LoRaTools.Regions
                 }
                 else
                 {
-                    var datr = this.DRtoConfiguration[this.RX2DefaultReceiveWindows.dr].configuration;
-                    Logger.Log(devEUI, $"device twins rx2 ({rx2DrFromTwins.Value}) is invalid, using default: {this.RX2DefaultReceiveWindows.dr}, datr: {datr}", LogLevel.Debug);
-                    return datr;
+                    Logger.Log(devEUI, $"device twins rx2 ({rx2DrFromTwins.Value}) is invalid", LogLevel.Error);
                 }
             }
             else
             {
                 // Otherwise we check if we have some properties set on the server (server Specific)
-                if (string.IsNullOrEmpty(nwkSrvRx2Dr))
-                {
-                    // If not we use the region default.
-                    var datr = this.DRtoConfiguration[this.RX2DefaultReceiveWindows.dr].configuration;
-                    Logger.Log(devEUI, $"using standard region RX2 datarate {datr}", LogLevel.Debug);
-                    return datr;
-                }
-                else
+                if (!string.IsNullOrEmpty(nwkSrvRx2Dr))
                 {
                     var datr = nwkSrvRx2Dr;
                     Logger.Log(devEUI, $"using custom gateway RX2 datarate {datr}", LogLevel.Debug);
                     return datr;
                 }
             }
+
+            // if no settings was set we use region default.
+            var defaultDatr = this.DRtoConfiguration[this.RX2DefaultReceiveWindows.dr].configuration;
+            Logger.Log(devEUI, $"using standard region RX2 datarate {defaultDatr}", LogLevel.Debug);
+            return defaultDatr;
         }
 
         /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
@@ -26,7 +26,7 @@ namespace LoRaTools.Regions
         /// max application payload size N should be N= M-8 bytes.
         /// This is in case of absence of Fopts field.
         /// </summary>
-        public Dictionary<uint, (string configuration, uint maxPyldSize)> DRtoConfiguration { get; set; } = new Dictionary<uint, (string, uint)>();
+        public Dictionary<ushort, (string configuration, uint maxPyldSize)> DRtoConfiguration { get; set; } = new Dictionary<ushort, (string, uint)>();
 
         /// <summary>
         /// Gets or sets by default MaxEIRP is considered to be +16dBm.
@@ -44,7 +44,7 @@ namespace LoRaTools.Regions
         /// <summary>
         /// Gets or sets default parameters for the RX2 receive Windows, This windows use a fix frequency and Data rate.
         /// </summary>
-        public (double frequency, uint dr) RX2DefaultReceiveWindows { get; set; }
+        public (double frequency, ushort dr) RX2DefaultReceiveWindows { get; set; }
 
         /// <summary>
         /// Gets or sets default first receive windows. [sec]
@@ -99,7 +99,7 @@ namespace LoRaTools.Regions
         /// </summary>
         public int MaxADRDataRate { get; set; }
 
-        public Region(LoRaRegionType regionEnum, byte loRaSyncWord, byte[] gFSKSyncWord, (double frequency, uint datr) rx2DefaultReceiveWindows, uint receive_delay1, uint receive_delay2, uint join_accept_delay1, uint join_accept_delay2, int max_fcnt_gap, uint adr_ack_limit, uint adr_adr_delay, (uint min, uint max) ack_timeout)
+        public Region(LoRaRegionType regionEnum, byte loRaSyncWord, byte[] gFSKSyncWord, (double frequency, ushort datr) rx2DefaultReceiveWindows, uint receive_delay1, uint receive_delay2, uint join_accept_delay1, uint join_accept_delay2, int max_fcnt_gap, uint adr_ack_limit, uint adr_adr_delay, (uint min, uint max) ack_timeout)
         {
             this.LoRaRegion = regionEnum;
             this.Ack_timeout = ack_timeout;
@@ -157,52 +157,69 @@ namespace LoRaTools.Regions
         }
 
         /// <summary>
-        /// Method to calculate the RX2 DataRate and frequency.
-        /// Those parameters can be set in the device twins, Server Twins, or it could be a regional feature.
+        /// Get the downstream RX2 frequency.
         /// </summary>
-        public (double freq, string datr) GetDownstreamRX2DRAndFreq(string devEUI, string nwkSrvRx2Dr, double nwkSrvRx2Freq, int? rx2DrFromTwins)
+        /// <param name="devEUI">the device id.</param>
+        /// <param name="nwkSrvRx2Freq">the value of the rx2freq env var on the nwk srv.</param>
+        /// <returns>rx2 freq.</returns>
+        public double GetDownstreamRX2Freq(string devEUI, double? nwkSrvRx2Freq)
         {
-            double freq = 0;
-            string datr;
+            // resolve frequency to gateway if setted to region's default
+            if (nwkSrvRx2Freq.HasValue)
+            {
+                Logger.Log(devEUI, $"using custom gateway RX2 frequency {nwkSrvRx2Freq}", LogLevel.Debug);
+                return nwkSrvRx2Freq.Value;
+            }
+            else
+            {
+                // default frequency
+                Logger.Log(devEUI, $"using standard region RX2 frequency {this.RX2DefaultReceiveWindows.frequency}", LogLevel.Debug);
+                return this.RX2DefaultReceiveWindows.frequency;
+            }
+        }
 
-            // If the rx2 property is in twins, it is device specific and take precedence
-            if (rx2DrFromTwins == null)
+        /// <summary>
+        /// Get downstream RX2 datarate
+        /// </summary>
+        /// <param name="devEUI">the device id.</param>
+        /// <param name="nwkSrvRx2Dr">the network server rx2 datarate.</param>
+        /// <param name="rx2DrFromTwins">rx2 datarate value from twins.</param>
+        /// <returns>the rx2 datarate.</returns>
+        public string GetDownstreamRX2Datarate(string devEUI, string nwkSrvRx2Dr, ushort? rx2DrFromTwins)
+        {
+            // If the rx2 datarate property is in twins, we take it from there
+            if (rx2DrFromTwins.HasValue)
+            {
+                if (this.RegionLimits.IsCurrentDownstreamDRIndexWithinAcceptableValue(rx2DrFromTwins))
+                {
+                    var datr = this.DRtoConfiguration[rx2DrFromTwins.Value].configuration;
+                    Logger.Log(devEUI, $"using device twins rx2: {rx2DrFromTwins.Value}, datr: {datr}", LogLevel.Debug);
+                    return datr;
+                }
+                else
+                {
+                    var datr = this.DRtoConfiguration[this.RX2DefaultReceiveWindows.dr].configuration;
+                    Logger.Log(devEUI, $"device twins rx2 ({rx2DrFromTwins.Value}) is invalid, using default: {this.RX2DefaultReceiveWindows.dr}, datr: {datr}", LogLevel.Debug);
+                    return datr;
+                }
+            }
+            else
             {
                 // Otherwise we check if we have some properties set on the server (server Specific)
                 if (string.IsNullOrEmpty(nwkSrvRx2Dr))
                 {
                     // If not we use the region default.
-                    Logger.Log(devEUI, $"using standard second receive windows for join request", LogLevel.Debug);
-                    // using EU fix DR for RX2
-                    freq = this.RX2DefaultReceiveWindows.frequency;
-                    datr = this.DRtoConfiguration[this.RX2DefaultReceiveWindows.dr].configuration;
+                    var datr = this.DRtoConfiguration[this.RX2DefaultReceiveWindows.dr].configuration;
+                    Logger.Log(devEUI, $"using standard region RX2 datarate {datr}", LogLevel.Debug);
+                    return datr;
                 }
                 else
                 {
-                    Logger.Log(devEUI, $"using custom second receive windows for join request", LogLevel.Debug);
-                    freq = nwkSrvRx2Freq;
-                    datr = nwkSrvRx2Dr;
+                    var datr = nwkSrvRx2Dr;
+                    Logger.Log(devEUI, $"using custom gateway RX2 datarate {datr}", LogLevel.Debug);
+                    return datr;
                 }
             }
-            else
-            {
-                uint rx2Dr = (uint)rx2DrFromTwins;
-                if (this.RegionLimits.IsCurrentDownstreamDRIndexWithinAcceptableValue(rx2Dr))
-                {
-                    datr = this.DRtoConfiguration[rx2Dr].configuration;
-                    Logger.Log(devEUI, $"using device rx2: {rx2Dr}, datr: {datr}, region: {this.LoRaRegion}", LogLevel.Debug);
-                }
-                else
-                {
-                    datr = this.DRtoConfiguration[this.RX2DefaultReceiveWindows.dr].configuration;
-                    Logger.Log(devEUI, $"device rx2 ({rx2Dr}) is invalid, using default: {this.RX2DefaultReceiveWindows.dr}, datr: {datr}, region: {this.LoRaRegion}", LogLevel.Debug);
-                }
-
-                // Todo add optional frequencies via Mac Commands
-                freq = this.RX2DefaultReceiveWindows.frequency;
-            }
-
-            return (freq, datr);
         }
 
         /// <summary>
@@ -217,7 +234,7 @@ namespace LoRaTools.Regions
                 if (rx1DrOffset <= this.RX1DROffsetTable.GetUpperBound(1))
                 {
                     // in case of EU, you respond on same frequency as you sent data.
-                    return this.DRtoConfiguration[(uint)this.RX1DROffsetTable[this.GetDRFromFreqAndChan(upstreamChannel.Datr), rx1DrOffset]].configuration;
+                    return this.DRtoConfiguration[(ushort)this.RX1DROffsetTable[this.GetDRFromFreqAndChan(upstreamChannel.Datr), rx1DrOffset]].configuration;
                 }
                 else
                 {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
@@ -216,7 +216,7 @@ namespace LoRaTools.Regions
             var defaultDatr = this.DRtoConfiguration[this.RX2DefaultReceiveWindows.dr].configuration;
             Logger.Log(devEUI, $"using standard region RX2 datarate {defaultDatr}", LogLevel.Debug);
             return defaultDatr;
-        }
+            }
 
         /// <summary>
         /// Implement correct logic to get the downstream data rate based on the region.
@@ -229,11 +229,11 @@ namespace LoRaTools.Regions
                 // If the rx1 offset is a valid value we use it, otherwise we keep answering on normal datar
                 if (rx1DrOffset <= this.RX1DROffsetTable.GetUpperBound(1))
                 {
-                    // in case of EU, you respond on same frequency as you sent data.
                     return this.DRtoConfiguration[(ushort)this.RX1DROffsetTable[this.GetDRFromFreqAndChan(upstreamChannel.Datr), rx1DrOffset]].configuration;
                 }
                 else
                 {
+                    Logger.Log($"rx1 Dr Offset was not set to a valid value {rx1DrOffset}, defaulting to {upstreamChannel.Datr} datarate", LogLevel.Error);
                     return upstreamChannel.Datr;
                 }
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionLimits.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionLimits.cs
@@ -34,8 +34,8 @@ namespace LoRaTools.Regions
 
         public bool IsCurrentDownstreamDRValueWithinAcceptableValue(string dr) => this.downstreamValidDR.Contains(dr);
 
-        public bool IsCurrentUpstreamDRIndexWithinAcceptableValue(uint dr) => (dr >= this.startUpstreamDRIndex) && dr < this.startUpstreamDRIndex + this.upstreamValidDR.Count;
+        public bool IsCurrentUpstreamDRIndexWithinAcceptableValue(ushort dr) => (dr >= this.startUpstreamDRIndex) && dr < this.startUpstreamDRIndex + this.upstreamValidDR.Count;
 
-        public bool IsCurrentDownstreamDRIndexWithinAcceptableValue(uint dr) => (dr >= this.startDownstreamDRIndex) && dr < this.startDownstreamDRIndex + this.downstreamValidDR.Count;
+        public bool IsCurrentDownstreamDRIndexWithinAcceptableValue(ushort? dr) => (dr >= this.startDownstreamDRIndex) && dr < this.startDownstreamDRIndex + this.downstreamValidDR.Count;
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionManager.cs
@@ -56,7 +56,7 @@ namespace LoRaTools.Regions
                 region = EU868;
                 return true;
             }// US902-928
-            else if (rxpk.Freq <= 928 && rxpk.Freq >= 902)
+            else if (rxpk.Freq <= 915 && rxpk.Freq >= 902)
             {
                 region = US915;
                 return true;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionManager.cs
@@ -55,7 +55,7 @@ namespace LoRaTools.Regions
             {
                 region = EU868;
                 return true;
-            }// US902-928
+            }// US902-928 frequency band, upstream messages are between 902 and 915.
             else if (rxpk.Freq <= 915 && rxpk.Freq >= 902)
             {
                 region = US915;

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/CaseInsensitiveEnvironmentVariablesTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/CaseInsensitiveEnvironmentVariablesTest.cs
@@ -17,7 +17,7 @@ namespace LoRaWan.NetworkServer.Test
             };
 
             var target = new CaseInsensitiveEnvironmentVariables(variables);
-            var actual = target.GetEnvVar("NOT_EXISTS", null);
+            var actual = target.GetEnvVar("NOT_EXISTS", (string)null);
             Assert.Null(actual);
         }
 

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaDeviceTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaDeviceTest.cs
@@ -786,8 +786,8 @@ namespace LoRaWan.NetworkServer.Test
             Assert.Equal("mygateway", loRaDevice.GatewayID);
             Assert.Equal(9u, loRaDevice.FCntDown);
             Assert.Equal(100u, loRaDevice.FCntUp);
-            Assert.Equal(10, loRaDevice.ReportedRX2DataRate);
-            Assert.Equal(10, loRaDevice.DesiredRX2DataRate);
+            Assert.Equal(10, loRaDevice.ReportedRX2DataRate.Value);
+            Assert.Equal(10, loRaDevice.DesiredRX2DataRate.Value);
             Assert.Equal(appSKey, loRaDevice.AppSKey);
             Assert.Equal(nwkSKey, loRaDevice.NwkSKey);
             Assert.Equal(LoRaRegionType.US915, loRaDevice.LoRaRegion);

--- a/azure-pipeline-integration-test-steps-template.yaml
+++ b/azure-pipeline-integration-test-steps-template.yaml
@@ -15,7 +15,7 @@ steps:
   displayName: 'Use .NET Core sdk'
   inputs:
     packageType: sdk
-    version: 2.1
+    version: 2.1.807
 
 - task: qetza.replacetokens.replacetokens-task.replacetokens@3
   displayName: 'Configure test in **/test/LoRaWan.IntegrationTest/appsettings.json'  

--- a/azure-pipeline-integration-test-steps-template.yaml
+++ b/azure-pipeline-integration-test-steps-template.yaml
@@ -11,6 +11,12 @@ parameters:
   - ClassCTest
   
 steps:
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk'
+  inputs:
+    packageType: sdk
+    version: 2.1
+
 - task: qetza.replacetokens.replacetokens-task.replacetokens@3
   displayName: 'Configure test in **/test/LoRaWan.IntegrationTest/appsettings.json'  
   inputs:


### PR DESCRIPTION
Current implementation had RX2 as non nullable type, therefore the RX2 always defaulted to 0, it was not a problem for EU and US, but it is a problem for other frequency plan we could implement in the future