### PR TITLE
Remove unused imports

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/CreateEdgeDevice.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/CreateEdgeDevice.cs
@@ -4,7 +4,6 @@
 namespace LoraKeysManagerFacade
 {
     using System;
-    using System.Globalization;
     using System.Net;
     using System.Net.Http;
     using System.Text;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ChangeTrackingProperty.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ChangeTrackingProperty.cs
@@ -3,7 +3,6 @@
 
 namespace LoRaWan.NetworkServer
 {
-    using System;
     using System.Collections.Generic;
 
     /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
@@ -7,7 +7,6 @@ namespace LoRaWan.NetworkServer
     using System.Collections.Generic;
     using System.Linq;
     using System.Security.Cryptography;
-    using System.Text;
     using LoRaTools;
     using LoRaTools.ADR;
     using LoRaTools.LoRaMessage;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinDeviceLoader.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinDeviceLoader.cs
@@ -3,7 +3,6 @@
 
 namespace LoRaWan.NetworkServer
 {
-    using System;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs
@@ -4,7 +4,6 @@
 namespace LoRaWan.NetworkServer
 {
     using System;
-    using System.Collections.Generic;
     using System.Globalization;
     using System.Net;
     using System.Net.Sockets;
@@ -17,7 +16,6 @@ namespace LoRaWan.NetworkServer
     using LoRaTools.CommonAPI;
     using LoRaTools.LoRaPhysical;
     using LoRaTools.Utils;
-    using LoRaWan.Core;
     using LoRaWan.NetworkServer.ADR;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Shared;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
@@ -4,7 +4,6 @@
 namespace LoRaWan
 {
     using System;
-    using System.Globalization;
     using System.Net;
     using System.Net.Sockets;
     using System.Text;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -12,7 +12,6 @@ namespace LoRaTools.LoRaMessage
     using LoRaWan;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
-    using Org.BouncyCastle.Crypto;
     using Org.BouncyCastle.Crypto.Engines;
     using Org.BouncyCastle.Crypto.Parameters;
     using Org.BouncyCastle.Security;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinRequest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinRequest.cs
@@ -8,7 +8,6 @@ namespace LoRaTools.LoRaMessage
     using System.Linq;
     using LoRaTools.LoRaPhysical;
     using LoRaTools.Utils;
-    using Org.BouncyCastle.Crypto;
     using Org.BouncyCastle.Crypto.Parameters;
     using Org.BouncyCastle.Security;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionManager.cs
@@ -6,7 +6,6 @@ namespace LoRaTools.Regions
     using System;
     using System.Collections.Generic;
     using LoRaTools.LoRaPhysical;
-    using LoRaTools.Utils;
 
     public static class RegionManager
     {

--- a/Tests/Common/MessageProcessorMultipleGatewayBase.cs
+++ b/Tests/Common/MessageProcessorMultipleGatewayBase.cs
@@ -5,15 +5,12 @@ namespace LoRaWan.Tests.Common
 {
     using System;
     using System.Globalization;
-    using System.Threading.Tasks;
     using LoRaTools.ADR;
     using LoRaWan.NetworkServer;
     using LoRaWan.NetworkServer.ADR;
-    using Microsoft.Azure.Devices.Client;
     using Microsoft.Extensions.Caching.Memory;
     using Microsoft.Extensions.Logging;
     using Moq;
-    using Xunit;
 
     public class MessageProcessorMultipleGatewayBase : MessageProcessorTestBase
     {

--- a/Tests/E2E/LoRaArduinoSerial.Helper.cs
+++ b/Tests/E2E/LoRaArduinoSerial.Helper.cs
@@ -5,7 +5,6 @@ namespace LoRaWan.Tests.E2E
 {
     using System;
     using System.IO.Ports;
-    using System.Runtime.InteropServices;
     using System.Threading.Tasks;
     using LoRaWan.Tests.Common;
 

--- a/Tests/Integration/CloudToDeviceMessageSizeLimitShouldAbandonTests.cs
+++ b/Tests/Integration/CloudToDeviceMessageSizeLimitShouldAbandonTests.cs
@@ -8,7 +8,6 @@ namespace LoRaWan.Tests.Integration
     using System.Threading.Tasks;
     using LoRaTools;
     using LoRaTools.LoRaMessage;
-    using LoRaTools.LoRaPhysical;
     using LoRaTools.Regions;
     using LoRaTools.Utils;
     using LoRaWan.NetworkServer;

--- a/Tests/Integration/CloudToDeviceMessageSizeLimitShouldAcceptTests.cs
+++ b/Tests/Integration/CloudToDeviceMessageSizeLimitShouldAcceptTests.cs
@@ -8,7 +8,6 @@ namespace LoRaWan.Tests.Integration
     using System.Threading.Tasks;
     using LoRaTools;
     using LoRaTools.LoRaMessage;
-    using LoRaTools.LoRaPhysical;
     using LoRaTools.Regions;
     using LoRaTools.Utils;
     using LoRaWan.NetworkServer;

--- a/Tests/Integration/CloudToDeviceMessageSizeLimitShouldRejectTests.cs
+++ b/Tests/Integration/CloudToDeviceMessageSizeLimitShouldRejectTests.cs
@@ -7,7 +7,6 @@ namespace LoRaWan.Tests.Integration
     using System.Threading.Tasks;
     using LoRaTools;
     using LoRaTools.LoRaMessage;
-    using LoRaTools.LoRaPhysical;
     using LoRaTools.Regions;
     using LoRaTools.Utils;
     using LoRaWan.NetworkServer;


### PR DESCRIPTION
## What is being addressed

Unused imports.

## How is this addressed

Removed.

---
PS Seems these creep because [IDE0005](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0005) doesn't get flagged unless XML documentation is also generated (see bug dotnet/roslyn#41640).
