### PR TITLE
Add a custom start address to the packet forwarder

### DIFF
--- a/LoRaEngine/modules/LoRaWanPktFwdModule/start_pktfwd.sh
+++ b/LoRaEngine/modules/LoRaWanPktFwdModule/start_pktfwd.sh
@@ -15,6 +15,13 @@ else
     fi
 fi
 
+if [ ! -z "$NETWORK_SERVER" ]; then
+    echo "custom server address $NETWORK_SERVER was defined"
+    sed -i "s/172.17.0.1/$NETWORK_SERVER/g" /LoRa/local_conf.json 
+else
+  echo "No custom server address was defined"
+fi
+
 ./reset_lgw.sh start $RESET_PIN
 
 #get current architecture for the mess processor


### PR DESCRIPTION
Now using the Environment variable "NETWORK_SERVER" on the pkt_fwd enable to forward UDP frames to a network server at this location.
Closing #289
@MaggieSalak beware of the naming change to adapt to existing documentation