### PR TITLE
CI agent IP address is set on secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,7 +161,7 @@ jobs:
       NET_SRV_LOGTO_HUB: false
       NET_SRV_LOGTO_UDP: true
       NET_SRV_IOTEDGE_TIMEOUT: 0
-      NET_SRV_LOG_TO_UDP_ADDRESS: "192.168.1.22"
+      NET_SRV_LOG_TO_UDP_ADDRESS: ${{ secrets.LOG_TO_UDP_ADDRESS }}
       EDGEHUB_ROUTE: "FROM /* INTO $upstream"
       RESET_PIN: 7
       REGION: "EU"


### PR DESCRIPTION
Due to changes in network topology on where the CI is running, we need to update its IP address. In order to avoid PRs for every time this happens, I propose to use a secret. Downside is that we cannot see the current value.