### PR TITLE
Enforce accessibility modifiers consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -58,9 +58,6 @@ dotnet_diagnostic.IDE0022.severity=suggestion
 # Simplify if statement
 dotnet_diagnostic.IDE0046.severity=suggestion
 
-# Add accessibility modifiers
-dotnet_diagnostic.IDE0040.severity=suggestion
-
 # CA1721: Property names should not match get methods
 dotnet_diagnostic.CA1721.severity = suggestion
 

--- a/LoRaEngine/LoraKeysManagerFacade/CheckPreferredGateway/LoRaDevicePreferredGateway.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/CheckPreferredGateway/LoRaDevicePreferredGateway.cs
@@ -32,13 +32,13 @@ namespace LoraKeysManagerFacade
         /// Creates a string representation of the object for caching.
         /// </summary>
         /// <returns>A string containing {GatewayID};{FcntUp};{UpdateTime}.</returns>
-        string ToCachedString() => string.Concat(GatewayID, ";", FcntUp, ";", UpdateTime);
+        private string ToCachedString() => string.Concat(GatewayID, ";", FcntUp, ";", UpdateTime);
 
         /// <summary>
         /// Creates a <see cref="LoRaDevicePreferredGateway"/> from a string
         /// String format should be: {GatewayID};{FcntUp};{UpdateTime}.
         /// </summary>
-        static LoRaDevicePreferredGateway CreateFromCachedString(string cachedString)
+        private static LoRaDevicePreferredGateway CreateFromCachedString(string cachedString)
         {
             if (string.IsNullOrEmpty(cachedString))
                 return null;

--- a/LoRaEngine/LoraKeysManagerFacade/EUIValidator.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/EUIValidator.cs
@@ -7,7 +7,7 @@ namespace LoraKeysManagerFacade
 
     internal static class EUIValidator
     {
-        const string InvalidZero = "0000000000000000";
+        private const string InvalidZero = "0000000000000000";
 
         /// <summary>
         /// DevEUI are required to be IEEE EUI-64.

--- a/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
@@ -57,7 +57,7 @@ namespace LoraKeysManagerFacade
                     .AddSingleton<LoRaDevAddrCache>();
         }
 
-        abstract class ConfigHandler
+        private abstract class ConfigHandler
         {
             internal const string IoTHubConnectionStringKey = "IoTHubConnectionString";
             internal const string RedisConnectionStringKey = "RedisConnectionString";
@@ -80,7 +80,7 @@ namespace LoraKeysManagerFacade
 
             internal abstract string IoTHubConnectionString { get; }
 
-            class ProductionConfigHandler : ConfigHandler
+            private class ProductionConfigHandler : ConfigHandler
             {
                 private readonly IConfiguration config;
 
@@ -94,7 +94,7 @@ namespace LoraKeysManagerFacade
                 internal override string IoTHubConnectionString => this.config.GetConnectionString(IoTHubConnectionStringKey);
             }
 
-            class LocalConfigHandler : ConfigHandler
+            private class LocalConfigHandler : ConfigHandler
             {
                 private readonly IConfiguration config;
 

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaADRFunction/LoRaADRRedisStore.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaADRFunction/LoRaADRRedisStore.cs
@@ -13,11 +13,11 @@ namespace LoraKeysManagerFacade
 
     public class LoRaADRRedisStore : LoRaADRStoreBase, ILoRaADRStore
     {
-        const string CacheToken = ":ADR";
-        const string LockToken = ":lock";
-        readonly IDatabase redisCache;
+        private const string CacheToken = ":ADR";
+        private const string LockToken = ":lock";
+        private readonly IDatabase redisCache;
 
-        sealed class RedisLockWrapper : IDisposable
+        private sealed class RedisLockWrapper : IDisposable
         {
             private static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(10);
             private static readonly TimeSpan LockDuration = TimeSpan.FromSeconds(15);

--- a/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
@@ -135,7 +135,7 @@ namespace LoraKeysManagerFacade
             return new NotFoundObjectResult($"Device '{devEUI}' was not found");
         }
 
-        async Task<IActionResult> SendMessageViaCloudToDeviceMessageAsync(string devEUI, LoRaCloudToDeviceMessage c2dMessage)
+        private async Task<IActionResult> SendMessageViaCloudToDeviceMessageAsync(string devEUI, LoRaCloudToDeviceMessage c2dMessage)
         {
             try
             {
@@ -159,7 +159,7 @@ namespace LoraKeysManagerFacade
             }
         }
 
-        async Task<IActionResult> SendMessageViaDirectMethodAsync(
+        private async Task<IActionResult> SendMessageViaDirectMethodAsync(
             string preferredGatewayID,
             string devEUI,
             LoRaCloudToDeviceMessage c2dMessage)
@@ -202,6 +202,6 @@ namespace LoraKeysManagerFacade
         /// <summary>
         /// Gets if the http status code indicates success.
         /// </summary>
-        static bool IsSuccessStatusCode(int statusCode) => statusCode is >= 200 and <= 299;
+        private static bool IsSuccessStatusCode(int statusCode) => statusCode is >= 200 and <= 299;
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServer.cs
@@ -11,8 +11,8 @@ namespace LoRaWan.NetworkServer.BasicsStation
 
     public static class BasicsStationNetworkServer
     {
-        const int SecurePort = 5001;
-        const int Port = 5000;
+        private const int SecurePort = 5001;
+        private const int Port = 5000;
 
         public static async Task RunServerAsync(CancellationToken cancellationToken)
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -12,7 +12,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
 
-    sealed class BasicsStationNetworkServerStartup
+    internal sealed class BasicsStationNetworkServerStartup
     {
         public IConfiguration Configuration { get; }
         public NetworkServerConfiguration NetworkServerConfiguration { get; }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ChangeTrackingProperty.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ChangeTrackingProperty.cs
@@ -12,8 +12,8 @@ namespace LoRaWan.NetworkServer
     /// <typeparam name="T">The underlying type that we keep track of. Must implement <see cref="IEqualityComparer{T}"/>.</typeparam>
     public sealed class ChangeTrackingProperty<T> : IChangeTrackingProperty
     {
-        T current;
-        T original;
+        private T current;
+        private T original;
 
         public ChangeTrackingProperty(string propertyName)
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -423,7 +423,7 @@ namespace LoRaWan.NetworkServer
             }
         }
 
-        void HandlePreferredGatewayChanges(
+        private void HandlePreferredGatewayChanges(
             LoRaRequest request,
             LoRaDevice loRaDevice,
             FunctionBundlerResult bundlerResult)
@@ -456,7 +456,7 @@ namespace LoRaWan.NetworkServer
 
         internal void SetClassCMessageSender(IClassCDeviceMessageSender classCMessageSender) => this.classCDeviceMessageSender = classCMessageSender;
 
-        void SendClassCDeviceMessage(IReceivedLoRaCloudToDeviceMessage cloudToDeviceMessage)
+        private void SendClassCDeviceMessage(IReceivedLoRaCloudToDeviceMessage cloudToDeviceMessage)
         {
             if (this.classCDeviceMessageSender != null)
             {
@@ -567,7 +567,7 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Send detected MAC commands as message properties.
         /// </summary>
-        static void ProcessAndSendMacCommands(LoRaPayloadData payloadData, ref Dictionary<string, string> eventProperties)
+        private static void ProcessAndSendMacCommands(LoRaPayloadData payloadData, ref Dictionary<string, string> eventProperties)
         {
             if (payloadData.MacCommands?.Count > 0)
             {
@@ -584,7 +584,7 @@ namespace LoRaWan.NetworkServer
         /// Helper method to resolve FcntDown in case one was not yet acquired.
         /// </summary>
         /// <returns>0 if the resolution failed or > 0 if a valid frame count was acquired.</returns>
-        static async ValueTask<uint> EnsureHasFcntDownAsync(
+        private static async ValueTask<uint> EnsureHasFcntDownAsync(
             LoRaDevice loRaDevice,
             uint? fcntDown,
             uint payloadFcnt,

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
@@ -15,7 +15,7 @@ namespace LoRaWan.NetworkServer
     /// - Prevents querying the registry and loading twins multiple times
     /// - Ensure that requests are queued by <see cref="LoRaDevice"/> in the order they come.
     /// </summary>
-    class DeviceLoaderSynchronizer : ILoRaDeviceRequestQueue
+    internal class DeviceLoaderSynchronizer : ILoRaDeviceRequestQueue
     {
         internal enum LoaderState
         {
@@ -78,7 +78,7 @@ namespace LoRaWan.NetworkServer
                                                                    TaskScheduler.Default));
         }
 
-        async Task Load()
+        private async Task Load()
         {
             try
             {
@@ -299,7 +299,7 @@ namespace LoRaWan.NetworkServer
             }
         }
 
-        void SetState(LoaderState newState)
+        private void SetState(LoaderState newState)
         {
             if (this.state != newState)
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
@@ -317,7 +317,7 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Prepare the Mac Commands to be sent in the downstream message.
         /// </summary>
-        static ICollection<MacCommand> PrepareMacCommandAnswer(
+        private static ICollection<MacCommand> PrepareMacCommandAnswer(
             string devEUI,
             IEnumerable<MacCommand> requestedMacCommands,
             IEnumerable<MacCommand> serverMacCommands,

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinDeviceLoader.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinDeviceLoader.cs
@@ -15,8 +15,8 @@ namespace LoRaWan.NetworkServer
     {
         private readonly IoTHubDeviceInfo ioTHubDevice;
         private readonly ILoRaDeviceFactory deviceFactory;
-        readonly Task<LoRaDevice> loading;
-        volatile bool canCache;
+        private readonly Task<LoRaDevice> loading;
+        private volatile bool canCache;
 
         internal bool CanCache => this.canCache;
 
@@ -34,7 +34,7 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         internal Task<LoRaDevice> WaitCompleteAsync() => this.loading;
 
-        async Task<LoRaDevice> LoadAsync()
+        private async Task<LoRaDevice> LoadAsync()
         {
             var loRaDevice = this.deviceFactory.Create(this.ioTHubDevice);
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -30,7 +30,7 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Process OTAA join request.
         /// </summary>
-        async Task ProcessJoinRequestAsync(LoRaRequest request)
+        private async Task ProcessJoinRequestAsync(LoRaRequest request)
         {
             LoRaDevice loRaDevice = null;
             string devEUI = null;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaCloudToDeviceMessageWrapper.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaCloudToDeviceMessageWrapper.cs
@@ -12,7 +12,7 @@ namespace LoRaWan.NetworkServer
     using Microsoft.Azure.Devices.Client;
     using Newtonsoft.Json;
 
-    class LoRaCloudToDeviceMessageWrapper : IReceivedLoRaCloudToDeviceMessage
+    internal class LoRaCloudToDeviceMessageWrapper : IReceivedLoRaCloudToDeviceMessage
     {
         private readonly LoRaDevice loRaDevice;
         private readonly Message message;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -76,23 +76,22 @@ namespace LoRaWan.NetworkServer
 
         public bool Supports32BitFCnt { get; set; }
 
-        readonly ChangeTrackingProperty<int> dataRate = new ChangeTrackingProperty<int>(TwinProperty.DataRate);
+        private readonly ChangeTrackingProperty<int> dataRate = new ChangeTrackingProperty<int>(TwinProperty.DataRate);
 
         public int DataRate => this.dataRate.Get();
 
-        readonly ChangeTrackingProperty<int> txPower = new ChangeTrackingProperty<int>(TwinProperty.TxPower);
-
-        readonly ILoRaDeviceClientConnectionManager connectionManager;
+        private readonly ChangeTrackingProperty<int> txPower = new ChangeTrackingProperty<int>(TwinProperty.TxPower);
+        private readonly ILoRaDeviceClientConnectionManager connectionManager;
 
         public int TxPower => this.txPower.Get();
 
-        readonly ChangeTrackingProperty<int> nbRep = new ChangeTrackingProperty<int>(TwinProperty.NbRep);
+        private readonly ChangeTrackingProperty<int> nbRep = new ChangeTrackingProperty<int>(TwinProperty.NbRep);
 
         public int NbRep => this.nbRep.Get();
 
         public DeduplicationMode Deduplication { get; set; }
 
-        int preferredWindow;
+        private int preferredWindow;
 
         /// <summary>
         /// Gets or sets value indicating the preferred receive window for the device.
@@ -115,7 +114,7 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         public LoRaDeviceClassType ClassType { get; set; }
 
-        ChangeTrackingProperty<LoRaRegionType> region = new ChangeTrackingProperty<LoRaRegionType>(TwinProperty.Region, LoRaRegionType.NotSet);
+        private ChangeTrackingProperty<LoRaRegionType> region = new ChangeTrackingProperty<LoRaRegionType>(TwinProperty.Region, LoRaRegionType.NotSet);
 
         /// <summary>
         /// Gets or sets the <see cref="LoRaTools.Regions.LoRaRegionType"/> of the device
@@ -127,7 +126,7 @@ namespace LoRaWan.NetworkServer
             set => this.region.Set(value);
         }
 
-        ChangeTrackingProperty<string> preferredGatewayID = new ChangeTrackingProperty<string>(TwinProperty.PreferredGatewayID, string.Empty);
+        private ChangeTrackingProperty<string> preferredGatewayID = new ChangeTrackingProperty<string>(TwinProperty.PreferredGatewayID, string.Empty);
 
         /// <summary>
         /// Gets the device preferred gateway identifier
@@ -451,7 +450,7 @@ namespace LoRaWan.NetworkServer
             return newfCnt;
         }
 
-        static uint? GetUintFromTwin(TwinCollection collection, string propertyName)
+        private static uint? GetUintFromTwin(TwinCollection collection, string propertyName)
         {
             if (!collection.Contains(propertyName))
             {
@@ -461,7 +460,7 @@ namespace LoRaWan.NetworkServer
             return GetTwinPropertyUIntValue(collection[propertyName].Value);
         }
 
-        static int GetTwinPropertyIntValue(dynamic value)
+        private static int GetTwinPropertyIntValue(dynamic value)
         {
             if (value is string valueString)
             {
@@ -487,7 +486,7 @@ namespace LoRaWan.NetworkServer
             return 0;
         }
 
-        static uint GetTwinPropertyUIntValue(dynamic value)
+        private static uint GetTwinPropertyUIntValue(dynamic value)
         {
             if (value is string valueString)
             {
@@ -513,7 +512,7 @@ namespace LoRaWan.NetworkServer
             return 0;
         }
 
-        static bool GetTwinPropertyBoolValue(dynamic value)
+        private static bool GetTwinPropertyBoolValue(dynamic value)
         {
             if (value is string valueString)
             {
@@ -641,7 +640,7 @@ namespace LoRaWan.NetworkServer
         /// Accept changes to the frame count
         /// This method is not protected by locks.
         /// </summary>
-        void InternalAcceptFrameCountChanges(uint savedFcntUp, uint savedFcntDown)
+        private void InternalAcceptFrameCountChanges(uint savedFcntUp, uint savedFcntDown)
         {
             this.lastSavedFcntUp = savedFcntUp;
             this.lastSavedFcntDown = savedFcntDown;
@@ -1032,7 +1031,7 @@ namespace LoRaWan.NetworkServer
             return ++val;
         }
 
-        async Task RunAndQueueNext(LoRaRequest request)
+        private async Task RunAndQueueNext(LoRaRequest request)
         {
             LoRaDeviceRequestProcessResult result = null;
             Exception processingError = null;
@@ -1085,7 +1084,7 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Gets the properties that are trackable.
         /// </summary>
-        IEnumerable<IChangeTrackingProperty> GetTrackableProperties()
+        private IEnumerable<IChangeTrackingProperty> GetTrackableProperties()
         {
             yield return this.preferredGatewayID;
             yield return this.region;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
@@ -106,7 +106,7 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Helper method that calls the API GetDevice method.
         /// </summary>
-        async Task<SearchDevicesResult> SearchDevicesAsync(string gatewayID = null, string devAddr = null, string devEUI = null, string appEUI = null, string devNonce = null)
+        private async Task<SearchDevicesResult> SearchDevicesAsync(string gatewayID = null, string devAddr = null, string devEUI = null, string appEUI = null, string devNonce = null)
         {
             var client = this.serviceFacadeHttpClientProvider.GetHttpClient();
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
@@ -23,8 +23,8 @@ namespace LoRaWan.NetworkServer
         private DeviceClient deviceClient;
 
         // TODO: verify if those are thread safe and can be static
-        readonly NoRetry noRetryPolicy;
-        readonly ExponentialBackoff exponentialBackoff;
+        private readonly NoRetry noRetryPolicy;
+        private readonly ExponentialBackoff exponentialBackoff;
 
         public LoRaDeviceClient(string devEUI, string connectionString, ITransportSettings[] transportSettings)
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -37,8 +37,8 @@ namespace LoRaWan.NetworkServer
             }
         }
 
-        readonly IMemoryCache cache;
-        readonly ConcurrentDictionary<string, ManagedConnection> managedConnections = new ConcurrentDictionary<string, ManagedConnection>();
+        private readonly IMemoryCache cache;
+        private readonly ConcurrentDictionary<string, ManagedConnection> managedConnections = new ConcurrentDictionary<string, ManagedConnection>();
 
         public LoRaDeviceClientConnectionManager(IMemoryCache cache)
         {
@@ -86,7 +86,7 @@ namespace LoRaWan.NetworkServer
                     });
         }
 
-        void OnScheduledDisconnect(object key, object value, EvictionReason reason, object state)
+        private void OnScheduledDisconnect(object key, object value, EvictionReason reason, object state)
         {
             var managedConnection = (ManagedConnection)value;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
@@ -20,16 +20,15 @@ namespace LoRaWan.NetworkServer
     public sealed class LoRaDeviceRegistry : ILoRaDeviceRegistry
     {
         // Caches a device making join for 30 minutes
-        const int INTERVAL_TO_CACHE_DEVICE_IN_JOIN_PROCESS_IN_MINUTES = 30;
+        private const int INTERVAL_TO_CACHE_DEVICE_IN_JOIN_PROCESS_IN_MINUTES = 30;
 
         private readonly LoRaDeviceAPIServiceBase loRaDeviceAPIService;
         private readonly ILoRaDeviceFactory deviceFactory;
         private readonly HashSet<ILoRaDeviceInitializer> initializers;
         private readonly NetworkServerConfiguration configuration;
-        readonly object getOrCreateLoadingDevicesRequestQueueLock;
-        readonly object getOrCreateJoinDeviceLoaderLock;
-
-        readonly object devEUIToLoRaDeviceDictionaryLock;
+        private readonly object getOrCreateLoadingDevicesRequestQueueLock;
+        private readonly object getOrCreateJoinDeviceLoaderLock;
+        private readonly object devEUIToLoRaDeviceDictionaryLock;
 
         private readonly IMemoryCache cache;
 
@@ -93,7 +92,7 @@ namespace LoRaWan.NetworkServer
             return cachedValue;
         }
 
-        DeviceLoaderSynchronizer GetOrCreateLoadingDevicesRequestQueue(string devAddr)
+        private DeviceLoaderSynchronizer GetOrCreateLoadingDevicesRequestQueue(string devAddr)
         {
             // Need to get and ensure it has started since the GetOrAdd can create multiple objects
             // https://github.com/aspnet/Extensions/issues/708
@@ -167,7 +166,7 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Called to sync up list of devices kept by device registry.
         /// </summary>
-        void UpdateDeviceRegistration(LoRaDevice loRaDevice, string oldDevAddr = null)
+        private void UpdateDeviceRegistration(LoRaDevice loRaDevice, string oldDevAddr = null)
         {
             var dictionary = InternalGetCachedDevicesForDevAddr(loRaDevice.DevAddr);
             dictionary[loRaDevice.DevEUI] = loRaDevice;
@@ -234,13 +233,13 @@ namespace LoRaWan.NetworkServer
         }
 
         // Creates cache key for join device loader: "joinloader:{devEUI}"
-        static string GetJoinDeviceLoaderCacheKey(string devEUI) => string.Concat("joinloader:", devEUI);
+        private static string GetJoinDeviceLoaderCacheKey(string devEUI) => string.Concat("joinloader:", devEUI);
 
         // Removes join device loader from cache
-        void RemoveJoinDeviceLoader(string devEUI) => this.cache.Remove(GetJoinDeviceLoaderCacheKey(devEUI));
+        private void RemoveJoinDeviceLoader(string devEUI) => this.cache.Remove(GetJoinDeviceLoaderCacheKey(devEUI));
 
         // Gets or adds a join device loader to the memory cache
-        JoinDeviceLoader GetOrCreateJoinDeviceLoader(IoTHubDeviceInfo ioTHubDeviceInfo)
+        private JoinDeviceLoader GetOrCreateJoinDeviceLoader(IoTHubDeviceInfo ioTHubDeviceInfo)
         {
             // Need to get and ensure it has started since the GetOrAdd can create multiple objects
             // https://github.com/aspnet/Extensions/issues/708

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaOperationTimeWatcher.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaOperationTimeWatcher.cs
@@ -44,7 +44,7 @@ namespace LoRaWan.NetworkServer
         // Gets start time
         public DateTimeOffset Start { get; }
 
-        readonly Region loraRegion;
+        private readonly Region loraRegion;
 
         public LoRaOperationTimeWatcher(Region loraRegion)
             : this(loraRegion, DateTimeOffset.UtcNow)
@@ -84,7 +84,7 @@ namespace LoRaWan.NetworkServer
             return loRaDevice.ReceiveDelay1 ?? (int)this.loraRegion.ReceiveDelay1;
         }
 
-        bool InTimeForReceiveFirstWindow(LoRaDevice loRaDevice, TimeSpan elapsed) => elapsed.Add(ExpectedTimeToPackageAndSendMessage).TotalSeconds <= GetReceiveWindow1Delay(loRaDevice);
+        private bool InTimeForReceiveFirstWindow(LoRaDevice loRaDevice, TimeSpan elapsed) => elapsed.Add(ExpectedTimeToPackageAndSendMessage).TotalSeconds <= GetReceiveWindow1Delay(loRaDevice);
 
         /// <summary>
         /// Gets the receive window 2 (RX2) delay in seconds
@@ -97,7 +97,7 @@ namespace LoRaWan.NetworkServer
             return loRaDevice.ReceiveDelay2 ?? (int)this.loraRegion.ReceiveDelay2;
         }
 
-        bool InTimeForReceiveSecondWindow(LoRaDevice loRaDevice, TimeSpan elapsed) => elapsed.Add(ExpectedTimeToPackageAndSendMessage).TotalSeconds <= GetReceiveWindow2Delay(loRaDevice);
+        private bool InTimeForReceiveSecondWindow(LoRaDevice loRaDevice, TimeSpan elapsed) => elapsed.Add(ExpectedTimeToPackageAndSendMessage).TotalSeconds <= GetReceiveWindow2Delay(loRaDevice);
 
         /// <summary>
         /// Calculate if there is still time to send join accept response.
@@ -158,12 +158,12 @@ namespace LoRaWan.NetworkServer
             return Constants.InvalidReceiveWindow;
         }
 
-        bool InTimeForJoinAcceptFirstWindow(TimeSpan elapsed)
+        private bool InTimeForJoinAcceptFirstWindow(TimeSpan elapsed)
         {
             return elapsed.Add(ExpectedTimeToPackageAndSendMessage).TotalSeconds <= this.loraRegion.JoinAcceptDelay1;
         }
 
-        bool InTimeForJoinAcceptSecondWindow(TimeSpan elapsed)
+        private bool InTimeForJoinAcceptSecondWindow(TimeSpan elapsed)
         {
             return elapsed.Add(ExpectedTimeToPackageAndSendMessage).TotalSeconds <= this.loraRegion.JoinAcceptDelay2;
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaPayloadDecoder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaPayloadDecoder.cs
@@ -25,7 +25,7 @@ namespace LoRaWan.NetworkServer
 
         // Http client used by decoders
         // Decoder calls don't need proxy since they will never leave the IoT Edge device
-        readonly Lazy<HttpClient> decodersHttpClient;
+        private readonly Lazy<HttpClient> decodersHttpClient;
 
         public LoRaPayloadDecoder()
         {
@@ -98,7 +98,7 @@ namespace LoRaWan.NetworkServer
             }
         }
 
-        async Task<DecodePayloadResult> CallSensorDecoderModule(string devEUI, Uri sensorDecoderModuleUrl)
+        private async Task<DecodePayloadResult> CallSensorDecoderModule(string devEUI, Uri sensorDecoderModuleUrl)
         {
             try
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
@@ -85,7 +85,7 @@ namespace LoRaWan.NetworkServer
 
         private void DispatchLoRaJoinRequest(LoggingLoRaRequest request) => this.joinRequestHandler.DispatchRequest(request);
 
-        void DispatchLoRaDataMessage(LoRaRequest request)
+        private void DispatchLoRaDataMessage(LoRaRequest request)
         {
             var loRaPayload = (LoRaPayloadData)request.Payload;
             if (!IsValidNetId(loRaPayload))
@@ -98,7 +98,7 @@ namespace LoRaWan.NetworkServer
             this.deviceRegistry.GetLoRaRequestQueue(request).Queue(request);
         }
 
-        bool IsValidNetId(LoRaPayloadData loRaPayload)
+        private bool IsValidNetId(LoRaPayloadData loRaPayload)
         {
             // Check if the current dev addr is in our network id
             var devAddrNwkid = loRaPayload.DevAddrNetID;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NullDisposable.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NullDisposable.cs
@@ -10,7 +10,7 @@ namespace LoRaWan.NetworkServer
     /// </summary>
     internal class NullDisposable : IDisposable
     {
-        static readonly NullDisposable instance = new NullDisposable();
+        private static readonly NullDisposable instance = new NullDisposable();
 
         internal static IDisposable Instance => instance;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ServiceFacadeHttpClientProvider.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ServiceFacadeHttpClientProvider.cs
@@ -27,7 +27,7 @@ namespace LoRaWan.NetworkServer
 
         public HttpClient GetHttpClient() => this.httpClient.Value;
 
-        HttpClient CreateHttpClient()
+        private HttpClient CreateHttpClient()
         {
 #pragma warning disable CA2000 // Dispose objects before losing scope
             // Will be handled once we migrate to DI.

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
@@ -30,7 +30,7 @@ namespace LoRaWan.NetworkServer
     /// </summary>
     public sealed class UdpServer : IPacketForwarder, IDisposable
     {
-        const int PORT = 1680;
+        private const int PORT = 1680;
         private readonly NetworkServerConfiguration configuration;
         private readonly MessageDispatcher messageDispatcher;
         private readonly LoRaDeviceAPIServiceBase loRaDeviceAPIService;
@@ -41,7 +41,7 @@ namespace LoRaWan.NetworkServer
         private ModuleClient ioTHubModuleClient;
         private volatile int pullAckRemoteLoRaAggregatorPort;
         private volatile string pullAckRemoteLoRaAddress;
-        UdpClient udpClient;
+        private UdpClient udpClient;
 
         private Task<byte[]> GetTokenAsync()
         {
@@ -99,7 +99,7 @@ namespace LoRaWan.NetworkServer
             await udpServer.RunUdpListener();
         }
 
-        async Task UdpSendMessageAsync(byte[] messageToSend, string remoteLoRaAggregatorIp, int remoteLoRaAggregatorPort)
+        private async Task UdpSendMessageAsync(byte[] messageToSend, string remoteLoRaAggregatorIp, int remoteLoRaAggregatorPort)
         {
             if (messageToSend != null && messageToSend.Length != 0)
             {
@@ -111,7 +111,7 @@ namespace LoRaWan.NetworkServer
             }
         }
 
-        async Task RunUdpListener()
+        private async Task RunUdpListener()
         {
             var endPoint = new IPEndPoint(IPAddress.Any, PORT);
             this.udpClient = new UdpClient(endPoint);
@@ -205,7 +205,7 @@ namespace LoRaWan.NetworkServer
             _ = UdpSendMessageAsync(response, remoteEndpoint.Address.ToString(), remoteEndpoint.Port);
         }
 
-        async Task InitCallBack()
+        private async Task InitCallBack()
         {
             try
             {
@@ -292,7 +292,7 @@ namespace LoRaWan.NetworkServer
             Logger.LogAlways($"Log Level: {Logger.LoggerLevel}");
         }
 
-        async Task<MethodResponse> OnDirectMethodCalled(MethodRequest methodRequest, object userContext)
+        private async Task<MethodResponse> OnDirectMethodCalled(MethodRequest methodRequest, object userContext)
         {
             if (string.Equals("clearcache", methodRequest.Name, StringComparison.OrdinalIgnoreCase))
             {
@@ -337,7 +337,7 @@ namespace LoRaWan.NetworkServer
             return Task.FromResult(new MethodResponse(200));
         }
 
-        Task OnDesiredPropertiesUpdate(TwinCollection desiredProperties, object userContext)
+        private Task OnDesiredPropertiesUpdate(TwinCollection desiredProperties, object userContext)
         {
             try
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Data128.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Data128.cs
@@ -9,12 +9,11 @@ namespace LoRaWan
     /// <summary>
     /// Represents byte data of 128 bits as a single unit.
     /// </summary>
-    readonly struct Data128 : IEquatable<Data128>
+    internal readonly struct Data128 : IEquatable<Data128>
     {
         public const int Size = sizeof(ulong) * 2;
-
-        readonly ulong lo;
-        readonly ulong hi;
+        private readonly ulong lo;
+        private readonly ulong hi;
 
         public Data128(ulong hi, ulong lo) => (this.hi, this.lo) = (hi, lo);
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/DataRate.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/DataRate.cs
@@ -12,7 +12,7 @@ namespace LoRaWan
     /// </summary>
     public readonly struct DataRate : IEquatable<DataRate>
     {
-        readonly byte value;
+        private readonly byte value;
 
         public DataRate(int value) =>
             this.value = value is var v and >= 0 and <= 15

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/DevAddr.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/DevAddr.cs
@@ -20,10 +20,8 @@ namespace LoRaWan
            +--------|---------+ */
 
         public const int Size = sizeof(uint);
-
-        const uint NetworkAddressMask = 0x01ff_ffff;
-
-        readonly uint value;
+        private const uint NetworkAddressMask = 0x01ff_ffff;
+        private readonly uint value;
 
         public DevAddr(uint value) => this.value = value;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/DevNonce.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/DevNonce.cs
@@ -21,7 +21,7 @@ namespace LoRaWan
         public const int Size = sizeof(ushort);
 
 #pragma warning disable IDE0032 // Use auto property (explicit name)
-        readonly ushort value;
+        private readonly ushort value;
 
         public DevNonce(ushort value) => this.value = value;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/FrameControl.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/FrameControl.cs
@@ -25,11 +25,10 @@ namespace LoRaWan
     /// </summary>
     public readonly struct FrameControl : IEquatable<FrameControl>
     {
-        const byte FOptsLenMask = 0xf;
+        private const byte FOptsLenMask = 0xf;
 
         public const int Size = sizeof(byte);
-
-        readonly byte value;
+        private readonly byte value;
 
         public FrameControl(byte value) => this.value = value;
 
@@ -37,7 +36,7 @@ namespace LoRaWan
             this(unchecked((byte)((byte)(((byte)flags & FOptsLenMask) == 0 ? flags : throw new ArgumentException(null, nameof(flags)))
                                          | (optionsLength is >= 0 and <= 15 ? optionsLength : throw new ArgumentOutOfRangeException(nameof(optionsLength), optionsLength, null))))) { }
 
-        bool HasFlags(FCtrlFlags flags) => ((FCtrlFlags)this.value & flags) == flags;
+        private bool HasFlags(FCtrlFlags flags) => ((FCtrlFlags)this.value & flags) == flags;
 
         /// <summary>
         /// Indicates whether the network will control the data rate of the end-device.

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Hertz.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Hertz.cs
@@ -11,7 +11,7 @@ namespace LoRaWan
     /// </summary>
     public readonly struct Hertz : IEquatable<Hertz>
     {
-        readonly ulong value;
+        private readonly ulong value;
 
         public Hertz(ulong value) => this.value = value;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Hexadecimal.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Hexadecimal.cs
@@ -9,12 +9,11 @@ namespace LoRaWan
 
     public static class Hexadecimal
     {
-        const string UpperCaseDigits = "0123456789ABCDEF";
-        const string LowerCaseDigits = "0123456789abcdef";
+        private const string UpperCaseDigits = "0123456789ABCDEF";
+        private const string LowerCaseDigits = "0123456789abcdef";
+        private const string InsufficientBufferSizeErrorMessage = "Insufficient buffer size to encode hexadecimal.";
 
-        const string InsufficientBufferSizeErrorMessage = "Insufficient buffer size to encode hexadecimal.";
-
-        static void ValidateSufficientlySizedBuffer(int targetCharsLength, int expectedByteSize, string paramName)
+        private static void ValidateSufficientlySizedBuffer(int targetCharsLength, int expectedByteSize, string paramName)
         {
             if (targetCharsLength < expectedByteSize * 2)
                 throw new ArgumentException(InsufficientBufferSizeErrorMessage, paramName);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Id6.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Id6.cs
@@ -32,7 +32,7 @@ namespace LoRaWan
             FixedWidth = 2,
         }
 
-        enum FormatterState
+        private enum FormatterState
         {
             Init,
             Word,
@@ -120,10 +120,10 @@ namespace LoRaWan
             return output[..i];
         }
 
-        struct WordAccumulator
+        private struct WordAccumulator
         {
-            byte digits;
-            ushort value;
+            private byte digits;
+            private ushort value;
 
             public static implicit operator ushort(WordAccumulator acc) => acc.value;
 
@@ -147,7 +147,7 @@ namespace LoRaWan
             }
         }
 
-        enum ParserState
+        private enum ParserState
         {
             BeforeColonColon,
             ColonBeforeColonColon,

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/MacHeader.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/MacHeader.cs
@@ -14,8 +14,7 @@ namespace LoRaWan
     public readonly struct MacHeader : IEquatable<MacHeader>
     {
         public const int Size = sizeof(byte);
-
-        readonly byte value;
+        private readonly byte value;
 
         public MacHeader(byte value) => this.value = value;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Mic.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Mic.cs
@@ -15,8 +15,7 @@ namespace LoRaWan
     public readonly struct Mic : IEquatable<Mic>
     {
         public const int Size = sizeof(uint);
-
-        readonly uint value;
+        private readonly uint value;
 
         public Mic(uint value) => this.value = value;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/NetId.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/NetId.cs
@@ -15,8 +15,7 @@ namespace LoRaWan
     public readonly struct NetId : IEquatable<NetId>
     {
         public const int Size = 3;
-
-        readonly int value; // 24-bit
+        private readonly int value; // 24-bit
 
         public NetId(int value)
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
@@ -16,14 +16,14 @@ namespace LoRaWan
     public static class Logger
     {
         // Interval where we try to estabilish connection to udp logger
-        const int RETRY_UDP_LOG_CONNECTION_INTERVAL_IN_MS = 1000 * 10;
+        private const int RETRY_UDP_LOG_CONNECTION_INTERVAL_IN_MS = 1000 * 10;
 
         public static LogLevel LoggerLevel => configuration.LogLevel;
 
-        static LoggerConfiguration configuration = new LoggerConfiguration();
-        static volatile UdpClient udpClient;
-        static IPEndPoint udpEndpoint;
-        static volatile bool isInitializeUdpLoggerRunning;
+        private static LoggerConfiguration configuration = new LoggerConfiguration();
+        private static volatile UdpClient udpClient;
+        private static IPEndPoint udpEndpoint;
+        private static volatile bool isInitializeUdpLoggerRunning;
         private static Timer retryUdpLogInitializationTimer;
 
         public static void Init(LoggerConfiguration loggerConfiguration)
@@ -122,7 +122,7 @@ namespace LoRaWan
             }
         }
 
-        static void LogToConsole(string message, LogLevel logLevel = LogLevel.Information)
+        private static void LogToConsole(string message, LogLevel logLevel = LogLevel.Information)
         {
             var loggedMessage = FormattableString.Invariant($"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} {message}");
 
@@ -136,7 +136,7 @@ namespace LoRaWan
             }
         }
 
-        static void LogToUdp(string message)
+        private static void LogToUdp(string message)
         {
             try
             {
@@ -158,7 +158,7 @@ namespace LoRaWan
         // Might be called from a timer while it does not work
         // Need to make this retries because NetworkServer might become alive
         // before listening container is started
-        static void InitializeUdpLogger(bool isRetry = false)
+        private static void InitializeUdpLogger(bool isRetry = false)
         {
             if (isInitializeUdpLoggerRunning)
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
@@ -17,7 +17,7 @@ namespace LoRaTools.LoRaMessage
     /// </summary>
     public class LoRaPayloadJoinAccept : LoRaPayload
     {
-        const ushort MaxRxDelayValue = 16;
+        private const ushort MaxRxDelayValue = 16;
 
         /// <summary>
         /// Gets or sets server Nonce aka JoinNonce.

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/PktFwdMessage.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/PktFwdMessage.cs
@@ -15,7 +15,7 @@ namespace LoRaTools.LoRaPhysical
         [JsonIgnore]
         public abstract PktFwdMessageAdapter PktFwdMessageAdapter { get; }
 
-        enum PktFwdType
+        private enum PktFwdType
         {
             Downlink,
             Uplink

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/ConversionHelper.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/ConversionHelper.cs
@@ -8,7 +8,7 @@ namespace LoRaTools.Utils
 
     public static class ConversionHelper
     {
-        const string HexAlphabet = "0123456789ABCDEF";
+        private const string HexAlphabet = "0123456789ABCDEF";
 
         /// <summary>
         /// Method enabling to convert a hex string to a byte array.

--- a/Tests/Common/EventHubDataCollector.cs
+++ b/Tests/Common/EventHubDataCollector.cs
@@ -15,8 +15,8 @@ namespace LoRaWan.Tests.Common
         private readonly ConcurrentQueue<EventData> events;
         private readonly string connectionString;
         private EventHubClient eventHubClient;
-        readonly List<PartitionReceiver> receivers;
-        readonly HashSet<Action<IEnumerable<EventData>>> subscribers;
+        private readonly List<PartitionReceiver> receivers;
+        private readonly HashSet<Action<IEnumerable<EventData>>> subscribers;
 
         public bool LogToConsole { get; set; } = true;
 

--- a/Tests/Common/FindTimeResult.cs
+++ b/Tests/Common/FindTimeResult.cs
@@ -3,7 +3,7 @@
 
 namespace LoRaWan.Tests.Common
 {
-    class FindTimeResult
+    internal class FindTimeResult
     {
         public bool Success { get; set; }
 

--- a/Tests/Common/IntegrationTestFixtureBase.Asserts.cs
+++ b/Tests/Common/IntegrationTestFixtureBase.Asserts.cs
@@ -24,7 +24,7 @@ namespace LoRaWan.Tests.Common
             return actualMessageIdentifier?.ToString();
         }
 
-        static bool IsDeviceMessage(string expectedDeviceID, string jsonPropertyToValidate, string expectedValue, string eventDeviceID, string eventDataMessageBody)
+        private static bool IsDeviceMessage(string expectedDeviceID, string jsonPropertyToValidate, string expectedValue, string eventDeviceID, string eventDataMessageBody)
         {
             if (eventDeviceID != null && eventDeviceID == expectedDeviceID)
             {
@@ -282,7 +282,7 @@ namespace LoRaWan.Tests.Common
         /// <summary>
         /// Helper method to find the time of the message that contain the message argument.
         /// </summary>
-        async Task<FindTimeResult> TryFindMessageTimeAsync(string message, string sourceIdFilter, bool isUpstream = false)
+        private async Task<FindTimeResult> TryFindMessageTimeAsync(string message, string sourceIdFilter, bool isUpstream = false)
         {
             const string token = @"""tmst"":";
             SearchLogResult log;
@@ -314,7 +314,7 @@ namespace LoRaWan.Tests.Common
             };
         }
 
-        async Task<SearchLogResult> SearchUdpLogs(Func<SearchLogEvent, bool> predicate, SearchLogOptions options = null)
+        private async Task<SearchLogResult> SearchUdpLogs(Func<SearchLogEvent, bool> predicate, SearchLogOptions options = null)
         {
             var maxAttempts = options?.MaxAttempts ?? Configuration.EnsureHasEventMaximumTries;
             var processedEvents = new HashSet<SearchLogEvent>();
@@ -359,12 +359,12 @@ namespace LoRaWan.Tests.Common
             return new SearchLogResult(false, processedEvents);
         }
 
-        async Task<SearchLogResult> SearchUdpLogs(Func<string, bool> predicate, SearchLogOptions options = null)
+        private async Task<SearchLogResult> SearchUdpLogs(Func<string, bool> predicate, SearchLogOptions options = null)
         {
             return await SearchUdpLogs(evt => predicate(evt.Message), options);
         }
 
-        async Task<SearchLogResult> SearchIoTHubLogs(Func<SearchLogEvent, bool> predicate, SearchLogOptions options = null)
+        private async Task<SearchLogResult> SearchIoTHubLogs(Func<SearchLogEvent, bool> predicate, SearchLogOptions options = null)
         {
             var maxAttempts = options?.MaxAttempts ?? Configuration.EnsureHasEventMaximumTries;
             var processedEvents = new HashSet<SearchLogEvent>();
@@ -409,7 +409,7 @@ namespace LoRaWan.Tests.Common
         }
 
         // Searches IoT Hub for messages
-        async Task<SearchLogResult> SearchIoTHubLogs(Func<string, bool> predicate, SearchLogOptions options = null)
+        private async Task<SearchLogResult> SearchIoTHubLogs(Func<string, bool> predicate, SearchLogOptions options = null)
         {
             return await SearchIoTHubLogs(evt => predicate(evt.Message), options);
         }

--- a/Tests/Common/IntegrationTestFixtureBase.cs
+++ b/Tests/Common/IntegrationTestFixtureBase.cs
@@ -25,16 +25,15 @@ namespace LoRaWan.Tests.Common
         private const int C2dExpiryTime = 5;
 
         public const string MESSAGE_IDENTIFIER_PROPERTY_NAME = "messageIdentifier";
-
-        RegistryManager registryManager;
+        private RegistryManager registryManager;
         private UdpLogListener udpLogListener;
 
         public TestConfiguration Configuration { get; }
 
         public EventHubDataCollector IoTHubMessages { get; private set; }
 
-        readonly Lazy<ServiceClient> serviceClient;
-        Microsoft.Azure.Devices.Client.ModuleClient moduleClient;
+        private readonly Lazy<ServiceClient> serviceClient;
+        private Microsoft.Azure.Devices.Client.ModuleClient moduleClient;
 
         protected IntegrationTestFixtureBase()
         {
@@ -54,7 +53,7 @@ namespace LoRaWan.Tests.Common
         }
 
         // Helper method to return all devices
-        IEnumerable<TestDeviceInfo> GetAllDevices()
+        private IEnumerable<TestDeviceInfo> GetAllDevices()
         {
             var types = GetType();
             foreach (var prop in types.GetProperties())
@@ -84,7 +83,7 @@ namespace LoRaWan.Tests.Common
 
         public Task DisposeAsync() => Task.FromResult(0);
 
-        RegistryManager GetRegistryManager()
+        private RegistryManager GetRegistryManager()
         {
             return this.registryManager ??= RegistryManager.CreateFromConnectionString(Configuration.IoTHubConnectionString);
         }
@@ -157,7 +156,7 @@ namespace LoRaWan.Tests.Common
             await SendCloudToDeviceMessageAsync(deviceId, msg);
         }
 
-        ServiceClient GetServiceClient() => this.serviceClient.Value;
+        private ServiceClient GetServiceClient() => this.serviceClient.Value;
 
         public async Task SendCloudToDeviceMessageAsync(string deviceId, Message message)
         {

--- a/Tests/Common/MessageProcessorMultipleGatewayBase.cs
+++ b/Tests/Common/MessageProcessorMultipleGatewayBase.cs
@@ -17,7 +17,7 @@ namespace LoRaWan.Tests.Common
 
     public class MessageProcessorMultipleGatewayBase : MessageProcessorTestBase
     {
-        const string SecondServerGatewayID = "second-gateway";
+        private const string SecondServerGatewayID = "second-gateway";
 
         private readonly MemoryCache cache;
 

--- a/Tests/Common/RecordedDuration.cs
+++ b/Tests/Common/RecordedDuration.cs
@@ -8,11 +8,11 @@ namespace LoRaWan.Tests.Common
 
     public class RecordedDuration
     {
-        int Duration { get; set; }
+        private int Duration { get; set; }
 
-        IReadOnlyList<int> Sequence { get; set; }
+        private IReadOnlyList<int> Sequence { get; set; }
 
-        int sequenceIndex;
+        private int sequenceIndex;
 
         public RecordedDuration(int duration)
         {

--- a/Tests/Common/SimulatedDevice.cs
+++ b/Tests/Common/SimulatedDevice.cs
@@ -261,7 +261,7 @@ namespace LoRaWan.Tests.Common
             return await joinCompleted.WaitAsync(timeoutInMs);
         }
 
-        bool HandleJoinAccept(LoRaPayloadJoinAccept payload)
+        private bool HandleJoinAccept(LoRaPayloadJoinAccept payload)
         {
             try
             {

--- a/Tests/Common/SimulatedPacketForwarder.cs
+++ b/Tests/Common/SimulatedPacketForwarder.cs
@@ -52,7 +52,7 @@ namespace LoRaWan.Tests.Common
             TestLogger.Log($"*** Simulated Packed Forwarder created: {ip}:{port} ***");
         }
 
-        string CreateMessagePacket(byte[] data)
+        private string CreateMessagePacket(byte[] data)
         {
             Rxpk.Data = Convert.ToBase64String(data);
             Rxpk.Size = (uint)data.Length;
@@ -78,7 +78,7 @@ namespace LoRaWan.Tests.Common
         private Task pullDataTask;
         private Task listenerTask;
 
-        static byte[] GetRandomToken()
+        private static byte[] GetRandomToken()
         {
             // random is not thread safe
             var token = new byte[2];
@@ -94,7 +94,7 @@ namespace LoRaWan.Tests.Common
             this.listenerTask = Task.Run(async () => await ListenAsync(this.cancellationTokenSource.Token));
         }
 
-        async Task ListenAsync(CancellationToken cts)
+        private async Task ListenAsync(CancellationToken cts)
         {
             try
             {
@@ -140,14 +140,14 @@ namespace LoRaWan.Tests.Common
             }
         }
 
-        readonly HashSet<Func<byte[], bool>> subscribers = new HashSet<Func<byte[], bool>>();
+        private readonly HashSet<Func<byte[], bool>> subscribers = new HashSet<Func<byte[], bool>>();
 
         internal void SubscribeOnce(Func<byte[], bool> value)
         {
             this.subscribers.Add(value);
         }
 
-        async Task PullDataAsync(CancellationToken cts)
+        private async Task PullDataAsync(CancellationToken cts)
         {
             try
             {
@@ -168,7 +168,7 @@ namespace LoRaWan.Tests.Common
             }
         }
 
-        async Task PushDataAsync(CancellationToken cts)
+        private async Task PushDataAsync(CancellationToken cts)
         {
             try
             {

--- a/Tests/Common/UdpLogListener.cs
+++ b/Tests/Common/UdpLogListener.cs
@@ -35,7 +35,7 @@ namespace LoRaWan.Tests.Common
             TestLogger.Log($"*** UDP Log Listener created: {ip}:{port} ***");
         }
 
-        void OnMessageReceived(string msg)
+        private void OnMessageReceived(string msg)
         {
             this.events.Enqueue(msg);
 

--- a/Tests/Common/WaitableLoRaRequest.cs
+++ b/Tests/Common/WaitableLoRaRequest.cs
@@ -12,7 +12,7 @@ namespace LoRaWan.Tests.Common
 
     public sealed class WaitableLoRaRequest : LoRaRequest, IDisposable
     {
-        readonly SemaphoreSlim complete;
+        private readonly SemaphoreSlim complete;
 
         public bool ProcessingFailed { get; private set; }
 
@@ -74,7 +74,7 @@ namespace LoRaWan.Tests.Common
             return this.complete.WaitAsync(timeout);
         }
 
-        LoRaOperationTimeWatcher fixTimeWacher;
+        private LoRaOperationTimeWatcher fixTimeWacher;
 
         internal void UseTimeWatcher(LoRaOperationTimeWatcher timeWatcher) => this.fixTimeWacher = timeWatcher;
 

--- a/Tests/E2E/LoraArduinoSerial.cs
+++ b/Tests/E2E/LoraArduinoSerial.cs
@@ -137,9 +137,9 @@ namespace LoRaWan.Tests.E2E
             DR15
         }
 
-        readonly byte[] serialPortBuffer;
+        private readonly byte[] serialPortBuffer;
 
-        LoRaArduinoSerial(SerialPort sp)
+        private LoRaArduinoSerial(SerialPort sp)
         {
             this.serialPort = sp;
             this.serialPortBuffer = new byte[this.serialPort.ReadBufferSize];
@@ -162,7 +162,7 @@ namespace LoRaWan.Tests.E2E
             }
         }
 
-        void OnSerialDataReceived(string rawData)
+        private void OnSerialDataReceived(string rawData)
         {
             try
             {
@@ -196,10 +196,10 @@ namespace LoRaWan.Tests.E2E
             }
         }
 
-        readonly ConcurrentQueue<string> serialLogs = new ConcurrentQueue<string>();
-        string buff = string.Empty;
+        private readonly ConcurrentQueue<string> serialLogs = new ConcurrentQueue<string>();
+        private string buff = string.Empty;
 
-        void AppendSerialLog(string message)
+        private void AppendSerialLog(string message)
         {
             TestLogger.Log($"[SERIAL] {message}");
             this.serialLogs.Enqueue(message);
@@ -982,7 +982,7 @@ namespace LoRaWan.Tests.E2E
             await EnsureSerialAnswerAsync("+FDEFAULT:", 10);
         }
 
-        short getBatteryVoltage()
+        private short getBatteryVoltage()
         {
             short battery = 0;
 
@@ -1018,7 +1018,7 @@ namespace LoRaWan.Tests.E2E
             GC.SuppressFinalize(this);
         }
 
-        async Task EnsureSerialAnswerAsync(string expectedSerialStartText, int retries = 10, [CallerMemberName] string memberName = "")
+        private async Task EnsureSerialAnswerAsync(string expectedSerialStartText, int retries = 10, [CallerMemberName] string memberName = "")
         {
             for (var i = 0; i < retries; i++)
             {

--- a/Tests/E2E/XunitRetryHelper/Constants.cs
+++ b/Tests/E2E/XunitRetryHelper/Constants.cs
@@ -3,7 +3,7 @@
 
 namespace XunitRetryHelper
 {
-    class Constants
+    internal class Constants
     {
         internal const int DefaultMaxRetries = 3;
     }

--- a/Tests/E2E/XunitRetryHelper/TestCaseDiscoverer/RetryFactTestDiscoverer.cs
+++ b/Tests/E2E/XunitRetryHelper/TestCaseDiscoverer/RetryFactTestDiscoverer.cs
@@ -10,7 +10,7 @@ namespace XunitRetryHelper
 
     public class RetryFactTestDiscoverer : IXunitTestCaseDiscoverer
     {
-        readonly IMessageSink diagnosticMessageSink;
+        private readonly IMessageSink diagnosticMessageSink;
 
         public RetryFactTestDiscoverer(IMessageSink diagnosticMessageSink)
         {

--- a/Tests/E2E/XunitRetryHelper/TestCaseDiscoverer/RetryTheoryTestDiscoverer.cs
+++ b/Tests/E2E/XunitRetryHelper/TestCaseDiscoverer/RetryTheoryTestDiscoverer.cs
@@ -10,7 +10,7 @@ namespace XunitRetryHelper
 
     public class RetryTheoryTestDiscoverer : IXunitTestCaseDiscoverer
     {
-        readonly IMessageSink diagnosticMessageSink;
+        private readonly IMessageSink diagnosticMessageSink;
 
         public RetryTheoryTestDiscoverer(IMessageSink diagnosticMessageSink)
         {

--- a/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
+++ b/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
@@ -24,7 +24,7 @@ namespace LoRaWan.Tests.Integration
     [Collection(TestConstants.C2D_Size_Limit_TestCollectionName)]
     public sealed class ClassCCloudToDeviceMessageSizeLimitTests : IDisposable
     {
-        const string ServerGatewayID = "test-gateway";
+        private const string ServerGatewayID = "test-gateway";
 
         private TestPacketForwarder PacketForwarder { get; }
 

--- a/Tests/Integration/LockDevAddrHelper.cs
+++ b/Tests/Integration/LockDevAddrHelper.cs
@@ -7,7 +7,7 @@ namespace LoRaWan.Tests.Integration
     using System;
     using System.Threading.Tasks;
 
-    static class LockDevAddrHelper
+    internal static class LockDevAddrHelper
     {
         private const string FullUpdateKey = "fullUpdateKey";
         private const string GlobalDevAddrUpdateKey = "globalUpdateKey";

--- a/Tests/Integration/ParallelProcessingTests.cs
+++ b/Tests/Integration/ParallelProcessingTests.cs
@@ -266,7 +266,7 @@ namespace LoRaWan.Tests.Integration
             LoRaDeviceApi.VerifyAll();
         }
 
-        async Task<List<WaitableLoRaRequest>> SendMessages(SimulatedDevice device, MessageDispatcher dispatcher, uint payloadInitialFcnt, int delayBetweenMessages = 1000, int messagePerDeviceCount = 5)
+        private async Task<List<WaitableLoRaRequest>> SendMessages(SimulatedDevice device, MessageDispatcher dispatcher, uint payloadInitialFcnt, int delayBetweenMessages = 1000, int messagePerDeviceCount = 5)
         {
             var requests = new List<WaitableLoRaRequest>();
             for (uint i = 0; i < messagePerDeviceCount; ++i)

--- a/Tests/Integration/RedisFixture.cs
+++ b/Tests/Integration/RedisFixture.cs
@@ -27,10 +27,8 @@ namespace LoRaWan.Tests.Integration
         private ConnectionMultiplexer redis;
 
         private int redisPort;
-
-        string containerId;
-
-        static int uniqueRedisPort = 6000;
+        private string containerId;
+        private static int uniqueRedisPort = 6000;
 
         public IDatabase Database { get; set; }
 

--- a/Tests/Simulation/IntegrationTestFixtureSim.cs
+++ b/Tests/Simulation/IntegrationTestFixtureSim.cs
@@ -19,15 +19,15 @@ namespace LoRaWan.Tests.Simulation
         // Device1003_Simulated_HttpBasedDecoder: used for simulator http based decoding test
         public TestDeviceInfo Device1003_Simulated_HttpBasedDecoder { get; private set; }
 
-        readonly List<TestDeviceInfo> deviceRange1000_ABP = new List<TestDeviceInfo>();
+        private readonly List<TestDeviceInfo> deviceRange1000_ABP = new List<TestDeviceInfo>();
 
         public IReadOnlyCollection<TestDeviceInfo> DeviceRange1000_ABP => this.deviceRange1000_ABP;
 
-        readonly List<TestDeviceInfo> deviceRange2000_1000_ABP = new List<TestDeviceInfo>();
+        private readonly List<TestDeviceInfo> deviceRange2000_1000_ABP = new List<TestDeviceInfo>();
 
         public IReadOnlyCollection<TestDeviceInfo> DeviceRange2000_1000_ABP => this.deviceRange2000_1000_ABP;
 
-        readonly List<TestDeviceInfo> deviceRange3000_10_OTAA = new List<TestDeviceInfo>();
+        private readonly List<TestDeviceInfo> deviceRange3000_10_OTAA = new List<TestDeviceInfo>();
 
         public IReadOnlyCollection<TestDeviceInfo> DeviceRange3000_10_OTAA => this.deviceRange3000_10_OTAA;
 

--- a/Tests/Simulation/SimulatorTestCollection.cs
+++ b/Tests/Simulation/SimulatorTestCollection.cs
@@ -33,7 +33,7 @@ namespace LoRaWan.Tests.Simulation
 
         // check if we need to parametrize address
         // IPEndPoint CreateNetworkServerEndpoint() => new IPEndPoint(IPAddress.Broadcast, 1680);
-        IPEndPoint CreateNetworkServerEndpoint() => new IPEndPoint(IPAddress.Parse(Configuration.NetworkServerIP), 1680);
+        private IPEndPoint CreateNetworkServerEndpoint() => new IPEndPoint(IPAddress.Parse(Configuration.NetworkServerIP), 1680);
 
         // [Fact]
         // public async Task Ten_Devices_Sending_Messages_Each_Second()

--- a/Tests/Unit/LoRaWanTests/ADRTest.cs
+++ b/Tests/Unit/LoRaWanTests/ADRTest.cs
@@ -15,7 +15,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
     public class ADRTest
     {
-        readonly ITestOutputHelper output;
+        private readonly ITestOutputHelper output;
 
         public ADRTest(ITestOutputHelper output)
         {

--- a/Tests/Unit/LoRaWanTests/ADRTestData.cs
+++ b/Tests/Unit/LoRaWanTests/ADRTestData.cs
@@ -10,7 +10,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
 #pragma warning disable CA1812 // Unused class
     // Used as Theory Data
-    class ADRTestData : TheoryData<string, string, List<LoRaADRTableEntry>, Rxpk, LoRaADRResult>
+    internal class ADRTestData : TheoryData<string, string, List<LoRaADRTableEntry>, Rxpk, LoRaADRResult>
 #pragma warning restore CA1812 // Unused class
     {
         public ADRTestData()

--- a/Tests/Unit/LoRaWanTests/DataRateTests.cs
+++ b/Tests/Unit/LoRaWanTests/DataRateTests.cs
@@ -9,8 +9,8 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
     public class DataRateTests
     {
-        readonly DataRate subject = new(5);
-        readonly DataRate other = new(10);
+        private readonly DataRate subject = new(5);
+        private readonly DataRate other = new(10);
 
         [Fact]
         public void Initialization_Succeeds_For_Valid_Values()

--- a/Tests/Unit/LoRaWanTests/DevAddrTests.cs
+++ b/Tests/Unit/LoRaWanTests/DevAddrTests.cs
@@ -8,8 +8,8 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
     public class DevAddrTests
     {
-        readonly DevAddr subject = new(0xeb6f7bde);
-        readonly DevAddr other = new(0x12345678);
+        private readonly DevAddr subject = new(0xeb6f7bde);
+        private readonly DevAddr other = new(0x12345678);
 
         [Fact]
         public void Size()

--- a/Tests/Unit/LoRaWanTests/DevNonceTests.cs
+++ b/Tests/Unit/LoRaWanTests/DevNonceTests.cs
@@ -9,8 +9,8 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
     public class DevNonceTests
     {
-        readonly DevNonce subject = new(0x1234);
-        readonly DevNonce other = new(0x5678);
+        private readonly DevNonce subject = new(0x1234);
+        private readonly DevNonce other = new(0x5678);
 
         [Fact]
         public void Size()

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -9,15 +9,16 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
     public abstract class EuiTests<T> where T : struct, IEquatable<T>
     {
-        T Subject => Parse("01-23-45-67-89-AB-CD-EF");
-        T Other => Parse("FE-DC-BA-98-76-54-32-10");
+        private T Subject => Parse("01-23-45-67-89-AB-CD-EF");
+
+        private T Other => Parse("FE-DC-BA-98-76-54-32-10");
 
         protected abstract int Size { get; }
         protected abstract T Parse(string input);
         protected abstract bool TryParse(string input, out T result);
 
-        static readonly Func<T, T, bool> Equal = Operators<T>.Equality;
-        static readonly Func<T, T, bool> NotEqual = Operators<T>.Inequality;
+        private static readonly Func<T, T, bool> Equal = Operators<T>.Equality;
+        private static readonly Func<T, T, bool> NotEqual = Operators<T>.Inequality;
 
         [Fact]
         public void Size_Returns_Width_In_Bytes()

--- a/Tests/Unit/LoRaWanTests/FrameControlTests.cs
+++ b/Tests/Unit/LoRaWanTests/FrameControlTests.cs
@@ -10,8 +10,8 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
     public class FrameControlTests
     {
-        readonly FrameControl subject = new(FCtrlFlags.FPending, 5);
-        readonly FrameControl other = new(FCtrlFlags.Ack, 0);
+        private readonly FrameControl subject = new(FCtrlFlags.FPending, 5);
+        private readonly FrameControl other = new(FCtrlFlags.Ack, 0);
 
         [Fact]
         public void Size()
@@ -22,7 +22,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
         // The following two types are purely for the purpose of making the in-line theory data for
         // the properties test more readable.
 
-        static class True
+        private static class True
         {
             public const bool Adr = true;
             public const bool AdrAckRequested = true;
@@ -30,7 +30,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
             public const bool DownlinkFramePending = true;
         }
 
-        static class False
+        private static class False
         {
             public const bool Adr = false;
             public const bool AdrAckRequested = false;
@@ -38,7 +38,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
             public const bool DownlinkFramePending = false;
         }
 
-        const FCtrlFlags AllFCtrlFlags = FCtrlFlags.Adr | FCtrlFlags.AdrAckReq | FCtrlFlags.Ack | FCtrlFlags.FPending;
+        private const FCtrlFlags AllFCtrlFlags = FCtrlFlags.Adr | FCtrlFlags.AdrAckReq | FCtrlFlags.Ack | FCtrlFlags.FPending;
 
         [Theory]
         [InlineData(FCtrlFlags.None         , 0, False.Adr, False.AdrAckRequested, False.Ack, False.DownlinkFramePending, 0)]

--- a/Tests/Unit/LoRaWanTests/HertzTest.cs
+++ b/Tests/Unit/LoRaWanTests/HertzTest.cs
@@ -8,11 +8,10 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
     public class HertzTest
     {
-        const ulong EuropeanFrequencyInHertz = 863_000_000;
-        const ulong AmericanFrequencyInHertz = 902_000_000;
-
-        readonly Hertz euFrequency = new(EuropeanFrequencyInHertz);
-        readonly Hertz usFrequency = new(AmericanFrequencyInHertz);
+        private const ulong EuropeanFrequencyInHertz = 863_000_000;
+        private const ulong AmericanFrequencyInHertz = 902_000_000;
+        private readonly Hertz euFrequency = new(EuropeanFrequencyInHertz);
+        private readonly Hertz usFrequency = new(AmericanFrequencyInHertz);
 
         [Fact]
         public void HertzConversions_Behave_Properly()

--- a/Tests/Unit/LoRaWanTests/KeysTests.cs
+++ b/Tests/Unit/LoRaWanTests/KeysTests.cs
@@ -9,15 +9,16 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
     public abstract class KeyTests<T> where T : struct, IEquatable<T>
     {
-        T Subject => Parse("0123456789abcdeffedcba9876543210");
-        T Other => Parse("fedcba98765432100123456789abcdef");
+        private T Subject => Parse("0123456789abcdeffedcba9876543210");
+
+        private T Other => Parse("fedcba98765432100123456789abcdef");
 
         protected abstract int Size { get; }
         protected abstract T Parse(string input);
         protected abstract bool TryParse(string input, out T result);
 
-        static readonly Func<T, T, bool> Equal = Operators<T>.Equality;
-        static readonly Func<T, T, bool> NotEqual = Operators<T>.Inequality;
+        private static readonly Func<T, T, bool> Equal = Operators<T>.Equality;
+        private static readonly Func<T, T, bool> NotEqual = Operators<T>.Inequality;
 
         [Fact]
         public void Size_Returns_Width_In_Bytes()

--- a/Tests/Unit/LoRaWanTests/MacHeaderTest.cs
+++ b/Tests/Unit/LoRaWanTests/MacHeaderTest.cs
@@ -8,8 +8,8 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
     public class MacHeaderTest
     {
-        readonly MacHeader confirmedDataDown = new(128);
-        readonly MacHeader unconfirmedDataUp = new(64);
+        private readonly MacHeader confirmedDataDown = new(128);
+        private readonly MacHeader unconfirmedDataUp = new(64);
 
         [Theory]
         [InlineData(  0, MacMessageType.JoinRequest        , 0)]

--- a/Tests/Unit/LoRaWanTests/MicTests.cs
+++ b/Tests/Unit/LoRaWanTests/MicTests.cs
@@ -8,8 +8,8 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
     public class MicTests
     {
-        readonly Mic subject = new(0x12345678);
-        readonly Mic other = new(0x87654321);
+        private readonly Mic subject = new(0x12345678);
+        private readonly Mic other = new(0x87654321);
 
         [Fact]
         public void Size()

--- a/Tests/Unit/LoRaWanTests/NetIdTests.cs
+++ b/Tests/Unit/LoRaWanTests/NetIdTests.cs
@@ -8,8 +8,8 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
     public class NetIdTests
     {
-        readonly NetId subject = new(0x1a2b3c);
-        readonly NetId other = new(0x4d5e6f);
+        private readonly NetId subject = new(0x1a2b3c);
+        private readonly NetId other = new(0x4d5e6f);
 
         [Fact]
         public void Size()

--- a/Tests/Unit/LoRaWanTests/Operators.cs
+++ b/Tests/Unit/LoRaWanTests/Operators.cs
@@ -6,13 +6,13 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
     using System;
     using System.Runtime.CompilerServices;
 
-    static class Operators<T>
+    internal static class Operators<T>
     {
-        static Func<T, T, bool> LogicalBinary([CallerMemberName] string name = null) =>
+        private static Func<T, T, bool> LogicalBinary([CallerMemberName] string name = null) =>
             (Func<T, T, bool>)Delegate.CreateDelegate(typeof(Func<T, T, bool>), typeof(T), $"op_{name}");
 
-        static Func<T, T, bool> equality;
-        static Func<T, T, bool> inequality;
+        private static Func<T, T, bool> equality;
+        private static Func<T, T, bool> inequality;
 
         public static Func<T, T, bool> Equality => equality ??= LogicalBinary();
         public static Func<T, T, bool> Inequality => inequality ??= LogicalBinary();

--- a/Tests/Unit/NetworkServerTests/DefaultClassCDevicesMessageSenderTest.cs
+++ b/Tests/Unit/NetworkServerTests/DefaultClassCDevicesMessageSenderTest.cs
@@ -20,7 +20,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
 
     public sealed class DefaultClassCDevicesMessageSenderTest : IDisposable
     {
-        const string ServerGatewayID = "test-gateway";
+        private const string ServerGatewayID = "test-gateway";
 
         private readonly NetworkServerConfiguration serverConfiguration;
         private readonly Region loRaRegion;

--- a/Tests/Unit/NetworkServerTests/LoRaDeviceRegistryTest.cs
+++ b/Tests/Unit/NetworkServerTests/LoRaDeviceRegistryTest.cs
@@ -15,12 +15,11 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
 
     public sealed class LoRaDeviceRegistryTest : IDisposable
     {
-        const string ServerGatewayID = "test-gateway";
-
-        readonly Mock<ILoRaDeviceFactory> loraDeviceFactoryMock;
-        readonly Mock<ILoRaDeviceClient> loRaDeviceClient;
-        readonly NetworkServerConfiguration serverConfiguration;
-        readonly MemoryCache cache;
+        private const string ServerGatewayID = "test-gateway";
+        private readonly Mock<ILoRaDeviceFactory> loraDeviceFactoryMock;
+        private readonly Mock<ILoRaDeviceClient> loRaDeviceClient;
+        private readonly NetworkServerConfiguration serverConfiguration;
+        private readonly MemoryCache cache;
 
         public LoRaDeviceRegistryTest()
         {

--- a/Tests/Unit/NetworkServerTests/LoRaDeviceTest.cs
+++ b/Tests/Unit/NetworkServerTests/LoRaDeviceTest.cs
@@ -19,7 +19,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
     /// </summary>
     public class LoRaDeviceTest
     {
-        readonly Mock<ILoRaDeviceClient> loRaDeviceClient;
+        private readonly Mock<ILoRaDeviceClient> loRaDeviceClient;
 
         public LoRaDeviceTest()
         {

--- a/Tests/Unit/NetworkServerTests/MessageProcessorJoinTest.cs
+++ b/Tests/Unit/NetworkServerTests/MessageProcessorJoinTest.cs
@@ -128,7 +128,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             return array;
         }
 
-        static Memory<byte> ByteArray(string value) => ConversionHelper.StringToByteArray(value);
+        private static Memory<byte> ByteArray(string value) => ConversionHelper.StringToByteArray(value);
 
         [Fact]
         public async Task When_Api_Takes_Too_Long_Should_Return_Null()

--- a/Tests/Unit/NetworkServerTests/MessageProcessorSingleGatewayTest.cs
+++ b/Tests/Unit/NetworkServerTests/MessageProcessorSingleGatewayTest.cs
@@ -355,7 +355,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             Assert.False(loraDevice.HasFrameCountChanges);
         }
 
-        static bool IsTwinFcntZero(TwinCollection t) => (int)t[TwinProperty.FCntDown] == 0 && (int)t[TwinProperty.FCntUp] == 0;
+        private static bool IsTwinFcntZero(TwinCollection t) => (int)t[TwinProperty.FCntDown] == 0 && (int)t[TwinProperty.FCntUp] == 0;
 
         [Theory]
         [InlineData(0)]


### PR DESCRIPTION
## What is being addressed

With this PR we remove the `IDE0040` suppression from the `.editorconfig`.

The number of errors generated per setting are:
- `never`: 0 (equivalent to suppressing the issue)
- `omit_if_default`: 445
- `for_non_interface_members`: 205
- `always`: 205

which is why we chose to go with the "default", which seems to have been what the project used (205 errors fixed in this PR).