### PR TITLE
Bumps up Moq version to latest

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
     <PropertyGroup> <!-- this group is meant for packages required from test projects -->
       <DockerDotnetVersion>3.125.5</DockerDotnetVersion>
       <MicrosoftNETTestSdkVersion>16.6.1</MicrosoftNETTestSdkVersion>
-      <MoqVersion>4.14.4</MoqVersion>
+      <MoqVersion>4.16.1</MoqVersion>
       <XUnitVersion>2.4.1</XUnitVersion>
       <XunitCombinatorialVersion>1.3.2</XunitCombinatorialVersion>
       <MicrosoftExtensionsConfigurationVersion>5.0.0</MicrosoftExtensionsConfigurationVersion>


### PR DESCRIPTION
@p-schuler noticed during investigation for #648 that we are behind a couple of minor versions. This does not fix the issue at hand but doesn't hurt to get it in (curious why dependabot has not caught this?).