### PR TITLE
Prepare Release 1.0.5

### DIFF
--- a/Docs/devguide.md
+++ b/Docs/devguide.md
@@ -4,7 +4,7 @@
 
 The code is organized into three sections:
 
-- **LoRaEngine** - a .NET Standard 2.1 solution with the following folders:
+- **LoRaEngine** - a .NET core 3.1 solution with the following folders:
   - **modules** - Azure IoT Edge modules.
   - **LoraKeysManagerFacade** - An Azure function handling device provisioning (e.g. LoRa network join, OTAA) with Azure IoT Hub as persistence layer.
   - **LoRaDevTools** - library for dev tools (git submodule)
@@ -17,7 +17,7 @@ The code is organized into three sections:
 
 ## LoRaEngine
 
-A **.NET Core 2.1** solution with the following projects:
+A **.NET Core 3.1** solution with the following projects:
 
 - **modules** - Azure IoT Edge modules.
   - **LoRaWanPktFwdModule** packages the network forwarder into an IoT Edge compatible docker container. See https://github.com/Lora-net/packet_forwarder and https://github.com/Lora-net/lora_gateway. If you are using a RAK833-USB see this [submodule](/Docs/LoRaWanPktFwdRAK833USB)

--- a/Docs/upgrade.md
+++ b/Docs/upgrade.md
@@ -1,5 +1,26 @@
 # Upgrade LoRaWAN to a new version
 
+## Release 1.0.5
+To update from version 1.0.4 or 1.0.3 you can follow the below instructions. If you want to update manually from a version prior to 1.0.3, please refer to the instructions in the [Release 1.0.3](#Release-1.0.3) section below.
+
+### Updating from 1.0.4 or 1.0.3
+|Deployment Module|Image URI|
+|-|-|
+|LoRaWanNetworkSrvModule|loraedge/lorawannetworksrvmodule:1.0.5|
+|LoRaWanPktFwdModule|loraedge/lorawanpktfwdmodule:1.0.5|
+
+On the same `Set Modules` page, also update your current edge version to 1.0.9.5 by pressing the `Configure Advanced Edge Runtime settings` button. On the menu, ensure the edge hub and edge agent are using version 1.0.9.5 by respectively setting image name to mcr.microsoft.com/azureiotedge-hub:1.0.9.5 and mcr.microsoft.com/azureiotedge-agent:1.0.9.5.
+
+### Updating the Azure Function Facade
+
+If you have manually deployed the Azure Function, re-deploy the updated version of the Azure Function Facade as outlined [here](./devguide.md#setup-azure-function-facade-and-azure-container-registry) if you have a previous version of this Azure Function running.
+
+If you have deployed the solution and with it the Azure Function through the Azure Resource Manager template, you will see an `App Setting` in the function with the name "WEBSITE_RUN_FROM_ZIP". Update it's value to:
+
+```
+https://github.com/Azure/iotedge-lorawan-starterkit/releases/download/v1.0.5/function-1.0.5.zip
+```
+
 ## Release 1.0.4
 To update from version 1.0.3 you can follow the below instructions. If you want to update manually from a version prior to 1.0.3, please refer to the instructions in the [Release 1.0.3](#Release-1.0.3) section below.
 

--- a/LoRaEngine/deployment.template.json
+++ b/LoRaEngine/deployment.template.json
@@ -21,7 +21,7 @@
           "edgeAgent": {
             "type": "docker",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-agent:1.0.9.4",
+              "image": "mcr.microsoft.com/azureiotedge-agent:1.0.9.5",
               "createOptions": ""
             }
           },
@@ -30,7 +30,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-hub:1.0.9.4",
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.0.9.5",
               "createOptions": {
                 "HostConfig": {
                   "PortBindings": {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApiVersion.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApiVersion.cs
@@ -25,7 +25,7 @@ namespace LoRaWan.Shared
         /// Gets the latest version released.
         /// Update this once a new API version is released.
         /// </summary>
-        public static ApiVersion LatestVersion => Version_2020_08_11;
+        public static ApiVersion LatestVersion => Version_2020_10_09;
 
         /// <summary>
         /// Gets the Version from 0.1 and 0.2 had not versioning information.
@@ -100,6 +100,13 @@ namespace LoRaWan.Shared
         public static ApiVersion Version_2020_08_11 { get; }
 
         /// <summary>
+        /// Gets2020_10_09 version
+        /// Fix function major issue
+        /// Not backward compatible.
+        /// </summary>
+        public static ApiVersion Version_2020_10_09 { get; }
+
+        /// <summary>
         /// Gets the version that is assumed in case none is specified.
         /// </summary>
         public static ApiVersion DefaultVersion => Version_0_2_Or_Earlier;
@@ -120,6 +127,7 @@ namespace LoRaWan.Shared
             yield return Version_2019_07_05;
             yield return Version_2019_07_16;
             yield return Version_2020_08_11;
+            yield return Version_2020_10_09;
         }
 
         /// <summary>
@@ -178,6 +186,9 @@ namespace LoRaWan.Shared
 
             Version_2020_08_11 = new ApiVersion("2020-08-11");
             Version_2020_08_11.MinCompatibleVersion = Version_2019_07_16;
+
+            Version_2020_10_09 = new ApiVersion("2020-10-09");
+            Version_2020_10_09.MinCompatibleVersion = Version_2020_10_09;
         }
 
         /// <summary>

--- a/Template/deviceConfiguration.json
+++ b/Template/deviceConfiguration.json
@@ -14,14 +14,14 @@
 					"edgeAgent": {
 						"type": "docker",
 						"settings": {
-							"image": "mcr.microsoft.com/azureiotedge-agent:1.0.9.4",
+							"image": "mcr.microsoft.com/azureiotedge-agent:1.0.9.5",
 							"createOptions": "{}"
 						}
 					},
 					"edgeHub": {
 						"type": "docker",
 						"settings": {
-							"image": "mcr.microsoft.com/azureiotedge-hub:1.0.9.4",
+							"image": "mcr.microsoft.com/azureiotedge-hub:1.0.9.5",
 							"createOptions": "{ \"HostConfig\": {   \"PortBindings\": {\"8883/tcp\": [  {\"HostPort\": \"8883\" }  ], \"443/tcp\": [ { \"HostPort\": \"443\" } ], \"5671/tcp\": [ { \"HostPort\": \"5671\"  }] } }}"
 						},
 						"env": {
@@ -37,7 +37,7 @@
               "TwinManagerVersion": {
                 "value": "v2"
               }
-						},
+			},
 						"status": "running",
 						"restartPolicy": "always"
 					}
@@ -46,7 +46,7 @@
 					"LoRaWanNetworkSrvModule": {
 						"type": "docker",
 						"settings": {
-							"image": "loraedge/lorawannetworksrvmodule:1.0.4",
+							"image": "loraedge/lorawannetworksrvmodule:1.0.5",
 							"createOptions": "{\"ExposedPorts\": { \"1680/udp\": {}}, \"HostConfig\": {  \"PortBindings\": {\"1680/udp\": [  { \"HostPort\": \"1680\", \"HostIp\":\"172.17.0.1\" } ]}}}"
 						},
 						"version": "1.0",
@@ -64,7 +64,7 @@
 					"LoRaWanPktFwdModule": {
 						"type": "docker",
 						"settings": {
-							"image": "loraedge/lorawanpktfwdmodule:1.0.4",
+							"image": "loraedge/lorawanpktfwdmodule:1.0.5",
 							"createOptions": "  {\"HostConfig\": {\"NetworkMode\": \"host\", \"Privileged\": true },  \"NetworkingConfig\": {\"EndpointsConfig\": {\"host\": {} }}}"
 						},
 						"env": {

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -12,8 +12,8 @@ variables:
 
   buildConfiguration: 'Release'
 
-  edgeAgentVersion: 1.0.9
-  edgeHubVersion: 1.0.9
+  edgeAgentVersion: 1.0.9.5
+  edgeHubVersion: 1.0.9.5
   edgeHubRoute: FROM /* INTO $upstream
 
   # Defines the name of the VSTS agent in ARM architecture


### PR DESCRIPTION
Prepare release 1.0.5 with latest improvements from master and upgrade iot edge to latest security version. Please refer to the draft release note for more details.

This new release will fix #258 , 