### PR TITLE
Add ModuleConnection host

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,6 +39,7 @@
       <CoverletMSBuild>3.1.0</CoverletMSBuild>
       <MicrosoftAzureEventHubsVersion>4.3.2</MicrosoftAzureEventHubsVersion>
       <MicrosoftAzureEventHubsProcessorVersion>4.3.2</MicrosoftAzureEventHubsProcessorVersion>
+      <BogusVersion>33.1.1</BogusVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServer.cs
@@ -6,8 +6,10 @@ namespace LoRaWan.NetworkServer.BasicsStation
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using LoRaWan.NetworkServer.BasicsStation.ModuleConnection;
     using Microsoft.AspNetCore;
     using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.DependencyInjection;
 
     public static class BasicsStationNetworkServer
     {
@@ -25,6 +27,16 @@ namespace LoRaWan.NetworkServer.BasicsStation
                                        .UseStartup<BasicsStationNetworkServerStartup>()
                                        .UseKestrel()
                                        .Build();
+
+            // We want to make sure the module connection is started at the start of the Network server.
+            // This is needed when we run as module, therefore we are blocking.
+            if (webHost.Services.GetRequiredService<NetworkServerConfiguration>().RunningAsIoTEdgeModule)
+            {
+                var moduleConnection = webHost.Services.GetRequiredService<ModuleConnectionHost>();
+                await moduleConnection.CreateAsync(cancellationToken);
+            }
+
+
             await webHost.RunAsync(cancellationToken);
         }
     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServer.cs
@@ -36,7 +36,6 @@ namespace LoRaWan.NetworkServer.BasicsStation
                 await moduleConnection.CreateAsync(cancellationToken);
             }
 
-
             await webHost.RunAsync(cancellationToken);
         }
     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -51,6 +51,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         .AddSingleton<IJoinRequestMessageHandler, JoinRequestMessageHandler>()
                         .AddSingleton<IMessageDispatcher, MessageDispatcher>()
                         .AddSingleton<IBasicsStationConfigurationService, BasicsStationConfigurationService>();
+                        .AddSingleton<IClassCDeviceMessageSender, DefaultClassCDevicesMessageSender>()
                         .AddTransient<LoRaDeviceAPIServiceBase, LoRaDeviceAPIService>()
                         .AddTransient<ILnsProtocolMessageProcessor, LnsProtocolMessageProcessor>();
         }
@@ -75,6 +76,12 @@ namespace LoRaWan.NetworkServer.BasicsStation
                 var moduleConnection = app.ApplicationServices.GetService<ModuleConnectionHost>();
                 moduleConnection.CreateAsync().GetAwaiter().GetResult();
             }
+
+            // Manually set the class C as otherwise the DI fails.
+            var classCMessageSender = app.ApplicationServices.GetService<IClassCDeviceMessageSender>();
+            var dataHandlerImplementation = app.ApplicationServices.GetService<DefaultLoRaDataRequestHandler>();
+            dataHandlerImplementation.SetClassCMessageSender(classCMessageSender);
+
 
             _ = app.UseRouting()
                    .UseWebSockets()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -74,7 +74,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
 
             // Manually set the class C as otherwise the DI fails.
             var classCMessageSender = app.ApplicationServices.GetService<IClassCDeviceMessageSender>();
-            var dataHandlerImplementation = app.ApplicationServices.GetService<DefaultLoRaDataRequestHandler>();
+            var dataHandlerImplementation = app.ApplicationServices.GetService<ILoRaDataRequestHandler>();
             dataHandlerImplementation.SetClassCMessageSender(classCMessageSender);
 
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -11,6 +11,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
     using LoRaWan.NetworkServer.BasicsStation.Stubs;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Azure.Devices.Client;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
@@ -29,6 +30,9 @@ namespace LoRaWan.NetworkServer.BasicsStation
 
         public void ConfigureServices(IServiceCollection services)
         {
+            ITransportSettings[] settings = { new AmqpTransportSettings(TransportType.Amqp_Tcp_Only) };
+            var loraModuleFactory = new LoRaModuleClientFactory(settings);
+
             _ = services.AddLogging(loggingBuilder =>
                         {
                             _ = loggingBuilder.SetMinimumLevel((LogLevel)int.Parse(NetworkServerConfiguration.LogLevel, CultureInfo.InvariantCulture));
@@ -52,6 +56,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         .AddSingleton<IMessageDispatcher, MessageDispatcher>()
                         .AddSingleton<IBasicsStationConfigurationService, BasicsStationConfigurationService>()
                         .AddSingleton<IClassCDeviceMessageSender, DefaultClassCDevicesMessageSender>()
+                        .AddSingleton<ILoRaModuleClientFactory>(loraModuleFactory)
                         .AddTransient<LoRaDeviceAPIServiceBase, LoRaDeviceAPIService>()
                         .AddTransient<ILnsProtocolMessageProcessor, LnsProtocolMessageProcessor>()
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -50,7 +50,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         .AddSingleton<ILoRaDeviceRegistry, LoRaDeviceRegistry>()
                         .AddSingleton<IJoinRequestMessageHandler, JoinRequestMessageHandler>()
                         .AddSingleton<IMessageDispatcher, MessageDispatcher>()
-                        .AddSingleton<IBasicsStationConfigurationService, BasicsStationConfigurationService>();
+                        .AddSingleton<IBasicsStationConfigurationService, BasicsStationConfigurationService>()
                         .AddSingleton<IClassCDeviceMessageSender, DefaultClassCDevicesMessageSender>()
                         .AddTransient<LoRaDeviceAPIServiceBase, LoRaDeviceAPIService>()
                         .AddTransient<ILnsProtocolMessageProcessor, LnsProtocolMessageProcessor>();

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ILoRaModuleClientFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ILoRaModuleClientFactory.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
+{
+    using System.Threading.Tasks;
+
+    public interface ILoRaModuleClientFactory
+    {
+        Task<ILoraModuleClient> CreateAsync();
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ILoraModuleClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ILoraModuleClient.cs
@@ -12,7 +12,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
     public interface ILoraModuleClient : IAsyncDisposable
     {
         /// <summary>
-        /// Operation Timeout for the module connection in milliseconds.
+        /// Operation Timeout for the module connection.
         /// </summary>
         public TimeSpan OperationTimeout { get; set; }
 
@@ -20,7 +20,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
 
         public ModuleClient GetModuleClient();
         Task<Twin> GetTwinAsync(CancellationToken cancellationToken);
-        Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback onDesiredPropertiesUpdate, object p);
-        Task SetMethodDefaultHandlerAsync(MethodCallback onDirectMethodCalled, object p);
+        Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback onDesiredPropertiesUpdate, object usercontext);
+        Task SetMethodDefaultHandlerAsync(MethodCallback onDirectMethodCalled, object usercontext);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ILoraModuleClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ILoraModuleClient.cs
@@ -6,16 +6,20 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Shared;
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
 
-    public interface ILoraModuleClient:IAsyncDisposable
+    public interface ILoraModuleClient : IAsyncDisposable
     {
-        uint OperationTimeoutInMilliseconds { get; set; }
+        /// <summary>
+        /// Operation Timeout for the module connection in milliseconds.
+        /// </summary>
+        public TimeSpan OperationTimeout { get; set; }
 
         public Task CreateFromEnvironmentAsync(ITransportSettings[] settings);
 
         public ModuleClient GetModuleClient();
-        Task<Twin> GetTwinAsync();
+        Task<Twin> GetTwinAsync(CancellationToken cancellationToken);
         Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback onDesiredPropertiesUpdate, object p);
         Task SetMethodDefaultHandlerAsync(MethodCallback onDirectMethodCalled, object p);
     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ILoraModuleClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ILoraModuleClient.cs
@@ -12,11 +12,9 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
     public interface ILoraModuleClient : IAsyncDisposable
     {
         /// <summary>
-        /// Operation Timeout for the module connection.
+        /// Operation timeout for the module connection.
         /// </summary>
         public TimeSpan OperationTimeout { get; set; }
-
-        public Task CreateFromEnvironmentAsync(ITransportSettings[] settings);
 
         public ModuleClient GetModuleClient();
         Task<Twin> GetTwinAsync(CancellationToken cancellationToken);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ILoraModuleClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ILoraModuleClient.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
+{
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Shared;
+    using System;
+    using System.Threading.Tasks;
+
+    public interface ILoraModuleClient:IAsyncDisposable
+    {
+        uint OperationTimeoutInMilliseconds { get; set; }
+
+        public Task CreateFromEnvironmentAsync(ITransportSettings[] settings);
+
+        public ModuleClient GetModuleClient();
+        Task<Twin> GetTwinAsync();
+        Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback onDesiredPropertiesUpdate, object p);
+        Task SetMethodDefaultHandlerAsync(Func<MethodRequest, object, Task<MethodResponse>> onDirectMethodCalled, object p);
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ILoraModuleClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ILoraModuleClient.cs
@@ -17,6 +17,6 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
         public ModuleClient GetModuleClient();
         Task<Twin> GetTwinAsync();
         Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback onDesiredPropertiesUpdate, object p);
-        Task SetMethodDefaultHandlerAsync(Func<MethodRequest, object, Task<MethodResponse>> onDirectMethodCalled, object p);
+        Task SetMethodDefaultHandlerAsync(MethodCallback onDirectMethodCalled, object p);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/LoRaModuleClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/LoRaModuleClient.cs
@@ -37,14 +37,14 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
             return this.moduleClient.GetTwinAsync(cancellationToken);
         }
 
-        public async Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback onDesiredPropertiesUpdate, object p)
+        public async Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback onDesiredPropertiesUpdate, object usercontext)
         {
-            await this.moduleClient.SetDesiredPropertyUpdateCallbackAsync(onDesiredPropertiesUpdate, p);
+            await this.moduleClient.SetDesiredPropertyUpdateCallbackAsync(onDesiredPropertiesUpdate, usercontext);
         }
 
-        public async Task SetMethodDefaultHandlerAsync(MethodCallback onDirectMethodCalled, object p)
+        public async Task SetMethodDefaultHandlerAsync(MethodCallback onDirectMethodCalled, object usercontext)
         {
-            await this.moduleClient.SetMethodDefaultHandlerAsync(onDirectMethodCalled, p);
+            await this.moduleClient.SetMethodDefaultHandlerAsync(onDirectMethodCalled, usercontext);
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/LoRaModuleClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/LoRaModuleClient.cs
@@ -5,6 +5,8 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
 {
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Shared;
+    using System;
+    using System.Threading;
     using System.Threading.Tasks;
 
     public sealed class LoRaModuleClient : ILoraModuleClient
@@ -12,15 +14,15 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
         private ModuleClient moduleClient;
 
         public uint OperationTimeoutInMilliseconds { get => this.moduleClient.OperationTimeoutInMilliseconds; set => this.moduleClient.OperationTimeoutInMilliseconds = value; }
+        public TimeSpan OperationTimeout { get; set; }
 
         public async Task CreateFromEnvironmentAsync(ITransportSettings[] settings)
         {
-            moduleClient = await ModuleClient.CreateFromEnvironmentAsync();
+            moduleClient = await ModuleClient.CreateFromEnvironmentAsync(settings);
         }
 
         public async ValueTask DisposeAsync()
         {
-            // this check is needed for tests.
             if (moduleClient != null)
             {
                 await this.moduleClient.CloseAsync();
@@ -30,9 +32,9 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
 
         public ModuleClient GetModuleClient() => this.moduleClient;
 
-        public async Task<Twin> GetTwinAsync()
+        public Task<Twin> GetTwinAsync(CancellationToken cancellationToken)
         {
-            return await this.moduleClient.GetTwinAsync();
+            return this.moduleClient.GetTwinAsync(cancellationToken);
         }
 
         public async Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback onDesiredPropertiesUpdate, object p)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/LoRaModuleClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/LoRaModuleClient.cs
@@ -5,7 +5,6 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
 {
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Shared;
-    using System;
     using System.Threading.Tasks;
 
     public sealed class LoRaModuleClient : ILoraModuleClient
@@ -41,9 +40,9 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
             await this.moduleClient.SetDesiredPropertyUpdateCallbackAsync(onDesiredPropertiesUpdate, p);
         }
 
-        public async Task SetMethodDefaultHandlerAsync(Func<MethodRequest, object, Task<MethodResponse>> onDirectMethodCalled, object p)
+        public async Task SetMethodDefaultHandlerAsync(MethodCallback onDirectMethodCalled, object p)
         {
-            await this.SetMethodDefaultHandlerAsync(onDirectMethodCalled, p);
+            await this.moduleClient.SetMethodDefaultHandlerAsync(onDirectMethodCalled, p);
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/LoRaModuleClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/LoRaModuleClient.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
+{
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Shared;
+    using System;
+    using System.Threading.Tasks;
+
+    public sealed class LoRaModuleClient : ILoraModuleClient
+    {
+        private ModuleClient moduleClient;
+
+        public uint OperationTimeoutInMilliseconds { get => this.moduleClient.OperationTimeoutInMilliseconds; set => this.moduleClient.OperationTimeoutInMilliseconds = value; }
+
+        public async Task CreateFromEnvironmentAsync(ITransportSettings[] settings)
+        {
+            moduleClient = await ModuleClient.CreateFromEnvironmentAsync();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            // this check is needed for tests.
+            if (moduleClient != null)
+            {
+                await this.moduleClient.CloseAsync();
+                this.moduleClient.Dispose();
+            }
+        }
+
+        public ModuleClient GetModuleClient() => this.moduleClient;
+
+        public async Task<Twin> GetTwinAsync()
+        {
+            return await this.moduleClient.GetTwinAsync();
+        }
+
+        public async Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback onDesiredPropertiesUpdate, object p)
+        {
+            await this.moduleClient.SetDesiredPropertyUpdateCallbackAsync(onDesiredPropertiesUpdate, p);
+        }
+
+        public async Task SetMethodDefaultHandlerAsync(Func<MethodRequest, object, Task<MethodResponse>> onDirectMethodCalled, object p)
+        {
+            await this.SetMethodDefaultHandlerAsync(onDirectMethodCalled, p);
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/LoRaModuleClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/LoRaModuleClient.cs
@@ -11,15 +11,15 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
 
     public sealed class LoRaModuleClient : ILoraModuleClient
     {
-        private ModuleClient moduleClient;
+        private readonly ModuleClient moduleClient;
 
-        public uint OperationTimeoutInMilliseconds { get => this.moduleClient.OperationTimeoutInMilliseconds; set => this.moduleClient.OperationTimeoutInMilliseconds = value; }
+        public LoRaModuleClient(ModuleClient moduleClient)
+        {
+            this.moduleClient = moduleClient;
+        }
+
         public TimeSpan OperationTimeout { get; set; }
 
-        public async Task CreateFromEnvironmentAsync(ITransportSettings[] settings)
-        {
-            moduleClient = await ModuleClient.CreateFromEnvironmentAsync(settings);
-        }
 
         public async ValueTask DisposeAsync()
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/LoRaModuleClientFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/LoRaModuleClientFactory.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
+{
+    using Microsoft.Azure.Devices.Client;
+    using System.Threading.Tasks;
+
+    public class LoRaModuleClientFactory : ILoRaModuleClientFactory
+    {
+        private readonly ITransportSettings[] settings;
+
+        public LoRaModuleClientFactory(ITransportSettings[] settings)
+        {
+            this.settings = settings;
+        }
+
+        public async Task<ILoraModuleClient> CreateAsync()
+        {
+            return new LoRaModuleClient(await ModuleClient.CreateFromEnvironmentAsync(this.settings));
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
+{
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Client.Exceptions;
+    using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Logging;
+    using System;
+    using System.Net;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public sealed class ModuleConnectionHost : IAsyncDisposable
+    {
+        private readonly NetworkServerConfiguration networkServerConfiguration;
+        private readonly IClassCDeviceMessageSender classCMessageSender;
+        private readonly ILoRaDeviceRegistry loRaDeviceRegistry;
+        private readonly ILoraModuleClient loRaModuleClient;
+
+        public ModuleConnectionHost(
+            NetworkServerConfiguration networkServerConfiguration,
+            IClassCDeviceMessageSender defaultClassCDevicesMessageSender,
+            ILoRaDeviceRegistry loRaDeviceRegistry)
+        {
+            this.networkServerConfiguration = networkServerConfiguration ?? throw new ArgumentNullException(nameof(networkServerConfiguration));
+            this.classCMessageSender = defaultClassCDevicesMessageSender ?? throw new ArgumentNullException(nameof(defaultClassCDevicesMessageSender));
+            this.loRaDeviceRegistry = loRaDeviceRegistry ?? throw new ArgumentNullException(nameof(loRaDeviceRegistry));
+            this.loRaModuleClient = new LoRaModuleClient();
+        }
+
+        /// <summary>
+        /// This constructor is only to be used by tests.
+        /// </summary>
+        internal ModuleConnectionHost(
+           NetworkServerConfiguration networkServerConfiguration,
+           IClassCDeviceMessageSender defaultClassCDevicesMessageSender,
+           ILoRaDeviceRegistry loRaDeviceRegistry,
+           ILoraModuleClient loraModuleClient)
+        {
+            this.networkServerConfiguration = networkServerConfiguration ?? throw new ArgumentNullException(nameof(networkServerConfiguration));
+            this.classCMessageSender = defaultClassCDevicesMessageSender ?? throw new ArgumentNullException(nameof(defaultClassCDevicesMessageSender));
+            this.loRaDeviceRegistry = loRaDeviceRegistry ?? throw new ArgumentNullException(nameof(loRaDeviceRegistry));
+            this.loRaModuleClient = loraModuleClient;
+        }
+
+        public async Task CreateAsync()
+        {
+            ITransportSettings[] settings = { new AmqpTransportSettings(Microsoft.Azure.Devices.Client.TransportType.Amqp_Tcp_Only) };
+
+            await this.loRaModuleClient.CreateFromEnvironmentAsync(settings);
+            await InitModuleAsync();
+
+        }
+
+        internal async Task InitModuleAsync()
+        { 
+            // Obsolete, this should be removed as part of #456
+            Logger.Init(new LoggerConfiguration
+            {
+                ModuleClient = this.loRaModuleClient.GetModuleClient(),
+                LogLevel = LoggerConfiguration.InitLogLevel(networkServerConfiguration.LogLevel),
+                LogToConsole = networkServerConfiguration.LogToConsole,
+                LogToHub = networkServerConfiguration.LogToHub,
+                LogToUdp = networkServerConfiguration.LogToUdp,
+                LogToUdpPort = networkServerConfiguration.LogToUdpPort,
+                LogToUdpAddress = networkServerConfiguration.LogToUdpAddress,
+                GatewayId = networkServerConfiguration.GatewayID
+            });
+
+            if (networkServerConfiguration.IoTEdgeTimeout > 0)
+            {
+                this.loRaModuleClient.OperationTimeoutInMilliseconds = networkServerConfiguration.IoTEdgeTimeout;
+                Logger.Log($"Changing timeout to {networkServerConfiguration.IoTEdgeTimeout} ms", LogLevel.Debug);
+            }
+
+            Logger.Log("Getting properties from module twin...", LogLevel.Information);
+            Twin moduleTwin;
+            try
+            {
+                moduleTwin = await this.loRaModuleClient.GetTwinAsync();
+            }
+            catch (IotHubCommunicationException)
+            {
+                Logger.Log($"There was a critical problem with the IoT Hub in getting the module twins.", LogLevel.Error);
+                throw;
+            }
+
+            var moduleTwinCollection = moduleTwin.Properties.Desired;
+
+            if (!TryUpdateConfigurationWithDesiredProperties(moduleTwinCollection))
+            {
+                Logger.Log($"The initial configuration of the facade function could not be found in the desired properties", LogLevel.Error);
+                throw new ArgumentException("Could not get Facade information from module twin");
+            }
+
+            await this.loRaModuleClient.SetDesiredPropertyUpdateCallbackAsync(OnDesiredPropertiesUpdate, null);
+
+            await this.loRaModuleClient.SetMethodDefaultHandlerAsync(OnDirectMethodCalled, null);
+        }
+
+        internal async Task<MethodResponse> OnDirectMethodCalled(MethodRequest methodRequest, object userContext)
+        {
+            if (string.Equals(Constants.CloudToDeviceClearCache, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return await ClearCache();
+            }
+            else if (string.Equals(Constants.CloudToDeviceDecoderElementName, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return await SendCloudToDeviceMessageAsync(methodRequest);
+            }
+
+            Logger.Log($"Unknown direct method called: {methodRequest?.Name}", LogLevel.Error);
+
+            return new MethodResponse((int)HttpStatusCode.NotFound);
+        }
+
+        internal async Task<MethodResponse> SendCloudToDeviceMessageAsync(MethodRequest methodRequest)
+        {
+            if (!string.IsNullOrEmpty(methodRequest.DataAsJson))
+            {
+                ReceivedLoRaCloudToDeviceMessage c2d = null;
+
+                try
+                {
+                    c2d = JsonSerializer.Deserialize<ReceivedLoRaCloudToDeviceMessage>(methodRequest.DataAsJson);
+                }
+                catch (JsonException ex)
+                {
+                    Logger.Log($"Impossible to parse Json for c2d message {c2d}, error: {ex}", LogLevel.Error);
+                    return new MethodResponse((int)HttpStatusCode.BadRequest);
+                }
+
+
+                Logger.Log(c2d.DevEUI, $"received cloud to device message from direct method: {methodRequest.DataAsJson}", LogLevel.Debug);
+
+                using var cts = methodRequest.ResponseTimeout.HasValue ? new CancellationTokenSource(methodRequest.ResponseTimeout.Value) : null;
+
+                if (await this.classCMessageSender.SendAsync(c2d, cts?.Token ?? CancellationToken.None))
+                {
+                    return new MethodResponse((int)HttpStatusCode.OK);
+                }
+            }
+
+            return new MethodResponse((int)HttpStatusCode.BadRequest);
+        }
+
+        private Task<MethodResponse> ClearCache()
+        {
+            this.loRaDeviceRegistry.ResetDeviceCache();
+
+            return Task.FromResult(new MethodResponse((int)HttpStatusCode.OK));
+        }
+
+        /// <summary>
+        /// Method to update the desired properties.
+        /// We only want to update the auth code if the facadeUri was performed.
+        /// If the update is not acceptable we don't apply it.
+        /// </summary>
+        internal Task OnDesiredPropertiesUpdate(TwinCollection desiredProperties, object userContext)
+        {
+            try
+            {
+                _ = TryUpdateConfigurationWithDesiredProperties(desiredProperties);
+            } catch (ArgumentOutOfRangeException ex)
+            {
+                Logger.Log($"A desired properties update was detected but the parameters are out of range with exception :  {ex}", LogLevel.Warning);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private bool TryUpdateConfigurationWithDesiredProperties(TwinCollection desiredProperties)
+        {
+            if (desiredProperties.Contains(Constants.FacadeServerUrlKey) && !string.IsNullOrEmpty((string)desiredProperties[Constants.FacadeServerUrlKey]))
+            {
+                if (Uri.TryCreate((string)desiredProperties[Constants.FacadeServerUrlKey], UriKind.Absolute, out var uri) && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+                {
+                    this.networkServerConfiguration.FacadeServerUrl = uri;
+                    if (desiredProperties.Contains(Constants.FacadeServerAuthCodeKey))
+                    {
+                        this.networkServerConfiguration.FacadeAuthCode = (string)desiredProperties[Constants.FacadeServerAuthCodeKey];
+                    }
+
+                    Logger.Log("Desired property changed", LogLevel.Debug);
+                    return true;
+                }
+                else
+                {
+                    Logger.Log("The Facade server Url present in device desired properties was malformed.", LogLevel.Error);
+                    throw new ArgumentOutOfRangeException(nameof(desiredProperties));
+                }
+            }
+
+            Logger.Log("no desired property changed", LogLevel.Debug);
+            return false;
+
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await this.loRaModuleClient.DisposeAsync();
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
@@ -117,7 +117,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
 
             Logger.Log($"Unknown direct method called: {methodRequest.Name}", LogLevel.Error);
 
-            return new MethodResponse((int)HttpStatusCode.NotFound);
+            return new MethodResponse((int)HttpStatusCode.BadRequest);
         }
 
         internal async Task<MethodResponse> SendCloudToDeviceMessageAsync(MethodRequest methodRequest)
@@ -167,7 +167,8 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
             try
             {
                 _ = TryUpdateConfigurationWithDesiredProperties(desiredProperties);
-            } catch (ConfigurationErrorsException ex)
+            }
+            catch (ConfigurationErrorsException ex)
             {
                 Logger.Log($"A desired properties update was detected but the parameters are out of range with exception :  {ex}", LogLevel.Warning);
             }
@@ -200,7 +201,6 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
 
             Logger.Log("no desired property changed", LogLevel.Debug);
             return false;
-
         }
 
         public async ValueTask DisposeAsync()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Stubs/PacketForwarderStub.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Stubs/PacketForwarderStub.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.BasicsStation.Stubs
+{
+    using LoRaTools.LoRaPhysical;
+    using System;
+    using System.Threading.Tasks;
+
+    public class PacketForwarderStub : IPacketForwarder
+    {
+        public Task SendDownstreamAsync(DownlinkPktFwdMessage message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Constants.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Constants.cs
@@ -45,6 +45,11 @@ namespace LoRaWan.NetworkServer
         public const string CloudToDeviceDecoderElementName = "cloudToDeviceMessage";
 
         /// <summary>
+        /// Property in decoder json response containing the cloud to the device message.
+        /// </summary>
+        public const string CloudToDeviceClearCache = "clearcache";
+
+        /// <summary>
         /// Convert the time to the packet forward time (millionth of seconds).
         /// </summary>
         public const uint ConvertToPktFwdTime = 1000000;
@@ -53,5 +58,10 @@ namespace LoRaWan.NetworkServer
         /// Minimum value for device connection keep alive timeout (1 minute).
         /// </summary>
         public const int MinKeepAliveTimeout = 60;
+
+        public const string FacadeServerUrlKey = "FacadeServerUrl";
+
+        public const string FacadeServerAuthCodeKey = "FacadeAuthCode";
+
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -460,7 +460,7 @@ namespace LoRaWan.NetworkServer
             }
         }
 
-        internal void SetClassCMessageSender(IClassCDeviceMessageSender classCMessageSender) => this.classCDeviceMessageSender = classCMessageSender;
+        public void SetClassCMessageSender(IClassCDeviceMessageSender classCMessageSender) => this.classCDeviceMessageSender = classCMessageSender;
 
         private void SendClassCDeviceMessage(IReceivedLoRaCloudToDeviceMessage cloudToDeviceMessage)
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -33,14 +33,12 @@ namespace LoRaWan.NetworkServer
             IDeduplicationStrategyFactory deduplicationFactory,
             ILoRaADRStrategyProvider loRaADRStrategyProvider,
             ILoRAADRManagerFactory loRaADRManagerFactory,
-            IFunctionBundlerProvider functionBundlerProvider,
-            IClassCDeviceMessageSender classCDeviceMessageSender = null)
+            IFunctionBundlerProvider functionBundlerProvider)
         {
             this.configuration = configuration;
             this.frameCounterUpdateStrategyProvider = frameCounterUpdateStrategyProvider;
             this.payloadDecoder = payloadDecoder;
             this.deduplicationFactory = deduplicationFactory;
-            this.classCDeviceMessageSender = classCDeviceMessageSender;
             this.loRaADRStrategyProvider = loRaADRStrategyProvider;
             this.loRaADRManagerFactory = loRaADRManagerFactory;
             this.functionBundlerProvider = functionBundlerProvider;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDataRequestHandler.cs
@@ -11,5 +11,6 @@ namespace LoRaWan.NetworkServer
     public interface ILoRaDataRequestHandler
     {
         Task<LoRaDeviceRequestProcessResult> ProcessRequestAsync(LoRaRequest request, LoRaDevice loRaDevice);
+        void SetClassCMessageSender(IClassCDeviceMessageSender classCMessageSender);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -50,7 +50,7 @@ namespace LoRaWan.NetworkServer
         public double? Rx2Frequency { get; set; }
 
         /// <summary>
-        /// Gets or sets the IoT Edge timeout, 0 keeps default value,.
+        /// Gets or sets the IoT Edge timeout in milliseconds, 0 keeps default value,.
         /// </summary>
         public uint IoTEdgeTimeout { get; set; }
 

--- a/Tests/Unit/LoRaWan.Tests.Unit.csproj
+++ b/Tests/Unit/LoRaWan.Tests.Unit.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="33.1.1" />
+    <PackageReference Include="Bogus" Version="$(BogusVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/Tests/Unit/LoRaWan.Tests.Unit.csproj
+++ b/Tests/Unit/LoRaWan.Tests.Unit.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Bogus" Version="33.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/Tests/Unit/NetworkServerTests/ModuleConnectionHostTest.cs
+++ b/Tests/Unit/NetworkServerTests/ModuleConnectionHostTest.cs
@@ -106,10 +106,10 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             {
                 Desired = new TwinCollection($"{{\"FacadeServerUrl\": \"{facadeUri}\", \"FacadeAuthCode\":\"{facadeCode}\"}}")
             };
-            loRaModuleClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(new Twin(twinProperty));
+            loRaModuleClient.Setup(x => x.GetTwinAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new Twin(twinProperty));
 
             await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, loRaDeviceRegistry.Object, loRaModuleClient.Object);
-            await moduleClient.InitModuleAsync();
+            await moduleClient.InitModuleAsync(CancellationToken.None);
             Assert.Equal(facadeUri + "/", networkServerConfiguration.FacadeServerUrl.ToString());
             Assert.Equal(facadeCode, networkServerConfiguration.FacadeAuthCode);
         }
@@ -129,10 +129,10 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             {
                 Desired = new TwinCollection(twin)
             };
-            loRaModuleClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(new Twin(twinProperty));
+            loRaModuleClient.Setup(x => x.GetTwinAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new Twin(twinProperty));
 
             await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, loRaDeviceRegistry.Object, loRaModuleClient.Object);
-            await Assert.ThrowsAsync<ArgumentException>(() => moduleClient.InitModuleAsync());
+            await Assert.ThrowsAsync<ArgumentException>(() => moduleClient.InitModuleAsync(CancellationToken.None));
         }
 
         [Fact]
@@ -148,10 +148,10 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var facadeUri = this.faker.Internet.Url();
             var facadeCode = this.faker.Internet.Password();
 
-            loRaModuleClient.Setup(x => x.GetTwinAsync()).Throws<IotHubCommunicationException>();
+            loRaModuleClient.Setup(x => x.GetTwinAsync(It.IsAny<CancellationToken>())).Throws<IotHubCommunicationException>();
 
             await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, loRaDeviceRegistry.Object, loRaModuleClient.Object);
-            await Assert.ThrowsAsync<IotHubCommunicationException>(() => moduleClient.InitModuleAsync());
+            await Assert.ThrowsAsync<IotHubCommunicationException>(() => moduleClient.InitModuleAsync(CancellationToken.None));
 
         }
 

--- a/Tests/Unit/NetworkServerTests/ModuleConnectionHostTest.cs
+++ b/Tests/Unit/NetworkServerTests/ModuleConnectionHostTest.cs
@@ -1,0 +1,261 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.NetworkServerTests
+{
+    using Bogus;
+    using LoRaWan.NetworkServer;
+    using LoRaWan.NetworkServer.BasicsStation.ModuleConnection;
+    using Microsoft.Azure.Devices.Client.Exceptions;
+    using Microsoft.Azure.Devices.Shared;
+    using Moq;
+    using System;
+    using System.Net;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class ModuleConnectionHostTest
+    {
+        private readonly Faker faker = new Faker();
+
+        [Fact]
+        public void When_Constructor_Receives_Null_Parameters_Should_Throw()
+        {
+            var networkServerConfiguration = new NetworkServerConfiguration();
+            var classCMessageSender = Mock.Of<IClassCDeviceMessageSender>();
+            var loRaDeviceRegistry = Mock.Of<ILoRaDeviceRegistry>();
+
+            // ASSERT
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+               {
+                   await using var tmp = new ModuleConnectionHost(null, classCMessageSender, loRaDeviceRegistry);
+               });
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await using var tmp = new ModuleConnectionHost(networkServerConfiguration, null, loRaDeviceRegistry);
+            });
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await using var tmp = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, null);
+            });
+
+        }
+
+        [Fact]
+        public async Task On_Desired_Properties_Correct_Update_Should_Update()
+        {
+            var networkServerConfiguration = new NetworkServerConfiguration();
+            var classCMessageSender = Mock.Of<IClassCDeviceMessageSender>();
+            var loRaDeviceRegistry = Mock.Of<ILoRaDeviceRegistry>();
+            var loRaModuleClient = new Mock<ILoraModuleClient>();
+            loRaModuleClient.Setup(x => x.DisposeAsync());
+
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, loRaDeviceRegistry);
+            var url1 = this.faker.Internet.Url();
+            var input = $"{{\"FacadeServerUrl\": \"{url1}\"}}";
+            await moduleClient.OnDesiredPropertiesUpdate(new Microsoft.Azure.Devices.Shared.TwinCollection(input), null);
+            Assert.Equal(url1 + "/", networkServerConfiguration.FacadeServerUrl.ToString());
+            var authCode = this.faker.Internet.Password();
+            var url2 = this.faker.Internet.Url();
+            var input2 = $"{{\"FacadeServerUrl\": \"{url2}\", \"FacadeAuthCode\":\"{authCode}\"}}";
+            await moduleClient.OnDesiredPropertiesUpdate(new Microsoft.Azure.Devices.Shared.TwinCollection(input2), null);
+            Assert.Equal(url2 + "/", networkServerConfiguration.FacadeServerUrl.ToString());
+            Assert.Equal(authCode, networkServerConfiguration.FacadeAuthCode.ToString());
+
+        }
+
+        [Theory]
+        [InlineData("{\"FacadeServerUrl\": \"url2\", \"FacadeAuthCode\":\"authCode\"}")]// not a url
+        [InlineData("{\"FacadeAuthCode\":\"authCode\"}")] // no Url
+        [InlineData("{\"FacadeServerUrl\": \"\", \"FacadeAuthCode\":\"authCode\"}")]// empty url
+
+        public async Task On_Desired_Properties_Incorrect_Update_Should_Not_Update(string twinUpdate)
+        {
+            var facadeUri = faker.Internet.Url();
+            var facadeCode = faker.Internet.Password();
+            var networkServerConfiguration = new NetworkServerConfiguration
+            {
+                FacadeServerUrl = new Uri(facadeUri),
+                FacadeAuthCode = facadeCode
+            };
+            var classCMessageSender = Mock.Of<IClassCDeviceMessageSender>();
+            var loRaDeviceRegistry = Mock.Of<ILoRaDeviceRegistry>();
+
+            await using var moduleClientFactory = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, loRaDeviceRegistry);
+
+            await moduleClientFactory.OnDesiredPropertiesUpdate(new Microsoft.Azure.Devices.Shared.TwinCollection(twinUpdate), null);
+            Assert.Equal(facadeUri + "/", networkServerConfiguration.FacadeServerUrl.ToString());
+            Assert.Equal(facadeCode, networkServerConfiguration.FacadeAuthCode);
+        }
+
+        [Fact]
+        public async Task InitModuleAsync_Update_Should_Perform_Happy_Path()
+        {
+            var networkServerConfiguration = new NetworkServerConfiguration();
+            var classCMessageSender = new Mock<IClassCDeviceMessageSender>(MockBehavior.Strict);
+            var loRaDeviceRegistry = new Mock<ILoRaDeviceRegistry>(MockBehavior.Strict);
+            var loRaModuleClient = new Mock<ILoraModuleClient>();
+            loRaModuleClient.Setup(x => x.DisposeAsync());
+            // Change the iot edge timeout.
+            networkServerConfiguration.IoTEdgeTimeout = 5;
+            var facadeUri = this.faker.Internet.Url();
+            var facadeCode = this.faker.Internet.Password();
+            var twinProperty = new TwinProperties
+            {
+                Desired = new TwinCollection($"{{\"FacadeServerUrl\": \"{facadeUri}\", \"FacadeAuthCode\":\"{facadeCode}\"}}")
+            };
+            loRaModuleClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(new Twin(twinProperty));
+
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, loRaDeviceRegistry.Object, loRaModuleClient.Object);
+            await moduleClient.InitModuleAsync();
+            Assert.Equal(facadeUri + "/", networkServerConfiguration.FacadeServerUrl.ToString());
+            Assert.Equal(facadeCode, networkServerConfiguration.FacadeAuthCode);
+        }
+
+        [Theory]
+        [InlineData("{}")]
+        [InlineData("{\"FacadeAuthCode\":\"asdasdada\"}")]
+        public async Task InitModuleAsync_Fails_When_Required_Twins_Are_Not_Set(string twin)
+        {
+            var networkServerConfiguration = new NetworkServerConfiguration();
+            var classCMessageSender = new Mock<IClassCDeviceMessageSender>(MockBehavior.Strict);
+            var loRaDeviceRegistry = new Mock<ILoRaDeviceRegistry>(MockBehavior.Strict);
+            var loRaModuleClient = new Mock<ILoraModuleClient>();
+            loRaModuleClient.Setup(x => x.DisposeAsync());
+
+            var twinProperty = new TwinProperties
+            {
+                Desired = new TwinCollection(twin)
+            };
+            loRaModuleClient.Setup(x => x.GetTwinAsync()).ReturnsAsync(new Twin(twinProperty));
+
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, loRaDeviceRegistry.Object, loRaModuleClient.Object);
+            await Assert.ThrowsAsync<ArgumentException>(() => moduleClient.InitModuleAsync());
+        }
+
+        [Fact]
+        public async Task InitModuleAsync_Fails_When_Fail_IoT_Hub_Communication()
+        {
+            var networkServerConfiguration = new NetworkServerConfiguration();
+            var classCMessageSender = new Mock<IClassCDeviceMessageSender>(MockBehavior.Strict);
+            var loRaDeviceRegistry = new Mock<ILoRaDeviceRegistry>(MockBehavior.Strict);
+            var loRaModuleClient = new Mock<ILoraModuleClient>();
+            loRaModuleClient.Setup(x => x.DisposeAsync());
+            // Change the iot edge timeout.
+            networkServerConfiguration.IoTEdgeTimeout = 5;
+            var facadeUri = this.faker.Internet.Url();
+            var facadeCode = this.faker.Internet.Password();
+
+            loRaModuleClient.Setup(x => x.GetTwinAsync()).Throws<IotHubCommunicationException>();
+
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, loRaDeviceRegistry.Object, loRaModuleClient.Object);
+            await Assert.ThrowsAsync<IotHubCommunicationException>(() => moduleClient.InitModuleAsync());
+
+        }
+
+        [Fact]
+        public async Task OnDirectMethodCall_ClearCache_When_Correct_Should_Work()
+        {
+            var networkServerConfiguration = new NetworkServerConfiguration();
+            var classCMessageSender = new Mock<IClassCDeviceMessageSender>(MockBehavior.Strict);
+            var loRaDeviceRegistry = new Mock<ILoRaDeviceRegistry>(MockBehavior.Strict);
+            loRaDeviceRegistry.Setup(x => x.ResetDeviceCache());
+            var loRaModuleClient = new Mock<ILoraModuleClient>();
+            loRaModuleClient.Setup(x => x.DisposeAsync());
+            // Change the iot edge timeout.
+            networkServerConfiguration.IoTEdgeTimeout = 5;
+            var facadeUri = this.faker.Internet.Url();
+            var facadeCode = this.faker.Internet.Password();
+
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, loRaDeviceRegistry.Object, loRaModuleClient.Object);
+            await moduleClient.OnDirectMethodCalled(new Microsoft.Azure.Devices.Client.MethodRequest(Constants.CloudToDeviceClearCache), null);
+            loRaDeviceRegistry.VerifyAll();
+        }
+
+        [Fact]
+        public async Task OnDirectMethodCall_CloudToDeviceDecoderElementName_When_Correct_Should_Work()
+        {
+            var networkServerConfiguration = new NetworkServerConfiguration();
+            var classCMessageSender = new Mock<IClassCDeviceMessageSender>(MockBehavior.Strict);
+            classCMessageSender.Setup(x => x.SendAsync(It.IsAny<ReceivedLoRaCloudToDeviceMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            var loRaDeviceRegistry = new Mock<ILoRaDeviceRegistry>(MockBehavior.Strict);
+            var loRaModuleClient = new Mock<ILoraModuleClient>();
+            loRaModuleClient.Setup(x => x.DisposeAsync());
+            // Change the iot edge timeout.
+            networkServerConfiguration.IoTEdgeTimeout = 5;
+            var facadeUri = this.faker.Internet.Url();
+            var facadeCode = this.faker.Internet.Password();
+
+
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, loRaDeviceRegistry.Object, loRaModuleClient.Object);
+            var c2d = "{\"test\":\"asd\"}";
+
+            var response = await moduleClient.OnDirectMethodCalled(new Microsoft.Azure.Devices.Client.MethodRequest(Constants.CloudToDeviceDecoderElementName, Encoding.UTF8.GetBytes(c2d), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5)), null);
+            Assert.Equal((int)HttpStatusCode.OK, response.Status);
+        }
+
+        [Fact]
+        public async Task OnDirectMethodCall_CloudToDeviceDecoderElementName_When_Incorrect_Should_Return_NotFound()
+        {
+            var networkServerConfiguration = new NetworkServerConfiguration();
+            var classCMessageSender = new Mock<IClassCDeviceMessageSender>(MockBehavior.Strict);
+            classCMessageSender.Setup(x => x.SendAsync(It.IsAny<ReceivedLoRaCloudToDeviceMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            var loRaDeviceRegistry = new Mock<ILoRaDeviceRegistry>(MockBehavior.Strict);
+            var loRaModuleClient = new Mock<ILoraModuleClient>();
+            loRaModuleClient.Setup(x => x.DisposeAsync());
+            // Change the iot edge timeout.
+            networkServerConfiguration.IoTEdgeTimeout = 5;
+            var facadeUri = this.faker.Internet.Url();
+            var facadeCode = this.faker.Internet.Password();
+
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, loRaDeviceRegistry.Object, loRaModuleClient.Object);
+            var c2d = "{\"test\":\"asd\"}";
+
+            var response = await moduleClient.OnDirectMethodCalled(new Microsoft.Azure.Devices.Client.MethodRequest("asd", Encoding.UTF8.GetBytes(c2d)), null);
+            Assert.Equal((int)HttpStatusCode.NotFound, response.Status);
+        }
+
+        [Fact]
+        public async Task SendCloudToDeviceMessageAsync_When_ClassC_Msg_Is_Null_Or_Empty_Should_Return_Not_Found()
+        {
+            var networkServerConfiguration = new NetworkServerConfiguration();
+            var classCMessageSender = new Mock<IClassCDeviceMessageSender>(MockBehavior.Strict);
+            classCMessageSender.Setup(x => x.SendAsync(It.IsAny<ReceivedLoRaCloudToDeviceMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            var loRaDeviceRegistry = new Mock<ILoRaDeviceRegistry>(MockBehavior.Strict);
+            var loRaModuleClient = new Mock<ILoraModuleClient>();
+            loRaModuleClient.Setup(x => x.DisposeAsync());
+            // Change the iot edge timeout.
+            networkServerConfiguration.IoTEdgeTimeout = 5;
+            var facadeUri = this.faker.Internet.Url();
+            var facadeCode = this.faker.Internet.Password();
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, loRaDeviceRegistry.Object, loRaModuleClient.Object);
+
+            var response = await moduleClient.OnDirectMethodCalled(new Microsoft.Azure.Devices.Client.MethodRequest(Constants.CloudToDeviceDecoderElementName, null), null);
+            Assert.Equal((int)HttpStatusCode.BadRequest, response.Status);
+
+            var response2 = await moduleClient.OnDirectMethodCalled(new Microsoft.Azure.Devices.Client.MethodRequest(Constants.CloudToDeviceDecoderElementName, Array.Empty<byte>()), null);
+            Assert.Equal((int)HttpStatusCode.BadRequest, response2.Status);
+        }
+
+        [Fact]
+        public async Task SendCloudToDeviceMessageAsync_When_ClassC_Msg_Is_Not_CorrectJson_Should_Return_Not_Found()
+        {
+            var networkServerConfiguration = new NetworkServerConfiguration();
+            var classCMessageSender = new Mock<IClassCDeviceMessageSender>(MockBehavior.Strict);
+            classCMessageSender.Setup(x => x.SendAsync(It.IsAny<ReceivedLoRaCloudToDeviceMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            var loRaDeviceRegistry = new Mock<ILoRaDeviceRegistry>(MockBehavior.Strict);
+            var loRaModuleClient = new Mock<ILoraModuleClient>();
+            loRaModuleClient.Setup(x => x.DisposeAsync());
+            // Change the iot edge timeout.
+            networkServerConfiguration.IoTEdgeTimeout = 5;
+            var facadeUri = this.faker.Internet.Url();
+            var facadeCode = this.faker.Internet.Password();
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, loRaDeviceRegistry.Object, loRaModuleClient.Object);
+
+            var response = await moduleClient.OnDirectMethodCalled(new Microsoft.Azure.Devices.Client.MethodRequest(Constants.CloudToDeviceDecoderElementName, Encoding.UTF8.GetBytes(faker.Random.String2(10))), null);
+            Assert.Equal((int)HttpStatusCode.BadRequest, response.Status);
+        }
+    }
+}

--- a/Tests/Unit/NetworkServerTests/ModuleConnectionHostTest.cs
+++ b/Tests/Unit/NetworkServerTests/ModuleConnectionHostTest.cs
@@ -29,9 +29,13 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var loRaDeviceRegistry = Mock.Of<ILoRaDeviceRegistry>();
 
             // ASSERT
-            Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(null, classCMessageSender, loRaDeviceRegistry));
-            Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, null, loRaDeviceRegistry));
-            Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, null));
+            ArgumentNullException ex;
+            ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(null, classCMessageSender, loRaDeviceRegistry));
+            Assert.Equal("networkServerConfiguration", ex.ParamName);
+            ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, null, loRaDeviceRegistry));
+            Assert.Equal("defaultClassCDevicesMessageSender", ex.ParamName);
+            ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, null));
+            Assert.Equal("loRaDeviceRegistry", ex.ParamName);
         }
 
         [Fact]
@@ -56,10 +60,9 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
         }
 
         [Theory]
-        [InlineData("{\"FacadeServerUrl\": \"url2\", \"FacadeAuthCode\":\"authCode\"}")]// not a url
-        [InlineData("{\"FacadeAuthCode\":\"authCode\"}")] // no Url
-        [InlineData("{\"FacadeServerUrl\": \"\", \"FacadeAuthCode\":\"authCode\"}")]// empty url
-
+        [InlineData("{ FacadeServerUrl: 'url2', FacadeAuthCode: 'authCode' }")]// not a url
+        [InlineData("{ FacadeAuthCode: 'authCode' }")] // no Url
+        [InlineData("{ FacadeServerUrl: '', FacadeAuthCode: 'authCode' }")]// empty url
         public async Task On_Desired_Properties_Incorrect_Update_Should_Not_Update(string twinUpdate)
         {
             var facadeUri = faker.Internet.Url();

--- a/Tests/Unit/NetworkServerTests/ModuleConnectionHostTest.cs
+++ b/Tests/Unit/NetworkServerTests/ModuleConnectionHostTest.cs
@@ -30,15 +30,15 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             // ASSERT
             Assert.ThrowsAsync<ArgumentNullException>(async () =>
                {
-                   await using var tmp = new ModuleConnectionHost(null, classCMessageSender, loRaDeviceRegistry);
+                   await using var _ = new ModuleConnectionHost(null, classCMessageSender, loRaDeviceRegistry);
                });
             Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
-                await using var tmp = new ModuleConnectionHost(networkServerConfiguration, null, loRaDeviceRegistry);
+                await using var _ = new ModuleConnectionHost(networkServerConfiguration, null, loRaDeviceRegistry);
             });
             Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
-                await using var tmp = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, null);
+                await using var _ = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, null);
             });
 
         }

--- a/Tests/Unit/NetworkServerTests/ModuleConnectionHostTest.cs
+++ b/Tests/Unit/NetworkServerTests/ModuleConnectionHostTest.cs
@@ -40,8 +40,6 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var networkServerConfiguration = new NetworkServerConfiguration();
             var classCMessageSender = Mock.Of<IClassCDeviceMessageSender>();
             var loRaDeviceRegistry = Mock.Of<ILoRaDeviceRegistry>();
-            var loRaModuleClient = new Mock<ILoraModuleClient>();
-            loRaModuleClient.Setup(x => x.DisposeAsync());
 
             await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, loRaDeviceRegistry);
             var url1 = this.faker.Internet.Url();


### PR DESCRIPTION
# PR for issue #628

## What is being addressed

Migrate the Twin Logic out of the UDP server so that it is compatible with the new LBS implementation.

## How is this addressed

- Create a new Host for the Module Connection that is spawned by the DI.
- Enhance logic on the twin with correction and more checks
- Introduced new Library "Faker" to generate fake data for tests


Still waiting to be able to run this in LBS mode on edge before publishing the PR