### PR TITLE
Fix typo in `NetworkServerConfiguration` factory name

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -113,7 +113,7 @@ namespace LoRaWan.NetworkServer
         }
 
         // Creates a new instance of NetworkServerConfiguration by reading values from environment variables
-        public static NetworkServerConfiguration CreateFromEnviromentVariables()
+        public static NetworkServerConfiguration CreateFromEnvironmentVariables()
         {
             var config = new NetworkServerConfiguration();
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
@@ -59,7 +59,7 @@ namespace LoRaWan.NetworkServer
         // Creates a new instance of UdpServer
         public static UdpServer Create()
         {
-            var configuration = NetworkServerConfiguration.CreateFromEnviromentVariables();
+            var configuration = NetworkServerConfiguration.CreateFromEnvironmentVariables();
 
             var loRaDeviceAPIService = new LoRaDeviceAPIService(configuration, new ServiceFacadeHttpClientProvider(configuration, ApiVersion.LatestVersion));
             var frameCounterStrategyProvider = new LoRaDeviceFrameCounterUpdateStrategyProvider(configuration.GatewayID, loRaDeviceAPIService);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/ConfigurationTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/ConfigurationTest.cs
@@ -15,7 +15,7 @@ namespace LoRaWan.NetworkServer.Test
         public void Should_Setup_Allowed_Dev_Addresses_Correctly(string inputAllowedDevAddrValues, HashSet<string> expectedAllowedDevAddrValues)
         {
             Environment.SetEnvironmentVariable("AllowedDevAddresses", inputAllowedDevAddrValues);
-            NetworkServerConfiguration networkServerConfiguration = NetworkServerConfiguration.CreateFromEnviromentVariables();
+            NetworkServerConfiguration networkServerConfiguration = NetworkServerConfiguration.CreateFromEnvironmentVariables();
             Assert.Equal(expectedAllowedDevAddrValues.Count, networkServerConfiguration.AllowedDevAddresses.Count);
             foreach (string devAddr in expectedAllowedDevAddrValues)
             {


### PR DESCRIPTION
# PR for issue #450

## What is being addressed

Typo in the name of the factory method for `NetworkServerConfiguration`.

## How is this addressed

Typo has been fixed.
