### PR TITLE
More precise naming of RunTestsOnly label

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,8 @@ on: # rebuild any PRs and main branch changes
       - dev
   workflow_dispatch:
     inputs:
-      RunTestsOnly:
-        description: 'Run tests only'
+      RunE2ETestsOnly:
+        description: 'Run E2E tests only'
         default: false
       TestsToRun:
         default: '[\"SensorDecodingTest\",\"OTAAJoinTest\",\"ABPTest\",\"OTAATest\",\"MacTest\",\"ClassCTest\",\"C2DMessageTest\",\"MultiGatewayTest\"]'
@@ -56,7 +56,7 @@ jobs:
 
     outputs:
       AZURE_FUNCTIONAPP_NAME: ${{ env.AZURE_FUNCTIONAPP_NAME }}
-      RunTestsOnly: ${{ github.event.inputs.RunTestsOnly == 'true' || contains(github.event.client_payload.labels.*.name, 'RunTestsOnly') == true}}
+      RunE2ETestsOnly: ${{ github.event.inputs.RunE2ETestsOnly == 'true' || contains(github.event.client_payload.labels.*.name, 'RunE2ETestsOnly') == true}}
       E2ETestsToRun: ${{ steps.e2e_list_step.outputs.E2ETestsToRun }}
       StopFullCi: ${{ steps.check-if-run.outputs.StopFullCi }}
 
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - env_var
-    if: needs.env_var.outputs.RunTestsOnly != 'true'
+    if: needs.env_var.outputs.RunE2ETestsOnly != 'true'
     steps:
     - uses: actions/checkout@v2
       name: Checkout current branch
@@ -108,7 +108,7 @@ jobs:
       - env_var
     runs-on: ubuntu-latest
     environment: CI
-    if: needs.env_var.outputs.RunTestsOnly != 'true' && needs.env_var.outputs.StopFullCi  != 'true'
+    if: needs.env_var.outputs.RunE2ETestsOnly != 'true' && needs.env_var.outputs.StopFullCi  != 'true'
     name: Deploy this run on the CI environment
     steps:
     - run : echo "Deployment was authorized"
@@ -120,7 +120,7 @@ jobs:
     - check_if_deploy
     name: Build and Deploy Facade Azure Function
     runs-on: ubuntu-latest
-    if: needs.env_var.outputs.RunTestsOnly != 'true'
+    if: needs.env_var.outputs.RunE2ETestsOnly != 'true'
     env:
       AZURE_FUNCTIONAPP_PACKAGE_PATH: 'LoRaEngine/LoraKeysManagerFacade/'
 
@@ -158,7 +158,7 @@ jobs:
     needs:
     - env_var
     - check_if_deploy
-    if: needs.env_var.outputs.RunTestsOnly != 'true'
+    if: needs.env_var.outputs.RunE2ETestsOnly != 'true'
     env:
       CONTAINER_REGISTRY_ADDRESS: "loramoduleintegrationtest.azurecr.io"
       CONTAINER_REGISTRY_SERVER: "loramoduleintegrationtest.azurecr.io"
@@ -248,7 +248,7 @@ jobs:
       max-parallel: 1
       matrix:
         testsToRun: ${{ fromjson(needs.env_var.outputs.E2ETestsToRun) }}
-    if: always() && (needs.env_var.outputs.RunTestsOnly == 'true' || (needs.deploy_arm_gw_iot_edge.result == 'success' && needs.deploy_facade_function.result == 'success' && needs.build_and_test.result == 'success'))
+    if: always() && (needs.env_var.outputs.RunE2ETestsOnly == 'true' || (needs.deploy_arm_gw_iot_edge.result == 'success' && needs.deploy_facade_function.result == 'success' && needs.build_and_test.result == 'success'))
     needs:
       - deploy_arm_gw_iot_edge
       - deploy_facade_function


### PR DESCRIPTION
The label `RunTestsOnly` does not specify which type of tests we are running.

With this PR we rename it to `RunE2ETestsOnly`

## Validation
- [Manual dispatch](https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/1345996826): running only SensorDecodingTests
- [Automated run](https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/1346000916) not running E2E tests

TODO after approval: delete previous label. 