### PR TITLE
Update .editorconfig with project-specific rules

### DIFF
--- a/LoRaEngine/.editorconfig
+++ b/LoRaEngine/.editorconfig
@@ -17,9 +17,6 @@ csharp_prefer_braces = when_multiline
 # Use new(...)
 dotnet_diagnostic.IDE0090.severity=silent
 
-# Expression value is never used
-dotnet_diagnostic.IDE0058.severity=suggestion
-
 # Namespace does not match folder structure
 dotnet_diagnostic.IDE0130.severity=suggestion
 

--- a/LoRaEngine/test/.editorconfig
+++ b/LoRaEngine/test/.editorconfig
@@ -5,3 +5,6 @@ dotnet_diagnostic.CA1707.severity = none
 
 # CA1303: Console.WriteLine should get strings from resource table
 dotnet_diagnostic.CA1303.severity = none
+
+# Expression value is never used
+dotnet_diagnostic.IDE0058.severity=suggestion


### PR DESCRIPTION
# PR for issue #436

## What is being addressed

With this PR we adapt the `.editorconfig` to get rid of some warnings that we will not address. These adaptions get us from 2700 warnings to 1500.

## How is this addressed

Adapt the `.editorconfig` of the `LoRaEngine`.
