### PR TITLE
Fix the regexp for integration tests

### DIFF
--- a/.github/workflows/test_report.yaml
+++ b/.github/workflows/test_report.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: dorny/test-reporter@v1
       with:
-        artifact: "*results"
-        name: UnitTestResults
+        artifact: /(.*)results/
+        name: '$1 Test Results'
         path: '*.trx'
         reporter: dotnet-trx


### PR DESCRIPTION
The current regular expression does not apply to the Integration tests, preventing to have a summary on the fullci tests. This PR aims to include them