### PR TITLE
Add Path filter to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,10 @@ on: # rebuild any PRs and main branch changes
     branches:
       - master
       - dev
+    paths-ignore:
+      - 'Docs/**'
+      - 'Arduino/**'
+      - 'Samples/**'
   push:
     branches:
       - master

--- a/.github/workflows/universal_decoder_ci.yaml
+++ b/.github/workflows/universal_decoder_ci.yaml
@@ -1,5 +1,11 @@
 name: Universal Decoder CI
 on: 
+  pr:
+    branches:
+      - master
+      - dev
+    paths:
+      - 'Samples/UniversalDecoder/**'
   push:
     branches:
       - master


### PR DESCRIPTION
# Fix the CI paths

Now the LoRa Ci is triggered to any change on the repo. Sometimes unnecessarily. In addition, Dependabot generate PR on the Javascript Universal decoder, where it'd be more useful to run the universal decoder CI. This CI is setting paths to run one CI or the other dependaing on changed file
