### PR TITLE
Feature/664 cache station info

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationConfigurationService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationConfigurationService.cs
@@ -9,23 +9,55 @@ namespace LoRaWan.NetworkServer.BasicsStation
     using System.Threading.Tasks;
     using LoRaWan.NetworkServer.BasicsStation.JsonHandlers;
     using Microsoft.Azure.Devices.Client.Exceptions;
+    using Microsoft.Extensions.Caching.Memory;
     using Microsoft.Extensions.Logging;
 
-    internal sealed class BasicsStationConfigurationService : IBasicsStationConfigurationService
+    internal sealed class BasicsStationConfigurationService : IBasicsStationConfigurationService, IDisposable
     {
         private const string RouterConfigPropertyName = "routerConfig";
-
+        private const string CachePrefixName = "routerConfig:";
+        
+        private static readonly TimeSpan CacheTimeout = TimeSpan.FromHours(2);
+        private readonly SemaphoreSlim cacheSemaphore = new SemaphoreSlim(1);
         private readonly LoRaDeviceAPIServiceBase loRaDeviceApiService;
         private readonly ILoRaDeviceFactory loRaDeviceFactory;
+        private readonly IMemoryCache cache;
 
         public BasicsStationConfigurationService(LoRaDeviceAPIServiceBase loRaDeviceApiService,
-                                                 ILoRaDeviceFactory loRaDeviceFactory)
+                                                 ILoRaDeviceFactory loRaDeviceFactory,
+                                                 IMemoryCache cache)
         {
             this.loRaDeviceApiService = loRaDeviceApiService;
             this.loRaDeviceFactory = loRaDeviceFactory;
+            this.cache = cache;
         }
 
+        public void Dispose() => this.cacheSemaphore.Dispose();
+
         public async Task<string> GetRouterConfigMessageAsync(StationEui stationEui, CancellationToken cancellationToken)
+        {
+            var cacheKey = $"{CachePrefixName}{stationEui}";
+
+            if (this.cache.TryGetValue(cacheKey, out var result))
+                return (string)result;
+
+            await this.cacheSemaphore.WaitAsync(cancellationToken);
+
+            try
+            {
+                return await this.cache.GetOrCreateAsync(cacheKey, cacheEntry =>
+                {
+                    _ = cacheEntry.SetAbsoluteExpiration(CacheTimeout);
+                    return GetRouterConfigMessageInternalAsync(stationEui);
+                });
+            }
+            finally
+            {
+                _ = this.cacheSemaphore.Release();
+            }
+        }
+
+        private async Task<string> GetRouterConfigMessageInternalAsync(StationEui stationEui)
         {
             void Log(string message) => Logger.Log(stationEui.ToString(), message, LogLevel.Error);
 


### PR DESCRIPTION
# PR for issue #664 

## What is being addressed

This PR introduces in-memory caching on the LNS for station configuration files.

## How is this addressed

The `router_config` message is cached in an in-memory cache on the LNS.
