### PR TITLE
Remove obsolete SA (Style Analysis) warnings

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Id6.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Id6.cs
@@ -168,9 +168,7 @@ namespace LoRaWan
 
             var si = 0;
             var cci = -1;
-#pragma warning disable SA1129 // Do not use default value type constructor
             var wa = new WordAccumulator();
-#pragma warning restore SA1129 // Do not use default value type constructor
 
             for (; !chars.IsEmpty; chars = chars[1..])
             {

--- a/Tests/E2E/LoraArduinoSerial.cs
+++ b/Tests/E2E/LoraArduinoSerial.cs
@@ -31,8 +31,6 @@
   THE SOFTWARE.1  USA
 */
 
-#pragma warning disable SA1300 // Elements should begin with an uppercase letter
-#pragma warning disable SA1313 // Parameters should begin with a lowercase letter
 #pragma warning disable CA1008 // Enums should have zero value
 #pragma warning disable IDE1006 // Naming Styles
 #pragma warning disable CA1822 // Mark members as static


### PR DESCRIPTION
# PR for story #436

## What is being addressed

Obsolete SAXXXX warnings that are probably a leftover after migrating away from [StyleCop](https://github.com/DotNetAnalyzers/StyleCopAnalyzers).

## How is this addressed

Removal of pragma directives that disable/restore obsolete SAXXXX warnings.
