### PR TITLE
Use `var` consistently

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,8 @@ indent_size = 2
 [*.{cs,tt}]
 charset = utf-8
 indent_size = 4
+
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion

--- a/LoRaEngine/LoraKeysManagerFacade/CreateEdgeDevice.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/CreateEdgeDevice.cs
@@ -34,15 +34,15 @@ namespace LoraKeysManagerFacade
             // parse query parameter
             var queryStrings = req.GetQueryParameterDictionary();
 
-            queryStrings.TryGetValue("deviceName", out string deviceName);
-            queryStrings.TryGetValue("publishingUserName", out string publishingUserName);
-            queryStrings.TryGetValue("publishingPassword", out string publishingPassword);
-            queryStrings.TryGetValue("region", out string region);
-            queryStrings.TryGetValue("resetPin", out string resetPin);
-            queryStrings.TryGetValue("spiSpeed", out string spiSpeed);
-            queryStrings.TryGetValue("spiDev", out string spiDev);
+            queryStrings.TryGetValue("deviceName", out var deviceName);
+            queryStrings.TryGetValue("publishingUserName", out var publishingUserName);
+            queryStrings.TryGetValue("publishingPassword", out var publishingPassword);
+            queryStrings.TryGetValue("region", out var region);
+            queryStrings.TryGetValue("resetPin", out var resetPin);
+            queryStrings.TryGetValue("spiSpeed", out var spiSpeed);
+            queryStrings.TryGetValue("spiDev", out var spiDev);
 
-            bool.TryParse(Environment.GetEnvironmentVariable("DEPLOY_DEVICE"), out bool deployEndDevice);
+            bool.TryParse(Environment.GetEnvironmentVariable("DEPLOY_DEVICE"), out var deployEndDevice);
 
             // Get function facade key
             var base64Auth = Convert.ToBase64String(Encoding.Default.GetBytes($"{publishingUserName}:{publishingPassword}"));
@@ -56,17 +56,17 @@ namespace LoraKeysManagerFacade
                 jwt = result.Content.ReadAsStringAsync().Result.Trim('"'); // get  JWT for call funtion key
             }
 
-            string facadeKey = string.Empty;
+            var facadeKey = string.Empty;
             using (var client = new HttpClient())
             {
                 client.DefaultRequestHeaders.Add("Authorization", "Bearer " + jwt);
 
-                string jsonResult = client.GetAsync($"{siteUrl}/admin/host/keys").Result.Content.ReadAsStringAsync().Result;
+                var jsonResult = client.GetAsync($"{siteUrl}/admin/host/keys").Result.Content.ReadAsStringAsync().Result;
                 dynamic resObject = JsonConvert.DeserializeObject(jsonResult);
                 facadeKey = resObject.keys[0].value;
             }
 
-            Device edgeGatewayDevice = new Device(deviceName);
+            var edgeGatewayDevice = new Device(deviceName);
             edgeGatewayDevice.Capabilities = new DeviceCapabilities()
             {
                 IotEdge = true
@@ -76,23 +76,23 @@ namespace LoraKeysManagerFacade
             {
                 await this.registryManager.AddDeviceAsync(edgeGatewayDevice);
 
-                string deviceConfigurationUrl = Environment.GetEnvironmentVariable("DEVICE_CONFIG_LOCATION");
+                var deviceConfigurationUrl = Environment.GetEnvironmentVariable("DEVICE_CONFIG_LOCATION");
                 string json = null;
 
                 // todo correct
-                using (WebClient wc = new WebClient())
+                using (var wc = new WebClient())
                 {
                     json = wc.DownloadString(deviceConfigurationUrl);
                 }
 
                 json = ReplaceJsonWithCorrectValues(region, resetPin, json, spiSpeed, spiDev);
 
-                ConfigurationContent spec = JsonConvert.DeserializeObject<ConfigurationContent>(json);
+                var spec = JsonConvert.DeserializeObject<ConfigurationContent>(json);
                 await this.registryManager.AddModuleAsync(new Module(deviceName, "LoRaWanNetworkSrvModule"));
 
                 await this.registryManager.ApplyConfigurationContentOnDeviceAsync(deviceName, spec);
 
-                Twin twin = new Twin();
+                var twin = new Twin();
                 twin.Properties.Desired = new TwinCollection(@"{FacadeServerUrl:'" + string.Format("https://{0}.azurewebsites.net/api/", GetEnvironmentVariable("FACADE_HOST_NAME")) + "',FacadeAuthCode: " +
                     "'" + facadeKey + "'}");
                 var remoteTwin = await this.registryManager.GetTwinAsync(deviceName);
@@ -184,7 +184,7 @@ namespace LoraKeysManagerFacade
         private static HttpResponseMessage PrepareResponse(HttpStatusCode httpStatusCode)
         {
             var template = @"{'$schema': 'https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#', 'contentVersion': '1.0.0.0', 'parameters': {}, 'variables': {}, 'resources': []}";
-            HttpResponseMessage response = new HttpResponseMessage(httpStatusCode);
+            var response = new HttpResponseMessage(httpStatusCode);
             if (httpStatusCode == HttpStatusCode.OK)
             {
                 response.Content = new StringContent(template, Encoding.UTF8, "application/json");

--- a/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
@@ -57,7 +57,7 @@ namespace LoraKeysManagerFacade
             try
             {
                 var results = await this.GetDeviceList(devEUI, gatewayId, devNonce, devAddr, log);
-                string json = JsonConvert.SerializeObject(results);
+                var json = JsonConvert.SerializeObject(results);
                 return new OkObjectResult(json);
             }
             catch (DeviceNonceUsedException)
@@ -127,9 +127,9 @@ namespace LoraKeysManagerFacade
                 {
                     try
                     {
-                        if (devAddrCache.TryGetInfo(devAddr, out List<DevAddrCacheInfo> devAddressesInfo))
+                        if (devAddrCache.TryGetInfo(devAddr, out var devAddressesInfo))
                         {
-                            for (int i = 0; i < devAddressesInfo.Count; i++)
+                            for (var i = 0; i < devAddressesInfo.Count; i++)
                             {
                                 if (!string.IsNullOrEmpty(devAddressesInfo[i].DevEUI))
                                 {
@@ -161,7 +161,7 @@ namespace LoraKeysManagerFacade
                                 try
                                 {
                                     var query = this.registryManager.CreateQuery($"SELECT * FROM devices WHERE properties.desired.DevAddr = '{devAddr}' OR properties.reported.DevAddr ='{devAddr}'", 100);
-                                    int resultCount = 0;
+                                    var resultCount = 0;
                                     while (query.HasMoreResults)
                                     {
                                         var page = await query.GetNextAsTwinAsync();

--- a/LoRaEngine/LoraKeysManagerFacade/FCntCacheCheck.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FCntCacheCheck.cs
@@ -43,9 +43,9 @@ namespace LoraKeysManagerFacade
 
             EUIValidator.ValidateDevEUI(devEUI);
 
-            if (!uint.TryParse(fCntUp, out uint clientFCntUp))
+            if (!uint.TryParse(fCntUp, out var clientFCntUp))
             {
-                string errorMsg = "Missing FCntUp";
+                var errorMsg = "Missing FCntUp";
                 throw new ArgumentException(errorMsg);
             }
 
@@ -73,10 +73,10 @@ namespace LoraKeysManagerFacade
             }
 
             // validate input parameters
-            if (!uint.TryParse(fCntDown, out uint clientFCntDown) ||
+            if (!uint.TryParse(fCntDown, out var clientFCntDown) ||
                 string.IsNullOrEmpty(gatewayId))
             {
-                string errorMsg = "Missing FCntDown or GatewayId";
+                var errorMsg = "Missing FCntDown or GatewayId";
                 throw new ArgumentException(errorMsg);
             }
 
@@ -92,7 +92,7 @@ namespace LoraKeysManagerFacade
             {
                 if (await deviceCache.TryToLockAsync())
                 {
-                    if (deviceCache.TryGetInfo(out DeviceCacheInfo serverStateForDeviceInfo))
+                    if (deviceCache.TryGetInfo(out var serverStateForDeviceInfo))
                     {
                         newFCntDown = ProcessExistingDeviceInfo(deviceCache, serverStateForDeviceInfo, gatewayId, clientFCntUp, clientFCntDown);
                     }

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/DeduplicationExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/DeduplicationExecutionItem.cs
@@ -37,14 +37,14 @@ namespace LoraKeysManagerFacade.FunctionBundler
         internal async Task<DuplicateMsgResult> GetDuplicateMessageResultAsync(string devEUI, string gatewayId, uint clientFCntUp, uint clientFCntDown, ILogger logger = null)
         {
             var isDuplicate = true;
-            string processedDevice = gatewayId;
+            var processedDevice = gatewayId;
 
             using (var deviceCache = new LoRaDeviceCache(this.cacheStore, devEUI, gatewayId))
             {
                 if (await deviceCache.TryToLockAsync())
                 {
                     // we are owning the lock now
-                    if (deviceCache.TryGetInfo(out DeviceCacheInfo cachedDeviceState))
+                    if (deviceCache.TryGetInfo(out var cachedDeviceState))
                     {
                         var updateCacheState = false;
 

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDevAddrCache.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDevAddrCache.cs
@@ -81,10 +81,10 @@ namespace LoraKeysManagerFacade
                 throw new ArgumentNullException("Required DevAddrCacheInfo argument was null");
             }
 
-            bool success = false;
+            var success = false;
             var serializedObjectValue = JsonConvert.SerializeObject(info);
 
-            string cacheKeyToUse = GenerateKey(info.DevAddr);
+            var cacheKeyToUse = GenerateKey(info.DevAddr);
 
             success = this.cacheStore.TrySetHashObject(cacheKeyToUse, info.DevEUI, serializedObjectValue);
 
@@ -290,7 +290,7 @@ namespace LoraKeysManagerFacade
         /// </summary>
         private IDictionary<string, DevAddrCacheInfo> MergeOldAndNewChanges(IDictionary<string, DevAddrCacheInfo> valueArrayBase, IDictionary<string, DevAddrCacheInfo> valueArrayimport, bool shouldImportFromNewValues)
         {
-            bool isSaveRequired = false;
+            var isSaveRequired = false;
             foreach (var baseValue in valueArrayBase)
             {
                 if (valueArrayimport.TryGetValue(baseValue.Key, out var importValue))

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCacheRedisStore.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCacheRedisStore.cs
@@ -127,8 +127,8 @@ namespace LoraKeysManagerFacade
                 this.redisCache.KeyDelete(cacheKey);
             }
 
-            HashEntry[] hashEntries = new HashEntry[input.Count];
-            int i = 0;
+            var hashEntries = new HashEntry[input.Count];
+            var i = 0;
             foreach (var element in input)
             {
                 hashEntries[i] = new HashEntry(element.Key, JsonConvert.SerializeObject(element.Value));

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/ADRTest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/ADRTest.cs
@@ -44,7 +44,7 @@ namespace LoRaWanTest
                 });
             }
 
-            for (int i = 0; i < tableEntries.Count; i++)
+            for (var i = 0; i < tableEntries.Count; i++)
             {
                 await loRaADRManager.Object.StoreADREntryAsync(tableEntries[i]);
             }
@@ -63,10 +63,10 @@ namespace LoRaWanTest
         [Fact]
         public async System.Threading.Tasks.Task CheckADRReturnsDefaultValueIfCacheCrash()
         {
-            string devEUI = "myloratest";
+            var devEUI = "myloratest";
             var region = RegionManager.EU868;
             ILoRaADRStrategyProvider provider = new LoRaADRStrategyProvider();
-            Rxpk rxpk = new Rxpk();
+            var rxpk = new Rxpk();
             rxpk.Datr = "SF7BW125";
             var loRaADRManager = new Mock<LoRaADRManagerBase>(MockBehavior.Loose, new LoRaADRInMemoryStore(), provider);
             loRaADRManager.CallBase = true;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/ADRTestData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/ADRTestData.cs
@@ -29,7 +29,7 @@ namespace LoRaWanTest
                 });
             }
 
-            Rxpk rxpk = new Rxpk();
+            var rxpk = new Rxpk();
             rxpk.Datr = "SF7BW125";
             this.AddRow("Not enough entries to calculate ADR", deviceNameNotEnoughEntries, tableentries, rxpk, true, new LoRaADRResult()
             {
@@ -57,10 +57,10 @@ namespace LoRaWanTest
                 });
             }
 
-            Rxpk notenoughentriesrxpk = new Rxpk();
+            var notenoughentriesrxpk = new Rxpk();
             // Set Input DR to 5
             notenoughentriesrxpk.Datr = "SF7BW125";
-            LoRaADRResult loRaADRResult = new LoRaADRResult()
+            var loRaADRResult = new LoRaADRResult()
             {
                 DataRate = 0,
                 NbRepetition = 1,
@@ -85,10 +85,10 @@ namespace LoRaWanTest
                 });
             }
 
-            Rxpk increaseNbReprxpk = new Rxpk();
+            var increaseNbReprxpk = new Rxpk();
             // DR5
             increaseNbReprxpk.Datr = "SF7BW125";
-            LoRaADRResult increaseNbReploRaADRResult = new LoRaADRResult()
+            var increaseNbReploRaADRResult = new LoRaADRResult()
             {
                 DataRate = 5,
                 NbRepetition = 3,
@@ -130,10 +130,10 @@ namespace LoRaWanTest
                     });
             }
 
-            Rxpk decreaseNbReprxpk = new Rxpk();
+            var decreaseNbReprxpk = new Rxpk();
             // DR5
             decreaseNbReprxpk.Datr = "SF7BW125";
-            LoRaADRResult decreaseNbReploRaADRResult = new LoRaADRResult()
+            var decreaseNbReploRaADRResult = new LoRaADRResult()
             {
                 DataRate = 5,
                 NbRepetition = 1,

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/LoRaLibraryTest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/LoRaLibraryTest.cs
@@ -24,25 +24,25 @@ namespace LoRaWanTest
         [Fact]
         public void TestJoinAccept()
         {
-            byte[] appNonce = new byte[3]
+            var appNonce = new byte[3]
             {
                 87, 11, 199,
             };
-            byte[] netId1 = new byte[3]
+            var netId1 = new byte[3]
             {
                 34, 17, 1,
             };
-            byte[] devAddr = new byte[4]
+            var devAddr = new byte[4]
             {
                 2, 3, 25, 128,
             };
 
             var netId = ConversionHelper.ByteArrayToString(netId1);
             var appkey = "00112233445566778899AABBCCDDEEFF";
-            LoRaPayloadJoinAccept joinAccept = new LoRaPayloadJoinAccept(netId, devAddr, appNonce, new byte[] { 0 }, 0, null);
+            var joinAccept = new LoRaPayloadJoinAccept(netId, devAddr, appNonce, new byte[] { 0 }, 0, null);
             var joinacceptbyte = joinAccept.Serialize(appkey, "SF10BW125", 866.349812, 10000, "test");
             var decodedJoinAccept = new LoRaPayloadJoinAccept(Convert.FromBase64String(joinacceptbyte.Txpk.Data), appkey);
-            byte[] joinAcceptMic = new byte[4]
+            var joinAcceptMic = new byte[4]
             {
                 67, 72, 91, 188,
             };
@@ -91,7 +91,7 @@ namespace LoRaWanTest
             rxpk.Data = Convert.ToBase64String(data);
             rxpk.Size = (uint)data.Length;
 
-            byte[] decodedJoinRequestBytes = Convert.FromBase64String(rxpk.Data);
+            var decodedJoinRequestBytes = Convert.FromBase64String(rxpk.Data);
             var decodedJoinRequest = new LoRaTools.LoRaMessage.LoRaPayloadJoinRequest(decodedJoinRequestBytes);
             Assert.True(decodedJoinRequest.CheckMic(appKey));
         }
@@ -102,9 +102,9 @@ namespace LoRaWanTest
         [Fact]
         public void TestJoinRequest()
         {
-            byte[] physicalUpstreamPyld = new byte[12];
+            var physicalUpstreamPyld = new byte[12];
             physicalUpstreamPyld[0] = 2;
-            string jsonUplink = @"{ ""rxpk"":[
+            var jsonUplink = @"{ ""rxpk"":[
  	            {
 		            ""time"":""2013-03-31T16:21:17.528002Z"",
  		            ""tmst"":3512348611,
@@ -121,17 +121,17 @@ namespace LoRaWanTest
  		            ""data"":""AAQDAgEEAwIBBQQDAgUEAwItEGqZDhI=""
                 }]}";
             var joinRequestInput = Encoding.Default.GetBytes(jsonUplink);
-            List<Rxpk> rxpk = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(joinRequestInput).ToArray());
+            var rxpk = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(joinRequestInput).ToArray());
             TestRxpk(rxpk[0]);
         }
 
         private static void TestRxpk(Rxpk rxpk)
         {
-            Assert.True(LoRaPayload.TryCreateLoRaPayload(rxpk, out LoRaPayload loRaPayload));
+            Assert.True(LoRaPayload.TryCreateLoRaPayload(rxpk, out var loRaPayload));
             Assert.Equal(LoRaMessageType.JoinRequest, loRaPayload.LoRaMessageType);
-            LoRaPayloadJoinRequest joinRequestMessage = (LoRaPayloadJoinRequest)loRaPayload;
+            var joinRequestMessage = (LoRaPayloadJoinRequest)loRaPayload;
 
-            byte[] joinRequestAppKey = new byte[16]
+            var joinRequestAppKey = new byte[16]
             {
                 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
             };
@@ -141,16 +141,16 @@ namespace LoRaWanTest
                 Console.WriteLine("Join Request type was not computed correclty");
             }
 
-            byte[] joinRequestAppEui = new byte[8]
+            var joinRequestAppEui = new byte[8]
             {
                 1, 2, 3, 4, 1, 2, 3, 4
             };
 
-            byte[] joinRequestDevEUI = new byte[8]
+            var joinRequestDevEUI = new byte[8]
             {
                2, 3, 4, 5, 2, 3, 4, 5
             };
-            byte[] joinRequestDevNonce = new byte[2]
+            var joinRequestDevNonce = new byte[2]
             {
                 16, 45
             };
@@ -169,7 +169,7 @@ namespace LoRaWanTest
         [Fact]
         public void TestUnconfirmedUplink()
         {
-            string jsonUplinkUnconfirmedDataUp = @"{ ""rxpk"":[
+            var jsonUplinkUnconfirmedDataUp = @"{ ""rxpk"":[
                {
                ""time"":""2013-03-31T16:21:17.528002Z"",
                 ""tmst"":3512348611,
@@ -186,24 +186,24 @@ namespace LoRaWanTest
                 ""data"":""QAQDAgGAAQABppRkJhXWw7WC""
                  }]}";
 
-            byte[] physicalUpstreamPyld = new byte[12];
+            var physicalUpstreamPyld = new byte[12];
             physicalUpstreamPyld[0] = 2;
 
             var jsonUplinkUnconfirmedDataUpBytes = Encoding.Default.GetBytes(jsonUplinkUnconfirmedDataUp);
-            List<Rxpk> rxpk = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(jsonUplinkUnconfirmedDataUpBytes).ToArray());
-            Assert.True(LoRaPayload.TryCreateLoRaPayload(rxpk[0], out LoRaPayload loRaPayload));
+            var rxpk = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(jsonUplinkUnconfirmedDataUpBytes).ToArray());
+            Assert.True(LoRaPayload.TryCreateLoRaPayload(rxpk[0], out var loRaPayload));
 
             Assert.Equal(LoRaMessageType.UnconfirmedDataUp, loRaPayload.LoRaMessageType);
 
-            LoRaPayloadData loRaPayloadUplinkObj = (LoRaPayloadData)loRaPayload;
+            var loRaPayloadUplinkObj = (LoRaPayloadData)loRaPayload;
             Assert.True(loRaPayloadUplinkObj.Fcnt.Span.SequenceEqual(new byte[2] { 1, 0 }));
 
             Assert.True(loRaPayloadUplinkObj.DevAddr.Span.SequenceEqual(new byte[4] { 1, 2, 3, 4 }));
-            byte[] loRaPayloadUplinkNwkKey = new byte[16] { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 };
+            var loRaPayloadUplinkNwkKey = new byte[16] { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 };
 
             Assert.True(loRaPayloadUplinkObj.CheckMic(ConversionHelper.ByteArrayToString(loRaPayloadUplinkNwkKey)));
 
-            byte[] loRaPayloadUplinkAppKey = new byte[16] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+            var loRaPayloadUplinkAppKey = new byte[16] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
             var key = ConversionHelper.ByteArrayToString(loRaPayloadUplinkAppKey);
             Assert.Equal("hello", Encoding.ASCII.GetString(loRaPayloadUplinkObj.PerformEncryption(key)));
         }
@@ -214,26 +214,26 @@ namespace LoRaWanTest
         [Fact]
         public void TestConfirmedDataUp()
         {
-            byte[] mhdr = new byte[1];
+            var mhdr = new byte[1];
             mhdr[0] = 128;
-            byte[] devAddr = new byte[4]
+            var devAddr = new byte[4]
                 {
                     4, 3, 2, 1
                 };
 
-            byte[] fctrl = new byte[1]
+            var fctrl = new byte[1]
             {
                 0,
             };
-            byte[] fcnt = new byte[2]
+            var fcnt = new byte[2]
             {
                 0, 0
             };
-            byte[] fport = new byte[1]
+            var fport = new byte[1]
             {
                     10,
             };
-            byte[] frmPayload = new byte[4]
+            var frmPayload = new byte[4]
             {
                4, 3, 2, 1,
             };
@@ -241,16 +241,16 @@ namespace LoRaWanTest
             var nwkkey = new byte[16] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
             var appkey = new byte[16] { 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
 
-            LoRaPayloadData lora = new LoRaPayloadData(LoRaMessageType.ConfirmedDataUp, devAddr, fctrl, fcnt, null, fport, frmPayload, 0);
+            var lora = new LoRaPayloadData(LoRaMessageType.ConfirmedDataUp, devAddr, fctrl, fcnt, null, fport, frmPayload, 0);
             lora.PerformEncryption(ConversionHelper.ByteArrayToString(appkey));
-            byte[] testEncrypt = new byte[4]
+            var testEncrypt = new byte[4]
             {
                 226, 100, 212, 247,
             };
             Assert.Equal(testEncrypt, lora.Frmpayload.ToArray());
             lora.SetMic(ConversionHelper.ByteArrayToString(nwkkey));
             lora.CheckMic(ConversionHelper.ByteArrayToString(nwkkey));
-            byte[] testMic = new byte[4]
+            var testMic = new byte[4]
             {
                 181, 106, 14, 117,
             };
@@ -267,7 +267,7 @@ namespace LoRaWanTest
         public void TestKeys()
         {
             // create random message
-            string jsonUplink = @"{ ""rxpk"":[
+            var jsonUplink = @"{ ""rxpk"":[
  	            {
 		            ""time"":""2013-03-31T16:21:17.528002Z"",
  		            ""tmst"":3512348611,
@@ -284,10 +284,10 @@ namespace LoRaWanTest
  		            ""data"":""AAQDAgEEAwIBBQQDAgUEAwItEGqZDhI=""
                 }]}";
             var joinRequestInput = Encoding.Default.GetBytes(jsonUplink);
-            byte[] physicalUpstreamPyld = new byte[12];
+            var physicalUpstreamPyld = new byte[12];
             physicalUpstreamPyld[0] = 2;
-            List<Rxpk> rxpk = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(joinRequestInput).ToArray());
-            Assert.True(LoRaPayload.TryCreateLoRaPayload(rxpk[0], out LoRaPayload loRaPayload));
+            var rxpk = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(joinRequestInput).ToArray());
+            Assert.True(LoRaPayload.TryCreateLoRaPayload(rxpk[0], out var loRaPayload));
             Assert.Equal(LoRaMessageType.JoinRequest, loRaPayload.LoRaMessageType);
             var joinReq = (LoRaPayloadJoinRequest)loRaPayload;
             joinReq.DevAddr = new byte[4]
@@ -307,15 +307,15 @@ namespace LoRaWanTest
                 1, 2, 3, 4, 5, 6, 7, 8,
             };
 
-            byte[] appNonce = new byte[3]
+            var appNonce = new byte[3]
             {
                 0, 0, 1,
             };
-            byte[] netId = new byte[3]
+            var netId = new byte[3]
             {
                 3, 2, 1,
             };
-            byte[] appKey = new byte[16]
+            var appKey = new byte[16]
             {
                 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,
             };
@@ -341,17 +341,17 @@ namespace LoRaWanTest
             var nwkSKeyText = "00000060000000600000006000000060";
 
             ushort fcnt = 12;
-            byte[] devAddr = ConversionHelper.StringToByteArray(devAddrText);
+            var devAddr = ConversionHelper.StringToByteArray(devAddrText);
             Array.Reverse(devAddr);
-            byte[] fCtrl = new byte[] { 0x80 };
+            var fCtrl = new byte[] { 0x80 };
             var fcntBytes = BitConverter.GetBytes(fcnt);
             var fopts = new List<MacCommand>();
-            byte[] fPort = new byte[] { 1 };
-            byte[] payload = Encoding.UTF8.GetBytes(data);
+            var fPort = new byte[] { 1 };
+            var payload = Encoding.UTF8.GetBytes(data);
             Array.Reverse(payload);
 
             // 0 = uplink, 1 = downlink
-            int direction = 0;
+            var direction = 0;
             var devicePayloadData = new LoRaPayloadData(loRaMessageType, devAddr, fCtrl, fcntBytes, fopts, fPort, payload, direction);
 
             Assert.Equal(12, devicePayloadData.GetFcnt());
@@ -364,7 +364,7 @@ namespace LoRaWanTest
             var uplinkMsg = devicePayloadData.SerializeUplink(appSKeyText, nwkSKeyText, datr, freq, 0);
 
             // Now try to recreate LoRaPayloadData from rxpk
-            Assert.True(LoRaPayload.TryCreateLoRaPayload(uplinkMsg.Rxpk[0], out LoRaPayload parsedLoRaPayload));
+            Assert.True(LoRaPayload.TryCreateLoRaPayload(uplinkMsg.Rxpk[0], out var parsedLoRaPayload));
             Assert.Equal(loRaMessageType, parsedLoRaPayload.LoRaMessageType);
             Assert.IsType<LoRaPayloadData>(parsedLoRaPayload);
             var parsedLoRaPayloadData = (LoRaPayloadData)parsedLoRaPayload;
@@ -439,7 +439,7 @@ namespace LoRaWanTest
 
             var rxpk = uplinkMessage.Rxpk[0];
 
-            Assert.True(LoRaPayload.TryCreateLoRaPayload(rxpk, out LoRaPayload parsedLoRaPayload));
+            Assert.True(LoRaPayload.TryCreateLoRaPayload(rxpk, out var parsedLoRaPayload));
             Assert.IsType<LoRaPayloadJoinRequest>(parsedLoRaPayload);
             var parsedLoRaJoinRequest = (LoRaPayloadJoinRequest)parsedLoRaPayload;
 
@@ -451,7 +451,7 @@ namespace LoRaWanTest
         public void TestMultipleRxpks()
         {
             // create multiple Rxpk message
-            string jsonUplink = @"{""rxpk"":[
+            var jsonUplink = @"{""rxpk"":[
 	{
 		            ""time"":""2013-03-31T16:21:17.528002Z"",
  		            ""tmst"":3512348611,
@@ -497,27 +497,27 @@ namespace LoRaWanTest
                 }
 ]}";
             var multiRxpkInput = Encoding.Default.GetBytes(jsonUplink);
-            byte[] physicalUpstreamPyld = new byte[12];
+            var physicalUpstreamPyld = new byte[12];
             physicalUpstreamPyld[0] = 2;
-            List<Rxpk> rxpk = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(multiRxpkInput).ToArray());
+            var rxpk = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(multiRxpkInput).ToArray());
 
             Assert.Equal(3, rxpk.Count);
             TestRxpk(rxpk[0]);
             TestRxpk(rxpk[2]);
 
-            Assert.True(LoRaPayload.TryCreateLoRaPayload(rxpk[1], out LoRaPayload jsonUplinkUnconfirmedMessage));
+            Assert.True(LoRaPayload.TryCreateLoRaPayload(rxpk[1], out var jsonUplinkUnconfirmedMessage));
             Assert.Equal(LoRaMessageType.UnconfirmedDataUp, jsonUplinkUnconfirmedMessage.LoRaMessageType);
 
-            LoRaPayloadData loRaPayloadUplinkObj = (LoRaPayloadData)jsonUplinkUnconfirmedMessage;
+            var loRaPayloadUplinkObj = (LoRaPayloadData)jsonUplinkUnconfirmedMessage;
 
             Assert.True(loRaPayloadUplinkObj.Fcnt.Span.SequenceEqual(new byte[2] { 1, 0 }));
 
             Assert.True(loRaPayloadUplinkObj.DevAddr.Span.SequenceEqual(new byte[4] { 1, 2, 3, 4 }));
-            byte[] loRaPayloadUplinkNwkKey = new byte[16] { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 };
+            var loRaPayloadUplinkNwkKey = new byte[16] { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 };
 
             Assert.True(loRaPayloadUplinkObj.CheckMic(ConversionHelper.ByteArrayToString(loRaPayloadUplinkNwkKey)));
 
-            byte[] loRaPayloadUplinkAppKey = new byte[16] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+            var loRaPayloadUplinkAppKey = new byte[16] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
             var key = ConversionHelper.ByteArrayToString(loRaPayloadUplinkAppKey);
             Assert.Equal("hello", Encoding.ASCII.GetString(loRaPayloadUplinkObj.PerformEncryption(key)));
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RegionImplementationTest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RegionImplementationTest.cs
@@ -18,12 +18,12 @@ namespace LoRaWanTest
       [CombinatorialValues("SF12BW125", "SF11BW125", "SF10BW125", "SF9BW125", "SF8BW125", "SF7BW125", "SF7BW250")]string datr,
       [CombinatorialValues(868.1, 868.3, 868.5)] double freq)
         {
-            List<Rxpk> rxpk = GenerateRxpk(datr, freq);
+            var rxpk = GenerateRxpk(datr, freq);
 
             // in EU in standard parameters the expectation is that the reply arrive at same place.
             var expFreq = freq;
             var expDatr = datr;
-            Assert.True(RegionManager.EU868.TryGetDownstreamChannelFrequency(rxpk[0], out double frequency));
+            Assert.True(RegionManager.EU868.TryGetDownstreamChannelFrequency(rxpk[0], out var frequency));
             Assert.Equal(frequency, expFreq);
             Assert.Equal(RegionManager.EU868.GetDownstreamDR(rxpk[0]), expDatr);
         }
@@ -34,12 +34,12 @@ namespace LoRaWanTest
            [CombinatorialValues("SF10BW125", "SF9BW125", "SF8BW125", "SF7BW125")] string datr,
            [CombinatorialValues(902.3, 902.5, 902.7, 902.9, 903.1, 903.3, 903.5, 903.7, 903.9)] double freq)
         {
-            List<Rxpk> rxpk = GenerateRxpk(datr, freq);
+            var rxpk = GenerateRxpk(datr, freq);
 
             // in EU in standard parameters the expectation is that the reply arrive at same place.
             double expFreq = 0;
 
-            string expDatr = string.Empty;
+            var expDatr = string.Empty;
 
             switch (datr)
             {
@@ -98,7 +98,7 @@ namespace LoRaWanTest
                     break;
             }
 
-            Assert.True(RegionManager.US915.TryGetDownstreamChannelFrequency(rxpk[0], out double frequency));
+            Assert.True(RegionManager.US915.TryGetDownstreamChannelFrequency(rxpk[0], out var frequency));
             Assert.Equal(frequency, expFreq);
             Assert.Equal(RegionManager.US915.GetDownstreamDR(rxpk[0]), expDatr);
         }
@@ -109,12 +109,12 @@ namespace LoRaWanTest
           [CombinatorialValues("SF8BW500")] string datr,
           [CombinatorialValues(903, 904.6, 906.2, 907.8, 909.4, 911, 912.6, 914.2)] double freq)
         {
-            List<Rxpk> rxpk = GenerateRxpk(datr, freq);
+            var rxpk = GenerateRxpk(datr, freq);
 
             // in EU in standard parameters the expectation is that the reply arrive at same place.
             double expFreq = 0;
 
-            string expDatr = "SF7BW500";
+            var expDatr = "SF7BW500";
 
             switch (freq)
             {
@@ -146,14 +146,14 @@ namespace LoRaWanTest
                     break;
             }
 
-            Assert.True(RegionManager.US915.TryGetDownstreamChannelFrequency(rxpk[0], out double frequency));
+            Assert.True(RegionManager.US915.TryGetDownstreamChannelFrequency(rxpk[0], out var frequency));
             Assert.Equal(frequency, expFreq);
             Assert.Equal(RegionManager.US915.GetDownstreamDR(rxpk[0]), expDatr);
         }
 
         private static List<Rxpk> GenerateRxpk(string datr, double freq)
         {
-            string jsonUplink =
+            var jsonUplink =
                 @"{ ""rxpk"":[
                 {
                     ""time"":""2013-03-31T16:21:17.528002Z"",
@@ -172,9 +172,9 @@ namespace LoRaWanTest
                 }]}";
 
             var multiRxpkInput = Encoding.Default.GetBytes(jsonUplink);
-            byte[] physicalUpstreamPyld = new byte[12];
+            var physicalUpstreamPyld = new byte[12];
             physicalUpstreamPyld[0] = 2;
-            List<Rxpk> rxpk = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(multiRxpkInput).ToArray());
+            var rxpk = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(multiRxpkInput).ToArray());
             return rxpk;
         }
 
@@ -194,13 +194,13 @@ namespace LoRaWanTest
             var rxpk = GenerateRxpk(datarate, freq);
             if (region == LoRaRegionType.EU868)
             {
-                Assert.False(RegionManager.EU868.TryGetDownstreamChannelFrequency(rxpk[0], out double frequency) &&
+                Assert.False(RegionManager.EU868.TryGetDownstreamChannelFrequency(rxpk[0], out var frequency) &&
                 RegionManager.EU868.GetDownstreamDR(rxpk[0]) != null);
             }
 
             if (region == LoRaRegionType.US915)
             {
-                Assert.False(RegionManager.US915.TryGetDownstreamChannelFrequency(rxpk[0], out double frequency) &&
+                Assert.False(RegionManager.US915.TryGetDownstreamChannelFrequency(rxpk[0], out var frequency) &&
                 RegionManager.US915.GetDownstreamDR(rxpk[0]) != null);
             }
         }
@@ -248,7 +248,7 @@ namespace LoRaWanTest
         public void GetDownStreamRx2(LoRaRegionType loRaRegion, string nwksrvrx2dr, double? nwksrvrx2freq, ushort? rx2drfromtwins, double expectedFreq, string expectedDr)
         {
             var devEui = "testDevice";
-            RegionManager.TryTranslateToRegion(loRaRegion, out Region region);
+            RegionManager.TryTranslateToRegion(loRaRegion, out var region);
             var datr = region.GetDownstreamRX2Datarate(devEui, nwksrvrx2dr, rx2drfromtwins);
             var freq = region.GetDownstreamRX2Freq(devEui, nwksrvrx2freq);
             Assert.Equal(expectedFreq, freq);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RxpkTest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RxpkTest.cs
@@ -14,7 +14,7 @@ namespace LoRaWanTest
         [Fact]
         public void When_Creating_From_Json_Has_Correct_Value()
         {
-            string jsonUplink = @"{ ""rxpk"":[
+            var jsonUplink = @"{ ""rxpk"":[
                 {
                     ""time"":""2013-03-31T16:21:17.528002Z"",
                     ""tmst"":3512348611,
@@ -31,7 +31,7 @@ namespace LoRaWanTest
                     ""data"":""AAQDAgEEAwIBBQQDAgUEAwItEGqZDhI=""
                 }]}";
 
-            byte[] physicalUpstreamPyld = new byte[12];
+            var physicalUpstreamPyld = new byte[12];
             physicalUpstreamPyld[0] = 2;
             var request = Encoding.Default.GetBytes(jsonUplink);
             var rxpks = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(request).ToArray());
@@ -42,7 +42,7 @@ namespace LoRaWanTest
         [Fact]
         public void When_Creating_From_Json_With_Custom_Elements_Has_Correct_Value()
         {
-            string jsonUplink = @"{ ""rxpk"":[
+            var jsonUplink = @"{ ""rxpk"":[
                 {
                     ""time"":""2013-03-31T16:21:17.528002Z"",
                     ""tmst"":3512348611,
@@ -61,7 +61,7 @@ namespace LoRaWanTest
                     ""custom_prop_b"":10
                 }]}";
 
-            byte[] physicalUpstreamPyld = new byte[12];
+            var physicalUpstreamPyld = new byte[12];
             physicalUpstreamPyld[0] = 2;
             var request = Encoding.Default.GetBytes(jsonUplink);
             var rxpks = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(request).ToArray());
@@ -76,8 +76,8 @@ namespace LoRaWanTest
         [Fact]
         public void Multiple_Rxpk_Are_Detected_Correctly()
         {
-            string jsonUplink = @"{""rxpk"":[{""tmst"":373051724,""time"":""2020-02-19T04:08:57.265951Z"",""chan"":0,""rfch"":0,""freq"":923.200000,""stat"":1,""modu"":""LORA"",""datr"":""SF9BW125"",""codr"":""4/5"",""lsnr"":12.5,""rssi"":-47,""size"":21,""data"":""gAMAABKgmAAIAvEgIbhjS0LBeM/d""},{""tmst"":373053772,""time"":""2020-02-19T04:08:57.265951Z"",""chan"":6,""rfch"":0,""freq"":923.000000,""stat"":-1,""modu"":""LORA"",""datr"":""SF9BW125"",""codr"":""4/5"",""lsnr"":-13.0,""rssi"":-97,""size"":21,""data"":""gJni7n4+wQBUl/E0sO4vB4gFePx7""}]}";
-            byte[] physicalUpstreamPyld = new byte[12];
+            var jsonUplink = @"{""rxpk"":[{""tmst"":373051724,""time"":""2020-02-19T04:08:57.265951Z"",""chan"":0,""rfch"":0,""freq"":923.200000,""stat"":1,""modu"":""LORA"",""datr"":""SF9BW125"",""codr"":""4/5"",""lsnr"":12.5,""rssi"":-47,""size"":21,""data"":""gAMAABKgmAAIAvEgIbhjS0LBeM/d""},{""tmst"":373053772,""time"":""2020-02-19T04:08:57.265951Z"",""chan"":6,""rfch"":0,""freq"":923.000000,""stat"":-1,""modu"":""LORA"",""datr"":""SF9BW125"",""codr"":""4/5"",""lsnr"":-13.0,""rssi"":-97,""size"":21,""data"":""gJni7n4+wQBUl/E0sO4vB4gFePx7""}]}";
+            var physicalUpstreamPyld = new byte[12];
             physicalUpstreamPyld[0] = 2;
             var request = Encoding.Default.GetBytes(jsonUplink);
             var rxpks = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(request).ToArray());
@@ -92,7 +92,7 @@ namespace LoRaWanTest
         [InlineData(868.1, "SF36BW125", null)]
         public void CheckEUValidUpstreamRxpk(double frequency, string datr, string expectedDatr)
         {
-            string jsonUplink =
+            var jsonUplink =
                 "{\"rxpk\":[{\"time\":\"2013-03-31T16:21:17.528002Z\"," +
                 "\"tmst\":3512348611," +
                 "\"chan\":2," +
@@ -109,7 +109,7 @@ namespace LoRaWanTest
                "\"custom_prop_a\":\"a\"," +
                "\"custom_prop_b\":10" +
                " }]}";
-            byte[] physicalUpstreamPyld = new byte[12];
+            var physicalUpstreamPyld = new byte[12];
             physicalUpstreamPyld[0] = 2;
             var request = Encoding.Default.GetBytes(jsonUplink);
             var rxpks = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(request).ToArray());
@@ -125,7 +125,7 @@ namespace LoRaWanTest
         [InlineData(915, "SF36BW125", null)]
         public void CheckUSValidUpstreamRxpk(double frequency, string datr, string expectedDatr)
         {
-            string jsonUplink =
+            var jsonUplink =
                 "{\"rxpk\":[{\"time\":\"2013-03-31T16:21:17.528002Z\"," +
                 "\"tmst\":3512348611," +
                 "\"chan\":2," +
@@ -142,7 +142,7 @@ namespace LoRaWanTest
                "\"custom_prop_a\":\"a\"," +
                "\"custom_prop_b\":10" +
                " }]}";
-            byte[] physicalUpstreamPyld = new byte[12];
+            var physicalUpstreamPyld = new byte[12];
             physicalUpstreamPyld[0] = 2;
             var request = Encoding.Default.GetBytes(jsonUplink);
             var rxpks = Rxpk.CreateRxpk(physicalUpstreamPyld.Concat(request).ToArray());

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -59,7 +59,7 @@ namespace LoRaWan.NetworkServer
 
                 var payloadFcnt = loraPayload.GetFcnt();
 
-                uint payloadFcntAdjusted = LoRaPayload.InferUpper32BitsForClientFcnt(payloadFcnt, loRaDevice.FCntUp);
+                var payloadFcntAdjusted = LoRaPayload.InferUpper32BitsForClientFcnt(payloadFcnt, loRaDevice.FCntUp);
                 Logger.Log(loRaDevice.DevEUI, $"converted 16bit FCnt {payloadFcnt} to 32bit FCnt {payloadFcntAdjusted}", LogLevel.Debug);
 
                 var payloadPort = loraPayload.GetFPort();
@@ -79,12 +79,12 @@ namespace LoRaWan.NetworkServer
 
                 // Leaf devices that restart lose the counter. In relax mode we accept the incoming frame counter
                 // ABP device does not reset the Fcnt so in relax mode we should reset for 0 (LMIC based) or 1
-                bool isFrameCounterFromNewlyStartedDevice = await this.DetermineIfFramecounterIsFromNewlyStartedDeviceAsync(loRaDevice, payloadFcntAdjusted, frameCounterStrategy);
+                var isFrameCounterFromNewlyStartedDevice = await this.DetermineIfFramecounterIsFromNewlyStartedDeviceAsync(loRaDevice, payloadFcntAdjusted, frameCounterStrategy);
 
                 // Reply attack or confirmed reply
                 // Confirmed resubmit: A confirmed message that was received previously but we did not answer in time
                 // Device will send it again and we just need to return an ack (but also check for C2D to send it over)
-                if (!ValidateRequest(request, isFrameCounterFromNewlyStartedDevice, payloadFcntAdjusted, loRaDevice, requiresConfirmation, out bool isConfirmedResubmit, out LoRaDeviceRequestProcessResult result))
+                if (!ValidateRequest(request, isFrameCounterFromNewlyStartedDevice, payloadFcntAdjusted, loRaDevice, requiresConfirmation, out var isConfirmedResubmit, out var result))
                 {
                     return result;
                 }
@@ -139,7 +139,7 @@ namespace LoRaWan.NetworkServer
                     }
 
                     // if deduplication already processed the next framecounter down, use that
-                    uint? fcntDown = loRaADRResult?.FCntDown != null ? loRaADRResult.FCntDown : bundlerResult?.NextFCntDown;
+                    var fcntDown = loRaADRResult?.FCntDown != null ? loRaADRResult.FCntDown : bundlerResult?.NextFCntDown;
 
                     if (fcntDown.HasValue)
                     {
@@ -505,7 +505,7 @@ namespace LoRaWan.NetworkServer
 
             if (cloudToDeviceMsg.MacCommands?.Count > 0)
             {
-                foreach (MacCommand macCommand in cloudToDeviceMsg.MacCommands)
+                foreach (var macCommand in cloudToDeviceMsg.MacCommands)
                 {
                     totalPayload += macCommand.Length;
                 }
@@ -572,7 +572,7 @@ namespace LoRaWan.NetworkServer
             {
                 eventProperties = eventProperties ?? new Dictionary<string, string>(payloadData.MacCommands.Count);
 
-                for (int i = 0; i < payloadData.MacCommands.Count; i++)
+                for (var i = 0; i < payloadData.MacCommands.Count; i++)
                 {
                     eventProperties[payloadData.MacCommands[i].Cid.ToString()] = JsonConvert.SerializeObject(payloadData.MacCommands[i].ToString(), Formatting.None);
                 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
@@ -42,7 +42,7 @@ namespace LoRaWan.NetworkServer
             var upstreamPayload = (LoRaPayloadData)request.Payload;
             var rxpk = request.Rxpk;
             var loRaRegion = request.Region;
-            bool isMessageTooLong = false;
+            var isMessageTooLong = false;
 
             // default fport
             byte fctrl = 0;
@@ -61,7 +61,7 @@ namespace LoRaWan.NetworkServer
                 return new DownlinkMessageBuilderResponse(null, isMessageTooLong);
             }
 
-            byte[] rndToken = new byte[2];
+            var rndToken = new byte[2];
 
             lock (RndLock)
             {
@@ -130,7 +130,7 @@ namespace LoRaWan.NetworkServer
                     // Add C2D Mac commands
                     if (macCommandsC2d?.Count > 0)
                     {
-                        foreach (MacCommand macCommand in macCommandsC2d)
+                        foreach (var macCommand in macCommandsC2d)
                         {
                             macCommands.Add(macCommand);
                         }
@@ -172,7 +172,7 @@ namespace LoRaWan.NetworkServer
             {
                 if (macCommandsRequest?.Count > 0)
                 {
-                    foreach (MacCommand macCommand in macCommandsRequest)
+                    foreach (var macCommand in macCommandsRequest)
                     {
                         macCommands.Add(macCommand);
                     }
@@ -191,7 +191,7 @@ namespace LoRaWan.NetworkServer
 
             var srcDevAddr = upstreamPayload.DevAddr.Span;
             var reversedDevAddr = new byte[srcDevAddr.Length];
-            for (int i = reversedDevAddr.Length - 1; i >= 0; --i)
+            for (var i = reversedDevAddr.Length - 1; i >= 0; --i)
             {
                 reversedDevAddr[i] = srcDevAddr[srcDevAddr.Length - (1 + i)];
             }
@@ -236,16 +236,16 @@ namespace LoRaWan.NetworkServer
 
             // default fport
             byte fctrl = 0;
-            CidEnum macCommandType = CidEnum.Zero;
+            var macCommandType = CidEnum.Zero;
 
-            byte[] rndToken = new byte[2];
+            var rndToken = new byte[2];
 
             lock (RndLock)
             {
                 RndDownlinkMessageBuilder.NextBytes(rndToken);
             }
 
-            bool isMessageTooLong = false;
+            var isMessageTooLong = false;
 
             // Class C always uses RX2
             string datr;
@@ -299,7 +299,7 @@ namespace LoRaWan.NetworkServer
 
             var payloadDevAddr = ConversionHelper.StringToByteArray(loRaDevice.DevAddr);
             var reversedDevAddr = new byte[payloadDevAddr.Length];
-            for (int i = reversedDevAddr.Length - 1; i >= 0; --i)
+            for (var i = reversedDevAddr.Length - 1; i >= 0; --i)
             {
                 reversedDevAddr[i] = payloadDevAddr[payloadDevAddr.Length - (1 + i)];
             }
@@ -384,7 +384,7 @@ namespace LoRaWan.NetworkServer
             if (loRaADRResult?.CanConfirmToDevice == true)
             {
                 const int placeholderChannel = 25;
-                LinkADRRequest linkADR = new LinkADRRequest((byte)loRaADRResult.DataRate, (byte)loRaADRResult.TxPower, placeholderChannel, 0, (byte)loRaADRResult.NbRepetition);
+                var linkADR = new LinkADRRequest((byte)loRaADRResult.DataRate, (byte)loRaADRResult.TxPower, placeholderChannel, 0, (byte)loRaADRResult.NbRepetition);
                 macCommands.Add((int)CidEnum.LinkADRCmd, linkADR);
                 Logger.Log(devEUI, $"performing a rate adaptation: DR {loRaADRResult.DataRate}, transmit power {loRaADRResult.TxPower}, #repetition {loRaADRResult.NbRepetition}", LogLevel.Information);
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -41,7 +41,7 @@ namespace LoRaWan.NetworkServer
                 var timeWatcher = new LoRaOperationTimeWatcher(loraRegion, request.StartTime);
 
                 var joinReq = (LoRaPayloadJoinRequest)request.Payload;
-                byte[] udpMsgForPktForwarder = new byte[0];
+                var udpMsgForPktForwarder = new byte[0];
 
                 devEUI = joinReq.GetDevEUIAsString();
                 var appEUI = joinReq.GetAppEUIAsString();
@@ -197,7 +197,7 @@ namespace LoRaWan.NetworkServer
                 Array.Reverse(appNonceBytes);
 
                 // Build the DlSettings fields that is a superposition of RX2DR and RX1DROffset field
-                byte[] dlSettings = new byte[1];
+                var dlSettings = new byte[1];
 
                 if (loRaDevice.DesiredRX2DataRate.HasValue)
                 {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaCloudToDeviceMessageWrapper.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaCloudToDeviceMessageWrapper.cs
@@ -32,7 +32,7 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         private void ParseMessage()
         {
-            string json = string.Empty;
+            var json = string.Empty;
             var bytes = this.message.GetBytes();
             if (bytes?.Length > 0)
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -322,7 +322,7 @@ namespace LoRaWan.NetworkServer
                     if (twin.Properties.Desired.Contains(TwinProperty.Deduplication))
                     {
                         var val = twin.Properties.Desired[TwinProperty.Deduplication].Value as string;
-                        Enum.TryParse<DeduplicationMode>(val, true, out DeduplicationMode mode);
+                        Enum.TryParse<DeduplicationMode>(val, true, out var mode);
                         this.Deduplication = mode;
                     }
 
@@ -386,7 +386,7 @@ namespace LoRaWan.NetworkServer
         {
             var toReport = new TwinCollection();
 
-            bool reset = false;
+            var reset = false;
             // check if there is a reset we need to process
             if (twin.Properties.Desired.Contains(TwinProperty.FCntResetCounter))
             {
@@ -597,12 +597,12 @@ namespace LoRaWan.NetworkServer
                         {
                             this.InternalAcceptFrameCountChanges(savedFcntUp, savedFcntDown);
 
-                            for (int i = 0; i < savedProperties.Count; i++)
+                            for (var i = 0; i < savedProperties.Count; i++)
                                 savedProperties[i].AcceptChanges();
                         }
                         else
                         {
-                            for (int i = 0; i < savedProperties.Count; i++)
+                            for (var i = 0; i < savedProperties.Count; i++)
                                 savedProperties[i].Rollback();
                         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
@@ -36,7 +36,7 @@ namespace LoRaWan.NetworkServer
                 return 0;
             }
 
-            string fcntDownString = await response.Content.ReadAsStringAsync();
+            var fcntDownString = await response.Content.ReadAsStringAsync();
 
             if (ushort.TryParse(fcntDownString, out var newFCntDown))
                 return newFCntDown;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
@@ -166,7 +166,7 @@ namespace LoRaWan.NetworkServer
 
                 Logger.Log(this.devEUI, $"checking cloud to device message for {timeout}", LogLevel.Debug);
 
-                Message msg = await this.deviceClient.ReceiveAsync(timeout);
+                var msg = await this.deviceClient.ReceiveAsync(timeout);
 
                 if (Logger.LoggerLevel >= LogLevel.Debug)
                 {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
@@ -43,7 +43,7 @@ namespace LoRaWan.NetworkServer
 
         private string CreateIoTHubConnectionString(string devEUI, string primaryKey)
         {
-            string connectionString = string.Empty;
+            var connectionString = string.Empty;
 
             if (string.IsNullOrEmpty(this.configuration.IoTHubHostName))
             {
@@ -69,8 +69,8 @@ namespace LoRaWan.NetworkServer
         {
             try
             {
-                string partConnection = this.CreateIoTHubConnectionString(devEUI, primaryKey);
-                string deviceConnectionStr = $"{partConnection}DeviceId={devEUI};SharedAccessKey={primaryKey}";
+                var partConnection = this.CreateIoTHubConnectionString(devEUI, primaryKey);
+                var deviceConnectionStr = $"{partConnection}DeviceId={devEUI};SharedAccessKey={primaryKey}";
 
                 // Enabling AMQP multiplexing
                 var transportSettings = new ITransportSettings[]

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaPayloadDecoder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaPayloadDecoder.cs
@@ -31,7 +31,7 @@ namespace LoRaWan.NetworkServer
         {
             this.decodersHttpClient = new Lazy<HttpClient>(() =>
             {
-                HttpClient client = new HttpClient();
+                var client = new HttpClient();
                 client.DefaultRequestHeaders.Add("Connection", "Keep-Alive");
                 client.DefaultRequestHeaders.Add("Keep-Alive", "timeout=86400");
                 return client;
@@ -56,8 +56,8 @@ namespace LoRaWan.NetworkServer
             // Call local decoder (no "http://" in SensorDecoder)
             if (!sensorDecoder.Contains("http://"))
             {
-                Type decoderType = typeof(LoRaPayloadDecoder);
-                MethodInfo toInvoke = decoderType.GetMethod(sensorDecoder, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.IgnoreCase);
+                var decoderType = typeof(LoRaPayloadDecoder);
+                var toInvoke = decoderType.GetMethod(sensorDecoder, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.IgnoreCase);
 
                 if (toInvoke != null)
                 {
@@ -75,7 +75,7 @@ namespace LoRaWan.NetworkServer
             {
                 // Call SensorDecoderModule hosted in seperate container ("http://" in SensorDecoder)
                 // Format: http://containername/api/decodername
-                string toCall = sensorDecoder;
+                var toCall = sensorDecoder;
 
                 if (sensorDecoder.EndsWith("/"))
                 {
@@ -103,7 +103,7 @@ namespace LoRaWan.NetworkServer
             try
             {
                 var httpClientToUse = this.httpClient ?? this.decodersHttpClient.Value;
-                HttpResponseMessage response = await httpClientToUse.GetAsync(sensorDecoderModuleUrl);
+                var response = await httpClientToUse.GetAsync(sensorDecoderModuleUrl);
 
                 if (!response.IsSuccessStatusCode)
                 {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
@@ -42,7 +42,7 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         public void DispatchRequest(LoRaRequest request)
         {
-            if (!LoRaPayload.TryCreateLoRaPayload(request.Rxpk, out LoRaPayload loRaPayload))
+            if (!LoRaPayload.TryCreateLoRaPayload(request.Rxpk, out var loRaPayload))
             {
                 Logger.Log("There was a problem in decoding the Rxpk", LogLevel.Error);
                 request.NotifyFailed(LoRaDeviceRequestFailedReason.InvalidRxpk);
@@ -99,7 +99,7 @@ namespace LoRaWan.NetworkServer
         bool IsValidNetId(LoRaPayloadData loRaPayload)
         {
             // Check if the current dev addr is in our network id
-            byte devAddrNwkid = loRaPayload.GetDevAddrNetID();
+            var devAddrNwkid = loRaPayload.GetDevAddrNetID();
             var netIdBytes = BitConverter.GetBytes(this.configuration.NetId);
             devAddrNwkid = (byte)(devAddrNwkid >> 1);
             if (devAddrNwkid == (netIdBytes[0] & 0b01111111))

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
@@ -47,7 +47,7 @@ namespace LoRaWan.NetworkServer
             try
             {
                 await this.randomLock.WaitAsync();
-                byte[] token = new byte[2];
+                var token = new byte[2];
                 this.random.NextBytes(token);
                 return token;
             }
@@ -116,14 +116,14 @@ namespace LoRaWan.NetworkServer
 
         async Task RunUdpListener()
         {
-            IPEndPoint endPoint = new IPEndPoint(IPAddress.Any, PORT);
+            var endPoint = new IPEndPoint(IPAddress.Any, PORT);
             this.udpClient = new UdpClient(endPoint);
 
             Logger.LogAlways($"LoRaWAN server started on port {PORT}");
 
             while (true)
             {
-                UdpReceiveResult receivedResults = await this.udpClient.ReceiveAsync();
+                var receivedResults = await this.udpClient.ReceiveAsync();
                 var startTimeProcessing = DateTime.UtcNow;
 
                 switch (PhysicalPayload.GetIdentifierFromPayload(receivedResults.Buffer))
@@ -178,7 +178,7 @@ namespace LoRaWan.NetworkServer
         {
             try
             {
-                List<Rxpk> messageRxpks = Rxpk.CreateRxpk(buffer);
+                var messageRxpks = Rxpk.CreateRxpk(buffer);
                 if (messageRxpks != null)
                 {
                     foreach (var rxpk in messageRxpks)
@@ -195,7 +195,7 @@ namespace LoRaWan.NetworkServer
 
         private void SendAcknowledgementMessage(UdpReceiveResult receivedResults, byte messageType, IPEndPoint remoteEndpoint)
         {
-            byte[] response = new byte[4]
+            var response = new byte[4]
             {
                 receivedResults.Buffer[0],
                 receivedResults.Buffer[1],
@@ -318,7 +318,7 @@ namespace LoRaWan.NetworkServer
             var c2d = JsonConvert.DeserializeObject<ReceivedLoRaCloudToDeviceMessage>(methodRequest.DataAsJson);
             Logger.Log(c2d.DevEUI, $"received cloud to device message from direct method: {methodRequest.DataAsJson}", LogLevel.Debug);
 
-            CancellationToken cts = CancellationToken.None;
+            var cts = CancellationToken.None;
             if (methodRequest.ResponseTimeout.HasValue)
                 cts = new CancellationTokenSource(methodRequest.ResponseTimeout.Value).Token;
 
@@ -357,7 +357,7 @@ namespace LoRaWan.NetworkServer
             }
             catch (AggregateException ex)
             {
-                foreach (Exception exception in ex.InnerExceptions)
+                foreach (var exception in ex.InnerExceptions)
                 {
                     Logger.Log($"Error when receiving desired property: {exception}", LogLevel.Error);
                 }
@@ -379,7 +379,7 @@ namespace LoRaWan.NetworkServer
                     var jsonMsg = JsonConvert.SerializeObject(downstreamMessage);
                     var messageByte = Encoding.UTF8.GetBytes(jsonMsg);
                     var token = await this.GetTokenAsync();
-                    PhysicalPayload pyld = new PhysicalPayload(token, PhysicalIdentifier.PULL_RESP, messageByte);
+                    var pyld = new PhysicalPayload(token, PhysicalIdentifier.PULL_RESP, messageByte);
                     if (this.pullAckRemoteLoRaAggregatorPort != 0 && !string.IsNullOrEmpty(this.pullAckRemoteLoRaAddress))
                     {
                         Logger.Log("UDP", $"sending message with ID {ConversionHelper.ByteArrayToString(token)}, to {this.pullAckRemoteLoRaAddress}:{this.pullAckRemoteLoRaAggregatorPort}", LogLevel.Debug);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/ADR/LoRaADRStandardStrategy.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/ADR/LoRaADRStandardStrategy.cs
@@ -52,7 +52,7 @@ namespace LoRaTools.ADR
 
             // This is a case of standard ADR calculus.
             var newNbRep = this.ComputeNbRepetion(table.Entries[0].FCnt, table.Entries[LoRaADRTable.FrameCountCaptureCount - 1].FCnt, table.CurrentNbRep.GetValueOrDefault());
-            (int newTxPowerIndex, int newDatarate) = this.GetPowerAndDRConfiguration(requiredSnr, upstreamDataRate, table.Entries.Max(x => x.Snr), table.CurrentTxPower.GetValueOrDefault(), minTxPower, maxDr);
+            (var newTxPowerIndex, var newDatarate) = this.GetPowerAndDRConfiguration(requiredSnr, upstreamDataRate, table.Entries.Max(x => x.Snr), table.CurrentTxPower.GetValueOrDefault(), minTxPower, maxDr);
 
             if (newNbRep != table.CurrentNbRep || newTxPowerIndex != table.CurrentTxPower || newDatarate != upstreamDataRate)
             {
@@ -69,11 +69,11 @@ namespace LoRaTools.ADR
 
         private (int txPower, int datarate) GetPowerAndDRConfiguration(float requiredSnr, int dataRate, double maxSnr, int currentTxPowerIndex, int minTxPowerIndex, int maxDr)
         {
-            double snrMargin = maxSnr - requiredSnr - MarginDb;
+            var snrMargin = maxSnr - requiredSnr - MarginDb;
 
-            int computedDataRate = dataRate;
+            var computedDataRate = dataRate;
 
-            int nStep = (int)snrMargin;
+            var nStep = (int)snrMargin;
 
             while (nStep != 0)
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayload.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayload.cs
@@ -92,13 +92,13 @@ namespace LoRaTools.LoRaMessage
         /// <returns> the Mic bytes.</returns>
         public byte[] CalculateMic(string appKey, byte[] algoinput)
         {
-            IMac mac = MacUtilities.GetMac("AESCMAC");
-            KeyParameter key = new KeyParameter(ConversionHelper.StringToByteArray(appKey));
+            var mac = MacUtilities.GetMac("AESCMAC");
+            var key = new KeyParameter(ConversionHelper.StringToByteArray(appKey));
             mac.Init(key);
-            byte[] rfu = new byte[1];
+            var rfu = new byte[1];
             rfu[0] = 0x0;
-            byte[] msgLength = BitConverter.GetBytes(algoinput.Length);
-            byte[] result = new byte[16];
+            var msgLength = BitConverter.GetBytes(algoinput.Length);
+            var result = new byte[16];
             mac.BlockUpdate(algoinput, 0, algoinput.Length);
             result = MacUtilities.DoFinal(mac);
             this.Mic = result.Take(4).ToArray();
@@ -110,7 +110,7 @@ namespace LoRaTools.LoRaMessage
         /// </summary>
         public byte[] CalculateKey(LoRaPayloadKeyType keyType, byte[] appnonce, byte[] netid, byte[] devnonce, byte[] appKey)
         {
-            byte[] type = new byte[1];
+            var type = new byte[1];
             type[0] = (byte)keyType;
             Aes aes = new AesManaged
             {
@@ -119,7 +119,7 @@ namespace LoRaTools.LoRaMessage
                 Padding = PaddingMode.None
             };
 
-            byte[] pt = type.Concat(appnonce).Concat(netid).Concat(devnonce).Concat(new byte[7]).ToArray();
+            var pt = type.Concat(appnonce).Concat(netid).Concat(devnonce).Concat(new byte[7]).ToArray();
 
             aes.IV = new byte[16];
             ICryptoTransform cipher;
@@ -130,7 +130,7 @@ namespace LoRaTools.LoRaMessage
 
         public static bool TryCreateLoRaPayload(Rxpk rxpk, out LoRaPayload loRaPayloadMessage)
         {
-            byte[] convertedInputMessage = Convert.FromBase64String(rxpk.Data);
+            var convertedInputMessage = Convert.FromBase64String(rxpk.Data);
             var messageType = convertedInputMessage[0];
 
             switch (messageType)
@@ -161,7 +161,7 @@ namespace LoRaTools.LoRaMessage
         {
             if (txpk.Data != null)
             {
-                byte[] convertedInputMessage = Convert.FromBase64String(txpk.Data);
+                var convertedInputMessage = Convert.FromBase64String(txpk.Data);
                 switch ((LoRaMessageType)convertedInputMessage[0])
                 {
                     case LoRaMessageType.JoinRequest:

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -123,7 +123,7 @@ namespace LoRaTools.LoRaMessage
             : base(inputMessage)
         {
             // get the address
-            byte[] addrbytes = new byte[4];
+            var addrbytes = new byte[4];
             Array.Copy(inputMessage, 1, addrbytes, 0, 4);
             // address correct but inversed
             Array.Reverse(addrbytes);
@@ -145,13 +145,13 @@ namespace LoRaTools.LoRaMessage
             this.Mhdr = new Memory<byte>(this.RawMessage, 0, 1);
             // Fctrl Frame Control Octet
             this.Fctrl = new Memory<byte>(inputMessage, 5, 1);
-            int foptsSize = this.Fctrl.Span[0] & 0x0f;
+            var foptsSize = this.Fctrl.Span[0] & 0x0f;
             // Fcnt
             this.Fcnt = new Memory<byte>(inputMessage, 6, 2);
             // FOpts
             this.Fopts = new Memory<byte>(inputMessage, 8, foptsSize);
             // in this case the message don't have a Fport as the payload is empty
-            int fportLength = 1;
+            var fportLength = 1;
             if (inputMessage.Length < 13)
             {
                 fportLength = 0;
@@ -177,7 +177,7 @@ namespace LoRaTools.LoRaMessage
         /// </summary>
         public LoRaPayloadData(LoRaMessageType mhdr, byte[] devAddr, byte[] fctrl, byte[] fcnt, IEnumerable<MacCommand> macCommands, byte[] fPort, byte[] frmPayload, int direction, uint? server32bitFcnt = null)
         {
-            List<byte> macBytes = new List<byte>(3);
+            var macBytes = new List<byte>(3);
             if (macCommands != null)
             {
                 foreach (var macCommand in macCommands)
@@ -189,9 +189,9 @@ namespace LoRaTools.LoRaMessage
             this.Ensure32BitFcntValue(server32bitFcnt);
 
             var fOpts = macBytes.ToArray();
-            int fOptsLen = fOpts == null ? 0 : fOpts.Length;
-            int frmPayloadLen = frmPayload == null ? 0 : frmPayload.Length;
-            int fPortLen = fPort == null ? 0 : fPort.Length;
+            var fOptsLen = fOpts == null ? 0 : fOpts.Length;
+            var frmPayloadLen = frmPayload == null ? 0 : frmPayload.Length;
+            var fPortLen = fPort == null ? 0 : fPort.Length;
 
             // TODO If there are mac commands to send and no payload, we need to put the mac commands in the frmpayload.
             if (macBytes.Count > 0 && (frmPayload == null || frmPayload?.Count() == 0))
@@ -204,7 +204,7 @@ namespace LoRaTools.LoRaMessage
                 fPort = new byte[1] { 0 };
             }
 
-            int macPyldSize = devAddr.Length + fctrl.Length + fcnt.Length + fOptsLen + frmPayloadLen + fPortLen;
+            var macPyldSize = devAddr.Length + fctrl.Length + fcnt.Length + fOptsLen + frmPayloadLen + fPortLen;
             this.RawMessage = new byte[1 + macPyldSize + 4];
             this.Mhdr = new Memory<byte>(this.RawMessage, 0, 1);
             this.RawMessage[0] = (byte)mhdr;
@@ -318,8 +318,8 @@ namespace LoRaTools.LoRaMessage
             this.Ensure32BitFcntValue(server32BitFcnt);
             var byteMsg = this.GetByteMessage();
 
-            IMac mac = MacUtilities.GetMac("AESCMAC");
-            KeyParameter key = new KeyParameter(ConversionHelper.StringToByteArray(nwskey));
+            var mac = MacUtilities.GetMac("AESCMAC");
+            var key = new KeyParameter(ConversionHelper.StringToByteArray(nwskey));
             mac.Init(key);
 
             var fcntBytes = this.GetFcntBlockInfo();
@@ -331,7 +331,7 @@ namespace LoRaTools.LoRaMessage
             };
             var algoinput = block.Concat(byteMsg.Take(byteMsg.Length - 4)).ToArray();
 
-            byte[] result = new byte[16];
+            var result = new byte[16];
             mac.BlockUpdate(algoinput, 0, algoinput.Length);
             result = MacUtilities.DoFinal(mac);
             return this.Mic.ToArray().SequenceEqual(result.Take(4).ToArray());
@@ -342,8 +342,8 @@ namespace LoRaTools.LoRaMessage
             var byteMsg = this.GetByteMessage();
             var fcntBytes = this.GetFcntBlockInfo();
 
-            IMac mac = MacUtilities.GetMac("AESCMAC");
-            KeyParameter key = new KeyParameter(ConversionHelper.StringToByteArray(nwskey));
+            var mac = MacUtilities.GetMac("AESCMAC");
+            var key = new KeyParameter(ConversionHelper.StringToByteArray(nwskey));
             mac.Init(key);
             byte[] block =
             {
@@ -375,8 +375,8 @@ namespace LoRaTools.LoRaMessage
         {
             if (!this.Frmpayload.Span.IsEmpty)
             {
-                AesEngine aesEngine = new AesEngine();
-                byte[] tmp = ConversionHelper.StringToByteArray(appSkey);
+                var aesEngine = new AesEngine();
+                var tmp = ConversionHelper.StringToByteArray(appSkey);
                 aesEngine.Init(true, new KeyParameter(tmp));
                 var fcntBytes = this.GetFcntBlockInfo();
 
@@ -387,8 +387,8 @@ namespace LoRaTools.LoRaMessage
                 };
 
                 byte[] sBlock = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-                int size = this.Frmpayload.Length;
-                byte[] decrypted = new byte[size];
+                var size = this.Frmpayload.Length;
+                var decrypted = new byte[size];
                 byte bufferIndex = 0;
                 short ctr = 1;
                 int i;
@@ -443,7 +443,7 @@ namespace LoRaTools.LoRaMessage
 
         public override byte[] GetByteMessage()
         {
-            List<byte> messageArray = new List<byte>();
+            var messageArray = new List<byte>();
             messageArray.AddRange(this.Mhdr.ToArray());
             this.DevAddr.Span.Reverse();
             messageArray.AddRange(this.DevAddr.ToArray());

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
@@ -55,13 +55,13 @@ namespace LoRaTools.LoRaMessage
 
         public LoRaPayloadJoinAccept(string netId, byte[] devAddr, byte[] appNonce, byte[] dlSettings, uint rxDelayValue, byte[] cfList)
         {
-            byte[] rxDelay = new byte[1];
+            var rxDelay = new byte[1];
             if (rxDelayValue >= 0 && rxDelayValue < MaxRxDelayValue)
             {
                 rxDelay[0] = (byte)rxDelayValue;
             }
 
-            int cfListLength = cfList == null ? 0 : cfList.Length;
+            var cfListLength = cfList == null ? 0 : cfList.Length;
             this.RawMessage = new byte[1 + 12 + cfListLength];
             this.Mhdr = new Memory<byte>(this.RawMessage, 0, 1);
             Array.Copy(new byte[] { 32 }, 0, this.RawMessage, 0, 1);
@@ -108,7 +108,7 @@ namespace LoRaTools.LoRaMessage
             // var decrypted = PerformEncryption(appKey);
             // Array.Copy(decrypted, 0, inputMessage, 0, decrypted.Length);
             // DecryptPayload(inputMessage);
-            AesEngine aesEngine = new AesEngine();
+            var aesEngine = new AesEngine();
             var key = ConversionHelper.StringToByteArray(appKey);
             aesEngine.Init(true, new KeyParameter(key));
             Aes aes = new AesManaged
@@ -122,7 +122,7 @@ namespace LoRaTools.LoRaMessage
             ICryptoTransform cipher;
 
             cipher = aes.CreateEncryptor();
-            byte[] pt = new byte[inputMessage.Length - 1];
+            var pt = new byte[inputMessage.Length - 1];
             Array.Copy(inputMessage, 1, pt, 0, pt.Length);
             // Array.Reverse(pt);
             var decryptedPayload = cipher.TransformFinalBlock(pt, 0, pt.Length);
@@ -190,7 +190,7 @@ namespace LoRaTools.LoRaMessage
 
         public override byte[] GetByteMessage()
         {
-            List<byte> messageArray = new List<byte>();
+            var messageArray = new List<byte>();
             messageArray.AddRange(this.Mhdr.ToArray());
             messageArray.AddRange(this.RawMessage);
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinRequest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinRequest.cs
@@ -92,9 +92,9 @@ namespace LoRaTools.LoRaMessage
 
         private byte[] PerformMic(string appKey)
         {
-            IMac mac = MacUtilities.GetMac("AESCMAC");
+            var mac = MacUtilities.GetMac("AESCMAC");
 
-            KeyParameter key = new KeyParameter(ConversionHelper.StringToByteArray(appKey));
+            var key = new KeyParameter(ConversionHelper.StringToByteArray(appKey));
             mac.Init(key);
             var algoInputBytes = new byte[19];
             var algoInput = new Memory<byte>(algoInputBytes);
@@ -118,7 +118,7 @@ namespace LoRaTools.LoRaMessage
 
         public override byte[] GetByteMessage()
         {
-            List<byte> messageArray = new List<byte>(23);
+            var messageArray = new List<byte>(23);
             messageArray.AddRange(this.Mhdr.ToArray());
             messageArray.AddRange(this.AppEUI.ToArray());
             messageArray.AddRange(this.DevEUI.ToArray());

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/DownlinkPktFwdMessage.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/DownlinkPktFwdMessage.cs
@@ -66,7 +66,7 @@ namespace LoRaTools.LoRaPhysical
         [Obsolete("ad")]
         public override PktFwdMessageAdapter GetPktFwdMessage()
         {
-            PktFwdMessageAdapter pktFwdMessageAdapter = new PktFwdMessageAdapter
+            var pktFwdMessageAdapter = new PktFwdMessageAdapter
             {
                 Txpk = this.Txpk
             };

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/PhysicalPayload.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/PhysicalPayload.cs
@@ -120,7 +120,7 @@ namespace LoRaTools
 
         public byte[] GetMessage()
         {
-            List<byte> returnList = new List<byte>
+            var returnList = new List<byte>
             {
                 this.protocolVersion
             };
@@ -138,7 +138,7 @@ namespace LoRaTools
         // Method used by Simulator
         public byte[] GetSyncHeader(byte[] mac)
         {
-            byte[] buff = new byte[12];
+            var buff = new byte[12];
             // first is the protocole version
             buff[0] = 2;
             // Random token
@@ -147,7 +147,7 @@ namespace LoRaTools
             // the identifier
             buff[3] = (byte)this.Identifier;
             // Then the MAC address specific to the server
-            for (int i = 0; i < 8; i++)
+            for (var i = 0; i < 8; i++)
                 buff[4 + i] = mac[i];
             return buff;
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Rxpk.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Rxpk.cs
@@ -85,7 +85,7 @@ namespace LoRaTools.LoRaPhysical
         /// <returns>List of rxpk or null if no Rxpk was found.</returns>
         public static List<Rxpk> CreateRxpk(byte[] inputMessage)
         {
-            PhysicalPayload physicalPayload = new PhysicalPayload(inputMessage);
+            var physicalPayload = new PhysicalPayload(inputMessage);
             if (physicalPayload.Message != null)
             {
                 var payload = Encoding.UTF8.GetString(physicalPayload.Message);
@@ -116,7 +116,7 @@ namespace LoRaTools.LoRaPhysical
             var requiredSNR = this.SpreadFactorToSNR[this.SpreadingFactor];
 
             // get the link budget
-            int signedMargin = Math.Max(0, (int)(this.Lsnr - requiredSNR));
+            var signedMargin = Math.Max(0, (int)(this.Lsnr - requiredSNR));
 
             return (uint)signedMargin;
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Txpk.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Txpk.cs
@@ -50,7 +50,7 @@ namespace LoRaTools.LoRaPhysical
         /// <param name="appKey">The appKey.</param>
         public static Txpk CreateTxpk(byte[] inputMessage, string appKey)
         {
-            PhysicalPayload physicalPayload = new PhysicalPayload(inputMessage, true);
+            var physicalPayload = new PhysicalPayload(inputMessage, true);
             var payload = Encoding.UTF8.GetString(physicalPayload.Message);
 
             // deserialize for a downlink message

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/UplinkPktFwdMessage.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/UplinkPktFwdMessage.cs
@@ -56,7 +56,7 @@ namespace LoRaTools.LoRaPhysical
         [Obsolete("to remove")]
         public override PktFwdMessageAdapter GetPktFwdMessage()
         {
-            PktFwdMessageAdapter pktFwdMessageAdapter = new PktFwdMessageAdapter
+            var pktFwdMessageAdapter = new PktFwdMessageAdapter
             {
                 Rxpks = this.Rxpk
             };

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/LinkADRRequest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/LinkADRRequest.cs
@@ -66,17 +66,17 @@ namespace LoRaTools
         /// </summary>
         public LinkADRRequest(IDictionary<string, string> dictionary)
         {
-            if (dictionary.TryGetValueCaseInsensitive("datarate", out string dataratestr) &&
-                dictionary.TryGetValueCaseInsensitive("txpower", out string txpowerstr) &&
-                dictionary.TryGetValueCaseInsensitive("chMask", out string chMaskstr) &&
-                dictionary.TryGetValueCaseInsensitive("chMaskCntl", out string chMaskCntlstr) &&
-                dictionary.TryGetValueCaseInsensitive("nbTrans", out string nbTransstr))
+            if (dictionary.TryGetValueCaseInsensitive("datarate", out var dataratestr) &&
+                dictionary.TryGetValueCaseInsensitive("txpower", out var txpowerstr) &&
+                dictionary.TryGetValueCaseInsensitive("chMask", out var chMaskstr) &&
+                dictionary.TryGetValueCaseInsensitive("chMaskCntl", out var chMaskCntlstr) &&
+                dictionary.TryGetValueCaseInsensitive("nbTrans", out var nbTransstr))
             {
-                if (byte.TryParse(dataratestr, out byte datarate) &&
-                    byte.TryParse(txpowerstr, out byte txPower) &&
-                    ushort.TryParse(chMaskstr, out ushort chMask) &&
-                    byte.TryParse(chMaskCntlstr, out byte chMaskCntl) &&
-                    byte.TryParse(nbTransstr, out byte nbTrans))
+                if (byte.TryParse(dataratestr, out var datarate) &&
+                    byte.TryParse(txpowerstr, out var txPower) &&
+                    ushort.TryParse(chMaskstr, out var chMask) &&
+                    byte.TryParse(chMaskCntlstr, out var chMaskCntl) &&
+                    byte.TryParse(nbTransstr, out var nbTrans))
                 {
                     this.Cid = CidEnum.LinkADRCmd;
                     this.DataRateTXPower = (byte)((datarate << 4) | txPower);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommand.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommand.cs
@@ -46,14 +46,14 @@ namespace LoRaTools
         /// </summary>
         public static List<MacCommand> CreateMacCommandFromBytes(string deviceId, ReadOnlyMemory<byte> input)
         {
-            int pointer = 0;
+            var pointer = 0;
             var macCommands = new List<MacCommand>(3);
 
             try
             {
                 while (pointer < input.Length)
                 {
-                    CidEnum cid = (CidEnum)input.Span[pointer];
+                    var cid = (CidEnum)input.Span[pointer];
                     switch (cid)
                     {
                         case CidEnum.LinkCheckCmd:
@@ -86,19 +86,19 @@ namespace LoRaTools
                             }
                             else
                             {
-                                DevStatusAnswer devStatus = new DevStatusAnswer(input.Span.Slice(pointer));
+                                var devStatus = new DevStatusAnswer(input.Span.Slice(pointer));
                                 pointer += devStatus.Length;
                                 macCommands.Add(devStatus);
                             }
 
                             break;
                         case CidEnum.NewChannelCmd:
-                            NewChannelAnswer newChannel = new NewChannelAnswer(input.Span.Slice(pointer));
+                            var newChannel = new NewChannelAnswer(input.Span.Slice(pointer));
                             pointer += newChannel.Length;
                             macCommands.Add(newChannel);
                             break;
                         case CidEnum.RXTimingCmd:
-                            RXTimingSetupAnswer rxTimingSetup = new RXTimingSetupAnswer();
+                            var rxTimingSetup = new RXTimingSetupAnswer();
                             pointer += rxTimingSetup.Length;
                             macCommands.Add(rxTimingSetup);
                             break;
@@ -107,7 +107,7 @@ namespace LoRaTools
                             return null;
                     }
 
-                    MacCommand addedMacCommand = macCommands[macCommands.Count - 1];
+                    var addedMacCommand = macCommands[macCommands.Count - 1];
                     Logger.Log(deviceId, $"{addedMacCommand.Cid} mac command detected in upstream payload: {addedMacCommand.ToString()}", LogLevel.Debug);
                 }
             }
@@ -124,14 +124,14 @@ namespace LoRaTools
         /// </summary>
         public static List<MacCommand> CreateServerMacCommandFromBytes(string deviceId, ReadOnlyMemory<byte> input)
         {
-            int pointer = 0;
+            var pointer = 0;
             var macCommands = new List<MacCommand>(3);
 
             while (pointer < input.Length)
             {
                 try
                 {
-                    CidEnum cid = (CidEnum)input.Span[pointer];
+                    var cid = (CidEnum)input.Span[pointer];
                     switch (cid)
                     {
                         case CidEnum.LinkCheckCmd:
@@ -149,7 +149,7 @@ namespace LoRaTools
                             return null;
                     }
 
-                    MacCommand addedMacCommand = macCommands[macCommands.Count - 1];
+                    var addedMacCommand = macCommands[macCommands.Count - 1];
                     Logger.Log(deviceId, $"{addedMacCommand.Cid} mac command detected in upstream payload: {addedMacCommand.ToString()}", LogLevel.Debug);
                 }
                 catch (MacCommandException ex)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommandJsonConverter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommandJsonConverter.cs
@@ -21,7 +21,7 @@ namespace LoRaTools
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            JObject item = JObject.Load(reader);
+            var item = JObject.Load(reader);
             var cidPropertyValue = item["cid"].Value<string>();
             if (string.IsNullOrEmpty(cidPropertyValue))
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
@@ -15,8 +15,8 @@ namespace LoRaTools
 
         public static string GetNwkId(byte[] netId)
         {
-            int nwkPart = netId[0] << 1;
-            byte[] devAddr = new byte[4];
+            var nwkPart = netId[0] << 1;
+            var devAddr = new byte[4];
 
             lock (RndLock)
             {
@@ -38,7 +38,7 @@ namespace LoRaTools
                 Padding = PaddingMode.None
             };
 
-            byte[] pt = type.Concat(appnonce).Concat(netid).Concat(devnonce).Concat(new byte[7]).ToArray();
+            var pt = type.Concat(appnonce).Concat(netid).Concat(devnonce).Concat(new byte[7]).ToArray();
 
             aes.IV = new byte[16];
             ICryptoTransform cipher;
@@ -80,7 +80,7 @@ namespace LoRaTools
 
         public static string GetAppNonce()
         {
-            byte[] appNonce = new byte[3];
+            var appNonce = new byte[3];
             lock (RndLock)
             {
                 RndKeysGenerator.NextBytes(appNonce);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionManager.cs
@@ -114,7 +114,7 @@ namespace LoRaTools.Regions
             { 6, 5, 4, 3, 2, 1 },
             { 7, 6, 5, 4, 3, 2 }
             };
-            HashSet<string> validDataRangeUpAndDownstream = new HashSet<string>()
+            var validDataRangeUpAndDownstream = new HashSet<string>()
             {
                 "SF12BW125", // 0
                 "SF11BW125", // 1
@@ -180,7 +180,7 @@ namespace LoRaTools.Regions
             { 13, 13, 12, 11 },
             };
 
-            HashSet<string> upstreamValidDataranges = new HashSet<string>()
+            var upstreamValidDataranges = new HashSet<string>()
             {
                 "SF10BW125", // 0
                 "SF9BW125", // 1
@@ -189,7 +189,7 @@ namespace LoRaTools.Regions
                 "SF8BW500", // 4
             };
 
-            HashSet<string> downstreamValidDataranges = new HashSet<string>()
+            var downstreamValidDataranges = new HashSet<string>()
             {
                 "SF12BW500", // 8
                 "SF11BW500", // 9

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/ArrayExtensions.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/ArrayExtensions.cs
@@ -9,7 +9,7 @@ namespace LoRaTools.Utils
     {
         public static T[] RangeSubset<T>(this T[] array, int startIndex, int length)
         {
-            T[] subset = new T[length];
+            var subset = new T[length];
             Array.Copy(array, startIndex, subset, 0, length);
             return subset;
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/ConversionHelper.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/ConversionHelper.cs
@@ -16,9 +16,9 @@ namespace LoRaTools.Utils
         /// <param name="hex">Input hex string.</param>
         public static byte[] StringToByteArray(string hex)
         {
-            int numberChars = hex.Length;
-            byte[] bytes = new byte[numberChars / 2];
-            for (int i = 0; i < numberChars; i += 2)
+            var numberChars = hex.Length;
+            var bytes = new byte[numberChars / 2];
+            for (var i = 0; i < numberChars; i += 2)
                 bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
             return bytes;
         }
@@ -53,9 +53,9 @@ namespace LoRaTools.Utils
 
         static string ByteArrayToString(byte[] bytes)
         {
-            StringBuilder result = new StringBuilder(bytes.Length * 2);
+            var result = new StringBuilder(bytes.Length * 2);
 
-            foreach (byte b in bytes)
+            foreach (var b in bytes)
             {
                 result.Append(HexAlphabet[b >> 4]);
                 result.Append(HexAlphabet[b & 0xF]);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/NetIdHelper.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/NetIdHelper.cs
@@ -12,9 +12,9 @@ namespace LoRaTools.Utils
         /// </summary>
         public static string SetNwkIdPart(string currentDevAddr, uint networkId)
         {
-            byte[] netId = BitConverter.GetBytes(networkId);
-            int nwkPart = netId[0] << 1;
-            byte[] deviceIdBytes = ConversionHelper.StringToByteArray(currentDevAddr);
+            var netId = BitConverter.GetBytes(networkId);
+            var nwkPart = netId[0] << 1;
+            var deviceIdBytes = ConversionHelper.StringToByteArray(currentDevAddr);
             deviceIdBytes[0] = (byte)((nwkPart & 0b11111110) | (deviceIdBytes[0] & 0b00000001));
             return ConversionHelper.ByteArrayToString(deviceIdBytes);
         }

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/LoraArduinoSerial.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/LoraArduinoSerial.cs
@@ -147,7 +147,7 @@ namespace LoRaWan.IntegrationTest
             try
             {
                 var myserialPort = (SerialPort)sender;
-                string input = myserialPort.ReadLine();
+                var input = myserialPort.ReadLine();
                 // var readCount = myserialPort.Read(this.serialPortBuffer, 0, this.serialPortBuffer.Length);
                 // var dataread = System.Text.Encoding.UTF8.GetString(this.serialPortBuffer, 0, readCount);
                 this.OnSerialDataReceived(input);
@@ -220,7 +220,7 @@ namespace LoRaWan.IntegrationTest
         {
             if (!string.IsNullOrEmpty(DevAddr))
             {
-                string cmd = $"AT+ID=DevAddr,{DevAddr}\r\n";
+                var cmd = $"AT+ID=DevAddr,{DevAddr}\r\n";
                 this.sendCommand(cmd);
 
                 Thread.Sleep(DEFAULT_TIMEWAIT);
@@ -228,14 +228,14 @@ namespace LoRaWan.IntegrationTest
 
             if (!string.IsNullOrEmpty(DevEUI))
             {
-                string cmd = $"AT+ID=DevEui,{DevEUI}\r\n";
+                var cmd = $"AT+ID=DevEui,{DevEUI}\r\n";
                 this.sendCommand(cmd);
                 Thread.Sleep(DEFAULT_TIMEWAIT);
             }
 
             if (!string.IsNullOrEmpty(AppEUI))
             {
-                string cmd = $"AT+ID=AppEui,{AppEUI}\r\n";
+                var cmd = $"AT+ID=AppEui,{AppEUI}\r\n";
                 this.sendCommand(cmd);
                 Thread.Sleep(DEFAULT_TIMEWAIT);
             }
@@ -249,7 +249,7 @@ namespace LoRaWan.IntegrationTest
             {
                 if (!string.IsNullOrEmpty(DevAddr))
                 {
-                    string cmd = $"AT+ID=DevAddr,{DevAddr}\r\n";
+                    var cmd = $"AT+ID=DevAddr,{DevAddr}\r\n";
                     this.sendCommand(cmd);
 
                     await this.EnsureSerialAnswerAsync("+ID: DevAddr", 30);
@@ -257,7 +257,7 @@ namespace LoRaWan.IntegrationTest
 
                 if (!string.IsNullOrEmpty(DevEUI))
                 {
-                    string cmd = $"AT+ID=DevEui,{DevEUI}\r\n";
+                    var cmd = $"AT+ID=DevEui,{DevEUI}\r\n";
                     this.sendCommand(cmd);
 
                     await this.EnsureSerialAnswerAsync("+ID: DevEui", 30);
@@ -265,7 +265,7 @@ namespace LoRaWan.IntegrationTest
 
                 if (!string.IsNullOrEmpty(AppEUI))
                 {
-                    string cmd = $"AT+ID=AppEui,{AppEUI}\r\n";
+                    var cmd = $"AT+ID=AppEui,{AppEUI}\r\n";
                     this.sendCommand(cmd);
 
                     await this.EnsureSerialAnswerAsync("+ID: AppEui", 30);
@@ -285,14 +285,14 @@ namespace LoRaWan.IntegrationTest
         {
             if (!string.IsNullOrEmpty(NwkSKey))
             {
-                string cmd = $"AT+KEY=NWKSKEY,{NwkSKey}\r\n";
+                var cmd = $"AT+KEY=NWKSKEY,{NwkSKey}\r\n";
                 this.sendCommand(cmd);
                 Thread.Sleep(DEFAULT_TIMEWAIT);
             }
 
             if (!string.IsNullOrEmpty(AppSKey))
             {
-                string cmd = $"AT+KEY=APPSKEY,{AppSKey}\r\n";
+                var cmd = $"AT+KEY=APPSKEY,{AppSKey}\r\n";
                 this.sendCommand(cmd);
 
                 Thread.Sleep(DEFAULT_TIMEWAIT);
@@ -300,7 +300,7 @@ namespace LoRaWan.IntegrationTest
 
             if (!string.IsNullOrEmpty(AppKey))
             {
-                string cmd = $"AT+KEY= APPKEY,{AppKey}\r\n";
+                var cmd = $"AT+KEY= APPKEY,{AppKey}\r\n";
                 this.sendCommand(cmd);
 
                 Thread.Sleep(DEFAULT_TIMEWAIT);
@@ -315,14 +315,14 @@ namespace LoRaWan.IntegrationTest
             {
                 if (!string.IsNullOrEmpty(NwkSKey))
                 {
-                    string cmd = $"AT+KEY=NWKSKEY,{NwkSKey}\r\n";
+                    var cmd = $"AT+KEY=NWKSKEY,{NwkSKey}\r\n";
                     this.sendCommand(cmd);
                     await this.EnsureSerialAnswerAsync("+KEY: NWKSKEY", 30);
                 }
 
                 if (!string.IsNullOrEmpty(AppSKey))
                 {
-                    string cmd = $"AT+KEY=APPSKEY,{AppSKey}\r\n";
+                    var cmd = $"AT+KEY=APPSKEY,{AppSKey}\r\n";
                     this.sendCommand(cmd);
 
                     await this.EnsureSerialAnswerAsync("+KEY: APPSKEY", 30);
@@ -330,7 +330,7 @@ namespace LoRaWan.IntegrationTest
 
                 if (!string.IsNullOrEmpty(AppKey))
                 {
-                    string cmd = $"AT+KEY= APPKEY,{AppKey}\r\n";
+                    var cmd = $"AT+KEY= APPKEY,{AppKey}\r\n";
                     this.sendCommand(cmd);
 
                     await this.EnsureSerialAnswerAsync("+KEY: APPKEY", 30);
@@ -373,7 +373,7 @@ namespace LoRaWan.IntegrationTest
 
             Thread.Sleep(DEFAULT_TIMEWAIT);
 
-            string cmd = $"AT+DR={dataRate}\r\n";
+            var cmd = $"AT+DR={dataRate}\r\n";
             this.sendCommand(cmd);
 
             Thread.Sleep(DEFAULT_TIMEWAIT);
@@ -410,7 +410,7 @@ namespace LoRaWan.IntegrationTest
 
             await Task.Delay(DEFAULT_TIMEWAIT);
 
-            string cmd = $"AT+DR={dataRate}\r\n";
+            var cmd = $"AT+DR={dataRate}\r\n";
             this.sendCommand(cmd);
 
             await this.EnsureSerialAnswerAsync("+DR:", 30);
@@ -418,7 +418,7 @@ namespace LoRaWan.IntegrationTest
 
         public LoRaArduinoSerial setPower(short power)
         {
-            string cmd = $"AT+POWER={power}\r\n";
+            var cmd = $"AT+POWER={power}\r\n";
             this.sendCommand(cmd);
 
             Thread.Sleep(DEFAULT_TIMEWAIT);
@@ -428,7 +428,7 @@ namespace LoRaWan.IntegrationTest
 
         public async Task setPowerAsync(short power)
         {
-            string cmd = $"AT+POWER={power}\r\n";
+            var cmd = $"AT+POWER={power}\r\n";
             this.sendCommand(cmd);
 
             await this.EnsureSerialAnswerAsync("+POWER:", 30);
@@ -436,7 +436,7 @@ namespace LoRaWan.IntegrationTest
 
         public async Task setPortAsync(int port)
         {
-            string cmd = $"AT+PORT={port}\r\n";
+            var cmd = $"AT+PORT={port}\r\n";
             this.sendCommand(cmd);
 
             await this.EnsureSerialAnswerAsync("+PORT:", 30);
@@ -486,7 +486,7 @@ namespace LoRaWan.IntegrationTest
 
         public LoRaArduinoSerial setChannel(int channel, float frequency)
         {
-            string cmd = $"AT+CH={channel},{(short)frequency}.{(short)(frequency * 10) % 10}\r\n";
+            var cmd = $"AT+CH={channel},{(short)frequency}.{(short)(frequency * 10) % 10}\r\n";
             this.sendCommand(cmd);
 
             Thread.Sleep(DEFAULT_TIMEWAIT);
@@ -496,7 +496,7 @@ namespace LoRaWan.IntegrationTest
 
         public async Task setChannelAsync(int channel, float frequency)
         {
-            string cmd = $"AT+CH={channel},{(short)frequency}.{(short)(frequency * 10) % 10}\r\n";
+            var cmd = $"AT+CH={channel},{(short)frequency}.{(short)(frequency * 10) % 10}\r\n";
             this.sendCommand(cmd);
 
             await this.EnsureSerialAnswerAsync("+CH:", 30);
@@ -504,7 +504,7 @@ namespace LoRaWan.IntegrationTest
 
         public LoRaArduinoSerial setChannel(char channel, float frequency, _data_rate_t dataRata)
         {
-            string cmd = $"AT+CH={channel},{(short)frequency}.{(short)(frequency * 10) % 10},{dataRata}\r\n";
+            var cmd = $"AT+CH={channel},{(short)frequency}.{(short)(frequency * 10) % 10},{dataRata}\r\n";
             this.sendCommand(cmd);
 
             Thread.Sleep(DEFAULT_TIMEWAIT);
@@ -514,7 +514,7 @@ namespace LoRaWan.IntegrationTest
 
         public LoRaArduinoSerial setChannel(char channel, float frequency, _data_rate_t dataRataMin, _data_rate_t dataRataMax)
         {
-            string cmd = $"AT+CH={channel},{(short)frequency}.{(short)(frequency * 10) % 10},{dataRataMin},{dataRataMax}\r\n";
+            var cmd = $"AT+CH={channel},{(short)frequency}.{(short)(frequency * 10) % 10},{dataRataMin},{dataRataMax}\r\n";
 
             this.sendCommand(cmd);
 
@@ -533,7 +533,7 @@ namespace LoRaWan.IntegrationTest
 
                 this.sendCommand("\"\r\n");
 
-                DateTime start = DateTime.UtcNow;
+                var start = DateTime.UtcNow;
 
                 while (true)
                 {
@@ -562,7 +562,7 @@ namespace LoRaWan.IntegrationTest
 
                 this.sendCommand("\"\r\n");
 
-                DateTime start = DateTime.UtcNow;
+                var start = DateTime.UtcNow;
 
                 while (true)
                 {
@@ -589,7 +589,7 @@ namespace LoRaWan.IntegrationTest
 
             this.sendCommand("\"\r\n");
 
-            DateTime start = DateTime.UtcNow;
+            var start = DateTime.UtcNow;
 
             while (true)
             {
@@ -617,7 +617,7 @@ namespace LoRaWan.IntegrationTest
             this.sendCommand(buffer);
             this.sendCommand("\"\r\n");
 
-            DateTime start = DateTime.UtcNow;
+            var start = DateTime.UtcNow;
 
             while (true)
             {
@@ -638,7 +638,7 @@ namespace LoRaWan.IntegrationTest
                 this.sendCommand(buffer);
                 this.sendCommand("\"\r\n");
 
-                DateTime start = DateTime.UtcNow;
+                var start = DateTime.UtcNow;
 
                 while (true)
                 {
@@ -666,7 +666,7 @@ namespace LoRaWan.IntegrationTest
             else if (time == 0)
                 time = 1;
 
-            string cmd = $"AT+REPT={time}\r\n";
+            var cmd = $"AT+REPT={time}\r\n";
             this.sendCommand(cmd);
 
             Thread.Sleep(DEFAULT_TIMEWAIT);
@@ -681,7 +681,7 @@ namespace LoRaWan.IntegrationTest
             else if (time == 0)
                 time = 1;
 
-            string cmd = $"AT+RETRY={time}\r\n";
+            var cmd = $"AT+RETRY={time}\r\n";
             this.sendCommand(cmd);
 
             Thread.Sleep(DEFAULT_TIMEWAIT);
@@ -696,7 +696,7 @@ namespace LoRaWan.IntegrationTest
             else if (time == 0)
                 time = 1;
 
-            string cmd = $"AT+RETRY={time}\r\n";
+            var cmd = $"AT+RETRY={time}\r\n";
             this.sendCommand(cmd);
 
             await Task.Delay(DEFAULT_TIMEWAIT);
@@ -716,7 +716,7 @@ namespace LoRaWan.IntegrationTest
 
         public LoRaArduinoSerial setReceiceWindowFirst(int channel, float frequency)
         {
-            string cmd = $"AT+RXWIN1={channel},{(short)frequency}.{(short)(frequency * 10) % 10}\r\n";
+            var cmd = $"AT+RXWIN1={channel},{(short)frequency}.{(short)(frequency * 10) % 10}\r\n";
             this.sendCommand(cmd);
 
             Thread.Sleep(DEFAULT_TIMEWAIT);
@@ -726,7 +726,7 @@ namespace LoRaWan.IntegrationTest
 
         public async Task setReceiceWindowFirstAsync(int channel, float frequency)
         {
-            string cmd = $"AT+RXWIN1={channel},{(short)frequency}.{(short)(frequency * 10) % 10}\r\n";
+            var cmd = $"AT+RXWIN1={channel},{(short)frequency}.{(short)(frequency * 10) % 10}\r\n";
             this.sendCommand(cmd);
 
             await Task.Delay(DEFAULT_TIMEWAIT);
@@ -734,7 +734,7 @@ namespace LoRaWan.IntegrationTest
 
         public LoRaArduinoSerial setReceiceWindowSecond(float frequency, _data_rate_t dataRate)
         {
-            string cmd = $"AT+RXWIN2={(short)frequency}.{(short)(frequency * 10) % 10},{dataRate}\r\n";
+            var cmd = $"AT+RXWIN2={(short)frequency}.{(short)(frequency * 10) % 10},{dataRate}\r\n";
             this.sendCommand(cmd);
 
             Thread.Sleep(DEFAULT_TIMEWAIT);
@@ -744,7 +744,7 @@ namespace LoRaWan.IntegrationTest
 
         public async Task setReceiceWindowSecondAsync(float frequency, _data_rate_t dataRate)
         {
-            string cmd = $"AT+RXWIN2={(short)frequency}.{(short)(frequency * 10) % 10},{dataRate}\r\n";
+            var cmd = $"AT+RXWIN2={(short)frequency}.{(short)(frequency * 10) % 10},{dataRate}\r\n";
             this.sendCommand(cmd);
 
             await this.EnsureSerialAnswerAsync("+RXWIN2:", 10);
@@ -752,7 +752,7 @@ namespace LoRaWan.IntegrationTest
 
         public LoRaArduinoSerial setReceiceWindowSecond(float frequency, _spreading_factor_t spreadingFactor, _band_width_t bandwidth)
         {
-            string cmd = $"AT+RXWIN2={(short)frequency}.{(short)(frequency * 10) % 10},{spreadingFactor},{bandwidth}\r\n";
+            var cmd = $"AT+RXWIN2={(short)frequency}.{(short)(frequency * 10) % 10},{spreadingFactor},{bandwidth}\r\n";
             this.sendCommand(cmd);
 
             Thread.Sleep(DEFAULT_TIMEWAIT);
@@ -805,7 +805,7 @@ namespace LoRaWan.IntegrationTest
 
         public LoRaArduinoSerial setReceiceWindowDelay(_window_delay_t command, short _delay)
         {
-            string cmd = string.Empty;
+            var cmd = string.Empty;
 
             if (command == _window_delay_t.RECEIVE_DELAY1)
                 cmd = $"AT+DELAY=RX1,{_delay}\r\n";
@@ -881,7 +881,7 @@ namespace LoRaWan.IntegrationTest
 
             Thread.Sleep(DEFAULT_TIMEWAIT);
 
-            DateTime start = DateTime.UtcNow;
+            var start = DateTime.UtcNow;
             while (true)
             {
                 if (this.ReceivedSerial(x => x.StartsWith("+JOIN: Done")))
@@ -912,7 +912,7 @@ namespace LoRaWan.IntegrationTest
 
                 await Task.Delay(DEFAULT_TIMEWAIT);
 
-                DateTime start = DateTime.UtcNow;
+                var start = DateTime.UtcNow;
 
                 while (DateTime.UtcNow.Subtract(start).TotalMilliseconds < timeoutPerTry)
                 {
@@ -1019,7 +1019,7 @@ namespace LoRaWan.IntegrationTest
 
         async Task EnsureSerialAnswerAsync(string expectedSerialStartText, int retries = 10, [CallerMemberName] string memberName = "")
         {
-            for (int i = 0; i < retries; i++)
+            for (var i = 0; i < retries; i++)
             {
                 if (this.ReceivedSerial(x => x.StartsWith(expectedSerialStartText, StringComparison.InvariantCultureIgnoreCase)))
                 {

--- a/LoRaEngine/test/LoRaWan.IntegrationTest/MultiGatewayTests.cs
+++ b/LoRaEngine/test/LoRaWan.IntegrationTest/MultiGatewayTests.cs
@@ -93,7 +93,7 @@ namespace LoRaWan.IntegrationTest
 
             await this.ArduinoDevice.SetupLora(this.TestFixtureCi.Configuration.LoraRegion);
 
-            for (int i = 0; i < 10; i++)
+            for (var i = 0; i < 10; i++)
             {
                 var msg = PayloadGenerator.Next().ToString();
                 await this.ArduinoDevice.transferPacketAsync(msg, 10);

--- a/LoRaEngine/test/LoRaWan.SimulatedTest/IntegrationTestFixtureSim.cs
+++ b/LoRaEngine/test/LoRaWan.SimulatedTest/IntegrationTestFixtureSim.cs
@@ -42,7 +42,7 @@ namespace LoRaWan.SimulatedTest
 
         public override void SetupTestDevices()
         {
-            string gatewayID = Environment.GetEnvironmentVariable("IOTEDGE_DEVICEID") ?? this.Configuration.LeafDeviceGatewayID;
+            var gatewayID = Environment.GetEnvironmentVariable("IOTEDGE_DEVICEID") ?? this.Configuration.LeafDeviceGatewayID;
 
             // Simulated devices start at 1000
 
@@ -80,7 +80,7 @@ namespace LoRaWan.SimulatedTest
                 SensorDecoder = "http://localhost:8888/api/DecoderValueSensor",
             };
 
-            for (int deviceID = 1100; deviceID <= 1110; deviceID++)
+            for (var deviceID = 1100; deviceID <= 1110; deviceID++)
             {
                 this.deviceRange1000_ABP.Add(
                     new TestDeviceInfo
@@ -98,7 +98,7 @@ namespace LoRaWan.SimulatedTest
             }
 
             // Range of 1000 ABP devices from 2000 to 2999: Used for load testing
-            for (int deviceID = 2000; deviceID <= 2999; deviceID++)
+            for (var deviceID = 2000; deviceID <= 2999; deviceID++)
             {
                 this.deviceRange2000_1000_ABP.Add(
                     new TestDeviceInfo
@@ -115,7 +115,7 @@ namespace LoRaWan.SimulatedTest
             }
 
             // Range of 10 OTAA devices from 3000 to 3009: Used for load testing
-            for (int deviceID = 3000; deviceID <= 3009; deviceID++)
+            for (var deviceID = 3000; deviceID <= 3009; deviceID++)
             {
                 this.deviceRange3000_10_OTAA.Add(
                     new TestDeviceInfo

--- a/LoRaEngine/test/LoRaWan.SimulatedTest/SimulatorTestCollection.cs
+++ b/LoRaEngine/test/LoRaWan.SimulatedTest/SimulatorTestCollection.cs
@@ -69,15 +69,15 @@ namespace LoRaWan.SimulatedTest
         {
             const int MessageCount = 5;
 
-            TestDeviceInfo device = this.TestFixtureSim.Device1001_Simulated_ABP;
-            SimulatedDevice simulatedDevice = new SimulatedDevice(device);
-            IPEndPoint networkServerIPEndpoint = this.CreateNetworkServerEndpoint();
+            var device = this.TestFixtureSim.Device1001_Simulated_ABP;
+            var simulatedDevice = new SimulatedDevice(device);
+            var networkServerIPEndpoint = this.CreateNetworkServerEndpoint();
 
-            using (SimulatedPacketForwarder simulatedPacketForwarder = new SimulatedPacketForwarder(networkServerIPEndpoint))
+            using (var simulatedPacketForwarder = new SimulatedPacketForwarder(networkServerIPEndpoint))
             {
                 simulatedPacketForwarder.Start();
 
-                for (int i = 1; i <= MessageCount; i++)
+                for (var i = 1; i <= MessageCount; i++)
                 {
                     await simulatedDevice.SendUnconfirmedMessageAsync(simulatedPacketForwarder, i.ToString(CultureInfo.InvariantCulture));
                     // await simulatedDevice.SendConfirmedMessageAsync(simulatedPacketForwarder, i.ToString());
@@ -93,20 +93,20 @@ namespace LoRaWan.SimulatedTest
         {
             const int MessageCount = 5;
 
-            TestDeviceInfo device = this.TestFixtureSim.Device1002_Simulated_OTAA;
-            SimulatedDevice simulatedDevice = new SimulatedDevice(device);
-            IPEndPoint networkServerIPEndpoint = this.CreateNetworkServerEndpoint();
+            var device = this.TestFixtureSim.Device1002_Simulated_OTAA;
+            var simulatedDevice = new SimulatedDevice(device);
+            var networkServerIPEndpoint = this.CreateNetworkServerEndpoint();
 
-            using (SimulatedPacketForwarder simulatedPacketForwarder = new SimulatedPacketForwarder(networkServerIPEndpoint))
+            using (var simulatedPacketForwarder = new SimulatedPacketForwarder(networkServerIPEndpoint))
             {
                 simulatedPacketForwarder.Start();
 
-                bool joined = await simulatedDevice.JoinAsync(simulatedPacketForwarder);
+                var joined = await simulatedDevice.JoinAsync(simulatedPacketForwarder);
                 Assert.True(joined, "OTAA join failed");
 
                 await Task.Delay(this.intervalAfterJoin);
 
-                for (int i = 1; i <= MessageCount; i++)
+                for (var i = 1; i <= MessageCount; i++)
                 {
                     await simulatedDevice.SendUnconfirmedMessageAsync(simulatedPacketForwarder, i.ToString());
                     await Task.Delay(this.intervalBetweenMessages);
@@ -118,28 +118,28 @@ namespace LoRaWan.SimulatedTest
             // wait 10 seconds before checking if iot hub content is available
             await Task.Delay(TimeSpan.FromSeconds(10));
 
-            IEnumerable<Microsoft.Azure.EventHubs.EventData> msgsFromDevice = this.TestFixture.IoTHubMessages.GetEvents().Where(x => x.GetDeviceId() == simulatedDevice.LoRaDevice.DeviceID);
-            int actualAmountOfMsgs = msgsFromDevice.Where(x => !x.Properties.ContainsKey("iothub-message-schema")).Count();
+            var msgsFromDevice = this.TestFixture.IoTHubMessages.GetEvents().Where(x => x.GetDeviceId() == simulatedDevice.LoRaDevice.DeviceID);
+            var actualAmountOfMsgs = msgsFromDevice.Where(x => !x.Properties.ContainsKey("iothub-message-schema")).Count();
             Assert.Equal(MessageCount, actualAmountOfMsgs);
         }
 
         [Fact(Skip = "simulated")]
         public async Task Simulated_Http_Based_Decoder_Scenario()
         {
-            TestDeviceInfo device = this.TestFixtureSim.Device1003_Simulated_HttpBasedDecoder;
-            SimulatedDevice simulatedDevice = new SimulatedDevice(device);
-            IPEndPoint networkServerIPEndpoint = this.CreateNetworkServerEndpoint();
+            var device = this.TestFixtureSim.Device1003_Simulated_HttpBasedDecoder;
+            var simulatedDevice = new SimulatedDevice(device);
+            var networkServerIPEndpoint = this.CreateNetworkServerEndpoint();
 
-            using (SimulatedPacketForwarder simulatedPacketForwarder = new SimulatedPacketForwarder(networkServerIPEndpoint))
+            using (var simulatedPacketForwarder = new SimulatedPacketForwarder(networkServerIPEndpoint))
             {
                 simulatedPacketForwarder.Start();
 
-                bool joined = await simulatedDevice.JoinAsync(simulatedPacketForwarder);
+                var joined = await simulatedDevice.JoinAsync(simulatedPacketForwarder);
                 Assert.True(joined, "OTAA join failed");
 
                 await Task.Delay(this.intervalAfterJoin);
 
-                for (int i = 1; i <= 3; i++)
+                for (var i = 1; i <= 3; i++)
                 {
                     await simulatedDevice.SendUnconfirmedMessageAsync(simulatedPacketForwarder, i.ToString(CultureInfo.InvariantCulture));
                     await Task.Delay(this.intervalBetweenMessages);
@@ -162,80 +162,80 @@ namespace LoRaWan.SimulatedTest
         {
             // amount of devices to test with. Maximum is 89
             // Do go beyond 100 deviceClients in IoT Edge, use edgeHub env var 'MaxConnectedClients'
-            int scenarioDeviceNumber = 250; // Default: 20
+            var scenarioDeviceNumber = 250; // Default: 20
 
             // amount of messages to send per device (without warm-up phase)
-            int scenarioMessagesPerDevice = 10; // Default: 10
+            var scenarioMessagesPerDevice = 10; // Default: 10
 
             // amount of devices to send data in parallel
-            int scenarioDeviceStepSize = 20; // Default: 20
+            var scenarioDeviceStepSize = 20; // Default: 20
 
             // amount of devices to send data in parallel for the warm-up phase
-            int warmUpDeviceStepSize = 2; // Default: 10
+            var warmUpDeviceStepSize = 2; // Default: 10
 
             // amount of messages to send before device join is to occur
-            int messagesBeforeJoin = 10; // Default: 10
+            var messagesBeforeJoin = 10; // Default: 10
 
             // amount of Unconfirmed messges to send before Confirmed message is to occur
-            int messagesBeforeConfirmed = 5; // Default: 5
+            var messagesBeforeConfirmed = 5; // Default: 5
 
             // amount of seconds to wait between sends in warmup phase
-            int delayWarmup = 5 * 1000; // Default 5 * 1000
+            var delayWarmup = 5 * 1000; // Default 5 * 1000
 
             // amount of seconds to wait between sends in main phase
-            int delayMessageSending = 5 * 1000; // Default 5 * 1000
+            var delayMessageSending = 5 * 1000; // Default 5 * 1000
 
             // amount of miliseconds to wait before checking LoRaWanNetworkSrvModule
             // for successful sending of messages to IoT Hub.
             // delay for 100 devices: 2 * 60 * 1000
             // delay for 20 devices: 15 * 1000
-            int delayNetworkServerCheck = 15 * 60 * 1000;
+            var delayNetworkServerCheck = 15 * 60 * 1000;
 
             // amount of miliseconds to wait before checking of messages in IoT Hub
             // delay for 100 devices: 1 * 60 * 1000
             // delay for 20 devices: 15 * 1000
-            int delayIoTHubCheck = 5 * 60 * 1000;
+            var delayIoTHubCheck = 5 * 60 * 1000;
 
             // Get random number seed
-            Random rnd = new Random();
-            int seed = rnd.Next(100, 999);
+            var rnd = new Random();
+            var seed = rnd.Next(100, 999);
 
-            int count = 0;
-            List<SimulatedDevice> listSimulatedDevices = new List<SimulatedDevice>();
-            foreach (TestDeviceInfo device in this.TestFixtureSim.DeviceRange2000_1000_ABP)
+            var count = 0;
+            var listSimulatedDevices = new List<SimulatedDevice>();
+            foreach (var device in this.TestFixtureSim.DeviceRange2000_1000_ABP)
             {
                 if (count < scenarioDeviceNumber)
                 {
-                    SimulatedDevice simulatedDevice = new SimulatedDevice(device);
+                    var simulatedDevice = new SimulatedDevice(device);
                     listSimulatedDevices.Add(simulatedDevice);
                     count++;
                 }
             }
 
-            int totalDevices = listSimulatedDevices.Count;
-            int totalJoinDevices = 0;
-            int totalJoins = 0;
+            var totalDevices = listSimulatedDevices.Count;
+            var totalJoinDevices = 0;
+            var totalJoins = 0;
 
-            List<SimulatedDevice> listSimulatedJoinDevices = new List<SimulatedDevice>();
-            foreach (TestDeviceInfo joinDevice in this.TestFixtureSim.DeviceRange3000_10_OTAA)
+            var listSimulatedJoinDevices = new List<SimulatedDevice>();
+            foreach (var joinDevice in this.TestFixtureSim.DeviceRange3000_10_OTAA)
             {
-                SimulatedDevice simulatedJoinDevice = new SimulatedDevice(joinDevice);
+                var simulatedJoinDevice = new SimulatedDevice(joinDevice);
                 listSimulatedJoinDevices.Add(simulatedJoinDevice);
             }
 
-            IPEndPoint networkServerIPEndpoint = this.CreateNetworkServerEndpoint();
+            var networkServerIPEndpoint = this.CreateNetworkServerEndpoint();
 
-            using (SimulatedPacketForwarder simulatedPacketForwarder = new SimulatedPacketForwarder(networkServerIPEndpoint))
+            using (var simulatedPacketForwarder = new SimulatedPacketForwarder(networkServerIPEndpoint))
             {
                 simulatedPacketForwarder.Start();
 
                 // 1. picking 2x devices send an initial message (warm device cache in NtwSrv module)
                 //    timeout of 2 seconds between each loop
-                List<Task> tasks = new List<Task>();
-                for (int i = 0; i < totalDevices;)
+                var tasks = new List<Task>();
+                for (var i = 0; i < totalDevices;)
                 {
                     tasks.Clear();
-                    foreach (SimulatedDevice device in listSimulatedDevices.Skip(i).Take(warmUpDeviceStepSize))
+                    foreach (var device in listSimulatedDevices.Skip(i).Take(warmUpDeviceStepSize))
                     {
                         await Task.Delay(rnd.Next(10, 250)); // Sleep between 10 and 250ms
 
@@ -251,17 +251,17 @@ namespace LoRaWan.SimulatedTest
 
                 // 2. picking 20x devices sends messages (send 10 messages for each device)
                 //    timeout of 5 seconds between each
-                int messageCounter = 1;
-                int joinDevice = 0;
+                var messageCounter = 1;
+                var joinDevice = 0;
 
-                for (int messageId = 1; messageId <= scenarioMessagesPerDevice; ++messageId)
+                for (var messageId = 1; messageId <= scenarioMessagesPerDevice; ++messageId)
                 {
-                    for (int i = 0; i < totalDevices;)
+                    for (var i = 0; i < totalDevices;)
                     {
                         tasks.Clear();
-                        string payload = seed + messageId.ToString().PadLeft(3, '0');
+                        var payload = seed + messageId.ToString().PadLeft(3, '0');
 
-                        foreach (SimulatedDevice device in listSimulatedDevices.Skip(i).Take(scenarioDeviceStepSize))
+                        foreach (var device in listSimulatedDevices.Skip(i).Take(scenarioDeviceStepSize))
                         {
                             await Task.Delay(rnd.Next(10, 250)); // Sleep between 10 and 250ms
 
@@ -315,10 +315,10 @@ namespace LoRaWan.SimulatedTest
 
             // 3. test Network Server logs if messages have been sent successfully
             string expectedPayload;
-            foreach (SimulatedDevice device in listSimulatedDevices)
+            foreach (var device in listSimulatedDevices)
             {
                 TestLogger.Log($"[INFO] Looking for upstream messages for {device.LoRaDevice.DeviceID}");
-                for (int messageId = 0; messageId <= scenarioMessagesPerDevice; ++messageId)
+                for (var messageId = 0; messageId <= scenarioMessagesPerDevice; ++messageId)
                 {
                     // Find "<all Device ID>: message '{"value":<seed+0 to number of msg/device>}' sent to hub" in network server logs
                     expectedPayload = $"{device.LoRaDevice.DeviceID}: message '{{\"value\":{seed + messageId.ToString().PadLeft(3, '0')}}}' sent to hub";
@@ -330,9 +330,9 @@ namespace LoRaWan.SimulatedTest
             await Task.Delay(delayIoTHubCheck);
 
             // IoT Hub test for arrival of messages.
-            Dictionary<object, List<Microsoft.Azure.EventHubs.EventData>> eventsByDevices = this.TestFixture.IoTHubMessages.GetEvents()
-                .GroupBy(x => x.SystemProperties["iothub-connection-device-id"])
-                .ToDictionary(x => x.Key, x => x.ToList());
+            var eventsByDevices = this.TestFixture.IoTHubMessages.GetEvents()
+                                      .GroupBy(x => x.SystemProperties["iothub-connection-device-id"])
+                                      .ToDictionary(x => x.Key, x => x.ToList());
 
             // 4. Check that we have the right amount of devices receiving messages in IoT Hub
             // Assert.Equal(totalDevices, eventsByDevices.Count());
@@ -347,15 +347,15 @@ namespace LoRaWan.SimulatedTest
 
             // 5. Check that the correct number of messages have arrived in IoT Hub per device
             //    Warn only.
-            foreach (SimulatedDevice device in listSimulatedDevices)
+            foreach (var device in listSimulatedDevices)
             {
                 // Assert.True(
                 //    eventsByDevices.TryGetValue(device.LoRaDevice.DeviceID, out var events),
                 //    $"No messages were found for device {device.LoRaDevice.DeviceID}");
                 // if (events.Count > 0)
-                if (eventsByDevices.TryGetValue(device.LoRaDevice.DeviceID, out List<Microsoft.Azure.EventHubs.EventData> events))
+                if (eventsByDevices.TryGetValue(device.LoRaDevice.DeviceID, out var events))
                 {
-                    int actualAmountOfMsgs = events.Where(x => !x.Properties.ContainsKey("iothub-message-schema")).Count();
+                    var actualAmountOfMsgs = events.Where(x => !x.Properties.ContainsKey("iothub-message-schema")).Count();
                     // Assert.Equal((1 + scenarioMessagesPerDevice), actualAmountOfMsgs);
                     if ((1 + scenarioMessagesPerDevice) != actualAmountOfMsgs)
                     {
@@ -374,10 +374,10 @@ namespace LoRaWan.SimulatedTest
 
             // 6. Check if all expected messages have arrived in IoT Hub
             //    Warn only.
-            foreach (SimulatedDevice device in listSimulatedDevices)
+            foreach (var device in listSimulatedDevices)
             {
                 TestLogger.Log($"[INFO] Looking for IoT Hub messages for {device.LoRaDevice.DeviceID}");
-                for (int messageId = 0; messageId <= scenarioMessagesPerDevice; ++messageId)
+                for (var messageId = 0; messageId <= scenarioMessagesPerDevice; ++messageId)
                 {
                     // Find message containing '{"value":<seed>.<0 to number of msg/device>}' for all leaf devices in IoT Hub
                     expectedPayload = $"{{\"value\":{seed + messageId.ToString().PadLeft(3, '0')}}}";

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/ADRTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/ADRTest.cs
@@ -67,7 +67,7 @@ namespace LoRaWan.NetworkServer.Test
                 payloadFcnt++;
             }
 
-            for (int i = 0; i < count; i++)
+            for (var i = 0; i < count; i++)
             {
                 var payloadInt = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: payloadFcnt, fctrl: (byte)((int)LoRaTools.LoRaMessage.FctrlEnum.ADR));
                 var rxpkInt = payloadInt.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
@@ -145,7 +145,7 @@ namespace LoRaWan.NetworkServer.Test
         [InlineData(5, -30, "SF9BW125", 3, 0)]
         public async Task Perform_DR_Adaptation_When_Needed(uint deviceId, float currentLsnr, string currentDR, int expectedDR, int expectedTxPower)
         {
-            int messageCount = 21;
+            var messageCount = 21;
             uint payloadFcnt = 0;
             const uint InitialDeviceFcntUp = 9;
             const uint ExpectedDeviceFcntDown = 0;
@@ -162,8 +162,8 @@ namespace LoRaWan.NetworkServer.Test
             this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
-            int twinDR = 0;
-            int twinTxPower = 0;
+            var twinDR = 0;
+            var twinTxPower = 0;
 
             this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
                 .Callback<TwinCollection>((t) =>
@@ -185,7 +185,7 @@ namespace LoRaWan.NetworkServer.Test
 
             payloadFcnt = await this.InitializeCacheToDefaultValuesAsync(payloadFcnt, simulatedDevice, messageProcessor);
 
-            for (int i = 0; i < messageCount; i++)
+            for (var i = 0; i < messageCount; i++)
             {
                 payloadFcnt = await this.SendMessage(currentLsnr, currentDR, payloadFcnt, simulatedDevice, messageProcessor, (byte)((int)LoRaTools.LoRaMessage.FctrlEnum.ADR));
             }
@@ -243,7 +243,7 @@ namespace LoRaWan.NetworkServer.Test
         public async Task Perform_TXPower_Adaptation_When_Needed()
         {
             uint deviceId = 44;
-            int messageCount = 21;
+            var messageCount = 21;
             uint payloadFcnt = 0;
             const uint InitialDeviceFcntUp = 9;
             const uint InitialDeviceFcntDown = 0;
@@ -260,8 +260,8 @@ namespace LoRaWan.NetworkServer.Test
             this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
-            int reportedDR = 0;
-            int reportedTxPower = 0;
+            var reportedDR = 0;
+            var reportedTxPower = 0;
 
             this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
             .Callback<TwinCollection>((t) =>
@@ -286,10 +286,10 @@ namespace LoRaWan.NetworkServer.Test
             // ****************************************************
             // set to very good lsnr and DR3
             float currentLsnr = 20;
-            string currentDR = "SF9BW125";
+            var currentDR = "SF9BW125";
 
             // todo add case without buffer
-            for (int i = 0; i < messageCount; i++)
+            for (var i = 0; i < messageCount; i++)
             {
                 payloadFcnt = await this.SendMessage(currentLsnr, currentDR, payloadFcnt, simulatedDevice, messageProcessor, (byte)((int)LoRaTools.LoRaMessage.FctrlEnum.ADR));
             }
@@ -335,7 +335,7 @@ namespace LoRaWan.NetworkServer.Test
             currentDR = "SF7BW125";
 
             // todo add case without buffer
-            for (int i = 0; i < messageCount; i++)
+            for (var i = 0; i < messageCount; i++)
             {
                 payloadFcnt = await this.SendMessage(currentLsnr, currentDR, payloadFcnt, simulatedDevice, messageProcessor, (byte)((int)LoRaTools.LoRaMessage.FctrlEnum.ADR));
             }
@@ -384,9 +384,9 @@ namespace LoRaWan.NetworkServer.Test
         public async Task Perform_NbRep_Adaptation_When_Needed()
         {
             uint deviceId = 31;
-            string currentDR = "SF8BW125";
-            int currentLsnr = -20;
-            int messageCount = 20;
+            var currentDR = "SF8BW125";
+            var currentLsnr = -20;
+            var messageCount = 20;
             uint payloadFcnt = 0;
             const uint InitialDeviceFcntUp = 1;
             const uint ExpectedDeviceFcntDown = 4;
@@ -402,7 +402,7 @@ namespace LoRaWan.NetworkServer.Test
 
             this.LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
-            int reportedNbRep = 0;
+            var reportedNbRep = 0;
             this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>()))
             .Callback<TwinCollection>((t) =>
             {
@@ -425,7 +425,7 @@ namespace LoRaWan.NetworkServer.Test
             // First part send messages with spaces in fcnt to simulate wrong network connectivity
             // ****************************************************
             // send a message with a fcnt every 4.
-            for (int i = 0; i < messageCount; i++)
+            for (var i = 0; i < messageCount; i++)
             {
                 payloadFcnt = await this.SendMessage(currentLsnr, currentDR, payloadFcnt + 3, simulatedDevice, messageProcessor, (byte)((int)LoRaTools.LoRaMessage.FctrlEnum.ADR));
             }
@@ -460,7 +460,7 @@ namespace LoRaWan.NetworkServer.Test
             // Second part send normal messages to decrease NbRep
             // ****************************************************
             // send a message with a fcnt every 1
-            for (int i = 0; i < messageCount; i++)
+            for (var i = 0; i < messageCount; i++)
             {
                 payloadFcnt = await this.SendMessage(currentLsnr, currentDR, payloadFcnt, simulatedDevice, messageProcessor, (byte)((int)LoRaTools.LoRaMessage.FctrlEnum.ADR));
             }
@@ -502,7 +502,7 @@ namespace LoRaWan.NetworkServer.Test
             // Third part send normal messages to decrease NbRep to 1
             // ****************************************************
             // send a message with a fcnt every 1
-            for (int i = 0; i < messageCount; i++)
+            for (var i = 0; i < messageCount; i++)
             {
                 payloadFcnt = await this.SendMessage(currentLsnr, currentDR, payloadFcnt, simulatedDevice, messageProcessor, (byte)((int)LoRaTools.LoRaMessage.FctrlEnum.ADR));
             }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/ConfigurationTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/ConfigurationTest.cs
@@ -15,9 +15,9 @@ namespace LoRaWan.NetworkServer.Test
         public void Should_Setup_Allowed_Dev_Addresses_Correctly(string inputAllowedDevAddrValues, HashSet<string> expectedAllowedDevAddrValues)
         {
             Environment.SetEnvironmentVariable("AllowedDevAddresses", inputAllowedDevAddrValues);
-            NetworkServerConfiguration networkServerConfiguration = NetworkServerConfiguration.CreateFromEnvironmentVariables();
+            var networkServerConfiguration = NetworkServerConfiguration.CreateFromEnvironmentVariables();
             Assert.Equal(expectedAllowedDevAddrValues.Count, networkServerConfiguration.AllowedDevAddresses.Count);
-            foreach (string devAddr in expectedAllowedDevAddrValues)
+            foreach (var devAddr in expectedAllowedDevAddrValues)
             {
                 Assert.Contains(devAddr, networkServerConfiguration.AllowedDevAddresses);
             }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/DeduplicationStrategy_End2End_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/DeduplicationStrategy_End2End_Tests.cs
@@ -30,7 +30,7 @@ namespace LoRaWan.NetworkServer.Test
         public async Task Validate_Dup_Message_Processing(DeduplicationMode mode)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
-            bool messageProcessed = mode == DeduplicationMode.Drop;
+            var messageProcessed = mode == DeduplicationMode.Drop;
             messageProcessed = false;
 
             this.LoRaDeviceApi.Setup(x => x.ExecuteFunctionBundlerAsync(simulatedDevice.DevEUI, It.IsNotNull<FunctionBundlerRequest>()))

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/DefaultClassCDevicesMessageSenderTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/DefaultClassCDevicesMessageSenderTest.cs
@@ -56,7 +56,7 @@ namespace LoRaWan.NetworkServer.Test
             Assert.Equal(0, downlink.Txpk.Tmst);
             Assert.NotEmpty(downlink.Txpk.Data);
 
-            byte[] downstreamPayloadBytes = Convert.FromBase64String(downlink.Txpk.Data);
+            var downstreamPayloadBytes = Convert.FromBase64String(downlink.Txpk.Data);
             var downstreamPayload = new LoRaPayloadData(downstreamPayloadBytes);
             Assert.Equal(sentMessage.Fport, downstreamPayload.GetFPort());
             Assert.Equal(downstreamPayload.DevAddr.ToArray(), ConversionHelper.StringToByteArray(simDevice.DevAddr));

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorJoinTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessorJoinTest.cs
@@ -420,7 +420,7 @@ namespace LoRaWan.NetworkServer.Test
         [InlineData(2, 0)]
         public async Task When_Getting_DLSettings_From_Twin_Returns_JoinAccept_With_Correct_Settings(int rx1DROffset, int rx2datarate)
         {
-            string deviceGatewayID = ServerGatewayID;
+            var deviceGatewayID = ServerGatewayID;
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, gatewayID: deviceGatewayID));
             var joinRequest = simulatedDevice.CreateJoinRequest();
 
@@ -486,14 +486,14 @@ namespace LoRaWan.NetworkServer.Test
         [InlineData(-2)]
         public async Task When_Getting_Custom_RX2_DR_From_Twin_Returns_JoinAccept_With_Correct_Settings_And_Behaves_Correctly(int rx2datarate)
         {
-            string deviceGatewayID = ServerGatewayID;
+            var deviceGatewayID = ServerGatewayID;
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, gatewayID: deviceGatewayID));
             var joinRequest = simulatedDevice.CreateJoinRequest();
             string afterJoinAppSKey = null;
             string afterJoinNwkSKey = null;
             string afterJoinDevAddr = null;
-            int afterJoinFcntDown = -1;
-            int afterJoinFcntUp = -1;
+            var afterJoinFcntDown = -1;
+            var afterJoinFcntUp = -1;
             uint startingPayloadFcnt = 0;
 
             // Create Rxpk
@@ -603,16 +603,16 @@ namespace LoRaWan.NetworkServer.Test
         {
             var beforeJoinValues = 2;
             var afterJoinValues = 3;
-            int reportedBeforeJoinRx1DROffsetValue = 0;
-            int reportedBeforeJoinRx2DRValue = 0;
-            int reportedBeforeJoinRxDelayValue = 0;
-            string deviceGatewayID = ServerGatewayID;
+            var reportedBeforeJoinRx1DROffsetValue = 0;
+            var reportedBeforeJoinRx2DRValue = 0;
+            var reportedBeforeJoinRxDelayValue = 0;
+            var deviceGatewayID = ServerGatewayID;
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, gatewayID: deviceGatewayID));
             string afterJoinAppSKey = null;
             string afterJoinNwkSKey = null;
             string afterJoinDevAddr = null;
-            int afterJoinFcntDown = -1;
-            int afterJoinFcntUp = -1;
+            var afterJoinFcntDown = -1;
+            var afterJoinFcntUp = -1;
             var devAddr = string.Empty;
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
             var appEUI = simulatedDevice.LoRaDevice.AppEUI;
@@ -712,14 +712,14 @@ namespace LoRaWan.NetworkServer.Test
         [InlineData(-2, 0)]
         public async Task When_Getting_RX1_Offset_From_Twin_Returns_JoinAccept_With_Correct_Settings_And_Behaves_Correctly(int rx1offset, int expectedDR)
         {
-            string deviceGatewayID = ServerGatewayID;
+            var deviceGatewayID = ServerGatewayID;
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, gatewayID: deviceGatewayID));
             var joinRequest = simulatedDevice.CreateJoinRequest();
             string afterJoinAppSKey = null;
             string afterJoinNwkSKey = null;
             string afterJoinDevAddr = null;
-            int afterJoinFcntDown = -1;
-            int afterJoinFcntUp = -1;
+            var afterJoinFcntDown = -1;
+            var afterJoinFcntUp = -1;
             uint startingPayloadFcnt = 0;
 
             // Create Rxpk
@@ -836,14 +836,14 @@ namespace LoRaWan.NetworkServer.Test
         [InlineData(2147483647, 1)]
         public async Task When_Getting_RXDelay_Offset_From_Twin_Returns_JoinAccept_With_Correct_Settings_And_Behaves_Correctly(int rxDelay, uint expectedDelay)
         {
-            string deviceGatewayID = ServerGatewayID;
+            var deviceGatewayID = ServerGatewayID;
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, gatewayID: deviceGatewayID));
             var joinRequest = simulatedDevice.CreateJoinRequest();
             string afterJoinAppSKey = null;
             string afterJoinNwkSKey = null;
             string afterJoinDevAddr = null;
-            int afterJoinFcntDown = -1;
-            int afterJoinFcntUp = -1;
+            var afterJoinFcntDown = -1;
+            var afterJoinFcntUp = -1;
             uint startingPayloadFcnt = 0;
 
             // Create Rxpk

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_ClassC_CloudToDeviceMessage_SizeLimit_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_ClassC_CloudToDeviceMessage_SizeLimit_Tests.cs
@@ -60,7 +60,7 @@ namespace LoRaWan.NetworkServer.Test
             Assert.Equal(0, downlink.Txpk.Tmst);
             Assert.NotEmpty(downlink.Txpk.Data);
 
-            byte[] downstreamPayloadBytes = Convert.FromBase64String(downlink.Txpk.Data);
+            var downstreamPayloadBytes = Convert.FromBase64String(downlink.Txpk.Data);
             var downstreamPayload = new LoRaPayloadData(downstreamPayloadBytes);
             Assert.Equal(sentMessage.Fport, downstreamPayload.GetFPort());
             Assert.Equal(downstreamPayload.DevAddr.ToArray(), ConversionHelper.StringToByteArray(simDevice.DevAddr));
@@ -217,12 +217,12 @@ namespace LoRaWan.NetworkServer.Test
 
         private string GeneratePayload(string allowedChars, int length)
         {
-            Random random = new Random();
+            var random = new Random();
 
-            char[] chars = new char[length];
-            int setLength = allowedChars.Length;
+            var chars = new char[length];
+            var setLength = allowedChars.Length;
 
-            for (int i = 0; i < length; ++i)
+            for (var i = 0; i < length; ++i)
             {
                 chars[i] = allowedChars[random.Next(setLength)];
             }

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_ClassC_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_ClassC_Tests.cs
@@ -109,7 +109,7 @@ namespace LoRaWan.NetworkServer.Test
             Assert.Single(this.PacketForwarder.DownlinkMessages);
             var downstreamMsg = this.PacketForwarder.DownlinkMessages[0];
 
-            byte[] downstreamPayloadBytes = Convert.FromBase64String(downstreamMsg.Txpk.Data);
+            var downstreamPayloadBytes = Convert.FromBase64String(downstreamMsg.Txpk.Data);
             var downstreamPayload = new LoRaPayloadData(downstreamPayloadBytes);
             Assert.Equal(expectedFcntDown, downstreamPayload.GetFcnt());
             Assert.Equal(c2d.Fport, downstreamPayload.GetFPort());
@@ -212,7 +212,7 @@ namespace LoRaWan.NetworkServer.Test
 
             TestLogger.Log($"appSKey: {simDevice.AppSKey}, nwkSKey: {simDevice.NwkSKey}");
 
-            byte[] downstreamPayloadBytes = Convert.FromBase64String(downstreamMsg.Txpk.Data);
+            var downstreamPayloadBytes = Convert.FromBase64String(downstreamMsg.Txpk.Data);
             var downstreamPayload = new LoRaPayloadData(downstreamPayloadBytes);
             Assert.Equal(1, downstreamPayload.GetFcnt());
             Assert.Equal(c2d.Fport, downstreamPayload.GetFPort());

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Should_Abandon.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Should_Abandon.cs
@@ -37,7 +37,7 @@ namespace LoRaWan.NetworkServer.Test
 
             var loraDevice = this.CreateLoRaDevice(simulatedDevice);
 
-            Rxpk rxpk = this.CreateUpstreamRxpk(isConfirmed, hasMacInUpstream, datr, simulatedDevice);
+            var rxpk = this.CreateUpstreamRxpk(isConfirmed, hasMacInUpstream, datr, simulatedDevice);
 
             if (!hasMacInUpstream)
             {

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Should_Accept.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Should_Accept.cs
@@ -45,7 +45,7 @@ namespace LoRaWan.NetworkServer.Test
 
             var loraDevice = this.CreateLoRaDevice(simulatedDevice);
 
-            Rxpk rxpk = this.CreateUpstreamRxpk(isConfirmed, hasMacInUpstream, datr, simulatedDevice);
+            var rxpk = this.CreateUpstreamRxpk(isConfirmed, hasMacInUpstream, datr, simulatedDevice);
 
             if (!hasMacInUpstream)
             {

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Should_Reject.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_SizeLimit_Should_Reject.cs
@@ -35,7 +35,7 @@ namespace LoRaWan.NetworkServer.Test
 
             var loraDevice = this.CreateLoRaDevice(simulatedDevice);
 
-            Rxpk rxpk = this.CreateUpstreamRxpk(isConfirmed, hasMacInUpstream, datr, simulatedDevice);
+            var rxpk = this.CreateUpstreamRxpk(isConfirmed, hasMacInUpstream, datr, simulatedDevice);
 
             if (!hasMacInUpstream)
             {

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
@@ -369,7 +369,7 @@ namespace LoRaWan.NetworkServer.Test
             var downlinkMessage = this.PacketForwarder.DownlinkMessages[0];
             var txpk = downlinkMessage.Txpk;
             var euRegion = RegionManager.EU868;
-            Assert.True(euRegion.TryGetDownstreamChannelFrequency(rxpk, out double frequency));
+            Assert.True(euRegion.TryGetDownstreamChannelFrequency(rxpk, out var frequency));
             // Ensure we are using second window frequency
             Assert.Equal(frequency, txpk.Freq);
 

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Join_Tests.cs
@@ -188,7 +188,7 @@ namespace LoRaWan.NetworkServer.Test
             var downstreamMessage = this.PacketForwarder.DownlinkMessages[1];
 
             // validates txpk according to eu region
-            Assert.True(RegionManager.EU868.TryGetDownstreamChannelFrequency(confirmedMessageRxpk, out double frequency));
+            Assert.True(RegionManager.EU868.TryGetDownstreamChannelFrequency(confirmedMessageRxpk, out var frequency));
             Assert.Equal(frequency, downstreamMessage.Txpk.Freq);
             Assert.Equal("4/5", downstreamMessage.Txpk.Codr);
             Assert.False(downstreamMessage.Txpk.Imme);
@@ -479,7 +479,7 @@ namespace LoRaWan.NetworkServer.Test
             var downlinkJoinAcceptMessage = this.PacketForwarder.DownlinkMessages[0];
             // validates txpk according to eu region
             Assert.Equal(0U, downlinkJoinAcceptMessage.Txpk.Rfch);
-            Assert.True(RegionManager.EU868.TryGetDownstreamChannelFrequency(joinRxpk, out double receivedFrequency));
+            Assert.True(RegionManager.EU868.TryGetDownstreamChannelFrequency(joinRxpk, out var receivedFrequency));
             Assert.Equal(receivedFrequency, downlinkJoinAcceptMessage.Txpk.Freq);
             Assert.Equal("4/5", downlinkJoinAcceptMessage.Txpk.Codr);
             Assert.False(downlinkJoinAcceptMessage.Txpk.Imme);

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_Processing_Tests.cs
@@ -203,7 +203,7 @@ namespace LoRaWan.NetworkServer.Test
         [Fact]
         public async Task ABP_Unconfirmed_Sends_Valid_Mac_Commands_As_Part_Of_Payload_And_Receives_Answer_As_Part_Of_Payload()
         {
-            string deviceGatewayID = ServerGatewayID;
+            var deviceGatewayID = ServerGatewayID;
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID));
             var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
             loRaDevice.SensorDecoder = string.Empty;
@@ -224,7 +224,7 @@ namespace LoRaWan.NetworkServer.Test
                 this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed mac LinkCheckCmd
-            string msgPayload = "02";
+            var msgPayload = "02";
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload, fcnt: 1, isHexPayload: true, fport: 0);
             // only use nwkskey
             var rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.NwkSKey, simulatedDevice.NwkSKey).Rxpk[0];
@@ -233,11 +233,11 @@ namespace LoRaWan.NetworkServer.Test
             Assert.True(await request.WaitCompleteAsync());
             // Server should reply with MacCommand Answer
             Assert.NotNull(request.ResponseDownlink);
-            LoRaPayloadData data = new LoRaPayloadData(Convert.FromBase64String(request.ResponseDownlink.Txpk.Data));
+            var data = new LoRaPayloadData(Convert.FromBase64String(request.ResponseDownlink.Txpk.Data));
             Assert.True(data.CheckMic(simulatedDevice.NwkSKey));
             data.PerformEncryption(simulatedDevice.NwkSKey);
             data.Frmpayload.Span.Reverse();
-            LoRaTools.LinkCheckAnswer link = new LoRaTools.LinkCheckAnswer(data.Frmpayload.Span);
+            var link = new LoRaTools.LinkCheckAnswer(data.Frmpayload.Span);
             Assert.NotNull(link);
             Assert.Equal(1, (int)link.GwCnt);
             Assert.Equal(15, (int)link.Margin);
@@ -251,7 +251,7 @@ namespace LoRaWan.NetworkServer.Test
         [Fact]
         public async Task ABP_Unconfirmed_Sends_Valid_Mac_Commands_In_Fopts_And_Reply_In_Fopts()
         {
-            string deviceGatewayID = ServerGatewayID;
+            var deviceGatewayID = ServerGatewayID;
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID));
             var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
             loRaDevice.SensorDecoder = string.Empty;
@@ -297,8 +297,8 @@ namespace LoRaWan.NetworkServer.Test
                 this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed mac LinkCheckCmd
-            string msgPayload = "Hello World";
-            List<LoRaTools.MacCommand> macCommands = new List<LoRaTools.MacCommand>()
+            var msgPayload = "Hello World";
+            var macCommands = new List<LoRaTools.MacCommand>()
             {
                 new LoRaTools.LinkCheckRequest()
             };
@@ -310,10 +310,10 @@ namespace LoRaWan.NetworkServer.Test
             Assert.True(await request.WaitCompleteAsync());
             // Server should reply with MacCommand Answer
             Assert.NotNull(request.ResponseDownlink);
-            LoRaPayloadData data = new LoRaPayloadData(Convert.FromBase64String(request.ResponseDownlink.Txpk.Data));
+            var data = new LoRaPayloadData(Convert.FromBase64String(request.ResponseDownlink.Txpk.Data));
             Assert.True(data.CheckMic(simulatedDevice.NwkSKey));
             // FOpts are not encrypted
-            LoRaTools.LinkCheckAnswer link = new LoRaTools.LinkCheckAnswer(data.Fopts.Span);
+            var link = new LoRaTools.LinkCheckAnswer(data.Fopts.Span);
             Assert.NotNull(link);
             Assert.NotNull(eventProperties);
             Assert.Contains("LinkCheckCmd", eventProperties.Keys);
@@ -331,7 +331,7 @@ namespace LoRaWan.NetworkServer.Test
         [InlineData("25")]
         public async Task ABP_Unconfirmed_Sends_Invalid_Mac_Commands_In_Fopts(string macCommand)
         {
-            string deviceGatewayID = ServerGatewayID;
+            var deviceGatewayID = ServerGatewayID;
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID));
             var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
             loRaDevice.SensorDecoder = string.Empty;
@@ -369,7 +369,7 @@ namespace LoRaWan.NetworkServer.Test
                 this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed mac LinkCheckCmd
-            string msgPayload = "Hello World";
+            var msgPayload = "Hello World";
 
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload, fcnt: 1);
             unconfirmedMessagePayload.Fopts = ConversionHelper.StringToByteArray(macCommand);
@@ -381,11 +381,11 @@ namespace LoRaWan.NetworkServer.Test
             Assert.True(await request.WaitCompleteAsync());
             // Server should reply with MacCommand Answer
             Assert.NotNull(request.ResponseDownlink);
-            LoRaPayloadData data = new LoRaPayloadData(Convert.FromBase64String(request.ResponseDownlink.Txpk.Data));
+            var data = new LoRaPayloadData(Convert.FromBase64String(request.ResponseDownlink.Txpk.Data));
             Assert.True(data.CheckMic(simulatedDevice.NwkSKey));
             // FOpts are not encrypted
             var payload = data.GetDecryptedPayload(simulatedDevice.AppSKey);
-            string c2dreceivedPayload = Encoding.UTF8.GetString(payload);
+            var c2dreceivedPayload = Encoding.UTF8.GetString(payload);
             Assert.Equal(c2dMessage.Payload, c2dreceivedPayload);
             // Nothing should be sent to IoT Hub
             Assert.NotNull(loRaDeviceTelemetry);
@@ -399,7 +399,7 @@ namespace LoRaWan.NetworkServer.Test
         [InlineData("26")]
         public async Task ABP_Unconfirmed_Sends_Invalid_Mac_Commands_As_Part_Of_Payload(string macCommand)
         {
-            string deviceGatewayID = ServerGatewayID;
+            var deviceGatewayID = ServerGatewayID;
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID));
             var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
             loRaDevice.SensorDecoder = string.Empty;
@@ -426,7 +426,7 @@ namespace LoRaWan.NetworkServer.Test
                 this.FrameCounterUpdateStrategyProvider);
 
             // sends unconfirmed mac LinkCheckCmd
-            string msgPayload = macCommand;
+            var msgPayload = macCommand;
             var unconfirmedMessagePayload = simulatedDevice.CreateUnconfirmedDataUpMessage(msgPayload, fcnt: 1, isHexPayload: true, fport: 0);
             // only use nwkskey
             var rxpk = unconfirmedMessagePayload.SerializeUplink(simulatedDevice.NwkSKey, simulatedDevice.NwkSKey).Rxpk[0];
@@ -450,13 +450,13 @@ namespace LoRaWan.NetworkServer.Test
         [InlineData(255, 255)]
         public async Task ABP_Device_NetId_Should_Match_Server(uint deviceNetId, uint serverNetId)
         {
-            string msgPayload = "1234";
+            var msgPayload = "1234";
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, netId: deviceNetId));
             var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
             loRaDevice.SensorDecoder = null;
 
             // message will be sent if there is a match
-            bool netIdMatches = deviceNetId == serverNetId;
+            var netIdMatches = deviceNetId == serverNetId;
             LoRaDeviceTelemetry loRaDeviceTelemetry = null;
             if (netIdMatches)
             {
@@ -636,7 +636,7 @@ namespace LoRaWan.NetworkServer.Test
             var confirmedMessageResult = this.PacketForwarder.DownlinkMessages[0];
 
             // validates txpk according to eu region
-            Assert.True(RegionManager.EU868.TryGetDownstreamChannelFrequency(rxpk, out double frequency));
+            Assert.True(RegionManager.EU868.TryGetDownstreamChannelFrequency(rxpk, out var frequency));
             Assert.Equal(frequency, confirmedMessageResult.Txpk.Freq);
             Assert.Equal("4/5", confirmedMessageResult.Txpk.Codr);
             Assert.False(confirmedMessageResult.Txpk.Imme);
@@ -809,7 +809,7 @@ namespace LoRaWan.NetworkServer.Test
             Assert.Single(this.PacketForwarder.DownlinkMessages);
             var txpk = this.PacketForwarder.DownlinkMessages[0].Txpk;
             Assert.Equal(0U, txpk.Rfch);
-            Assert.True(RegionManager.EU868.TryGetDownstreamChannelFrequency(rxpk, out double frequency));
+            Assert.True(RegionManager.EU868.TryGetDownstreamChannelFrequency(rxpk, out var frequency));
             Assert.Equal(frequency, txpk.Freq);
             Assert.Equal("4/5", txpk.Codr);
             Assert.False(txpk.Imme);
@@ -1220,7 +1220,7 @@ namespace LoRaWan.NetworkServer.Test
         [Fact]
         public async Task ABP_Device_With_Invalid_NetId_Should_Not_Load_Devices()
         {
-            string msgPayload = "1234";
+            var msgPayload = "1234";
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, netId: 0));
             var loRaDevice = this.CreateLoRaDevice(simulatedDevice);
 
@@ -1259,7 +1259,7 @@ namespace LoRaWan.NetworkServer.Test
         [Fact]
         public async Task ABP_Device_With_Invalid_NetId_In_Allowed_DevAdr_Should_Be_Accepted()
         {
-            string msgPayload = "1234";
+            var msgPayload = "1234";
             var deviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, netId: 0, gatewayID: ServerGatewayID));
 

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/TestUtils.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/TestUtils.cs
@@ -165,12 +165,12 @@ namespace LoRaWan.NetworkServer.Test
 
         public static string GeneratePayload(string allowedChars, int length)
         {
-            Random random = new Random();
+            var random = new Random();
 
-            char[] chars = new char[length];
-            int setLength = allowedChars.Length;
+            var chars = new char[length];
+            var setLength = allowedChars.Length;
 
-            for (int i = 0; i < length; ++i)
+            for (var i = 0; i < length; ++i)
             {
                 chars[i] = allowedChars[random.Next(setLength)];
             }

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/DevAddrCacheTest.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/DevAddrCacheTest.cs
@@ -32,10 +32,10 @@ namespace LoraKeysManagerFacade.Test
 
         private Mock<RegistryManager> InitRegistryManager(List<DevAddrCacheInfo> deviceIds, int numberOfDeviceDeltaUpdates = 2)
         {
-            List<DevAddrCacheInfo> currentDevAddrContext = new List<DevAddrCacheInfo>();
-            List<DevAddrCacheInfo> currentDevices = deviceIds;
+            var currentDevAddrContext = new List<DevAddrCacheInfo>();
+            var currentDevices = deviceIds;
             var mockRegistryManager = new Mock<RegistryManager>(MockBehavior.Strict);
-            bool hasMoreShouldReturn = true;
+            var hasMoreShouldReturn = true;
 
             var primaryKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(PrimaryKey));
             mockRegistryManager
@@ -46,7 +46,7 @@ namespace LoraKeysManagerFacade.Test
                 .Setup(x => x.GetTwinAsync(It.IsNotNull<string>()))
                 .ReturnsAsync((string deviceId) => new Twin(deviceId));
 
-            int numberOfDevices = deviceIds.Count;
+            var numberOfDevices = deviceIds.Count;
 
             // CacheMiss query
             var cacheMissQueryMock = new Mock<IQuery>(MockBehavior.Strict);
@@ -70,7 +70,7 @@ namespace LoraKeysManagerFacade.Test
                 .ReturnsAsync(() =>
                 {
                     var devAddressesToConsider = currentDevAddrContext;
-                    List<Twin> twins = new List<Twin>();
+                    var twins = new List<Twin>();
                     foreach (var devaddrItem in devAddressesToConsider)
                     {
                         var deviceTwin = new Twin();
@@ -135,9 +135,9 @@ namespace LoraKeysManagerFacade.Test
         {
             var devAddrcache = new LoRaDevAddrCache(this.cache, null, null);
             await LockDevAddrHelper.PrepareLocksForTests(this.cache, null, lockToTake);
-            List<DevAddrCacheInfo> managerInput = new List<DevAddrCacheInfo>();
+            var managerInput = new List<DevAddrCacheInfo>();
 
-            for (int i = 0; i < 2; i++)
+            for (var i = 0; i < 2; i++)
             {
                 managerInput.Add(new DevAddrCacheInfo()
                 {
@@ -164,11 +164,11 @@ namespace LoraKeysManagerFacade.Test
         // Server saves answer in the Cache for future usage
         public async Task When_DevAddr_Is_Not_In_Cache_Query_Iot_Hub_And_Save_In_Cache()
         {
-            string gatewayId = NewUniqueEUI64();
-            DateTime dateTime = DateTime.UtcNow;
-            List<DevAddrCacheInfo> managerInput = new List<DevAddrCacheInfo>();
+            var gatewayId = NewUniqueEUI64();
+            var dateTime = DateTime.UtcNow;
+            var managerInput = new List<DevAddrCacheInfo>();
 
-            for (int i = 0; i < 2; i++)
+            for (var i = 0; i < 2; i++)
             {
                 managerInput.Add(new DevAddrCacheInfo()
                 {
@@ -180,7 +180,7 @@ namespace LoraKeysManagerFacade.Test
             var devAddrJoining = managerInput[0].DevAddr;
             var registryManagerMock = this.InitRegistryManager(managerInput);
 
-            List<IoTHubDeviceInfo> items = new List<IoTHubDeviceInfo>();
+            var items = new List<IoTHubDeviceInfo>();
 
             // In this test we want no updates running
             // initialize locks for test to run correctly
@@ -209,11 +209,11 @@ namespace LoraKeysManagerFacade.Test
         // This test simulate a call received by multiple server. It ensures IoT Hub is only queried once.
         public async Task Multi_Gateway_When_DevAddr_Is_Not_In_Cache_Query_Iot_Hub_Only_Once_And_Save_In_Cache()
         {
-            string gatewayId = NewUniqueEUI64();
-            DateTime dateTime = DateTime.UtcNow;
-            List<DevAddrCacheInfo> managerInput = new List<DevAddrCacheInfo>();
+            var gatewayId = NewUniqueEUI64();
+            var dateTime = DateTime.UtcNow;
+            var managerInput = new List<DevAddrCacheInfo>();
 
-            for (int i = 0; i < 2; i++)
+            for (var i = 0; i < 2; i++)
             {
                 managerInput.Add(new DevAddrCacheInfo()
                 {
@@ -259,10 +259,10 @@ namespace LoraKeysManagerFacade.Test
         // This test ensure that if a device is in cache without a key, it get the keys from iot hub and saave it
         public async Task When_DevAddr_Is_In_Cache_Without_Key_Should_Not_Query_Iot_Hub_For_Twin_But_Should_Get_Key_And_Update()
         {
-            string gatewayId = NewUniqueEUI64();
-            DateTime dateTime = DateTime.UtcNow;
-            List<DevAddrCacheInfo> managerInput = new List<DevAddrCacheInfo>();
-            for (int i = 0; i < 2; i++)
+            var gatewayId = NewUniqueEUI64();
+            var dateTime = DateTime.UtcNow;
+            var managerInput = new List<DevAddrCacheInfo>();
+            for (var i = 0; i < 2; i++)
             {
                 managerInput.Add(new DevAddrCacheInfo()
                 {
@@ -276,7 +276,7 @@ namespace LoraKeysManagerFacade.Test
             var devAddrJoining = managerInput[0].DevAddr;
             this.InitCache(this.cache, managerInput);
             var registryManagerMock = this.InitRegistryManager(managerInput);
-            List<IoTHubDeviceInfo> items = new List<IoTHubDeviceInfo>();
+            var items = new List<IoTHubDeviceInfo>();
 
             // In this test we want no updates running
             // initialize locks for test to run correctly
@@ -305,10 +305,10 @@ namespace LoraKeysManagerFacade.Test
         // This test ensure that if a device is in cache without a key, it get the keys from iot hub and saave it
         public async Task Multi_Gateway_When_DevAddr_Is_In_Cache_Without_Key_Should_Not_Query_Iot_Hub_For_Twin_But_Should_Get_Key_And_Update()
         {
-            string gatewayId = NewUniqueEUI64();
-            DateTime dateTime = DateTime.UtcNow;
-            List<DevAddrCacheInfo> managerInput = new List<DevAddrCacheInfo>();
-            for (int i = 0; i < 2; i++)
+            var gatewayId = NewUniqueEUI64();
+            var dateTime = DateTime.UtcNow;
+            var managerInput = new List<DevAddrCacheInfo>();
+            for (var i = 0; i < 2; i++)
             {
                 managerInput.Add(new DevAddrCacheInfo()
                 {
@@ -354,11 +354,11 @@ namespace LoraKeysManagerFacade.Test
         // This test ensure that if the device has the key within the cache, it should not make any query to iot hub
         public async Task When_DevAddr_Is_In_Cache_With_Key_Should_Not_Query_Iot_Hub_For_Twin_At_All()
         {
-            string gatewayId = NewUniqueEUI64();
-            DateTime dateTime = DateTime.UtcNow;
+            var gatewayId = NewUniqueEUI64();
+            var dateTime = DateTime.UtcNow;
             var primaryKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(PrimaryKey));
-            List<DevAddrCacheInfo> managerInput = new List<DevAddrCacheInfo>();
-            for (int i = 0; i < 2; i++)
+            var managerInput = new List<DevAddrCacheInfo>();
+            for (var i = 0; i < 2; i++)
             {
                 managerInput.Add(new DevAddrCacheInfo()
                 {
@@ -374,7 +374,7 @@ namespace LoraKeysManagerFacade.Test
             this.InitCache(this.cache, managerInput);
             var registryManagerMock = this.InitRegistryManager(managerInput);
 
-            List<IoTHubDeviceInfo> items = new List<IoTHubDeviceInfo>();
+            var items = new List<IoTHubDeviceInfo>();
             // In this test we want no updates running
             // initialize locks for test to run correctly
             var lockToTake = new string[2] { FullUpdateKey, DeltaUpdateKey };
@@ -395,17 +395,17 @@ namespace LoraKeysManagerFacade.Test
         // This test ensure that if the device has the key within the cache, it should not make any query to iot hub
         public async Task When_Device_Is_Not_Ours_Save_In_Cache_And_Dont_Query_Hub_Again()
         {
-            string gatewayId = NewUniqueEUI64();
-            DateTime dateTime = DateTime.UtcNow;
+            var gatewayId = NewUniqueEUI64();
+            var dateTime = DateTime.UtcNow;
             // In this test we want no updates running
             // initialize locks for test to run correctly
             var lockToTake = new string[2] { FullUpdateKey, DeltaUpdateKey };
             await LockDevAddrHelper.PrepareLocksForTests(this.cache, null, lockToTake);
 
-            List<IoTHubDeviceInfo> items = new List<IoTHubDeviceInfo>();
+            var items = new List<IoTHubDeviceInfo>();
             var primaryKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(PrimaryKey));
-            List<DevAddrCacheInfo> managerInput = new List<DevAddrCacheInfo>();
-            for (int i = 0; i < 2; i++)
+            var managerInput = new List<DevAddrCacheInfo>();
+            for (var i = 0; i < 2; i++)
             {
                 managerInput.Add(new DevAddrCacheInfo()
                 {
@@ -445,11 +445,11 @@ namespace LoraKeysManagerFacade.Test
         // Check that the server perform a full reload if the locking key for full reload is not present
         public async Task When_FullUpdateKey_Is_Not_there_Should_Perform_Full_Reload()
         {
-            string gatewayId = NewUniqueEUI64();
-            DateTime dateTime = DateTime.UtcNow;
+            var gatewayId = NewUniqueEUI64();
+            var dateTime = DateTime.UtcNow;
             var primaryKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(PrimaryKey));
-            List<DevAddrCacheInfo> managerInput = new List<DevAddrCacheInfo>();
-            for (int i = 0; i < 5; i++)
+            var managerInput = new List<DevAddrCacheInfo>();
+            for (var i = 0; i < 5; i++)
             {
                 managerInput.Add(new DevAddrCacheInfo()
                 {
@@ -464,10 +464,10 @@ namespace LoraKeysManagerFacade.Test
             var registryManagerMock = this.InitRegistryManager(managerInput);
 
             // initialize locks for test to run correctly
-            string[] neededLocksForTestToRun = new string[2] { FullUpdateKey, GlobalDevAddrUpdateKey };
+            var neededLocksForTestToRun = new string[2] { FullUpdateKey, GlobalDevAddrUpdateKey };
             await LockDevAddrHelper.PrepareLocksForTests(this.cache, neededLocksForTestToRun, null);
 
-            List<IoTHubDeviceInfo> items = new List<IoTHubDeviceInfo>();
+            var items = new List<IoTHubDeviceInfo>();
 
             var deviceGetter = new DeviceGetter(registryManagerMock.Object, this.cache);
             items = await deviceGetter.GetDeviceList(null, gatewayId, "ABCD", devAddrJoining);
@@ -480,7 +480,7 @@ namespace LoraKeysManagerFacade.Test
             registryManagerMock.Verify(x => x.GetDeviceAsync(It.IsAny<string>()), Times.Once);
 
             // we expect the devices are saved
-            for (int i = 1; i < 5; i++)
+            for (var i = 1; i < 5; i++)
             {
                 var queryResult = this.cache.GetHashObject(string.Concat(CacheKeyPrefix, managerInput[i].DevAddr));
                 Assert.Single(queryResult);
@@ -494,11 +494,11 @@ namespace LoraKeysManagerFacade.Test
         // Trigger delta update correctly to see if it performs correctly on an empty cache
         public async Task Delta_Update_Perform_Correctly_On_Empty_Cache()
         {
-            string gatewayId = NewUniqueEUI64();
-            DateTime dateTime = DateTime.UtcNow;
+            var gatewayId = NewUniqueEUI64();
+            var dateTime = DateTime.UtcNow;
 
-            List<DevAddrCacheInfo> managerInput = new List<DevAddrCacheInfo>();
-            for (int i = 0; i < 5; i++)
+            var managerInput = new List<DevAddrCacheInfo>();
+            for (var i = 0; i < 5; i++)
             {
                 managerInput.Add(new DevAddrCacheInfo()
                 {
@@ -514,11 +514,11 @@ namespace LoraKeysManagerFacade.Test
             var registryManagerMock = this.InitRegistryManager(managerInput);
 
             // initialize locks for test to run correctly
-            string[] neededLocksForTestToRun = new string[2] { GlobalDevAddrUpdateKey, DeltaUpdateKey };
+            var neededLocksForTestToRun = new string[2] { GlobalDevAddrUpdateKey, DeltaUpdateKey };
             var locksGuideTest = new string[1] { FullUpdateKey };
             await LockDevAddrHelper.PrepareLocksForTests(this.cache, neededLocksForTestToRun, locksGuideTest);
 
-            LoRaDevAddrCache devAddrCache = new LoRaDevAddrCache(this.cache, null, gatewayId);
+            var devAddrCache = new LoRaDevAddrCache(this.cache, null, gatewayId);
             await devAddrCache.PerformNeededSyncs(registryManagerMock.Object);
 
             while (!string.IsNullOrEmpty(this.cache.StringGet(GlobalDevAddrUpdateKey)))
@@ -528,7 +528,7 @@ namespace LoraKeysManagerFacade.Test
 
             var foundItem = 0;
             // we expect the devices are saved
-            for (int i = 0; i < 5; i++)
+            for (var i = 0; i < 5; i++)
             {
                 var queryResult = this.cache.GetHashObject(string.Concat(CacheKeyPrefix, managerInput[i].DevAddr));
                 if (queryResult.Length > 0)
@@ -559,15 +559,15 @@ namespace LoraKeysManagerFacade.Test
         // Primary Key are kept as UpdateTime is similar
         public async Task Delta_Update_Perform_Correctly_On_Non_Empty_Cache_And_Keep_Old_Values()
         {
-            string oldGatewayId = NewUniqueEUI64();
-            string newGatewayId = NewUniqueEUI64();
-            DateTime dateTime = DateTime.UtcNow;
+            var oldGatewayId = NewUniqueEUI64();
+            var newGatewayId = NewUniqueEUI64();
+            var dateTime = DateTime.UtcNow;
 
             var primaryKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(PrimaryKey));
-            List<DevAddrCacheInfo> managerInput = new List<DevAddrCacheInfo>();
+            var managerInput = new List<DevAddrCacheInfo>();
 
             var adressForDuplicateDevAddr = NewUniqueEUI32();
-            for (int i = 0; i < 5; i++)
+            for (var i = 0; i < 5; i++)
             {
                 managerInput.Add(new DevAddrCacheInfo()
                 {
@@ -591,8 +591,8 @@ namespace LoraKeysManagerFacade.Test
             var registryManagerMock = this.InitRegistryManager(managerInput, managerInput.Count());
 
             // Set up the cache with expectation.
-            List<DevAddrCacheInfo> cacheInput = new List<DevAddrCacheInfo>();
-            for (int i = 0; i < 5; i++)
+            var cacheInput = new List<DevAddrCacheInfo>();
+            for (var i = 0; i < 5; i++)
             {
                 cacheInput.Add(new DevAddrCacheInfo()
                 {
@@ -618,15 +618,15 @@ namespace LoraKeysManagerFacade.Test
             this.InitCache(this.cache, cacheInput);
 
             // initialize locks for test to run correctly
-            string[] neededLocksForTestToRun = new string[2] { GlobalDevAddrUpdateKey, DeltaUpdateKey };
+            var neededLocksForTestToRun = new string[2] { GlobalDevAddrUpdateKey, DeltaUpdateKey };
             var locksGuideTest = new string[1] { FullUpdateKey };
             await LockDevAddrHelper.PrepareLocksForTests(this.cache, neededLocksForTestToRun, locksGuideTest);
 
-            LoRaDevAddrCache devAddrCache = new LoRaDevAddrCache(this.cache, null, newGatewayId);
+            var devAddrCache = new LoRaDevAddrCache(this.cache, null, newGatewayId);
             await devAddrCache.PerformNeededSyncs(registryManagerMock.Object);
 
             // we expect the devices are saved
-            for (int i = 0; i < managerInput.Count; i++)
+            for (var i = 0; i < managerInput.Count; i++)
             {
                 if (managerInput[i].DevAddr != adressForDuplicateDevAddr)
                 {
@@ -642,7 +642,7 @@ namespace LoraKeysManagerFacade.Test
             // let's check the devices with a double EUI
             var query2Result = this.cache.GetHashObject(string.Concat(CacheKeyPrefix, adressForDuplicateDevAddr));
             Assert.Equal(2, query2Result.Count());
-            for (int i = 0; i < 2; i++)
+            for (var i = 0; i < 2; i++)
             {
                 var resultObject = JsonConvert.DeserializeObject<DevAddrCacheInfo>(query2Result[0].Value);
                 if (resultObject.DevEUI == devEuiDoubleItem)
@@ -673,16 +673,16 @@ namespace LoraKeysManagerFacade.Test
         // Primary Key are dropped as updatetime is defferent
         public async Task Delta_Update_Perform_Correctly_On_Non_Empty_Cache_And_Keep_Old_Values_Except_Primary_Key()
         {
-            string oldGatewayId = NewUniqueEUI64();
-            string newGatewayId = NewUniqueEUI64();
-            DateTime dateTime = DateTime.UtcNow;
-            DateTime updateDateTime = DateTime.UtcNow.AddMinutes(10);
+            var oldGatewayId = NewUniqueEUI64();
+            var newGatewayId = NewUniqueEUI64();
+            var dateTime = DateTime.UtcNow;
+            var updateDateTime = DateTime.UtcNow.AddMinutes(10);
 
             var primaryKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(PrimaryKey));
-            List<DevAddrCacheInfo> managerInput = new List<DevAddrCacheInfo>();
+            var managerInput = new List<DevAddrCacheInfo>();
 
             var adressForDuplicateDevAddr = NewUniqueEUI32();
-            for (int i = 0; i < 5; i++)
+            for (var i = 0; i < 5; i++)
             {
                 managerInput.Add(new DevAddrCacheInfo()
                 {
@@ -696,8 +696,8 @@ namespace LoraKeysManagerFacade.Test
             var registryManagerMock = this.InitRegistryManager(managerInput, managerInput.Count());
 
             // Set up the cache with expectation.
-            List<DevAddrCacheInfo> cacheInput = new List<DevAddrCacheInfo>();
-            for (int i = 0; i < 5; i++)
+            var cacheInput = new List<DevAddrCacheInfo>();
+            for (var i = 0; i < 5; i++)
             {
                 cacheInput.Add(new DevAddrCacheInfo()
                 {
@@ -710,15 +710,15 @@ namespace LoraKeysManagerFacade.Test
 
             this.InitCache(this.cache, cacheInput);
             // initialize locks for test to run correctly
-            string[] neededLocksForTestToRun = new string[2] { GlobalDevAddrUpdateKey, DeltaUpdateKey };
+            var neededLocksForTestToRun = new string[2] { GlobalDevAddrUpdateKey, DeltaUpdateKey };
             var locksGuideTest = new string[1] { FullUpdateKey };
             await LockDevAddrHelper.PrepareLocksForTests(this.cache, neededLocksForTestToRun, locksGuideTest);
 
-            LoRaDevAddrCache devAddrCache = new LoRaDevAddrCache(this.cache, null, newGatewayId);
+            var devAddrCache = new LoRaDevAddrCache(this.cache, null, newGatewayId);
             await devAddrCache.PerformNeededSyncs(registryManagerMock.Object);
 
             // we expect the devices are saved
-            for (int i = 0; i < managerInput.Count; i++)
+            for (var i = 0; i < managerInput.Count; i++)
             {
                 var queryResult = this.cache.GetHashObject(string.Concat(CacheKeyPrefix, managerInput[i].DevAddr));
                 Assert.Single(queryResult);
@@ -746,14 +746,14 @@ namespace LoraKeysManagerFacade.Test
         // Primary Key are kept as UpdateTime is similar
         public async Task Full_Update_Perform_Correctly_On_Non_Empty_Cache_And_Keep_Old_Values()
         {
-            string oldGatewayId = NewUniqueEUI64();
-            string newGatewayId = NewUniqueEUI64();
-            DateTime dateTime = DateTime.UtcNow;
+            var oldGatewayId = NewUniqueEUI64();
+            var newGatewayId = NewUniqueEUI64();
+            var dateTime = DateTime.UtcNow;
             var primaryKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(PrimaryKey));
-            List<DevAddrCacheInfo> newValues = new List<DevAddrCacheInfo>();
+            var newValues = new List<DevAddrCacheInfo>();
 
             var adressForDuplicateDevAddr = NewUniqueEUI32();
-            for (int i = 0; i < 5; i++)
+            for (var i = 0; i < 5; i++)
             {
                 newValues.Add(new DevAddrCacheInfo()
                 {
@@ -777,8 +777,8 @@ namespace LoraKeysManagerFacade.Test
             var registryManagerMock = this.InitRegistryManager(newValues, newValues.Count());
 
             // Set up the cache with expectation.
-            List<DevAddrCacheInfo> cacheInput = new List<DevAddrCacheInfo>();
-            for (int i = 0; i < 5; i++)
+            var cacheInput = new List<DevAddrCacheInfo>();
+            for (var i = 0; i < 5; i++)
             {
                 cacheInput.Add(new DevAddrCacheInfo()
                 {
@@ -807,14 +807,14 @@ namespace LoraKeysManagerFacade.Test
             this.InitCache(this.cache, cacheInput);
 
             // initialize locks for test to run correctly
-            string[] neededLocksForTestToRun = new string[2] { GlobalDevAddrUpdateKey, FullUpdateKey };
+            var neededLocksForTestToRun = new string[2] { GlobalDevAddrUpdateKey, FullUpdateKey };
             await LockDevAddrHelper.PrepareLocksForTests(this.cache, neededLocksForTestToRun, null);
 
-            LoRaDevAddrCache devAddrCache = new LoRaDevAddrCache(this.cache, null, newGatewayId);
+            var devAddrCache = new LoRaDevAddrCache(this.cache, null, newGatewayId);
             await devAddrCache.PerformNeededSyncs(registryManagerMock.Object);
 
             // we expect the devices are saved, the double device id should not be there anymore
-            for (int i = 0; i < newValues.Count; i++)
+            for (var i = 0; i < newValues.Count; i++)
             {
                 var queryResult = this.cache.GetHashObject(string.Concat(CacheKeyPrefix, newValues[i].DevAddr));
                 Assert.Single(queryResult);
@@ -844,15 +844,15 @@ namespace LoraKeysManagerFacade.Test
         // Primary Key are not kept as UpdateTime is not similar
         public async Task Full_Update_Perform_Correctly_On_Non_Empty_Cache_And_Keep_Old_Values_Except_Primary_Keys()
         {
-            string oldGatewayId = NewUniqueEUI64();
-            string newGatewayId = NewUniqueEUI64();
-            DateTime dateTime = DateTime.UtcNow;
-            DateTime updateDateTime = DateTime.UtcNow.AddMinutes(3);
+            var oldGatewayId = NewUniqueEUI64();
+            var newGatewayId = NewUniqueEUI64();
+            var dateTime = DateTime.UtcNow;
+            var updateDateTime = DateTime.UtcNow.AddMinutes(3);
             var primaryKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(PrimaryKey));
-            List<DevAddrCacheInfo> newValues = new List<DevAddrCacheInfo>();
+            var newValues = new List<DevAddrCacheInfo>();
 
             var adressForDuplicateDevAddr = NewUniqueEUI32();
-            for (int i = 0; i < 5; i++)
+            for (var i = 0; i < 5; i++)
             {
                 newValues.Add(new DevAddrCacheInfo()
                 {
@@ -867,8 +867,8 @@ namespace LoraKeysManagerFacade.Test
             var registryManagerMock = this.InitRegistryManager(newValues, newValues.Count());
 
             // Set up the cache with expectation.
-            List<DevAddrCacheInfo> cacheInput = new List<DevAddrCacheInfo>();
-            for (int i = 0; i < 5; i++)
+            var cacheInput = new List<DevAddrCacheInfo>();
+            for (var i = 0; i < 5; i++)
             {
                 cacheInput.Add(new DevAddrCacheInfo()
                 {
@@ -883,14 +883,14 @@ namespace LoraKeysManagerFacade.Test
             this.InitCache(this.cache, cacheInput);
 
             // initialize locks for test to run correctly
-            string[] neededLocksForTestToRun = new string[2] { GlobalDevAddrUpdateKey, FullUpdateKey };
+            var neededLocksForTestToRun = new string[2] { GlobalDevAddrUpdateKey, FullUpdateKey };
             await LockDevAddrHelper.PrepareLocksForTests(this.cache, neededLocksForTestToRun, null);
 
-            LoRaDevAddrCache devAddrCache = new LoRaDevAddrCache(this.cache, null, newGatewayId);
+            var devAddrCache = new LoRaDevAddrCache(this.cache, null, newGatewayId);
             await devAddrCache.PerformNeededSyncs(registryManagerMock.Object);
 
             // we expect the devices are saved, the double device id should not be there anymore
-            for (int i = 0; i < newValues.Count; i++)
+            for (var i = 0; i < newValues.Count; i++)
             {
                 var queryResult = this.cache.GetHashObject(string.Concat(CacheKeyPrefix, newValues[i].DevAddr));
                 Assert.Single(queryResult);

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/DeviceGetterTest.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/DeviceGetterTest.cs
@@ -18,9 +18,9 @@ namespace LoraKeysManagerFacade.Test
         [Fact]
         public async void DeviceGetter_OTAA_Join()
         {
-            string devEUI = NewUniqueEUI64();
-            string devEUI2 = NewUniqueEUI64();
-            string gatewayId = NewUniqueEUI64();
+            var devEUI = NewUniqueEUI64();
+            var devEUI2 = NewUniqueEUI64();
+            var gatewayId = NewUniqueEUI64();
 
             var deviceGetter = new DeviceGetter(this.InitRegistryManager(devEUI, devEUI2), new LoRaInMemoryDeviceStore());
             var items = await deviceGetter.GetDeviceList(devEUI, gatewayId, "ABCD", null);
@@ -42,14 +42,14 @@ namespace LoraKeysManagerFacade.Test
                 .ReturnsAsync((string deviceId) => new Twin(deviceId));
 
             const int numberOfDevices = 2;
-            int deviceCount = 0;
+            var deviceCount = 0;
 
             var queryMock = new Mock<IQuery>(MockBehavior.Loose);
             queryMock
                 .Setup(x => x.HasMoreResults)
                 .Returns(() => (deviceCount < numberOfDevices));
 
-            string[] deviceIds = new string[numberOfDevices] { devEui1, devEui2 };
+            var deviceIds = new string[numberOfDevices] { devEui1, devEui2 };
 
             IEnumerable<Twin> Twins()
             {

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/FunctionTestBase.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/FunctionTestBase.cs
@@ -24,7 +24,7 @@ namespace LoraKeysManagerFacade.Test
 
             for (var i = 0; i < EUI64BitStringLength; i++)
             {
-                int n = 0;
+                var n = 0;
                 lock (RndLock)
                 {
                     n = Rnd.Next(0, ValidChars.Length);
@@ -53,7 +53,7 @@ namespace LoraKeysManagerFacade.Test
 
             for (var i = 0; i < EUI32BitStringLength; i++)
             {
-                int n = 0;
+                var n = 0;
                 lock (RndLock)
                 {
                     n = Rnd.Next(0, ValidChars.Length);

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/MessageDeduplicationTests.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/MessageDeduplicationTests.cs
@@ -19,9 +19,9 @@ namespace LoraKeysManagerFacade.Test
         [Fact]
         public async Task MessageDeduplication_Duplicates_Found()
         {
-            string gateway1Id = NewUniqueEUI64();
-            string gateway2Id = NewUniqueEUI64();
-            string dev1EUI = NewUniqueEUI64();
+            var gateway1Id = NewUniqueEUI64();
+            var gateway2Id = NewUniqueEUI64();
+            var dev1EUI = NewUniqueEUI64();
 
             var result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway1Id, 1, 1);
             Assert.False(result.IsDuplicate);
@@ -35,8 +35,8 @@ namespace LoraKeysManagerFacade.Test
         [Fact]
         public async Task MessageDeduplication_Resubmit_Allowed()
         {
-            string gateway1Id = NewUniqueEUI64();
-            string dev1EUI = NewUniqueEUI64();
+            var gateway1Id = NewUniqueEUI64();
+            var dev1EUI = NewUniqueEUI64();
 
             var result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway1Id, 1, 1);
             Assert.False(result.IsDuplicate);
@@ -50,10 +50,10 @@ namespace LoraKeysManagerFacade.Test
         [Fact]
         public async Task MessageDeduplication_DifferentDevices_Allowed()
         {
-            string gateway1Id = NewUniqueEUI64();
-            string gateway2Id = NewUniqueEUI64();
-            string dev1EUI = NewUniqueEUI64();
-            string dev2EUI = NewUniqueEUI64();
+            var gateway1Id = NewUniqueEUI64();
+            var gateway2Id = NewUniqueEUI64();
+            var dev1EUI = NewUniqueEUI64();
+            var dev2EUI = NewUniqueEUI64();
 
             var result = await this.deduplicationExecutionItem.GetDuplicateMessageResultAsync(dev1EUI, gateway1Id, 1, 1);
             Assert.False(result.IsDuplicate);

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/SearchDeviceByDevEUITest.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/SearchDeviceByDevEUITest.cs
@@ -28,7 +28,7 @@ namespace LoraKeysManagerFacade.Test
             var ctx = new DefaultHttpContext();
             ctx.Request.QueryString = new QueryString($"?{ApiVersion.QueryStringParamName}={ApiVersion.Version_2019_02_12_Preview.Version}");
             var registryManager = new Mock<RegistryManager>(MockBehavior.Strict);
-            SearchDeviceByDevEUI searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
+            var searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
             var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request, NullLogger.Instance, new ExecutionContext());
             Assert.IsType<BadRequestObjectResult>(result);
         }
@@ -39,7 +39,7 @@ namespace LoraKeysManagerFacade.Test
             var ctx = new DefaultHttpContext();
             ctx.Request.QueryString = new QueryString($"?devEUI=193123");
             var registryManager = new Mock<RegistryManager>(MockBehavior.Strict);
-            SearchDeviceByDevEUI searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
+            var searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
             var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request, NullLogger.Instance, new ExecutionContext());
             Assert.IsType<BadRequestObjectResult>(result);
         }
@@ -52,7 +52,7 @@ namespace LoraKeysManagerFacade.Test
             var ctx = new DefaultHttpContext();
             ctx.Request.QueryString = new QueryString($"?devEUI=193123&{ApiVersion.QueryStringParamName}={version}");
             var registryManager = new Mock<RegistryManager>(MockBehavior.Strict);
-            SearchDeviceByDevEUI searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
+            var searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
             var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request, NullLogger.Instance, new ExecutionContext());
             Assert.IsType<BadRequestObjectResult>(result);
         }
@@ -68,7 +68,7 @@ namespace LoraKeysManagerFacade.Test
             registryManager.Setup(x => x.GetDeviceAsync(devEUI))
                 .ReturnsAsync((Device)null);
 
-            SearchDeviceByDevEUI searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
+            var searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
 
             var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request, NullLogger.Instance, new ExecutionContext());
             Assert.IsType<NotFoundObjectResult>(result);
@@ -93,7 +93,7 @@ namespace LoraKeysManagerFacade.Test
             registryManager.Setup(x => x.GetDeviceAsync(devEUI))
                 .ReturnsAsync(deviceInfo);
 
-            SearchDeviceByDevEUI searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
+            var searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
 
             var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request, NullLogger.Instance, new ExecutionContext());
             Assert.IsType<OkObjectResult>(result);

--- a/Tests/Shared/EventHubDataCollector.cs
+++ b/Tests/Shared/EventHubDataCollector.cs
@@ -128,7 +128,7 @@ namespace LoRaWan.Tests.Shared
             {
                 if (disposing)
                 {
-                    for (int i = this.receivers.Count - 1; i >= 0; i--)
+                    for (var i = this.receivers.Count - 1; i >= 0; i--)
                     {
                         try
                         {

--- a/Tests/Shared/IntegrationTestFixtureBase.Asserts.cs
+++ b/Tests/Shared/IntegrationTestFixtureBase.Asserts.cs
@@ -125,9 +125,9 @@ namespace LoRaWan.Tests.Shared
         /// <returns>true, if it was found on all configured gateways otherwise false.</returns>
         public async Task<bool> ValidateMultiGatewaySources(Func<string, bool> predicate, int maxAttempts = 5)
         {
-            int numberOfGw = this.Configuration.NumberOfGateways;
+            var numberOfGw = this.Configuration.NumberOfGateways;
             var sourceIds = new HashSet<string>(numberOfGw);
-            for (int i = 0; i < maxAttempts && sourceIds.Count < numberOfGw; i++)
+            for (var i = 0; i < maxAttempts && sourceIds.Count < numberOfGw; i++)
             {
                 if (i > 0)
                 {
@@ -158,9 +158,9 @@ namespace LoRaWan.Tests.Shared
 
         public async Task AssertSingleGatewaySource(Func<string, bool> predicate, int maxAttempts = 5)
         {
-            int numberOfGw = this.Configuration.NumberOfGateways;
+            var numberOfGw = this.Configuration.NumberOfGateways;
             var sourceIds = new HashSet<string>(numberOfGw);
-            for (int i = 0; i < maxAttempts && sourceIds.Count < numberOfGw; i++)
+            for (var i = 0; i < maxAttempts && sourceIds.Count < numberOfGw; i++)
             {
                 if (i > 0)
                 {
@@ -208,7 +208,7 @@ namespace LoRaWan.Tests.Shared
             const int DelayForJoinTwinStore = 20 * 1000;
             const string DevAddrProperty = "DevAddr";
             const int MaxRuns = 10;
-            bool reported = false;
+            var reported = false;
             for (var i = 0; i < MaxRuns && !reported; i++)
             {
                 await Task.Delay(DelayForJoinTwinStore);
@@ -295,10 +295,10 @@ namespace LoRaWan.Tests.Shared
                 log = await this.SearchUdpLogs(x => x.Contains(message), new SearchLogOptions { SourceIdFilter = sourceIdFilter });
             }
 
-            int timeIndexStart = log.FoundLogResult.IndexOf(token) + token.Length;
-            int timeIndexStop = log.FoundLogResult.IndexOf(",", timeIndexStart);
+            var timeIndexStart = log.FoundLogResult.IndexOf(token) + token.Length;
+            var timeIndexStop = log.FoundLogResult.IndexOf(",", timeIndexStart);
             uint parsedValue = 0;
-            bool success = false;
+            var success = false;
             if (timeIndexStart > 0 && timeIndexStop > 0)
             {
                 if (uint.TryParse(log.FoundLogResult.Substring(timeIndexStart, timeIndexStop - timeIndexStart), out parsedValue))
@@ -318,7 +318,7 @@ namespace LoRaWan.Tests.Shared
         {
             var maxAttempts = options?.MaxAttempts ?? this.Configuration.EnsureHasEventMaximumTries;
             var processedEvents = new HashSet<SearchLogEvent>();
-            for (int i = 0; i < maxAttempts; i++)
+            for (var i = 0; i < maxAttempts; i++)
             {
                 if (i > 0)
                 {
@@ -368,7 +368,7 @@ namespace LoRaWan.Tests.Shared
         {
             var maxAttempts = options?.MaxAttempts ?? this.Configuration.EnsureHasEventMaximumTries;
             var processedEvents = new HashSet<SearchLogEvent>();
-            for (int i = 0; i < maxAttempts; i++)
+            for (var i = 0; i < maxAttempts; i++)
             {
                 if (i > 0)
                 {
@@ -419,7 +419,7 @@ namespace LoRaWan.Tests.Shared
         {
             var maxAttempts = options?.MaxAttempts ?? this.Configuration.EnsureHasEventMaximumTries;
             var processedEvents = new HashSet<SearchLogEvent>();
-            for (int i = 0; i < maxAttempts; i++)
+            for (var i = 0; i < maxAttempts; i++)
             {
                 if (i > 0)
                 {

--- a/Tests/Shared/IntegrationTestFixtureBase.cs
+++ b/Tests/Shared/IntegrationTestFixtureBase.cs
@@ -250,7 +250,7 @@ namespace LoRaWan.Tests.Shared
         {
             try
             {
-                Microsoft.Azure.Devices.Client.DeviceClient device = Microsoft.Azure.Devices.Client.DeviceClient.CreateFromConnectionString(this.Configuration.IoTHubConnectionString, deviceId);
+                var device = Microsoft.Azure.Devices.Client.DeviceClient.CreateFromConnectionString(this.Configuration.IoTHubConnectionString, deviceId);
                 var twinCollection = new TwinCollection();
                 twinCollection[twinName] = twinValue;
                 await device.UpdateReportedPropertiesAsync(twinCollection);

--- a/Tests/Shared/RandomTokenGenerator.cs
+++ b/Tests/Shared/RandomTokenGenerator.cs
@@ -23,7 +23,7 @@ namespace LoRaWan.Tests.Shared
             {
                 randomLock.Wait();
 
-                byte[] token = new byte[2];
+                var token = new byte[2];
                 random.NextBytes(token);
                 return token;
             }
@@ -38,7 +38,7 @@ namespace LoRaWan.Tests.Shared
             try
             {
                 await randomLock.WaitAsync();
-                byte[] token = new byte[2];
+                var token = new byte[2];
                 random.NextBytes(token);
                 return token;
             }

--- a/Tests/Shared/SimulatedDevice.cs
+++ b/Tests/Shared/SimulatedDevice.cs
@@ -75,10 +75,10 @@ namespace LoRaWan.Tests.Shared
 
         public LoRaPayloadJoinRequest CreateJoinRequest()
         {
-            byte[] devNonce = new byte[2];
+            var devNonce = new byte[2];
             if (string.IsNullOrEmpty(this.DevNonce) || (!this.isFirstJoinRequest))
             {
-                Random random = new Random();
+                var random = new Random();
                 // DevNonce[0] = 0xC8; DevNonce[1] = 0x86;
                 random.NextBytes(devNonce);
                 this.DevNonce = BitConverter.ToString(devNonce).Replace("-", string.Empty);
@@ -105,15 +105,15 @@ namespace LoRaWan.Tests.Shared
         /// </summary>
         public LoRaPayloadData CreateUnconfirmedDataUpMessage(string data, uint? fcnt = null, byte fport = 1, byte fctrl = 0, bool isHexPayload = false, List<MacCommand> macCommands = null)
         {
-            byte[] devAddr = ConversionHelper.StringToByteArray(this.LoRaDevice.DevAddr);
+            var devAddr = ConversionHelper.StringToByteArray(this.LoRaDevice.DevAddr);
             Array.Reverse(devAddr);
-            byte[] fCtrl = new byte[] { fctrl };
+            var fCtrl = new byte[] { fctrl };
             fcnt = fcnt ?? this.FrmCntUp + 1;
             this.FrmCntUp = fcnt.GetValueOrDefault();
 
             var fcntBytes = BitConverter.GetBytes((ushort)fcnt.Value);
 
-            byte[] fPort = new byte[] { fport };
+            var fPort = new byte[] { fport };
             // TestLogger.Log($"{LoRaDevice.DeviceID}: Simulated data: {data}");
             byte[] payload = null;
             if (data != null)
@@ -131,7 +131,7 @@ namespace LoRaWan.Tests.Shared
             }
 
             // 0 = uplink, 1 = downlink
-            int direction = 0;
+            var direction = 0;
 
             var payloadData = new LoRaPayloadData(
                 LoRaMessageType.UnconfirmedDataUp,
@@ -154,16 +154,16 @@ namespace LoRaWan.Tests.Shared
         /// </summary>
         public LoRaPayloadData CreateConfirmedDataUpMessage(string data, uint? fcnt = null, byte fport = 1, bool isHexPayload = false)
         {
-            byte[] devAddr = ConversionHelper.StringToByteArray(this.LoRaDevice.DevAddr);
+            var devAddr = ConversionHelper.StringToByteArray(this.LoRaDevice.DevAddr);
             Array.Reverse(devAddr);
-            byte[] fCtrl = new byte[] { 0x80 };
+            var fCtrl = new byte[] { 0x80 };
 
             fcnt = fcnt ?? this.FrmCntUp + 1;
             this.FrmCntUp = fcnt.GetValueOrDefault();
 
             var fcntBytes = BitConverter.GetBytes((ushort)fcnt.Value);
 
-            byte[] fPort = new byte[] { fport };
+            var fPort = new byte[] { fport };
 
             byte[] payload = null;
 
@@ -182,7 +182,7 @@ namespace LoRaWan.Tests.Shared
             }
 
             // 0 = uplink, 1 = downlink
-            int direction = 0;
+            var direction = 0;
             var payloadData = new LoRaPayloadData(LoRaMessageType.ConfirmedDataUp, devAddr, fCtrl, fcntBytes, null, fPort, payload, direction, this.Supports32BitFCnt ? fcnt : (uint?)null);
 
             return payloadData;
@@ -241,7 +241,7 @@ namespace LoRaWan.Tests.Shared
             {
                 // handle join
                 var txpk = Txpk.CreateTxpk(response, this.LoRaDevice.AppKey);
-                byte[] convertedInputMessage = Convert.FromBase64String(txpk.Data);
+                var convertedInputMessage = Convert.FromBase64String(txpk.Data);
 
                 var joinAccept = new LoRaPayloadJoinAccept(convertedInputMessage, this.AppKey);
 

--- a/Tests/Shared/SimulatedPacketForwarder.cs
+++ b/Tests/Shared/SimulatedPacketForwarder.cs
@@ -25,9 +25,9 @@ namespace LoRaWan.Tests.Shared
 
         public SimulatedPacketForwarder(IPEndPoint networkServerIPEndpoint, Rxpk rxpk = null)
         {
-            IPAddress ip = IPAddress.Any;
-            int port = 1681;
-            IPEndPoint endPoint = new IPEndPoint(ip, port);
+            var ip = IPAddress.Any;
+            var port = 1681;
+            var endPoint = new IPEndPoint(ip, port);
 
             this.udpClient = new UdpClient(endPoint);
             this.networkServerIPEndpoint = networkServerIPEndpoint;
@@ -79,7 +79,7 @@ namespace LoRaWan.Tests.Shared
         byte[] GetRandomToken()
         {
             // random is not thread safe
-            byte[] token = new byte[2];
+            var token = new byte[2];
             lock (this.random)
             {
                 this.random.NextBytes(token);
@@ -197,7 +197,7 @@ namespace LoRaWan.Tests.Shared
             var msg = "{\"rxpk\":[" + rxpkgateway + "]}";
 
             var gatewayInfo = Encoding.UTF8.GetBytes(msg);
-            byte[] packetData = new byte[syncHeader.Length + gatewayInfo.Length];
+            var packetData = new byte[syncHeader.Length + gatewayInfo.Length];
             Array.Copy(syncHeader, packetData, syncHeader.Length);
             Array.Copy(gatewayInfo, 0, packetData, syncHeader.Length, gatewayInfo.Length);
 

--- a/Tests/Shared/UdpLogListener.cs
+++ b/Tests/Shared/UdpLogListener.cs
@@ -29,7 +29,7 @@ namespace LoRaWan.Tests.Shared
 
         public UdpLogListener(int port)
         {
-            IPAddress ip = IPAddress.Any;
+            var ip = IPAddress.Any;
             this.events = new ConcurrentQueue<string>();
             this.udpClient = new UdpClient(new IPEndPoint(ip, port));
             TestLogger.Log($"*** UDP Log Listener created: {ip}:{port} ***");

--- a/Tests/Shared/Utility.cs
+++ b/Tests/Shared/Utility.cs
@@ -17,9 +17,9 @@ namespace LoRaWan.Tests.Shared
         /// </summary>
         public static byte[] GetMacAddress()
         {
-            string macAddresses = string.Empty;
+            var macAddresses = string.Empty;
 
-            foreach (NetworkInterface adapter in NetworkInterface.GetAllNetworkInterfaces())
+            foreach (var adapter in NetworkInterface.GetAllNetworkInterfaces())
             {
                 if (adapter.OperationalStatus == OperationalStatus.Up)
                 {


### PR DESCRIPTION
# PR for story #437

## What is being addressed

Mixed use of `var` and explicit typing, with majority case being the former.

## How is this addressed

- Update `.editorconfig` with suggestion to always use `var`
- Replace existing cases of explicit typing with `var` wherever possible.
