### PR TITLE
Fix #293 #292

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
+++ b/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Docker.DotNet.X509" Version="3.125.2" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.31.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.33.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />

--- a/LoRaEngine/modules/LoRaSimulator/LoRaSimulator.csproj
+++ b/LoRaEngine/modules/LoRaSimulator/LoRaSimulator.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.31.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.37.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.csproj
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.31.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.37.1" />
   </ItemGroup>
 
   <!-- StyleCop Setup -->

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/LinkADRRequest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/LinkADRRequest.cs
@@ -5,6 +5,7 @@ namespace LoRaTools
 {
     using System;
     using System.Collections.Generic;
+    using LoRaTools.Mac;
     using LoRaTools.Utils;
     using Newtonsoft.Json;
 
@@ -85,12 +86,12 @@ namespace LoRaTools
                 }
                 else
                 {
-                    throw new Exception("LinkADRRequest C2D properties must be in String Integer style");
+                    throw new MacCommandException("LinkADRRequest C2D properties must be in String Integer style");
                 }
             }
             else
             {
-                throw new Exception("LinkADRRequest C2D must have have the following message properties set : datarate, txpower, chMask, chMaskCntl, nbTrans");
+                throw new MacCommandException("LinkADRRequest C2D must have have the following message properties set : datarate, txpower, chMask, chMaskCntl, nbTrans");
             }
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommand.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommand.cs
@@ -50,71 +50,71 @@ namespace LoRaTools
             int pointer = 0;
             var macCommands = new List<MacCommand>(3);
 
-            while (pointer < input.Length)
+            try
             {
-                try
+                while (pointer < input.Length)
                 {
-                    CidEnum cid = (CidEnum)input.Span[pointer];
-                    switch (cid)
-                    {
-                        case CidEnum.LinkCheckCmd:
-                            var linkCheck = new LinkCheckRequest();
-                            pointer += linkCheck.Length;
-                            macCommands.Add(linkCheck);
-                            break;
-                        case CidEnum.LinkADRCmd:
-                            var linkAdrAnswer = new LinkADRAnswer(input.Span.Slice(pointer));
-                            pointer += linkAdrAnswer.Length;
-                            macCommands.Add(linkAdrAnswer);
-                            break;
-                        case CidEnum.DutyCycleCmd:
-                            var dutyCycle = new DutyCycleAnswer();
-                            pointer += dutyCycle.Length;
-                            macCommands.Add(dutyCycle);
-                            break;
-                        case CidEnum.RXParamCmd:
-                            var rxParamSetup = new RXParamSetupAnswer(input.Span.Slice(pointer));
-                            pointer += rxParamSetup.Length;
-                            macCommands.Add(rxParamSetup);
-                            break;
-                        case CidEnum.DevStatusCmd:
-                            // Added this case to enable unit testing
-                            if (input.Length == 1)
-                            {
-                                var devStatusRequest = new DevStatusRequest();
-                                pointer += devStatusRequest.Length;
-                                macCommands.Add(devStatusRequest);
-                            }
-                            else
-                            {
-                                DevStatusAnswer devStatus = new DevStatusAnswer(input.Span.Slice(pointer));
-                                pointer += devStatus.Length;
-                                macCommands.Add(devStatus);
-                            }
+                        CidEnum cid = (CidEnum)input.Span[pointer];
+                        switch (cid)
+                        {
+                            case CidEnum.LinkCheckCmd:
+                                var linkCheck = new LinkCheckRequest();
+                                pointer += linkCheck.Length;
+                                macCommands.Add(linkCheck);
+                                break;
+                            case CidEnum.LinkADRCmd:
+                                var linkAdrAnswer = new LinkADRAnswer(input.Span.Slice(pointer));
+                                pointer += linkAdrAnswer.Length;
+                                macCommands.Add(linkAdrAnswer);
+                                break;
+                            case CidEnum.DutyCycleCmd:
+                                var dutyCycle = new DutyCycleAnswer();
+                                pointer += dutyCycle.Length;
+                                macCommands.Add(dutyCycle);
+                                break;
+                            case CidEnum.RXParamCmd:
+                                var rxParamSetup = new RXParamSetupAnswer(input.Span.Slice(pointer));
+                                pointer += rxParamSetup.Length;
+                                macCommands.Add(rxParamSetup);
+                                break;
+                            case CidEnum.DevStatusCmd:
+                                // Added this case to enable unit testing
+                                if (input.Length == 1)
+                                {
+                                    var devStatusRequest = new DevStatusRequest();
+                                    pointer += devStatusRequest.Length;
+                                    macCommands.Add(devStatusRequest);
+                                }
+                                else
+                                {
+                                    DevStatusAnswer devStatus = new DevStatusAnswer(input.Span.Slice(pointer));
+                                    pointer += devStatus.Length;
+                                    macCommands.Add(devStatus);
+                                }
 
-                            break;
-                        case CidEnum.NewChannelCmd:
-                            NewChannelAnswer newChannel = new NewChannelAnswer(input.Span.Slice(pointer));
-                            pointer += newChannel.Length;
-                            macCommands.Add(newChannel);
-                            break;
-                        case CidEnum.RXTimingCmd:
-                            RXTimingSetupAnswer rxTimingSetup = new RXTimingSetupAnswer();
-                            pointer += rxTimingSetup.Length;
-                            macCommands.Add(rxTimingSetup);
-                            break;
-                        default:
-                            Logger.Log(deviceId, $"a transmitted Mac Command value ${input.Span[pointer]} was not from a supported type. Aborting Mac Command processing", LogLevel.Error);
-                            return null;
-                    }
+                                break;
+                            case CidEnum.NewChannelCmd:
+                                NewChannelAnswer newChannel = new NewChannelAnswer(input.Span.Slice(pointer));
+                                pointer += newChannel.Length;
+                                macCommands.Add(newChannel);
+                                break;
+                            case CidEnum.RXTimingCmd:
+                                RXTimingSetupAnswer rxTimingSetup = new RXTimingSetupAnswer();
+                                pointer += rxTimingSetup.Length;
+                                macCommands.Add(rxTimingSetup);
+                                break;
+                            default:
+                                Logger.Log(deviceId, $"a transmitted Mac Command value ${input.Span[pointer]} was not from a supported type. Aborting Mac Command processing", LogLevel.Error);
+                                return null;
+                        }
 
                     MacCommand addedMacCommand = macCommands[macCommands.Count - 1];
                     Logger.Log(deviceId, $"{addedMacCommand.Cid} mac command detected in upstream payload: {addedMacCommand.ToString()}", LogLevel.Debug);
                 }
-                catch (MacCommandException ex)
-                {
-                    Logger.Log(deviceId, ex.ToString(), LogLevel.Error);
-                }
+            }
+            catch (MacCommandException ex)
+            {
+                Logger.Log(deviceId, ex.ToString(), LogLevel.Error);
             }
 
             return macCommands;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommand.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommand.cs
@@ -54,59 +54,59 @@ namespace LoRaTools
             {
                 while (pointer < input.Length)
                 {
-                        CidEnum cid = (CidEnum)input.Span[pointer];
-                        switch (cid)
-                        {
-                            case CidEnum.LinkCheckCmd:
-                                var linkCheck = new LinkCheckRequest();
-                                pointer += linkCheck.Length;
-                                macCommands.Add(linkCheck);
-                                break;
-                            case CidEnum.LinkADRCmd:
-                                var linkAdrAnswer = new LinkADRAnswer(input.Span.Slice(pointer));
-                                pointer += linkAdrAnswer.Length;
-                                macCommands.Add(linkAdrAnswer);
-                                break;
-                            case CidEnum.DutyCycleCmd:
-                                var dutyCycle = new DutyCycleAnswer();
-                                pointer += dutyCycle.Length;
-                                macCommands.Add(dutyCycle);
-                                break;
-                            case CidEnum.RXParamCmd:
-                                var rxParamSetup = new RXParamSetupAnswer(input.Span.Slice(pointer));
-                                pointer += rxParamSetup.Length;
-                                macCommands.Add(rxParamSetup);
-                                break;
-                            case CidEnum.DevStatusCmd:
-                                // Added this case to enable unit testing
-                                if (input.Length == 1)
-                                {
-                                    var devStatusRequest = new DevStatusRequest();
-                                    pointer += devStatusRequest.Length;
-                                    macCommands.Add(devStatusRequest);
-                                }
-                                else
-                                {
-                                    DevStatusAnswer devStatus = new DevStatusAnswer(input.Span.Slice(pointer));
-                                    pointer += devStatus.Length;
-                                    macCommands.Add(devStatus);
-                                }
+                    CidEnum cid = (CidEnum)input.Span[pointer];
+                    switch (cid)
+                    {
+                        case CidEnum.LinkCheckCmd:
+                            var linkCheck = new LinkCheckRequest();
+                            pointer += linkCheck.Length;
+                            macCommands.Add(linkCheck);
+                            break;
+                        case CidEnum.LinkADRCmd:
+                            var linkAdrAnswer = new LinkADRAnswer(input.Span.Slice(pointer));
+                            pointer += linkAdrAnswer.Length;
+                            macCommands.Add(linkAdrAnswer);
+                            break;
+                        case CidEnum.DutyCycleCmd:
+                            var dutyCycle = new DutyCycleAnswer();
+                            pointer += dutyCycle.Length;
+                            macCommands.Add(dutyCycle);
+                            break;
+                        case CidEnum.RXParamCmd:
+                            var rxParamSetup = new RXParamSetupAnswer(input.Span.Slice(pointer));
+                            pointer += rxParamSetup.Length;
+                            macCommands.Add(rxParamSetup);
+                            break;
+                        case CidEnum.DevStatusCmd:
+                            // Added this case to enable unit testing
+                            if (input.Length == 1)
+                            {
+                                var devStatusRequest = new DevStatusRequest();
+                                pointer += devStatusRequest.Length;
+                                macCommands.Add(devStatusRequest);
+                            }
+                            else
+                            {
+                                DevStatusAnswer devStatus = new DevStatusAnswer(input.Span.Slice(pointer));
+                                pointer += devStatus.Length;
+                                macCommands.Add(devStatus);
+                            }
 
-                                break;
-                            case CidEnum.NewChannelCmd:
-                                NewChannelAnswer newChannel = new NewChannelAnswer(input.Span.Slice(pointer));
-                                pointer += newChannel.Length;
-                                macCommands.Add(newChannel);
-                                break;
-                            case CidEnum.RXTimingCmd:
-                                RXTimingSetupAnswer rxTimingSetup = new RXTimingSetupAnswer();
-                                pointer += rxTimingSetup.Length;
-                                macCommands.Add(rxTimingSetup);
-                                break;
-                            default:
-                                Logger.Log(deviceId, $"a transmitted Mac Command value ${input.Span[pointer]} was not from a supported type. Aborting Mac Command processing", LogLevel.Error);
-                                return null;
-                        }
+                            break;
+                        case CidEnum.NewChannelCmd:
+                            NewChannelAnswer newChannel = new NewChannelAnswer(input.Span.Slice(pointer));
+                            pointer += newChannel.Length;
+                            macCommands.Add(newChannel);
+                            break;
+                        case CidEnum.RXTimingCmd:
+                            RXTimingSetupAnswer rxTimingSetup = new RXTimingSetupAnswer();
+                            pointer += rxTimingSetup.Length;
+                            macCommands.Add(rxTimingSetup);
+                            break;
+                        default:
+                            Logger.Log(deviceId, $"a transmitted Mac Command value ${input.Span[pointer]} was not from a supported type. Aborting Mac Command processing", LogLevel.Error);
+                            return null;
+                    }
 
                     MacCommand addedMacCommand = macCommands[macCommands.Count - 1];
                     Logger.Log(deviceId, $"{addedMacCommand.Cid} mac command detected in upstream payload: {addedMacCommand.ToString()}", LogLevel.Debug);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/RXParamSetupAnswer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/RXParamSetupAnswer.cs
@@ -5,6 +5,7 @@ namespace LoRaTools
 {
     using System;
     using System.Collections.Generic;
+    using LoRaTools.Mac;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -36,7 +37,7 @@ namespace LoRaTools
         {
             if (readOnlySpan.Length < this.Length)
             {
-                throw new Exception("RXParamSetupAnswer detected but the byte format is not correct");
+                throw new MacCommandException("RXParamSetupAnswer detected but the byte format is not correct");
             }
             else
             {

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaWan.IntegrationTest.csproj
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/LoRaWan.IntegrationTest.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.31.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.33.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.2.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.5" />

--- a/LoRaEngine/test/LoRaWan.Test.Shared/LoRaWan.Test.Shared.csproj
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/LoRaWan.Test.Shared.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Docker.DotNet" Version="3.125.2" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.31.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.33.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.2.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.5" />

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorSingleGatewayTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorSingleGatewayTest.cs
@@ -203,7 +203,7 @@ namespace LoRaWan.NetworkServer.Test
         }
 
         [Fact]
-        public void MAC_Should_work()
+        public void When_Faulty_MAC_Message_Is_Received_Processing_Abort_Without_Infinite_Loop()
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: this.ServerConfiguration.GatewayID));
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: 10);
@@ -236,7 +236,7 @@ namespace LoRaWan.NetworkServer.Test
                 null,
                 DateTime.Now);
 
-            Assert.Throws<MacCommandException>(() => messageProcessor.DispatchRequest(request));
+            messageProcessor.DispatchRequest(request);
         }
 
         [Fact]


### PR DESCRIPTION
Fix #293
- An invalid max message caused the gateway to enter the process loop, due to wrong exception handling, the processing was stuck in an infinite loop. Added test case with the poisonous message.
Fix #292
- The former device SDK caused the devices to disconnect after 24 hours. Upgrading to the latest version seems to have risolved the issue