### PR TITLE
Update to use .NET 5 SDK

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout current branch
 
-    - name: .NET (Core) SDK Information
+    - name: .NET SDK Information
       run: dotnet --info
 
     # build LoRa Engine

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.400",
+    "version": "5.0.400",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## What is being addressed

Upgrade of .NET SDK version to 5.

## How is this addressed

Pinning to version 5 in `global.json`.

Note that the target runtime still remains 3.1.
