### PR TITLE
Revert null check on RX2

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/VersionValidator.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/VersionValidator.cs
@@ -16,7 +16,7 @@ namespace LoraKeysManagerFacade
             var requestedVersion = req.GetRequestedVersion();
             if (requestedVersion == null || !currentApiVersion.SupportsVersion(requestedVersion))
             {
-                throw new IncompatibleVersionException($"Incompatible versions (requested: '{requestedVersion.Name ?? string.Empty}', current: '{currentApiVersion.Name}')");
+                throw new IncompatibleVersionException($"Incompatible versions (requested: '{requestedVersion?.Name ?? string.Empty}', current: '{currentApiVersion.Name}')");
             }
         }
     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RxpkTest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RxpkTest.cs
@@ -152,6 +152,13 @@ namespace LoRaWanTest
             Assert.Equal(expectedDatr, downstream);
         }
 
+        [Fact]
+        public void Check_Downstream_DR_Returns_False_On_Null_Datarate()
+        {
+            Assert.False(RegionManager.EU868.RegionLimits.IsCurrentDownstreamDRIndexWithinAcceptableValue(null));
+            Assert.False(RegionManager.US915.RegionLimits.IsCurrentDownstreamDRIndexWithinAcceptableValue(null));
+        }
+
         [Theory]
         [InlineData(LoRaRegionType.EU868, 0)]
         [InlineData(LoRaRegionType.EU868, 1)]

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -572,9 +572,9 @@ namespace LoRaWan.NetworkServer
                 var fcntDownDelta = this.FCntDown >= this.LastSavedFCntDown ? this.FCntDown - this.LastSavedFCntDown : this.LastSavedFCntDown - this.FCntDown;
 
                 if (reportedProperties.Count > 0 ||
-                    fcntDownDelta >= Constants.MAX_FCNT_UNSAVED_DELTA ||
-                    fcntUpDelta >= Constants.MAX_FCNT_UNSAVED_DELTA ||
-                    (this.hasFrameCountChanges && force))
+                            fcntDownDelta >= Constants.MAX_FCNT_UNSAVED_DELTA ||
+                            fcntUpDelta >= Constants.MAX_FCNT_UNSAVED_DELTA ||
+                            (this.hasFrameCountChanges && force))
                 {
                     var savedFcntDown = this.FCntDown;
                     var savedFcntUp = this.FCntUp;
@@ -904,16 +904,13 @@ namespace LoRaWan.NetworkServer
                         Logger.Log(this.DevEUI, "the provided RX1DROffset is not valid", LogLevel.Error);
                     }
 
-                    if (this.DesiredRX2DataRate != null)
+                    if (currentRegion.RegionLimits.IsCurrentDownstreamDRIndexWithinAcceptableValue(this.DesiredRX2DataRate))
                     {
-                        if (currentRegion.RegionLimits.IsCurrentDownstreamDRIndexWithinAcceptableValue(this.DesiredRX2DataRate))
-                        {
-                            this.ReportedRX2DataRate = this.DesiredRX2DataRate;
-                        }
-                        else
-                        {
-                            Logger.Log(this.DevEUI, "the provided RX2DataRate is not valid", LogLevel.Error);
-                        }
+                        this.ReportedRX2DataRate = this.DesiredRX2DataRate;
+                    }
+                    else
+                    {
+                        Logger.Log(this.DevEUI, "the provided RX2DataRate is not valid", LogLevel.Error);
                     }
 
                     if (currentRegion.IsValidRXDelay(this.DesiredRXDelay))

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -12,8 +12,8 @@ variables:
 
   buildConfiguration: 'Release'
 
-  edgeAgentVersion: 1.0.9.5
-  edgeHubVersion: 1.0.9.5
+  edgeAgentVersion: 1.0.10
+  edgeHubVersion: 1.0.10
   edgeHubRoute: FROM /* INTO $upstream
 
   # Defines the name of the VSTS agent in ARM architecture
@@ -38,7 +38,7 @@ variables:
   NET_SRV_LOGTO_HUB: false
   NET_SRV_IOTEDGE_TIMEOUT: 0
   NET_SRV_VERSION: "" # Network Server module version
-  NET_SRV_LOG_TO_UDP_ADDRESS: 10.164.74.151 # Hostname of test runner
+  NET_SRV_LOG_TO_UDP_ADDRESS: $(LogsToUdpAdress) # Hostname of test runner
   PKT_FWD_VERSION: "" # Packet Forward module version
 
 # Enable PR validation on branches master and dev


### PR DESCRIPTION
* A bug was introduced in dev in #260 . Due to one device of the gateway being out use, this was not picked up until it was brought online again.
* This PR should also make the CI functional again
* This PR upgrade iot edge to 1.10
