### PR TITLE
Fix CI to test same configuration as being built

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,9 @@ jobs:
     # Run unit tests
     - name: Run unit tests
       run: |
-        dotnet test --logger trx LoRaEngine/test/LoRaWanNetworkServer.Test/*.csproj -r LoRaEngine/test/TestResults/  &&  dotnet test --logger trx LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/*.csproj -r LoRaEngine/test/TestResults/ && dotnet test --logger trx LoRaEngine/test/LoraKeysManagerFacade.Test/*.csproj -r LoRaEngine/test/TestResults/
+        dotnet test --configuration ${{ env.buildConfiguration }} --logger trx LoRaEngine/test/LoRaWanNetworkServer.Test/*.csproj -r LoRaEngine/test/TestResults/
+        dotnet test --configuration ${{ env.buildConfiguration }} --logger trx LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/*.csproj -r LoRaEngine/test/TestResults/
+        dotnet test --configuration ${{ env.buildConfiguration }} --logger trx LoRaEngine/test/LoraKeysManagerFacade.Test/*.csproj -r LoRaEngine/test/TestResults/
       
     # Upload test results as artifact
     - uses: actions/upload-artifact@v1


### PR DESCRIPTION
## What is being addressed

The unit test step in the CI workflow did not test the same configuration as [the one being built (release)](https://github.com/Azure/iotedge-lorawan-starterkit/blob/b34f8014100051c1a6a224ccead9ca856c7d640f/.github/workflows/ci.yaml#L21). For example, if the build step was building the release configuration:

https://github.com/Azure/iotedge-lorawan-starterkit/blob/b34f8014100051c1a6a224ccead9ca856c7d640f/.github/workflows/ci.yaml#L71-L73

the test step would _re-build_ the debug configuration before testing:

https://github.com/Azure/iotedge-lorawan-starterkit/blob/b34f8014100051c1a6a224ccead9ca856c7d640f/.github/workflows/ci.yaml#L87-L90

That's because the `--configuration` switch missing and the default configuration for `dotnet test` in debug.

## How is this addressed

Add the missing `--configuration` switch to `dotnet test` and passed the value of `buildConfiguration`.

---
PS I also put each `dotnet test` invocation on its line for readability since it would have the same effect as logically and-ing them with `&&`.
