### PR TITLE
Address IDE005 (formatting) warnings

### DIFF
--- a/LoRaEngine/.editorconfig
+++ b/LoRaEngine/.editorconfig
@@ -1,4 +1,5 @@
 [*.cs]
+csharp_indent_case_contents_when_block = false
 
 # CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = none

--- a/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
@@ -30,7 +30,7 @@ namespace LoraKeysManagerFacade
         /// </summary>
         [FunctionName(nameof(GetDevice))]
         public async Task<IActionResult> GetDevice(
-            [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)]HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req,
             ILogger log)
         {
             try

--- a/LoRaEngine/LoraKeysManagerFacade/FCntCacheCheck.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FCntCacheCheck.cs
@@ -22,7 +22,7 @@ namespace LoraKeysManagerFacade
 
         [FunctionName("NextFCntDown")]
         public async Task<IActionResult> NextFCntDownInvoke(
-            [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)]HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req,
             ILogger log)
         {
             try

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerFunction.cs
@@ -24,7 +24,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
 
         [FunctionName("FunctionBundler")]
         public async Task<IActionResult> FunctionBundlerImpl(
-            [HttpTrigger(AuthorizationLevel.Function, "post", Route = "FunctionBundler/{devEUI}")]HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Function, "post", Route = "FunctionBundler/{devEUI}")] HttpRequest req,
             ILogger logger,
             string devEUI)
         {

--- a/LoRaEngine/LoraKeysManagerFacade/SearchDeviceByDevEUI.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SearchDeviceByDevEUI.cs
@@ -23,7 +23,7 @@ namespace LoraKeysManagerFacade
         }
 
         [FunctionName(nameof(GetDeviceByDevEUI))]
-        public async Task<IActionResult> GetDeviceByDevEUI([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)]HttpRequest req, ILogger log, ExecutionContext context)
+        public async Task<IActionResult> GetDeviceByDevEUI([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req, ILogger log, ExecutionContext context)
         {
             try
             {

--- a/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
@@ -151,7 +151,7 @@ namespace LoraKeysManagerFacade
                     MessageID = message.MessageId,
                     ClassType = "A",
                 });
-             }
+            }
             catch (Exception ex)
             {
                 this.log.LogError(ex, "Failed to send message to {devEUI}", devEUI);

--- a/LoRaEngine/LoraKeysManagerFacade/SyncDevAddrCache.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SyncDevAddrCache.cs
@@ -20,7 +20,7 @@ namespace LoraKeysManagerFacade
         }
 
         [FunctionName("SyncDevAddrCache")]
-        public async Task Run([TimerTrigger("0 */5 * * * *")]TimerInfo myTimer, ILogger log)
+        public async Task Run([TimerTrigger("0 */5 * * * *")] TimerInfo myTimer, ILogger log)
         {
             log.LogDebug($"{(myTimer.IsPastDue ? "The timer is past due" : "The timer is on schedule")}, Function last ran at {myTimer.ScheduleStatus.Last} Function next scheduled run at {myTimer.ScheduleStatus.Next})");
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/ADRTestData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/ADRTestData.cs
@@ -141,6 +141,6 @@ namespace LoRaWanTest
                 FCntDown = 1
             };
             this.AddRow("ADR decrease NbRep", decreaseNbRepDeviceName, decreaseNbReptableentries, decreaseNbReprxpk, false, decreaseNbReploRaADRResult);
-    }
+        }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RegionImplementationTest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaToolsTest/RegionImplementationTest.cs
@@ -15,8 +15,8 @@ namespace LoRaWanTest
         [Theory]
         [CombinatorialData]
         public void TestPhysicalMappingEU(
-      [CombinatorialValues("SF12BW125", "SF11BW125", "SF10BW125", "SF9BW125", "SF8BW125", "SF7BW125", "SF7BW250")]string datr,
-      [CombinatorialValues(868.1, 868.3, 868.5)] double freq)
+            [CombinatorialValues("SF12BW125", "SF11BW125", "SF10BW125", "SF9BW125", "SF8BW125", "SF7BW125", "SF7BW250")] string datr,
+            [CombinatorialValues(868.1, 868.3, 868.5)] double freq)
         {
             var rxpk = GenerateRxpk(datr, freq);
 
@@ -221,6 +221,7 @@ namespace LoRaWanTest
         }
 
         [Theory]
+#pragma warning disable format
         [InlineData("SF10BW125",  19)]
         [InlineData("SF9BW125",   61)]
         [InlineData("SF8BW125",  133)]
@@ -231,6 +232,7 @@ namespace LoRaWanTest
         [InlineData("SF10BW500", 250)]
         [InlineData("SF9BW500",  250)]
         [InlineData("SF7BW500",  250)]
+#pragma warning restore format
 
         public void TestMaxPayloadLengthUS(string datr, uint maxPyldSize)
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ChangeTrackingProperty.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ChangeTrackingProperty.cs
@@ -28,7 +28,7 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Gets the property name.
         /// </summary>
-        public string PropertyName { get;  }
+        public string PropertyName { get; }
 
         /// <summary>
         /// Gets the value that must be persisted in twin collection.

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeduplicationStrategyFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeduplicationStrategyFactory.cs
@@ -27,10 +27,10 @@ namespace LoRaWan.NetworkServer
                 case DeduplicationMode.Drop: return new DeduplicationStrategyDrop(this.loRaDeviceAPIService, loRaDevice);
                 case DeduplicationMode.Mark: return new DeduplicationStrategyMark(this.loRaDeviceAPIService, loRaDevice);
                 default:
-                    {
-                        Logger.Log(loRaDevice.DevEUI, "no Deduplication Strategy selected", LogLevel.Debug);
-                        return null;
-                    }
+                {
+                    Logger.Log(loRaDevice.DevEUI, "no Deduplication Strategy selected", LogLevel.Debug);
+                    return null;
+                }
             }
         }
     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -553,13 +553,13 @@ namespace LoRaWan.NetworkServer
                 // before checking the current state and update again.
                 await this.syncSave.WaitAsync();
 
-                if (reportedProperties == null)
+                if (reportedProperties == null)
                 {
                     reportedProperties = new TwinCollection();
                 }
 
-                var savedProperties = new List<IChangeTrackingProperty>();
-                foreach (var prop in this.GetTrackableProperties())
+                var savedProperties = new List<IChangeTrackingProperty>();
+                foreach (var prop in this.GetTrackableProperties())
                 {
                     if (prop.IsDirty())
                     {
@@ -568,10 +568,10 @@ namespace LoRaWan.NetworkServer
                     }
                 }
 
-                var fcntUpDelta = this.FCntUp >= this.LastSavedFCntUp ? this.FCntUp - this.LastSavedFCntUp : this.LastSavedFCntUp - this.FCntUp;
-                var fcntDownDelta = this.FCntDown >= this.LastSavedFCntDown ? this.FCntDown - this.LastSavedFCntDown : this.LastSavedFCntDown - this.FCntDown;
+                var fcntUpDelta = this.FCntUp >= this.LastSavedFCntUp ? this.FCntUp - this.LastSavedFCntUp : this.LastSavedFCntUp - this.FCntUp;
+                var fcntDownDelta = this.FCntDown >= this.LastSavedFCntDown ? this.FCntDown - this.LastSavedFCntDown : this.LastSavedFCntDown - this.FCntDown;
 
-                if (reportedProperties.Count > 0 ||
+                if (reportedProperties.Count > 0 ||
                             fcntDownDelta >= Constants.MAX_FCNT_UNSAVED_DELTA ||
                             fcntUpDelta >= Constants.MAX_FCNT_UNSAVED_DELTA ||
                             (this.hasFrameCountChanges && force))
@@ -610,7 +610,7 @@ namespace LoRaWan.NetworkServer
                     }
                 }
 
-                return true;
+                return true;
             }
             finally
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
@@ -182,7 +182,7 @@ namespace LoRaTools.Regions
             var defaultDatr = this.DRtoConfiguration[this.RX2DefaultReceiveWindows.dr].configuration;
             Logger.Log(devEUI, $"using standard region RX2 datarate {defaultDatr}", LogLevel.Debug);
             return defaultDatr;
-            }
+        }
 
         /// <summary>
         /// Implement correct logic to get the downstream data rate based on the region.

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/BasicsStation/LnsProtocolMessageProcessorTests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/BasicsStation/LnsProtocolMessageProcessorTests.cs
@@ -103,7 +103,8 @@ namespace LoRaWan.NetworkServer.Test.BasicsStation
                          });
             // setting up the mock so that when ReceiveAsync is invoked the "testbytes" are written to the Memory portion
             socketMock.Setup(x => x.ReceiveAsync(It.IsAny<Memory<byte>>(), It.IsAny<CancellationToken>()))
-                         .Callback<Memory<byte>, CancellationToken>((m, c) => {
+                         .Callback<Memory<byte>, CancellationToken>((m, c) =>
+                         {
                              testbytes.CopyTo(m);
                          })
                          .ReturnsAsync(new ValueWebSocketReceiveResult(testbytes.Length, WebSocketMessageType.Text, true));

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/FcntLimitTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/FcntLimitTest.cs
@@ -153,7 +153,7 @@ namespace LoRaWan.NetworkServer.Test
         [InlineData(2, 1U, 1U, 0U, 0U, 0, 0, 1U, 1U, true)]
         // save reporting do not match
         [InlineData(11, 10U, 20U, 0U, 0U, 0, 0, 10U, 20U, true)]
-        public async Task ValidateFcnt_Start_Values_And_ResetCounter (
+        public async Task ValidateFcnt_Start_Values_And_ResetCounter(
             short fcntUp,
             uint startFcntUpDesired,
             uint startFcntDownDesired,

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_CloudToDeviceMessage_Tests.cs
@@ -97,7 +97,8 @@ namespace LoRaWan.NetworkServer.Test
                 // if we run with ADR, we will combine the call with the bundler
                 this.LoRaDeviceApi
                     .Setup(x => x.ExecuteFunctionBundlerAsync(devEUI, It.IsAny<FunctionBundlerRequest>()))
-                    .ReturnsAsync(() => new FunctionBundlerResult
+                    .ReturnsAsync(() =>
+                        new FunctionBundlerResult
                         {
                             AdrResult = new LoRaTools.ADR.LoRaADRResult
                             {

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_MultiGateway_Tests.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/MessageProcessor_End2End_NoDep_MultiGateway_Tests.cs
@@ -29,7 +29,10 @@ namespace LoRaWan.NetworkServer.Test
             var devEUI = simulatedDevice.LoRaDevice.DeviceID;
             var devAddr = simulatedDevice.LoRaDevice.DevAddr;
 
-            this.LoRaDeviceApi.Setup(x => x.ExecuteFunctionBundlerAsync(devEUI, It.IsAny<FunctionBundlerRequest>())).ReturnsAsync(() => new FunctionBundlerResult
+            this.LoRaDeviceApi
+                .Setup(x => x.ExecuteFunctionBundlerAsync(devEUI, It.IsAny<FunctionBundlerRequest>()))
+                .ReturnsAsync(() =>
+                    new FunctionBundlerResult
                     {
                         AdrResult = new LoRaTools.ADR.LoRaADRResult { CanConfirmToDevice = true, FCntDown = 0 },
                         NextFCntDown = 0

--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/TestUtils.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/TestUtils.cs
@@ -141,7 +141,7 @@ namespace LoRaWan.NetworkServer.Test
 
             if (reportedProperties != null)
             {
-               foreach (var kv in reportedProperties)
+                foreach (var kv in reportedProperties)
                 {
                     finalReportedProperties[kv.Key] = kv.Value;
                 }

--- a/LoRaEngine/test/LoraKeysManagerFacade.Test/SearchDeviceByDevEUITest.cs
+++ b/LoRaEngine/test/LoraKeysManagerFacade.Test/SearchDeviceByDevEUITest.cs
@@ -87,7 +87,7 @@ namespace LoraKeysManagerFacade.Test
             var registryManager = new Mock<RegistryManager>(MockBehavior.Strict);
             var deviceInfo = new Device(devEUI)
             {
-               Authentication = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = primaryKey } },
+                Authentication = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = primaryKey } },
             };
 
             registryManager.Setup(x => x.GetDeviceAsync(devEUI))


### PR DESCRIPTION
# PR for story #436

## What is being addressed

Some 80+ formatting warnings ([IDE005](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#rule-id-ide0055-fix-formatting)).

## How is this addressed

- Fixed formatting inconsistencies.
- Configured case blocks to not require indentation (`csharp_indent_case_contents_when_block = false`):
  ```c#
  // csharp_indent_case_contents_when_block = true
  case 0:
      {
          Console.WriteLine("Hello");
          break;
      }
  // csharp_indent_case_contents_when_block = false
  case 0:
  {
      Console.WriteLine("Hello");
      break;
  }
  ```
