### PR TITLE
Fix Dotnet E2E test version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -278,6 +278,9 @@ jobs:
       with:
         dotnet-version: '3.1.x' # SDK Version to use.
 
+    - name: .NET SDK Information
+      run: dotnet --info
+
     - name: 'Configure test in **/test/LoRaWan.IntegrationTest/appsettings.json'
       uses: cschleiden/replace-tokens@v1
       if: contains(github.event.pull_request.labels.*.name, matrix.testsToRun ) != true


### PR DESCRIPTION
Due to our recent migration to use the .net 5 sdk the E2E tests are not running, complaining that [the .net 3 runtime is not installed](https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/1321811390). Even when installing the runtime manually on the private runner (see image below), this does not work. In the end I followed [official recommendation](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net#specifying-a-net-version) on private runner and used this task to install .net 3 runtime.

![image](https://user-images.githubusercontent.com/8555833/137188380-1e8ba359-6667-4125-9878-c06511dda4b8.png)

Successful run [here](https://github.com/Azure/iotedge-lorawan-starterkit/runs/3885995282?check_suite_focus=true)