### PR TITLE
Add editorconfig to docker build to fix the CI (again)

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64
@@ -2,6 +2,8 @@ FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
 
 WORKDIR /build
 COPY Directory.Build.props ./
+COPY AssemblyInfo.cs ./
+COPY .editorconfig ./
 
 WORKDIR /build/LoRaEngine/modules/LoRaWanNetworkSrvModule/
 COPY ./LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger ./Logger

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64.debug
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64.debug
@@ -13,7 +13,8 @@ FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
 
 WORKDIR /build
 COPY Directory.Build.props ./
-
+COPY AssemblyInfo.cs ./
+COPY .editorconfig ./
 WORKDIR /build/LoRaEngine/modules/LoRaWanNetworkSrvModule/
 COPY ./LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger ./Logger
 COPY ./LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools ./LoraTools

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.arm32v7
@@ -1,9 +1,11 @@
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
 
 WORKDIR /build
-COPY Directory.Build.props ./
 
 WORKDIR /build/LoRaEngine/modules/LoRaWanNetworkSrvModule/
+COPY Directory.Build.props ./
+COPY AssemblyInfo.cs ./
+COPY .editorconfig ./
 COPY ./LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger ./Logger
 COPY ./LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools ./LoraTools
 COPY ./LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer ./LoRaWan.NetworkServer


### PR DESCRIPTION
This fix the E2E CI, otherwise the build break with stylecop issues.

cf : https://github.com/Azure/iotedge-lorawan-starterkit/runs/3953546026?check_suite_focus=true#step:4:349