### PR TITLE
Fix null reference on config URL in env vars

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -129,6 +129,8 @@ namespace LoRaWan.NetworkServer
             config.Rx2DataRate = envVars.GetEnvVar("RX2_DATR", string.Empty);
             config.Rx2Frequency = envVars.GetEnvVar("RX2_FREQ");
             config.IoTEdgeTimeout = envVars.GetEnvVar("IOTEDGE_TIMEOUT", config.IoTEdgeTimeout);
+
+            // facadeurl is allowed to be null as the value is coming from the twin in production.
             var facadeUrl = envVars.GetEnvVar("FACADE_SERVER_URL", string.Empty);
             config.FacadeServerUrl = string.IsNullOrEmpty(facadeUrl) ? null : new Uri(envVars.GetEnvVar("FACADE_SERVER_URL", string.Empty));
             config.FacadeAuthCode = envVars.GetEnvVar("FACADE_AUTH_CODE", string.Empty);


### PR DESCRIPTION
The LNS now fails if no facade URL is provided to it in the environment variable. In a real deployment, the facade URL is coming from the desired properties and are set later (in the [UDP server](https://github.com/Azure/iotedge-lorawan-starterkit/blob/7ecc3bf17c634c1dac202c1477e650f3ec02bffb/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/UdpServer.cs#L245)). Therefore the module don't start during E2E test, resulting of runs of E2E [without any logs from the LNS](https://github.com/Azure/iotedge-lorawan-starterkit/runs/3984384386?check_suite_focus=true).

After this fix, the CI is ok : https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/1378064163