### PR TITLE
Fix missleading logs

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -904,13 +904,16 @@ namespace LoRaWan.NetworkServer
                         Logger.Log(this.DevEUI, "the provided RX1DROffset is not valid", LogLevel.Error);
                     }
 
-                    if (currentRegion.RegionLimits.IsCurrentDownstreamDRIndexWithinAcceptableValue(this.DesiredRX2DataRate))
+                    if (this.DesiredRX2DataRate != null)
                     {
-                        this.ReportedRX2DataRate = this.DesiredRX2DataRate;
-                    }
-                    else
-                    {
-                        Logger.Log(this.DevEUI, "the provided RX2DataRate is not valid", LogLevel.Error);
+                        if (currentRegion.RegionLimits.IsCurrentDownstreamDRIndexWithinAcceptableValue(this.DesiredRX2DataRate))
+                        {
+                            this.ReportedRX2DataRate = this.DesiredRX2DataRate;
+                        }
+                        else
+                        {
+                            Logger.Log(this.DevEUI, "the provided RX2DataRate is not valid", LogLevel.Error);
+                        }
                     }
 
                     if (currentRegion.IsValidRXDelay(this.DesiredRXDelay))


### PR DESCRIPTION
A wrong "the provided RX2DataRate is not valid" was displayed on the join logs in case a custom RX2DR is not set.
