### PR TITLE
Allow identifiers in test projects to use underscores; suppress CA1707

### DIFF
--- a/LoRaEngine/LoRaEngine.sln
+++ b/LoRaEngine/LoRaEngine.sln
@@ -18,6 +18,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LoRaWan.IntegrationTest", "test\LoRaWan.IntegrationTest\LoRaWan.IntegrationTest.csproj", "{26DF2637-43E0-4FFF-92BD-F4395C88DD50}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A3AF6806-947C-426F-8063-7229B71A4472}"
+	ProjectSection(SolutionItems) = preProject
+		test\.editorconfig = test\.editorconfig
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LoRaWanNetworkServer.Test", "test\LoRaWanNetworkServer.Test\LoRaWanNetworkServer.Test.csproj", "{D65BF8E2-DB42-4EA9-8A5E-CD7E671C4305}"
 EndProject

--- a/LoRaEngine/test/.editorconfig
+++ b/LoRaEngine/test/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# CA1707: Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = none


### PR DESCRIPTION
# PR for issue #436

## What is being addressed

[CA1707] violation in test projects because test method names use underscore for clarity.

[CA1707]: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1707

## How is this addressed

Suppression of the rule via a new `.editorconfig` that applies to all test projects.

---
This removes 945 warnings (of total 1,547 at the moment of commit).

