### PR TITLE
Use .net 5.0 sdk docker image for build

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
 
 WORKDIR /build
 COPY Directory.Build.props ./

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64.debug
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64.debug
@@ -9,7 +9,7 @@ USER moduleuser
 RUN curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l ~/vsdbg
 
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
 
 WORKDIR /build
 COPY Directory.Build.props ./

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.arm32v7
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
 
 WORKDIR /build
 COPY Directory.Build.props ./


### PR DESCRIPTION
We currently build the application with the dotnet 3.1 sdk, this results in the following error: https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/1346304730

this pr solves it : https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/1349070458