### PR TITLE
Providing a better choice of Network Interface

### DIFF
--- a/Tests/Unit/NetworkServerTests/LnsProtocolMessageProcessorTests.cs
+++ b/Tests/Unit/NetworkServerTests/LnsProtocolMessageProcessorTests.cs
@@ -332,7 +332,10 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
 
             // mocking localIpAddress
             var connectionInfoMock = new Mock<ConnectionInfo>();
+            // this is going to select the network interface with most bytes received / sent
+            // this should correspond to the real ethernet/wifi interface on the machine
             var firstNic = isValidNic ? NetworkInterface.GetAllNetworkInterfaces()
+                                                        .OrderByDescending(x => x.GetIPv4Statistics().BytesReceived + x.GetIPv4Statistics().BytesSent)
                                                         .FirstOrDefault()
                                       : null;
             if (firstNic is not null)


### PR DESCRIPTION
# PR for issue #650 

## What is being addressed

Executing the "InternalHandleDiscoveryAsync_ShouldSendProperJson" test on local machines with "virtual" network interfaces enabled, could make the test fail.

## How is this addressed

Choice of Network Interface to use for the test is now being based on the interface with most received/sent bytes