### PR TITLE
Remove redundant default constructors

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessageResult.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessageResult.cs
@@ -10,10 +10,6 @@ namespace LoraKeysManagerFacade
     /// </summary>
     public class SendCloudToDeviceMessageResult
     {
-        public SendCloudToDeviceMessageResult()
-        {
-        }
-
         /// <summary>
         /// Gets or sets the device identifier.
         /// </summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FunctionBundler/PreferredGatewayResult.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FunctionBundler/PreferredGatewayResult.cs
@@ -32,10 +32,6 @@ namespace LoRaWan.NetworkServer
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string ErrorMessage { get; set; }
 
-        public PreferredGatewayResult()
-        {
-        }
-
         /// <summary>
         /// Indicates if the preferred gateway resolution was executed successfully.
         /// </summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -107,11 +107,6 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         public HashSet<string> AllowedDevAddresses { get; internal set; }
 
-        // Creates a new instance of NetworkServerConfiguration
-        public NetworkServerConfiguration()
-        {
-        }
-
         // Creates a new instance of NetworkServerConfiguration by reading values from environment variables
         public static NetworkServerConfiguration CreateFromEnviromentVariables()
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/SingleGatewayFrameCounterUpdateStrategy.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/SingleGatewayFrameCounterUpdateStrategy.cs
@@ -7,10 +7,6 @@ namespace LoRaWan.NetworkServer
 
     public class SingleGatewayFrameCounterUpdateStrategy : ILoRaDeviceFrameCounterUpdateStrategy, ILoRaDeviceInitializer
     {
-        public SingleGatewayFrameCounterUpdateStrategy()
-        {
-        }
-
         public async Task<bool> ResetAsync(LoRaDevice loRaDevice, uint fcntUp, string gatewayId)
         {
             loRaDevice.ResetFcnt();

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/E2E_KeepAliveConnection_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/E2E_KeepAliveConnection_Tests.cs
@@ -32,10 +32,6 @@ namespace LoRaWan.NetworkServer.Test
             }
         }
 
-        public E2E_KeepAliveConnection_Tests()
-        {
-        }
-
         private async Task EnsureDisconnectedAsync(SemaphoreSlim disconnectedEvent, int? timeout = null)
         {
             var actualTimeout = timeout ?? this.MaxWaitForDeviceConnectionInMs;

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorJoinTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorJoinTest.cs
@@ -18,10 +18,6 @@ namespace LoRaWan.NetworkServer.Test
 
     public class MessageProcessorJoinTest : MessageProcessorTestBase
     {
-        public MessageProcessorJoinTest()
-        {
-        }
-
         [Fact]
         public async Task When_Device_Is_Not_Found_In_Api_Should_Return_Null()
         {

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorSingleGatewayTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorSingleGatewayTest.cs
@@ -22,10 +22,6 @@ namespace LoRaWan.NetworkServer.Test
     /// </summary>
     public class MessageProcessorSingleGatewayTest : MessageProcessorTestBase
     {
-        public MessageProcessorSingleGatewayTest()
-        {
-        }
-
         [Theory]
         [InlineData(0)]
         [InlineData(2100)]

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_ClassC_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_ClassC_Tests.cs
@@ -23,10 +23,6 @@ namespace LoRaWan.NetworkServer.Test
     // Class C device tests
     public class MessageProcessor_End2End_NoDep_ClassC_Tests : MessageProcessorTestBase
     {
-        public MessageProcessor_End2End_NoDep_ClassC_Tests()
-        {
-        }
-
         [Theory]
         [InlineData(null, 0U, 0U)]
         [InlineData(null, 0U, 9U)]

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
@@ -24,10 +24,6 @@ namespace LoRaWan.NetworkServer.Test
     // Cloud to device message processing tests (Join tests are handled in other class)
     public class MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests : MessageProcessorTestBase
     {
-        public MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests()
-        {
-        }
-
         [Theory]
         [InlineData(ServerGatewayID)]
         [InlineData(null)]

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Decoder_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Decoder_Tests.cs
@@ -19,10 +19,6 @@ namespace LoRaWan.NetworkServer.Test
     // Decoder tests tests
     public class MessageProcessor_End2End_NoDep_Decoder_Tests : MessageProcessorTestBase
     {
-        public MessageProcessor_End2End_NoDep_Decoder_Tests()
-        {
-        }
-
         /// <summary>
         /// SensorDecoder: none
         /// Payload: multiple

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Tests.cs
@@ -20,10 +20,6 @@ namespace LoRaWan.NetworkServer.Test
     // Only join tests
     public class MessageProcessor_End2End_NoDep_Join_Tests : MessageProcessorTestBase
     {
-        public MessageProcessor_End2End_NoDep_Join_Tests()
-        {
-        }
-
         [Theory]
         [InlineData(ServerGatewayID, 200, 50, 0, 0)]
         [InlineData(ServerGatewayID, 200, 50, 17, 1)]

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
@@ -22,10 +22,6 @@ namespace LoRaWan.NetworkServer.Test
     // General message processor tests (Join tests are handled in other class)
     public class MessageProcessor_End2End_NoDep_Processing_Tests : MessageProcessorTestBase
     {
-        public MessageProcessor_End2End_NoDep_Processing_Tests()
-        {
-        }
-
         [Theory]
         [InlineData(ServerGatewayID, 0, 0, 0)]
         [InlineData(ServerGatewayID, 0, 1, 1)]


### PR DESCRIPTION
# PR for issue #450

## What is being addressed

Empty default constructors that are redundant with what the C# compiler generates anyway.

## How is this addressed

Removed all empty default constructors.