### PR TITLE
Address IDE0065 by configuring project default

### DIFF
--- a/LoRaEngine/.editorconfig
+++ b/LoRaEngine/.editorconfig
@@ -5,3 +5,7 @@ dotnet_diagnostic.CA2007.severity = none
 
 # Default severity for analyzer diagnostics with category 'Style' (escalated to build warnings)
 dotnet_analyzer_diagnostic.category-Style.severity = warning
+
+# IDE0065: Misplaced using directive
+# Prefer using directives to be placed inside the namespace
+csharp_using_directive_placement = inside_namespace


### PR DESCRIPTION
# PR for story #436 

## What is being addressed

[IDE0065](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0065) (`using` directive placement) warnings.

## How is this addressed

Adding the project preference to `.editorconfig`.

This takes care of a whopping 1,246 warnings!
