### PR TITLE
Remove IComparable on DevAddrCacheInfo

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/DevAddrCacheInfo.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/DevAddrCacheInfo.cs
@@ -12,23 +12,5 @@ namespace LoraKeysManagerFacade
         public DateTime LastUpdatedTwins { get; set; }
 
         public string NwkSKey { get; set; }
-
-        public override bool Equals(object obj) =>
-            obj is DevAddrCacheInfo info &&
-            DevAddr == info.DevAddr &&
-            DevEUI == info.DevEUI &&
-            PrimaryKey == info.PrimaryKey &&
-            GatewayId == info.GatewayId &&
-            LastUpdatedTwins == info.LastUpdatedTwins &&
-            NwkSKey == info.NwkSKey;
-
-        public override int GetHashCode() =>
-            HashCode.Combine(DevAddr, DevEUI, PrimaryKey, GatewayId, LastUpdatedTwins, NwkSKey);
-
-        public static bool operator ==(DevAddrCacheInfo left, DevAddrCacheInfo right) =>
-            left is null ? right is null : left.Equals(right);
-
-        public static bool operator !=(DevAddrCacheInfo left, DevAddrCacheInfo right) =>
-            !(left == right);
     }
 }


### PR DESCRIPTION
# PR for issue #570

## What is being addressed

With this PR we remove the erroneous `IComparable` implementation on `DevAddrCacheInfo`. Cache info is not comparable, hence we remove the method instead of fixing the implementation.
