### PR TITLE
Fix dev experience

### DIFF
--- a/LoRaEngine/modules/LoRaWanPktFwdModule/Dockerfile.amd64
+++ b/LoRaEngine/modules/LoRaWanPktFwdModule/Dockerfile.amd64
@@ -1,6 +1,6 @@
 #This docker builds a container for the AAEON intel LoRaWaN gateway
 
-FROM microsoft/dotnet:2.0-runtime AS builder1
+FROM debian AS builder1
 RUN apt-get update
 RUN apt-get install -y git
 RUN apt-get install -y --no-install-recommends apt-utils build-essential
@@ -11,7 +11,7 @@ WORKDIR /packet_forwarder
 RUN ./compile.sh
 RUN cp /packet_forwarder/lora_pkt_fwd/lora_pkt_fwd /lora_pkt_fwd_spidev1
 
-FROM microsoft/dotnet:2.0-runtime AS builder2
+FROM debian AS builder2
 RUN apt-get update
 RUN apt-get install -y git
 RUN apt-get install -y --no-install-recommends apt-utils build-essential

--- a/LoRaEngine/modules/LoRaWanPktFwdModule/start_pktfwd.sh
+++ b/LoRaEngine/modules/LoRaWanPktFwdModule/start_pktfwd.sh
@@ -20,7 +20,7 @@ fi
 #get current architecture for the mess processor
 arch="$(uname -m)"
 if [[ $arch != *"arm"* ]]; then
-    if [ -z "$SPI_DEV" ]; then
+    if [ -z "$SPI_DEV" ] || [ "$SPI_DEV" == '$PKT_FWD_SPI_DEV' ]; then
         echo "No SPI Dev version detected in environment variables on x86, defaulting to SPI Dev 2" 
         ./lora_pkt_fwd_spidev2
     else
@@ -32,12 +32,13 @@ if [[ $arch != *"arm"* ]]; then
                 echo "Using SPI dev 1 from environment variables"
                 ./lora_pkt_fwd_spidev1
             else
+                echo "$SPI_DEV"
                 echo "SPI_DEV variables not valid in a x86 architecture. Please select a valid value (1 or 2)."
             fi
         fi
     fi
 else
-    if [[ -z "$SPI_SPEED" ]]; then
+    if [ -z "$SPI_SPEED" ] || [ "$SPI_SPEED" == '$PKT_FWD_SPI_SPEED' ]; then
         ./lora_pkt_fwd
     else
         if [ "$SPI_SPEED" == "2" ]; then

--- a/LoRaEngine/modules/LoRaWanPktFwdModule/start_pktfwd.sh
+++ b/LoRaEngine/modules/LoRaWanPktFwdModule/start_pktfwd.sh
@@ -21,7 +21,7 @@ fi
 arch="$(uname -m)"
 if [[ $arch != *"arm"* ]]; then
     if [ -z "$SPI_DEV" ] || [ "$SPI_DEV" == '$PKT_FWD_SPI_DEV' ]; then
-        echo "No SPI Dev version detected in environment variables on x86, defaulting to SPI Dev 2" 
+        echo "No custom SPI Dev version detected in environment variables on x86, defaulting to SPI Dev 2" 
         ./lora_pkt_fwd_spidev2
     else
         if [ "$SPI_DEV" == "2" ]; then
@@ -39,6 +39,7 @@ if [[ $arch != *"arm"* ]]; then
     fi
 else
     if [ -z "$SPI_SPEED" ] || [ "$SPI_SPEED" == '$PKT_FWD_SPI_SPEED' ]; then
+        echo "No custom SPI Speed detected in environment variables, defaulting to standard." 
         ./lora_pkt_fwd
     else
         if [ "$SPI_SPEED" == "2" ]; then


### PR DESCRIPTION
The current PR aims to fix the current VS Code dev experience. In cases where the variables SPI_DEV and SPI_SPEED are not set the packet forwarder will crash. 
Also, amd64 version of the packet forwarder is depending on dotnet images no longer available, updating to plain debian (image size does not matter as it is only a build image).