### PR TITLE
Fix YAML in reporting github action

### DIFF
--- a/.github/workflows/test_report.yaml
+++ b/.github/workflows/test_report.yaml
@@ -7,8 +7,8 @@ on:
 jobs:
   report:
     permissions:
-      checks: read|write 
-      pull requests: read 
+      checks: write 
+      pull-requests: write 
     runs-on: ubuntu-latest
     steps:
     - uses: dorny/test-reporter@v1

--- a/Template/deviceConfiguration.json
+++ b/Template/deviceConfiguration.json
@@ -34,8 +34,8 @@
               "httpSettings__enabled": {
                 "value": "false"
               },
-              "TwinManagerVersion": {
-                "value": "v2"
+              "AuthenticationMode": {
+                "value": "CloudAndScope"
               }
 			},
 						"status": "running",


### PR DESCRIPTION
The Github Action setting the new test reports are invalid. This PR is correcting the syntax there based on [the docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions)