### PR TITLE
Reenable CA1031 in production code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -92,10 +92,6 @@ dotnet_style_qualification_for_event=false
 dotnet_diagnostic.CA1814.severity=suggestion
 dotnet_diagnostic.IDE0047.severity=suggestion
 
-# CA1031: Do not catch general exception types
-# Will be reenabled with https://github.com/Azure/iotedge-lorawan-starterkit/pull/549.
-dotnet_diagnostic.CA1031.severity=suggestion
-
 # These rules cannot be enforced during build time and are hence set to suggestion.
 # https://github.com/dotnet/roslyn/blob/9f87b444da9c48a4d492b19f8337339056bf2b95/src/Analyzers/Core/Analyzers/EnforceOnBuildValues.cs#L95
 # https://github.com/dotnet/roslyn/issues/53215

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -180,7 +180,9 @@ namespace LoRaWan.NetworkServer
                         {
                             decryptedPayloadData = loraPayload.GetDecryptedPayload(loRaDevice.AppSKey);
                         }
+#pragma warning disable CA1031 // Do not catch general exception types
                         catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
                         {
                             Logger.Log(loRaDevice.DevEUI, $"failed to decrypt message: {ex.Message}", LogLevel.Error);
                         }

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -23,3 +23,6 @@ dotnet_diagnostic.xUnit1004.severity=suggestion
 
 # CA1034: Do not nest types
 dotnet_diagnostic.CA1034.severity = none
+
+# CA1031: Do not catch general exception types
+dotnet_diagnostic.CA1031.severity=suggestion


### PR DESCRIPTION
## What is being addressed

With this PR we suppress CA1031 on a case-by-case basis and reenable CA1031 to break the build in order to avoid introduce more occurrences of said rule.

