### PR TITLE
Add tests version to directory build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
       <!-- <TreatWarningsAsErrors>true</TreatWarningsAsErrors> -->
     </PropertyGroup>
     <PropertyGroup>
-      <DockerDotnetVersion>3.125.2</DockerDotnetVersion>
+      <DockerDotNetX509Version>3.125.2</DockerDotNetX509Version>
       <MicrosoftAzureDevicesVersion>1.33.0</MicrosoftAzureDevicesVersion>
       <MicrosoftAzureDevicesClientVersion>1.37.1</MicrosoftAzureDevicesClientVersion>
       <MicrosoftExtensionsCachingMemoryVersion>3.1.5</MicrosoftExtensionsCachingMemoryVersion>
@@ -21,5 +21,20 @@
       <SystemDynamicRuntimeVersion>4.3.0</SystemDynamicRuntimeVersion>
       <StackExchangeRedisVersion>2.1.58</StackExchangeRedisVersion>
       <MicrosoftCSharpVersion>4.7.0</MicrosoftCSharpVersion>
+    </PropertyGroup>
+    <PropertyGroup>
+      <DockerDotnetVersion>3.125.5</DockerDotnetVersion>
+      <MicrosoftNETTestSdkVersion>16.6.1</MicrosoftNETTestSdkVersion>
+      <MoqVersion>4.14.4</MoqVersion>
+      <XUnitVersion>2.4.1</XUnitVersion>
+      <XunitCombinatorialVersion>1.3.2</XunitCombinatorialVersion>
+      <MicrosoftExtensionsConfigurationVersion>3.1.5</MicrosoftExtensionsConfigurationVersion>
+      <MicrosoftExtensionsConfigurationBinderVersion>5.0.0</MicrosoftExtensionsConfigurationBinderVersion>
+      <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>3.1.5</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
+      <MicrosoftExtensionsConfigurationJsonVersion>3.1.5</MicrosoftExtensionsConfigurationJsonVersion>
+      <SystemIOPortsVersion>4.7.0</SystemIOPortsVersion>
+      <XUnitRunnerVisualStudio>2.4.2</XUnitRunnerVisualStudio>
+      <MicrosoftAzureEventHubsVersion>4.2.0</MicrosoftAzureEventHubsVersion>
+      <MicrosoftAzureEventHubsProcessorVersion>4.2.0</MicrosoftAzureEventHubsProcessorVersion>
     </PropertyGroup>
 </Project>

--- a/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
+++ b/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet.X509" Version="$(DockerDotnetVersion)" />
+    <PackageReference Include="Docker.DotNet.X509" Version="$(DockerDotNetX509Version)" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="$(MicrosoftAzureDevicesVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryVersion)" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="$(MicrosoftAzureFunctionsExtensionsVersion)" />
@@ -25,9 +25,9 @@
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="local.settings.json">	
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>	
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>	
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/LoRaEngine/test/LoRaWan.SimulatedTest/LoRaWan.SimulatedTest.csproj
+++ b/LoRaEngine/test/LoRaWan.SimulatedTest/LoRaWan.SimulatedTest.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudio)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaWanNetworkServer.Test.csproj
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/LoRaWanNetworkServer.Test.csproj
@@ -4,11 +4,11 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Xunit.Combinatorial" Version="1.3.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
+    <PackageReference Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudio)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/LoraKeysManagerFacade.Test.csproj
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/LoraKeysManagerFacade.Test.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.4" />
-    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeRedisVersion)" />
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudio)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/E2E/LoRaWan.Tests.E2E.csproj
+++ b/Tests/E2E/LoRaWan.Tests.E2E.csproj
@@ -13,17 +13,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.33.0" />
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.3.2" />
-    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
-    <PackageReference Include="System.IO.Ports" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="Microsoft.Azure.Devices" Version="$(MicrosoftAzureDevicesVersion)" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="$(MicrosoftAzureEventHubsVersion)" />
+    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="$(MicrosoftAzureEventHubsProcessorVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonVersion)" />
+    <PackageReference Include="System.IO.Ports" Version="$(SystemIOPortsVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudio)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/Shared/LoRaWan.Tests.Shared.csproj
+++ b/Tests/Shared/LoRaWan.Tests.Shared.csproj
@@ -10,14 +10,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet" Version="3.125.5" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.33.0" />
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.3.2" />
-    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Docker.DotNet" Version="$(DockerDotNetVersion)" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="$(MicrosoftAzureDevicesVersion)" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="$(MicrosoftAzureEventHubsVersion)" />
+    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="$(MicrosoftAzureEventHubsProcessorVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonVersion)" />
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The nuget package version used by tests are not referenced in the directory.build.props. This PR aims to fix this. There is very little overlap, but added the test packages as part of a second propertygroup