### PR TITLE
Add report to tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       name: Check if deploy on local ci
       if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'fullci' ) != true 
       run: |
-        echo "::set-output name=stopfullci::true"
+        echo "::set-output name=StopFullCi::true"
 
     - name: Avoid concurrent run
       uses: softprops/turnstyle@v1
@@ -96,7 +96,7 @@ jobs:
       - env_var
     runs-on: ubuntu-latest
     environment: CI
-    if: needs.env_var.outputs.RunTestsOnly != 'true' && needs.env_var.outputs.stopfullci  != 'true'
+    if: needs.env_var.outputs.RunTestsOnly != 'true' && needs.env_var.outputs.StopFullCi  != 'true'
     name: Deploy this run on the CI environment
     steps:
     - run : echo "Deployment was authorized"
@@ -225,6 +225,7 @@ jobs:
           until `az iot edge deployment show-metric --deployment-id ${{ env.IOT_EDGE_DEPLOYMENT_ID }} --metric-id reportedSuccessfulCount --metric-type system --login '${{ secrets.IOTHUB_CONNECTION_STRING }}' | grep -q $DEVICE_ID`; do sleep 10 && echo wait; done
           
           # We add the 3 minutes sleep to let the container start up
+          # TODO We might want to revisit this once there are some options to check that the network server started.
           sleep 3m
 
 # Runs integration tests in dedicated agent, while having modules deployed into PI (arm32v7)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,8 +36,8 @@ jobs:
           if [ ${{ github.event_name }} == 'pull_request' ]; then
             echo "Checking if full ci run"
             labelNames=${{ github.event.pull_request.labels.*.name }}
-            echo labelNames[@]
-            if [[ " ${labelNames[@]} " == " fullci " ]]; then
+            echo "${labelNames[@]}"
+            if [[ " ${labelNames[@]} " =~ " fullci " ]]; then
               echo "::set-output name=fullci::true"
               echo "Full CI Run Detected"
               echo "Set up for standard run"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -224,7 +224,7 @@ jobs:
           az extension add --name azure-iot   
           until `az iot edge deployment show-metric --deployment-id ${{ env.IOT_EDGE_DEPLOYMENT_ID }} --metric-id reportedSuccessfulCount --metric-type system --login '${{ secrets.IOTHUB_CONNECTION_STRING }}' | grep -q $DEVICE_ID`; do sleep 10 && echo wait; done
           
-          // We add the 3 minutes sleep to let the container start up
+          # We add the 3 minutes sleep to let the container start up
           sleep 3m
 
 # Runs integration tests in dedicated agent, while having modules deployed into PI (arm32v7)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,7 @@ jobs:
       IntegrationTestsToRun: ${{ steps.set-integration-matrix.outputs.IntegrationTestsToRun }}
   
   build_and_test:
+  - needs: env_var
     name: Build and Test Solution
     runs-on: ubuntu-latest
     if: needs.env_var.outputs.RunTestsOnly != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,10 +38,10 @@ jobs:
             if [[ ${{ github.event.pull_request.labels.*.name }} == *"fullci"* ]]; then
               echo "::set-output name=fullci::true"
               echo "Full CI Run Detected"
+              echo "Set up for standard run"
+              echo "::set-output name=IntegrationTestsToRun::[\"SensorDecodingTest\",\"OTAAJoinTest\",\"ABPTest\",\"OTAATest\",\"MacTest\",\"ClassCTest\",\"C2DMessageTest\",\"MultiGatewayTest\"]" 
             fi
           fi
-          echo "Set up for standard run"
-          echo "::set-output name=IntegrationTestsToRun::[\"SensorDecodingTest\",\"OTAAJoinTest\",\"ABPTest\",\"OTAATest\",\"MacTest\",\"ClassCTest\",\"C2DMessageTest\",\"MultiGatewayTest\"]" 
         fi
 
     - name: Avoid concurrent run

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,6 @@ jobs:
         if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
           echo "Set up for workflow dispatch"  
           echo "::set-output name=IntegrationTestsToRun::${{ github.event.inputs.TestsToRun }}"
-        fi
         else
           echo "::set-output name=IntegrationTestsToRun::[\"SensorDecodingTest\",\"OTAAJoinTest\",\"ABPTest\",\"OTAATest\",\"MacTest\",\"ClassCTest\",\"C2DMessageTest\",\"MultiGatewayTest\"]" 
         fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,9 @@ jobs:
         else 
           if [ ${{ github.event_name }} == 'pull_request' ]; then
             echo "Checking if full ci run"
-            echo "  ${{ github.event.pull_request.labels.*.name[@] }} "
-            if [[ " ${{ github.event.pull_request.labels.*.name[@] }} " == " fullci " ]]; then
+            labelNames=${{ github.event.pull_request.labels.*.name }}
+            echo labelNames[@]
+            if [[ " ${labelNames[@]} " == " fullci " ]]; then
               echo "::set-output name=fullci::true"
               echo "Full CI Run Detected"
               echo "Set up for standard run"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,6 @@ jobs:
       IntegrationTestsToRun: ${{ steps.set-integration-matrix.outputs.IntegrationTestsToRun }}
   
   build_and_test:
-    needs: env_var
     name: Build and Test Solution
     runs-on: ubuntu-latest
     if: needs.env_var.outputs.RunTestsOnly != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -277,20 +277,10 @@ jobs:
     
     # Upload test results as artifact
     - uses: actions/upload-artifact@v1
-      if: contains(github.event.pull_request.labels.*.name, matrix.testsToRun ) != true 
+      if: success() || failure()
       with:
         name: ${{ matrix.testsToRun }}-results
         path: LoRaEngine/test/LoRaWan.IntegrationTest/TestResults
-
-    - uses: LouisBrunner/checks-action@v0.1.0
-      if: contains(github.event.pull_request.labels.*.name, matrix.testsToRun ) != true 
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        name: ${{ matrix.testsToRun }}
-        conclusion: ${{ job.status }}
-        # TODO can we enhance with some output?
-        # output: |
-        #   {"summary":${{ steps.integration_test.outputs.summary }} }
 
     - name: Add ${{ matrix.testsToRun }} Test Label
       uses: buildsville/add-remove-label@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,8 @@ jobs:
         else 
           if [ ${{ github.event_name }} == 'pull_request' ]; then
             echo "Checking if full ci run"
-            echo ${{ github.event.pull_request.labels.*.name }}
-            if [[ ${{ github.event.pull_request.labels.*.name }} == *"fullci"* ]]; then
+            echo "  ${{ github.event.pull_request.labels.*.name[@] }} "
+            if [[ " ${{ github.event.pull_request.labels.*.name[@] }} " == " fullci " ]]; then
               echo "::set-output name=fullci::true"
               echo "Full CI Run Detected"
               echo "Set up for standard run"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,6 +223,9 @@ jobs:
         run: |
           az extension add --name azure-iot   
           until `az iot edge deployment show-metric --deployment-id ${{ env.IOT_EDGE_DEPLOYMENT_ID }} --metric-id reportedSuccessfulCount --metric-type system --login '${{ secrets.IOTHUB_CONNECTION_STRING }}' | grep -q $DEVICE_ID`; do sleep 10 && echo wait; done
+          
+          // We add the 3 minutes sleep to let the container start up
+          sleep 3m
 
 # Runs integration tests in dedicated agent, while having modules deployed into PI (arm32v7)
   integration_test_ :

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,19 +32,16 @@ jobs:
         if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
           echo "Set up for workflow dispatch"  
           echo "::set-output name=IntegrationTestsToRun::${{ github.event.inputs.TestsToRun }}"
-        else 
-          if [ ${{ github.event_name }} == 'pull_request' ]; then
-            echo "Checking if full ci run"
-            labelNames=${{ github.event.pull_request.labels.*.name }}
-            echo "${labelNames[*]}"
-            if [[ " ${labelNames[*]} " =~ " fullci " ]]; then
-              echo "::set-output name=fullci::true"
-              echo "Full CI Run Detected"
-              echo "Set up for standard run"
-              echo "::set-output name=IntegrationTestsToRun::[\"SensorDecodingTest\",\"OTAAJoinTest\",\"ABPTest\",\"OTAATest\",\"MacTest\",\"ClassCTest\",\"C2DMessageTest\",\"MultiGatewayTest\"]" 
-            fi
-          fi
         fi
+        else
+          echo "::set-output name=IntegrationTestsToRun::[\"SensorDecodingTest\",\"OTAAJoinTest\",\"ABPTest\",\"OTAATest\",\"MacTest\",\"ClassCTest\",\"C2DMessageTest\",\"MultiGatewayTest\"]" 
+        fi
+
+    - id: check-if-run
+      name: Check if deploy on local ci
+      if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'fullci' ) != true 
+      run: |
+        echo "::set-output name=stopfullci::true"
 
     - name: Avoid concurrent run
       uses: softprops/turnstyle@v1
@@ -100,7 +97,7 @@ jobs:
       - env_var
     runs-on: ubuntu-latest
     environment: CI
-    if: needs.env_var.outputs.RunTestsOnly != 'true' && needs.env_var.outputs.fullci  == 'true'
+    if: needs.env_var.outputs.RunTestsOnly != 'true' && needs.env_var.outputs.stopfullci  != 'true'
     name: Deploy this run on the CI environment
     steps:
     - run : echo "Deployment was authorized"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
       IntegrationTestsToRun: ${{ steps.set-integration-matrix.outputs.IntegrationTestsToRun }}
   
   build_and_test:
-  - needs: env_var
+    needs: env_var
     name: Build and Test Solution
     runs-on: ubuntu-latest
     if: needs.env_var.outputs.RunTestsOnly != 'true'
@@ -88,8 +88,8 @@ jobs:
         path: LoRaEngine/test/TestResults
 
   check_if_deploy:
-  needs: 
-    - env_var
+    needs: 
+      - env_var
     runs-on: ubuntu-latest
     environment: CI
     if: needs.env_var.outputs.RunTestsOnly != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,8 +36,8 @@ jobs:
           if [ ${{ github.event_name }} == 'pull_request' ]; then
             echo "Checking if full ci run"
             labelNames=${{ github.event.pull_request.labels.*.name }}
-            echo "${labelNames[@]}"
-            if [[ " ${labelNames[@]} " =~ " fullci " ]]; then
+            echo "${labelNames[*]}"
+            if [[ " ${labelNames[*]} " =~ " fullci " ]]; then
               echo "::set-output name=fullci::true"
               echo "Full CI Run Detected"
               echo "Set up for standard run"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
         else 
           if [ ${{ github.event_name }} == 'pull_request' ]; then
             echo "Checking if full ci run"
+            echo ${{ github.event.pull_request.labels.*.name }}
             if [[ ${{ github.event.pull_request.labels.*.name }} == *"fullci"* ]]; then
               echo "::set-output name=fullci::true"
               echo "Full CI Run Detected"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,8 +33,15 @@ jobs:
           echo "Set up for workflow dispatch"  
           echo "::set-output name=IntegrationTestsToRun::${{ github.event.inputs.TestsToRun }}"
         else 
+          if [ ${{ github.event_name }} == 'pull_request' ]; then
+            echo "Checking if full ci run"
+            if [[ ${{ github.event.pull_request.labels.*.name }} == *"fullci"* ]]; then
+              echo "::set-output name=fullci::true"
+              echo "Full CI Run Detected"
+            fi
+          fi
           echo "Set up for standard run"
-          echo "::set-output name=IntegrationTestsToRun::[\"SensorDecodingTest\",\"OTAAJoinTest\",\"ABPTest\",\"OTAATest\",\"MacTest\",\"ClassCTest\",\"C2DMessageTest\",\"MultiGatewayTest\"]"
+          echo "::set-output name=IntegrationTestsToRun::[\"SensorDecodingTest\",\"OTAAJoinTest\",\"ABPTest\",\"OTAATest\",\"MacTest\",\"ClassCTest\",\"C2DMessageTest\",\"MultiGatewayTest\"]" 
         fi
 
     - name: Avoid concurrent run
@@ -91,7 +98,7 @@ jobs:
       - env_var
     runs-on: ubuntu-latest
     environment: CI
-    if: needs.env_var.outputs.RunTestsOnly != 'true'
+    if: needs.env_var.outputs.RunTestsOnly != 'true' && needs.env_var.outputs.fullci  == 'true'
     name: Deploy this run on the CI environment
     steps:
     - run : echo "Deployment was authorized"

--- a/.github/workflows/test_report.yaml
+++ b/.github/workflows/test_report.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: dorny/test-reporter@v1
       with:
-        artifact: unit-test-results            # artifact name
+        artifact: "*results"            # artifact name
         name: UnitTestResults                  # Name of the check run which will be created
         path: '*.trx'                     # Path to test results (inside artifact .zip)
         reporter: dotnet-trx            # Format of test results

--- a/.github/workflows/test_report.yaml
+++ b/.github/workflows/test_report.yaml
@@ -17,4 +17,3 @@ jobs:
         name: UnitTestResults
         path: '*.trx'
         reporter: dotnet-trx
-        fail-on-error: 'false'

--- a/.github/workflows/test_report.yaml
+++ b/.github/workflows/test_report.yaml
@@ -6,6 +6,8 @@ on:
       - completed
 jobs:
   report:
+    permissions:
+      checks: write 
     runs-on: ubuntu-latest
     steps:
     - uses: dorny/test-reporter@v1

--- a/.github/workflows/test_report.yaml
+++ b/.github/workflows/test_report.yaml
@@ -7,7 +7,8 @@ on:
 jobs:
   report:
     permissions:
-      checks: write 
+      checks: read/write 
+      pull requests: read/write 
     runs-on: ubuntu-latest
     steps:
     - uses: dorny/test-reporter@v1

--- a/.github/workflows/test_report.yaml
+++ b/.github/workflows/test_report.yaml
@@ -13,7 +13,8 @@ jobs:
     steps:
     - uses: dorny/test-reporter@v1
       with:
-        artifact: "*results"            # artifact name
-        name: UnitTestResults                  # Name of the check run which will be created
-        path: '*.trx'                     # Path to test results (inside artifact .zip)
-        reporter: dotnet-trx            # Format of test results
+        artifact: "*results"
+        name: UnitTestResults
+        path: '*.trx'
+        reporter: dotnet-trx
+        fail-on-error: 'false'


### PR DESCRIPTION
This PR aims at improving the CI experience:
* Add test reports ([example](https://github.com/Azure/iotedge-lorawan-starterkit/runs/3506902131)) using dorny/test-reporter@v1
* Prevent the deployment to the Edge and Integration Tests execution if the label FullCI is missing on the PR.
* Removed unnecessary calls to the check API
* Add a three minutes delay after deployment to the edge modules to ensure the Network server has the time to start