### PR TITLE
Clean up after test execution

### DIFF
--- a/LoRaEngine/test/LoRaWanNetworkServer.Test/ConfigurationTest.cs
+++ b/LoRaEngine/test/LoRaWanNetworkServer.Test/ConfigurationTest.cs
@@ -14,12 +14,21 @@ namespace LoRaWan.NetworkServer.Test
         [MemberData(nameof(AllowedDevAddressesInput))]
         public void Should_Setup_Allowed_Dev_Addresses_Correctly(string inputAllowedDevAddrValues, HashSet<string> expectedAllowedDevAddrValues)
         {
-            Environment.SetEnvironmentVariable("AllowedDevAddresses", inputAllowedDevAddrValues);
-            var networkServerConfiguration = NetworkServerConfiguration.CreateFromEnvironmentVariables();
-            Assert.Equal(expectedAllowedDevAddrValues.Count, networkServerConfiguration.AllowedDevAddresses.Count);
-            foreach (var devAddr in expectedAllowedDevAddrValues)
+            var envVariableName = "AllowedDevAddresses";
+
+            try
             {
-                Assert.Contains(devAddr, networkServerConfiguration.AllowedDevAddresses);
+                Environment.SetEnvironmentVariable(envVariableName, inputAllowedDevAddrValues);
+                var networkServerConfiguration = NetworkServerConfiguration.CreateFromEnvironmentVariables();
+                Assert.Equal(expectedAllowedDevAddrValues.Count, networkServerConfiguration.AllowedDevAddresses.Count);
+                foreach (var devAddr in expectedAllowedDevAddrValues)
+                {
+                    Assert.Contains(devAddr, networkServerConfiguration.AllowedDevAddresses);
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVariableName, string.Empty);
             }
         }
 


### PR DESCRIPTION
# PR for issue #545

## What is being addressed

A test did not clean up the environment variable that it set during the test setup. This PR does not ensure that there is no interference between this and other tests that are running in parallel.