### PR TITLE
Bug #270 Fix error NU1605: Detected package downgrade on dotnet publish

### DIFF
--- a/Tools/Cli-LoRa-Device-Provisioning/Cli-LoRa-Device-Provisioning.csproj
+++ b/Tools/Cli-LoRa-Device-Provisioning/Cli-LoRa-Device-Provisioning.csproj
@@ -30,9 +30,7 @@
     </ItemGroup>
     <PropertyGroup>
         <CodeAnalysisRuleSet>../../stylecop.ruleset</CodeAnalysisRuleSet><Authors>Sascha Corti (saschac@microsoft.com)</Authors><Version>1.1.0.0</Version><Company>Microsoft</Company><Product>Azure IoT Edge LoRaWAN Starter Kit LoRa Leaf Device Provisioning Utility.</Product><Description>This tool complements http://aka.ms/lora</Description><Copyright>Copyright (c) 2019 Microsoft. All rights reserved.</Copyright><PackageLicenseExpression>Licensed under the MIT license. See LICENSE file in the project GitHub repo root for full license information.</PackageLicenseExpression><PackageProjectUrl>https://github.com/Azure/iotedge-lorawan-starterkit</PackageProjectUrl><RepositoryUrl>https://github.com/Azure/iotedge-lorawan-starterkit</RepositoryUrl>
-    </PropertyGroup><PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-  <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-</PropertyGroup>
+    </PropertyGroup>
     <Import Project="../../stylecop.props" />
 
 </Project>

--- a/Tools/Cli-LoRa-Device-Provisioning/Cli-LoRa-Device-Provisioning.csproj
+++ b/Tools/Cli-LoRa-Device-Provisioning/Cli-LoRa-Device-Provisioning.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="3.1.0" PrivateAssets="all" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.22.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.6" />
@@ -29,7 +30,9 @@
     </ItemGroup>
     <PropertyGroup>
         <CodeAnalysisRuleSet>../../stylecop.ruleset</CodeAnalysisRuleSet><Authors>Sascha Corti (saschac@microsoft.com)</Authors><Version>1.1.0.0</Version><Company>Microsoft</Company><Product>Azure IoT Edge LoRaWAN Starter Kit LoRa Leaf Device Provisioning Utility.</Product><Description>This tool complements http://aka.ms/lora</Description><Copyright>Copyright (c) 2019 Microsoft. All rights reserved.</Copyright><PackageLicenseExpression>Licensed under the MIT license. See LICENSE file in the project GitHub repo root for full license information.</PackageLicenseExpression><PackageProjectUrl>https://github.com/Azure/iotedge-lorawan-starterkit</PackageProjectUrl><RepositoryUrl>https://github.com/Azure/iotedge-lorawan-starterkit</RepositoryUrl>
-    </PropertyGroup>
+    </PropertyGroup><PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+</PropertyGroup>
     <Import Project="../../stylecop.props" />
 
 </Project>


### PR DESCRIPTION
Fixes Bug #270 

Problem fixed according to solution described in https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1605#issue-1

Problem
Certain combinations of packages which shipped with .NET Core 1.0 and 1.1 are not compatible with each other when they are referenced together in a .NET Core 3.0 or higher project, and a RuntimeIdentifier is specified. The problematic packages generally start with System. or Microsoft., and have version numbers between 4.0.0 and 4.3.1. In this case, the downgrade message will have a package starting with runtime. in the dependency chain.

Solution
To work around this issue, add the following PackageReference:
```xml
<PackageReference Include="Microsoft.NETCore.Targets" Version="3.0.0" PrivateAssets="all" />
```