### PR TITLE
[Attempts to] fix intermittent failing LoRaDeviceRegistry unit test 

### DIFF
--- a/Tests/Unit/NetworkServerTests/LoRaDeviceRegistryTest.cs
+++ b/Tests/Unit/NetworkServerTests/LoRaDeviceRegistryTest.cs
@@ -404,8 +404,6 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             using var target = new LoRaDeviceRegistry(ServerConfiguration, this.cache, apiService.Object, deviceFactory);
             using var connectionManager = new SingleDeviceConnectionManager(LoRaDeviceClient.Object);
 
-            var getTwinMockSequence = LoRaDeviceClient.SetupSequence(x => x.GetTwinAsync());
-
             for (var deviceID = 1; deviceID <= deviceCount; ++deviceID)
             {
                 var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice((uint)deviceID, gatewayID: deviceGatewayID));


### PR DESCRIPTION
# PR for issue #648

## Logs (copied from the original story)
```
LoRaWan.Tests.Unit.NetworkServerTests.MessageProcessorMultipleGatewayTest.Multi_OTAA_Unconfirmed_Message_Should_Send_Data_To_IotHub_Update_FcntUp_And_Return_Null [1 ms]
[xUnit.net 00:00:01.88]     LoRaWan.Tests.Unit.NetworkServerTests.LoRaDeviceRegistryTest.When_Queueing_To_Multiple_Devices_With_Same_DevAddr_Should_Queue_To_Device_Matching_Mic(deviceGatewayID: "test-gateway") [FAIL]
  Failed LoRaWan.Tests.Unit.NetworkServerTests.LoRaDeviceRegistryTest.When_Queueing_To_Multiple_Devices_With_Same_DevAddr_Should_Queue_To_Device_Matching_Mic(deviceGatewayID: "test-gateway") [7 ms]
  Error Message:
   Moq.MockException : IDisposable.Dispose() invocation failed with mock behavior Strict.
All invocations on the mock must have a corresponding setup.
  Stack Trace:
     at Moq.FailForStrictMock.Handle(Invocation invocation, Mock mock)
   at Moq.Mock.Moq.IInterceptor.Intercept(Invocation invocation)
   at Moq.CastleProxyFactory.Interceptor.Intercept(IInvocation invocation)
   at Castle.DynamicProxy.AbstractInvocation.Proceed()
   at Castle.Proxies.ILoRaDeviceClientProxy.Dispose()
   at LoRaWan.Tests.Common.SingleDeviceConnectionManager.Dispose() in C:\Users\spgianna\code\michelin\iotedge-lorawan-starterkit\Tests\Common\SingleDeviceConnectionManager.cs:line 37
   at LoRaWan.Tests.Unit.NetworkServerTests.LoRaDeviceRegistryTest.When_Queueing_To_Multiple_Devices_With_Same_DevAddr_Should_Queue_To_Device_Matching_Mic(String deviceGatewayID) in C:\Users\spgianna\code\michelin\iotedge-lorawan-starterkit\Tests\Unit\NetworkServerTests\LoRaDeviceRegistryTest.cs:line 296
--- End of stack trace from previous location where exception was thrown ---
```

## Repro info
- In order to reproduce run in a loop e.g. > `for ($i = 0 ; $i -le 19; $i++) { dotnet test --filter FullyqualifiedName~NetworkServerTests .\Tests\Unit\ }` - don't run only the test class
- Only few of us experience this failure locally (Daniele, myself and not sure who else), could be due to faster machines?  

## The attempted fix
Failure is related to not having set up a mock for the `Dispose()` method. This is fixed by re-using the code from the `MessageProcessorTestBase`. The fix and underlying issue is not understood 100% but re-using that code is good practice anyway.

It seems that the issue is when the `LoraDeviceClient.Dispose()` method is called at the end of the test method in the `finally` block generated from the compiler. For some reason Moq complains about not having setup this call, although we do just before we get out of scope.

Another attempt was made by making the setup `Verifiable()` or introducing a `Task.Delay(1000)` after the setup but neither fixed the issue.

## Validation
Running 20 (+1!) $ dotnet test tests/unit in sequence.

### Before 
[before.txt](https://github.com/Azure/iotedge-lorawan-starterkit/files/7427616/before.txt)
Grep for `LoRaDeviceRegistryTest` -> 5 failures

### After
[after.txt](https://github.com/Azure/iotedge-lorawan-starterkit/files/7427619/after.txt) -> no failures


As it can be seen from the logs there are other tests failing too locally, another story was opened for these: #650 