### PR TITLE
Add LoRa Basic Station

### DIFF
--- a/LoRaEngine/deployment.template.lbs.json
+++ b/LoRaEngine/deployment.template.lbs.json
@@ -1,0 +1,179 @@
+{
+    "modulesContent": {
+      "$edgeAgent": {
+        "properties.desired": {
+          "schemaVersion": "1.0",
+          "runtime": {
+            "type": "docker",
+            "settings": {
+              "minDockerVersion": "v1.25",
+              "loggingOptions": "",
+              "registryCredentials": {
+                "$CONTAINER_REGISTRY_USERNAME": {
+                  "username": "$CONTAINER_REGISTRY_USERNAME",
+                  "password": "$CONTAINER_REGISTRY_PASSWORD",
+                  "address": "$CONTAINER_REGISTRY_ADDRESS"
+                }
+              }
+            }
+          },
+          "systemModules": {
+            "edgeAgent": {
+              "type": "docker",
+              "settings": {
+                "image": "mcr.microsoft.com/azureiotedge-agent:1.2.2",
+                "createOptions": ""
+              }
+            },
+            "edgeHub": {
+              "type": "docker",
+              "status": "running",
+              "restartPolicy": "always",
+              "settings": {
+                "image": "mcr.microsoft.com/azureiotedge-hub:1.2.2",
+                "createOptions": {
+                  "HostConfig": {
+                    "PortBindings": {
+                      "8883/tcp": [
+                        {
+                          "HostPort": "8883"
+                        }
+                      ],
+                      "443/tcp": [
+                        {
+                          "HostPort": "443"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "env": {
+                "OptimizeForPerformance": {
+                  "value": "false"
+                },
+                "mqttSettings__enabled": {
+                  "value": "false"
+                },
+                "httpSettings__enabled": {
+                  "value": "false"
+                },
+                "AuthenticationMode": {
+                  "value": "CloudAndScope"
+                }
+              }
+            }
+          },
+          "modules": {          
+            "LoRaWanNetworkSrvModule": {
+              "type": "docker",
+              "settings": {
+                "image": "${MODULES.LoRaWanNetworkSrvModule}",
+                "createOptions": {
+                  "ExposedPorts": {
+                    "1680/udp": {}
+                  },
+                  "HostConfig": {
+                    "PortBindings": {
+                      "1680/udp": [
+                        {
+                          "HostPort": "1680",
+                          "HostIp": "172.17.0.1"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "version": "1.0",
+              "env": {
+                "ENABLE_GATEWAY": {
+                  "value": "false"
+                },
+                "LOG_LEVEL": {
+                  "value": "$NET_SRV_LOG_LEVEL"
+                },
+                "LOG_TO_HUB": {
+                  "value": "$NET_SRV_LOGTO_HUB"
+                },
+                "LOG_TO_UDP": {
+                  "value": "$NET_SRV_LOGTO_UDP"
+                },
+                "IOTEDGE_TIMEOUT": {
+                  "value": "$NET_SRV_IOTEDGE_TIMEOUT"
+                },
+                "LOG_TO_UDP_ADDRESS": {
+                  "value": "$NET_SRV_LOG_TO_UDP_ADDRESS"
+                },
+                "USE_BASIC_STATION": {
+                  "value": true
+                },
+                "REGION":{
+                  "value": "EU868"
+                }
+              },
+              "status": "running",
+              "restartPolicy": "always"
+            },
+            "LoRaWanBaseStation": {
+              "type": "docker",
+              "settings": {
+                "image": "${MODULES.LoRaBaseStationModule}",
+                "createOptions": {
+                  "HostConfig": {
+                    "NetworkMode": "host",
+                    "Privileged": true
+                  },
+                  "NetworkingConfig": {
+                    "EndpointsConfig": {
+                      "host": {}
+                    }
+                  }
+                }
+              },
+              "env": {
+                "REGION": {
+                  "value": "$REGION"
+                },
+                "SPI_DEV":{
+                  "value":"$LBS_SPI_DEV"
+                },
+                "SPI_SPEED":
+                {
+                 "value":"$LBS_SPI_SPEED"
+                },
+                "TC_URI":{
+                  "value": "$LBS_TC_URI"
+                },
+                "RESET_PIN":{
+                  "value": "$RESET_PIN"
+                }
+              },
+              "version": "1.0",
+              "status": "running",
+              "restartPolicy": "always"
+            }
+          }
+        }
+      },
+      "$edgeHub": {
+        "properties.desired": {
+          "schemaVersion": "1.0",
+          "routes": {
+            "route": "$EDGEHUB_ROUTE"
+          },
+          "storeAndForwardConfiguration": {
+            "timeToLiveSecs": 7200
+          }
+        }
+      },
+      "LoRaWanNetworkSrvModule": {
+        "properties.desired": {
+          "schemaVersion": "1.0",
+          "FacadeServerUrl": "$FACADE_SERVER_URL",
+          "FacadeAuthCode": "$FACADE_AUTH_CODE"
+        }
+      }
+    }
+  }
+  

--- a/LoRaEngine/example.env
+++ b/LoRaEngine/example.env
@@ -10,9 +10,6 @@ CONTAINER_REGISTRY_PASSWORD=yourpassword
 # Region
 REGION=EU
 
-# Reset pin (GPIO to reset Packet Forwarder Antenna)
-RESET_PIN=7
-
 ##################
 # edgeHub settings
 ##################
@@ -41,3 +38,13 @@ NET_SRV_LOG_TO_UDP_ADDRESS=AzureDevOpsAgent
 NET_SRV_IOTEDGE_TIMEOUT=0
 FACADE_SERVER_URL=https://your-function.azurewebsites.net/api/
 FACADE_AUTH_CODE=yourauthcode
+
+# Part for the Lora Base Station
+
+# Reset pin (GPIO to reset Packet Forwarder Antenna)
+RESET_PIN=7
+
+LBS_SPI_DEV=0
+# not yet implemented LBS_SPI_SPEED=2
+LBS_TC_URI=ws://192.168.0.10:5000
+LBS_VERSION=1.0.6

--- a/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.amd64
+++ b/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.amd64
@@ -4,7 +4,7 @@ FROM debian as build
 RUN apt-get update
 RUN apt-get install -y git
 RUN apt-get install -y --no-install-recommends apt-utils build-essential
-RUN git clone https://github.com/lorabasics/basicstation.git
+RUN git clone --branch v2.0.5 --single-branch --depth 1 https://github.com/lorabasics/basicstation.git
 WORKDIR /basicstation
 RUN make platform=linux variant=std
 

--- a/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.amd64
+++ b/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.amd64
@@ -1,0 +1,18 @@
+#This docker builds a container for the LoRa Base station
+
+FROM debian as build
+RUN apt-get update
+RUN apt-get install -y git
+RUN apt-get install -y --no-install-recommends apt-utils build-essential
+RUN git clone https://github.com/lorabasics/basicstation.git
+WORKDIR /basicstation
+RUN cd examples/live-s2.sm.tc && rm -rf cups*
+RUN make platform=linux variant=std
+
+FROM debian
+WORKDIR /bin
+COPY --from=build /basicstation/build-linux-std/bin/station /bin/station
+COPY start_basestation_amd64.sh .
+COPY station.conf .
+COPY --from=build /basicstation/deps/lgw/platform-linux/reset_lgw.sh .
+ENTRYPOINT ["./start_basestation_amd64.sh"]

--- a/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.amd64
+++ b/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.amd64
@@ -6,7 +6,6 @@ RUN apt-get install -y git
 RUN apt-get install -y --no-install-recommends apt-utils build-essential
 RUN git clone https://github.com/lorabasics/basicstation.git
 WORKDIR /basicstation
-RUN cd examples/live-s2.sm.tc && rm -rf cups*
 RUN make platform=linux variant=std
 
 FROM debian

--- a/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.arm32v7
@@ -6,7 +6,6 @@ RUN apt-get install -y git
 RUN apt-get install -y --no-install-recommends apt-utils build-essential
 RUN git clone https://github.com/lorabasics/basicstation.git
 WORKDIR /basicstation
-RUN cd examples/live-s2.sm.tc && rm -rf cups*
 
 # make standard version
 RUN make platform=rpi variant=std
@@ -20,7 +19,6 @@ WORKDIR /basicstation
 RUN make platform=rpi variant=std clean
 # make spi speed 2 version
 RUN sed -i "s|8000000|2000000|g" /basicstation/deps/lgw/platform-rpi/libloragw/src/loragw_spi.native.c
-RUN cd examples/live-s2.sm.tc && rm -rf cups*
 RUN make platform=rpi variant=std
 
 FROM base

--- a/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.arm32v7
@@ -1,0 +1,32 @@
+#This docker builds a container for the LoRa Base station
+
+FROM arm32v7/debian:stretch-slim as build
+RUN apt-get update
+RUN apt-get install -y git
+RUN apt-get install -y --no-install-recommends apt-utils build-essential
+RUN git clone https://github.com/lorabasics/basicstation.git
+WORKDIR /basicstation
+RUN cd examples/live-s2.sm.tc && rm -rf cups*
+
+# make standard version
+RUN make platform=rpi variant=std
+
+FROM arm32v7/debian:stretch-slim as base
+COPY --from=build /basicstation/build-rpi-std/bin/station /bin/station.std
+
+FROM build
+# #reset 
+RUN make platform=rpi variant=std deps s-clean s-all
+WORKDIR /basicstation
+# make spi speed 2 version
+RUN sed -i "s|8000000|2000000|g" /basicstation/deps/lgw/platform-rpi/libloragw/src/loragw_spi.native.c
+RUN cd examples/live-s2.sm.tc && rm -rf cups*
+RUN make platform=rpi variant=std
+
+FROM base
+WORKDIR /bin
+COPY --from=build /basicstation/deps/lgw/platform-rpi/reset_lgw.sh .
+COPY --from=build /basicstation/build-rpi-std/bin/station /bin/station.spispeed2
+COPY station.conf .
+COPY start_basestation_arm.sh .
+ENTRYPOINT ["./start_basestation_arm.sh"]

--- a/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.arm32v7
@@ -16,17 +16,17 @@ COPY --from=build /basicstation/build-rpi-std/bin/station /bin/station.std
 
 FROM build
 # #reset 
-RUN make platform=rpi variant=std deps s-clean s-all
 WORKDIR /basicstation
+RUN make platform=rpi variant=std clean
 # make spi speed 2 version
 RUN sed -i "s|8000000|2000000|g" /basicstation/deps/lgw/platform-rpi/libloragw/src/loragw_spi.native.c
 RUN cd examples/live-s2.sm.tc && rm -rf cups*
-RUN make platform=rpi variant=std
+# RUN make platform=rpi variant=std
 
-FROM base
-WORKDIR /bin
-COPY --from=build /basicstation/deps/lgw/platform-rpi/reset_lgw.sh .
-COPY --from=build /basicstation/build-rpi-std/bin/station /bin/station.spispeed2
-COPY station.conf .
-COPY start_basestation_arm.sh .
-ENTRYPOINT ["./start_basestation_arm.sh"]
+# FROM base
+# WORKDIR /bin
+# COPY --from=build /basicstation/deps/lgw/platform-rpi/reset_lgw.sh .
+# COPY --from=build /basicstation/build-rpi-std/bin/station /bin/station.spispeed2
+# COPY station.conf .
+# COPY start_basestation_arm.sh .
+# ENTRYPOINT ["./start_basestation_arm.sh"]

--- a/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.arm32v7
@@ -4,7 +4,7 @@ FROM arm32v7/debian:stretch-slim as build
 RUN apt-get update
 RUN apt-get install -y git
 RUN apt-get install -y --no-install-recommends apt-utils build-essential
-RUN git clone https://github.com/lorabasics/basicstation.git
+RUN git clone --branch v2.0.5 --single-branch --depth 1 https://github.com/lorabasics/basicstation.git
 WORKDIR /basicstation
 
 # make standard version

--- a/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/LoRaBaseStationModule/Dockerfile.arm32v7
@@ -14,19 +14,19 @@ RUN make platform=rpi variant=std
 FROM arm32v7/debian:stretch-slim as base
 COPY --from=build /basicstation/build-rpi-std/bin/station /bin/station.std
 
-FROM build
+FROM build as build2
 # #reset 
 WORKDIR /basicstation
 RUN make platform=rpi variant=std clean
 # make spi speed 2 version
 RUN sed -i "s|8000000|2000000|g" /basicstation/deps/lgw/platform-rpi/libloragw/src/loragw_spi.native.c
 RUN cd examples/live-s2.sm.tc && rm -rf cups*
-# RUN make platform=rpi variant=std
+RUN make platform=rpi variant=std
 
-# FROM base
-# WORKDIR /bin
-# COPY --from=build /basicstation/deps/lgw/platform-rpi/reset_lgw.sh .
-# COPY --from=build /basicstation/build-rpi-std/bin/station /bin/station.spispeed2
-# COPY station.conf .
-# COPY start_basestation_arm.sh .
-# ENTRYPOINT ["./start_basestation_arm.sh"]
+FROM base
+WORKDIR /bin
+COPY --from=build /basicstation/deps/lgw/platform-rpi/reset_lgw.sh .
+COPY --from=build2 /basicstation/build-rpi-std/bin/station /bin/station.spispeed2
+COPY station.conf .
+COPY start_basestation_arm.sh .
+ENTRYPOINT ["./start_basestation_arm.sh"]

--- a/LoRaEngine/modules/LoRaBaseStationModule/module.json
+++ b/LoRaEngine/modules/LoRaBaseStationModule/module.json
@@ -1,0 +1,17 @@
+{
+  "$schema-version": "0.0.1",
+  "description": "",
+  "image": {
+    "repository": "$CONTAINER_REGISTRY_ADDRESS/lorawanbasestation",
+    "tag": {
+      "version": "$LBS_VERSION",
+      "platforms": {
+        "amd64": "./Dockerfile.amd64",
+        "arm32v7": "./Dockerfile.arm32v7"
+      }
+    },
+    "buildOptions": [],
+    "contextPath": "./"
+  },
+  "language": "csharp"
+}

--- a/LoRaEngine/modules/LoRaBaseStationModule/start_basestation_amd64.sh
+++ b/LoRaEngine/modules/LoRaBaseStationModule/start_basestation_amd64.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [[ -z "$RESET_PIN" ]]; then
+    echo "No RESET_PIN environment variable set, skipping the pin reset. If you experience problem with starting the concentrator please set this variable to your manufacturer reset pin"
+else
+    echo "Resetting the pin"
+    ./reset_lgw.sh stop $RESET_PIN
+    ./reset_lgw.sh start $RESET_PIN
+    echo "Finished resetting the pin"
+fi
+
+if [[ -z "$TC_URI" ]]; then
+    echo "No TC_URI detected in environment variables."
+else
+    echo "TC_URI is set to: $TC_URI"
+    touch tc.uri && echo "$TC_URI" > tc.uri
+
+    #start basestation
+    echo "Starting base station..."
+    RADIODEV=/dev/spidev$SPI_DEV.0 ./station -f
+fi

--- a/LoRaEngine/modules/LoRaBaseStationModule/start_basestation_amd64.sh
+++ b/LoRaEngine/modules/LoRaBaseStationModule/start_basestation_amd64.sh
@@ -9,6 +9,12 @@ else
     echo "Finished resetting the pin"
 fi
 
+
+if [[ -z "$SPI_DEV" ]] || [[ $SPI_DEV == '$LBS_SPI_DEV' ]]; then
+    echo "No custom SPI dev set up, defaulting to spi dev 0"
+    SPI_DEV = 0
+fi
+
 if [[ -z "$TC_URI" ]]; then
     echo "No TC_URI detected in environment variables."
 else

--- a/LoRaEngine/modules/LoRaBaseStationModule/start_basestation_arm.sh
+++ b/LoRaEngine/modules/LoRaBaseStationModule/start_basestation_arm.sh
@@ -9,6 +9,11 @@ else
     echo "Finished resetting the pin"
 fi
 
+if [[ -z "$SPI_DEV" ]] || [[ $SPI_DEV == '$LBS_SPI_DEV' ]]; then
+    echo "No custom SPI dev set up, defaulting to spi dev 0"
+    SPI_DEV = 0
+fi
+
 #Generate tc.uri file
 if [[ -z "$TC_URI" ]]; then
     echo "No TC_URI detected in environment variables."
@@ -18,7 +23,7 @@ else
 
     #start basestation
     echo "Starting base station..."
-    if [[ -z "$SPI_SPEED" ]]; then
+    if [[ -z "$SPI_SPEED"  ]] || [[ "$SPI_SPEED" == '$LBS_SPI_SPEED' ]]; then
         echo "No SPI Speed found defaulting to 8mbps"
         RADIODEV=/dev/spidev$SPI_DEV.0 /bin/station.std -f
     else 

--- a/LoRaEngine/modules/LoRaBaseStationModule/start_basestation_arm.sh
+++ b/LoRaEngine/modules/LoRaBaseStationModule/start_basestation_arm.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+if [[ -z "$RESET_PIN" ]]; then
+    echo "No RESET_PIN environment variable set, skipping the pin reset. If you experience problem with starting the concentrator please set this variable to your manufacturer reset pin"
+else
+    echo "Resetting the pin"
+    ./reset_lgw.sh stop $RESET_PIN
+    ./reset_lgw.sh start $RESET_PIN
+    echo "Finished resetting the pin"
+fi
+
+#Generate tc.uri file
+if [[ -z "$TC_URI" ]]; then
+    echo "No TC_URI detected in environment variables."
+else
+    echo "TC_URI is set to: $TC_URI"
+    touch tc.uri && echo "$TC_URI" > tc.uri
+
+    #start basestation
+    echo "Starting base station..."
+    if [[ -z "$SPI_SPEED" ]]; then
+        echo "No SPI Speed found defaulting to 8mbps"
+        RADIODEV=/dev/spidev$SPI_DEV.0 /bin/station.std -f
+    else 
+        if [ "$SPI_SPEED" == "2" ]; then
+            echo "Spi speed set to 2 mbps"
+            RADIODEV=/dev/spidev$SPI_DEV.0 /bin/station.spispeed2 -f
+        else 
+            if [ "$SPI_SPEED" == "8" ]; then
+                echo "Spi speed set to 8 mbps"
+                RADIODEV=/dev/spidev$SPI_DEV.0 /bin/station.std -f
+            else
+                echo "The value $SPI_SPEED is not supported as custom value. Supported values are 2 or 8"
+                exit 1;
+            fi
+        fi
+    fi
+fi

--- a/LoRaEngine/modules/LoRaBaseStationModule/station.conf
+++ b/LoRaEngine/modules/LoRaBaseStationModule/station.conf
@@ -1,0 +1,29 @@
+{
+    /* If slave-X.conf present this acts as default settings */
+    "SX1301_conf": {                 /* Actual channel plan is controlled by server */
+        "lorawan_public": true,      /* is default */
+        "clksrc": 1,                 /* radio_1 provides clock to concentrator */
+        /* path to the SPI device, un-comment if not specified on the command line e.g., RADIODEV=/dev/spidev0.0 */
+        /*"device": "/dev/spidev0.0",*/
+        /* freq/enable provided by LNS - only HW specific settings listed here */
+        "radio_0": {
+            "type": "SX1257",
+            "rssi_offset": -166.0,
+            "tx_enable": true,
+            "antenna_gain": 0
+        },
+        "radio_1": {
+            "type": "SX1257",
+            "rssi_offset": -166.0,
+            "tx_enable": false
+        }
+        /* chan_multiSF_X, chan_Lora_std, chan_FSK provided by LNS */
+    },
+    "station_conf": {
+        "log_file":  "stderr",
+        "log_level": "DEBUG",  /* XDEBUG,DEBUG,VERBOSE,INFO,NOTICE,WARNING,ERROR,CRITICAL */
+        "log_size":  10000000,
+        "log_rotate":  3,
+        "CUPS_RESYNC_INTV": "1s"
+    }
+}


### PR DESCRIPTION
# PR for issue #374 

## What is being addressed

**This PR is in draft now**
This PR aims at merging the bits we used for the basic station docker container into the standard dev and make it default.
This PR shall go in only after 1.0.7, not by replacing template.json as it will break E2E tests.

## How is this addressed

By providing new dockerfiles and edge modules.