### PR TITLE
Remove invalid `mkdir` command in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,6 @@ jobs:
     # Run unit tests
     - name: Run unit tests
       run: |
-        mkdir $(Build.SourcesDirectory)\results
         dotnet test --logger trx LoRaEngine/test/LoRaWanNetworkServer.Test/*.csproj -r LoRaEngine/test/TestResults/  &&  dotnet test --logger trx LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/*.csproj -r LoRaEngine/test/TestResults/ && dotnet test --logger trx LoRaEngine/test/LoraKeysManagerFacade.Test/*.csproj -r LoRaEngine/test/TestResults/
       
     # Upload test results as artifact


### PR DESCRIPTION
## What is being addressed

The invalid `mkdir` command identified and described in issue #427.

## How is this addressed

The command has been completely removed by this PR as it was invalid and serving no purpose.
