### PR TITLE
Report code coverage via unit tests to Codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,8 +91,7 @@ jobs:
     # Run unit tests
     - name: Run unit tests
       run: |
-        dotnet test --configuration ${{ env.buildConfiguration }} --logger trx -r \
-          LoRaEngine/test/TestResults \
+        dotnet test --configuration ${{ env.buildConfiguration }} --logger trx -r LoRaEngine/test/TestResults \
           /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura \
           --filter 'FullyQualifiedName~LoRaWanTest|FullyQualifiedName~LoRaWan.NetworkServer.Test|FullyQualifiedName~LoraKeysManagerFacade.Test' \
           LoRaEngine

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
         dotnet test --configuration ${{ env.buildConfiguration }} --logger trx -r \
           LoRaEngine/test/TestResults \
           /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura \
-          --filter 'FullyQualifiedName~LoRaWanTest|FullyQualifiedName~LoRaWan.NetworkServer.Test|FullyQualifiedName~LoraKeysManagerFacade.Test)' \
+          --filter 'FullyQualifiedName~LoRaWanTest|FullyQualifiedName~LoRaWan.NetworkServer.Test|FullyQualifiedName~LoraKeysManagerFacade.Test' \
           LoRaEngine
       
     # Upload test results as artifact

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,11 @@ jobs:
     # Run unit tests
     - name: Run unit tests
       run: |
-        dotnet test --logger trx LoRaEngine/test/LoRaWanNetworkServer.Test/*.csproj -r LoRaEngine/test/TestResults/  &&  dotnet test --logger trx LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/*.csproj -r LoRaEngine/test/TestResults/ && dotnet test --logger trx LoRaEngine/test/LoraKeysManagerFacade.Test/*.csproj -r LoRaEngine/test/TestResults/
+        dotnet test --configuration ${{ env.buildConfiguration }} --logger trx -r \
+          LoRaEngine/test/TestResults \
+          /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura \
+          --filter 'FullyQualifiedName~LoRaWanTest|FullyQualifiedName~LoRaWan.NetworkServer.Test|FullyQualifiedName~LoraKeysManagerFacade.Test)' \
+          LoRaEngine
       
     # Upload test results as artifact
     - uses: actions/upload-artifact@v1
@@ -99,6 +103,12 @@ jobs:
       with:
         name: unit-test-results
         path: LoRaEngine/test/TestResults
+
+    - name: Upload to Codecov
+      run: |
+        curl -OsSL https://uploader.codecov.io/v0.1.0_4653/linux/codecov
+        chmod +x codecov
+        ./codecov
 
   check_if_deploy:
     needs: 

--- a/LoRaEngine/test/LoRaWan.Test.Shared/LoRaWan.Test.Shared.csproj
+++ b/LoRaEngine/test/LoRaWan.Test.Shared/LoRaWan.Test.Shared.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LoRaEngine/test/XunitRetryHelper/XunitRetryHelper.csproj
+++ b/LoRaEngine/test/XunitRetryHelper/XunitRetryHelper.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# PR for story #366

## What is being addressed

Code coverage reporting via [Codecov](https://about.codecov.io/).

## How is this addressed

The code coverage results from running the unit tests is uploaded to [codecov.io](https://about.codecov.io/) using Codecov's supplied loader.