### PR TITLE
Fix link to LoRaWAN specification in read-me doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Azure IoT Edge LoRaWAN Starter Kit
 
-The LoRaWAN starter kit is an OSS cross platform private network implementation of the [LoRaWAN specification](https://lora-alliance.org/resource-hub/lorawantm-specification-v102) built for connectivity to Azure IoT Hub. It enables users to setup their own LoRaWAN network that can connect to LoRa based nodes (sensors) and send decoded message packets to Azure IoT Hub for cloud based processing, analytics and other workloads. Alternatively, it allows sending commands from the cloud to the end nodes. The goal of the the project is to provide guidance and a reference for Azure IoT Edge users to experiment with LoRaWAN technology.
+The LoRaWAN starter kit is an OSS cross platform private network implementation of the [LoRaWAN specification](https://lora-alliance.org/resource_hub/lorawan-specification-v1-0-2/) built for connectivity to Azure IoT Hub. It enables users to setup their own LoRaWAN network that can connect to LoRa based nodes (sensors) and send decoded message packets to Azure IoT Hub for cloud based processing, analytics and other workloads. Alternatively, it allows sending commands from the cloud to the end nodes. The goal of the the project is to provide guidance and a reference for Azure IoT Edge users to experiment with LoRaWAN technology.
 
 ![Architecture](/Docs/Pictures/EdgeArchitecture.png)
   


### PR DESCRIPTION
This PR fixes the link to the LoRaWAN specification in the read-me document that is [currently broken (404)](https://lora-alliance.org/resource-hub/lorawantm-specification-v102).