### PR TITLE
Pin .NET Core SDK to 3.1.4xx

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,11 +62,11 @@ jobs:
       - env_var
     if: needs.env_var.outputs.RunTestsOnly != 'true'
     steps:
-    - name: .NET (Core) SDK Information
-      run: dotnet --info
-
     - uses: actions/checkout@v2
       name: Checkout current branch
+
+    - name: .NET (Core) SDK Information
+      run: dotnet --info
 
     # build LoRa Engine
     - name: Build LoRa Engine

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,9 @@ jobs:
       - env_var
     if: needs.env_var.outputs.RunTestsOnly != 'true'
     steps:
+    - name: .NET (Core) SDK Information
+      run: dotnet --info
+
     - uses: actions/checkout@v2
       name: Checkout current branch
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.400",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## What is being addressed

The same build tools and SDK is used on the developer's machine as well as the CI.

## How is this addressed

The SDK used (3.1) is pinned via [`global.json`](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x). During CI builds, `dotnet --info` is executed to list the installed SDKs and runtimes as well as get a confirmation of the SDK being actually used.