### PR TITLE
Move `NetIdHelper` to tests where it's used

### DIFF
--- a/Tests/Common/IntegrationTestFixtureBase.cs
+++ b/Tests/Common/IntegrationTestFixtureBase.cs
@@ -250,14 +250,14 @@ namespace LoRaWan.Tests.Common
 
                     if (!string.IsNullOrEmpty(d.DevAddr))
                     {
-                        d.DevAddr = LoRaTools.Utils.NetIdHelper.SetNwkIdPart(string.Concat(Configuration.DevicePrefix, d.DevAddr[Configuration.DevicePrefix.Length..]), Configuration.NetId);
+                        d.DevAddr = NetIdHelper.SetNwkIdPart(string.Concat(Configuration.DevicePrefix, d.DevAddr[Configuration.DevicePrefix.Length..]), Configuration.NetId);
                     }
                 }
                 else
                 {
                     if (!string.IsNullOrEmpty(d.DevAddr))
                     {
-                        d.DevAddr = LoRaTools.Utils.NetIdHelper.SetNwkIdPart(d.DevAddr, Configuration.NetId);
+                        d.DevAddr = NetIdHelper.SetNwkIdPart(d.DevAddr, Configuration.NetId);
                     }
                 }
             }

--- a/Tests/Common/NetIdHelper.cs
+++ b/Tests/Common/NetIdHelper.cs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace LoRaTools.Utils
+namespace LoRaWan.Tests.Common
 {
     using System;
+    using LoRaTools.Utils;
 
     public static class NetIdHelper
     {


### PR DESCRIPTION
## What is being addressed

The `NetIdHelper` was not used anywhere in the **LoRaEngine** core projects, only tests.

## How is this addressed

Moved `NetIdHelper` to **LoRaWan.Tests.Common** project.
