### PR TITLE
Feature/590 suggestion for non enforcable ca

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -85,9 +85,6 @@ dotnet_diagnostic.IDE0055.severity=suggestion
 # IDE0052: Unused private member
 dotnet_diagnostic.IDE0052.severity=suggestion
 
-# xUnit1004: Do not skip tests
-dotnet_diagnostic.xUnit1004.severity=suggestion
-
 # This or Me qualifier
 dotnet_style_qualification_for_field=true
 dotnet_style_qualification_for_property=false

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -17,3 +17,6 @@ dotnet_diagnostic.CA5399.severity = none
 
 # CA1062: Validate arguments of public methods
 dotnet_diagnostic.CA1062.severity = suggestion
+
+# xUnit1004: Do not skip tests
+dotnet_diagnostic.xUnit1004.severity=suggestion


### PR DESCRIPTION
# PR for issue #590

## What is being addressed

With this PR we ensure that CA rules that [cannot be enforced on build](https://github.com/dotnet/roslyn/issues/53215) are set to severity level `suggestion`. This will ensure that we have less IntelliSense errors in our solution that we cannot enforce on build.

## How is this addressed

We clean up the severity levels for rules that cannot be enforced on build.
