### PR TITLE
Run the Markdown linter on dev

### DIFF
--- a/.github/workflows/md-linter.yaml
+++ b/.github/workflows/md-linter.yaml
@@ -7,7 +7,9 @@ on:
     paths: 
       - '**.md'
       - '**.markdown'
-
+  push:
+    branches:
+      - dev
 jobs:
   lint-markdown:    
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Run the MD linter on dev

The markdown linter is not executed on merge to dev, therefore the status badge is gray and never report success
![image](https://user-images.githubusercontent.com/8555833/135578763-7a9f5a6c-a68a-4ec7-b4ab-0edf36762870.png)

## How is this addressed

Run the CI on push to dev