### PR TITLE
Feature/710 Including a way to get Region from a cached station configuration

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationConfigurationService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationConfigurationService.cs
@@ -7,6 +7,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using LoRaTools.Regions;
     using LoRaWan.NetworkServer.BasicsStation.JsonHandlers;
     using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Extensions.Caching.Memory;
@@ -33,6 +34,12 @@ namespace LoRaWan.NetworkServer.BasicsStation
         }
 
         public void Dispose() => this.cacheSemaphore.Dispose();
+
+        public async Task<Region> GetRegionFromBasicsStationConfiguration(StationEui stationEui, CancellationToken cancellationToken)
+        {
+            var config = await this.GetRouterConfigMessageAsync(stationEui, cancellationToken);
+            return LnsStationConfiguration.GetRegion(config);
+        }
 
         public async Task<string> GetRouterConfigMessageAsync(StationEui stationEui, CancellationToken cancellationToken)
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationConfigurationService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationConfigurationService.cs
@@ -35,7 +35,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
 
         public void Dispose() => this.cacheSemaphore.Dispose();
 
-        public async Task<Region> GetRegionFromBasicsStationConfiguration(StationEui stationEui, CancellationToken cancellationToken)
+        public async Task<Region> GetRegionAsync(StationEui stationEui, CancellationToken cancellationToken)
         {
             var config = await this.GetRouterConfigMessageAsync(stationEui, cancellationToken);
             return LnsStationConfiguration.GetRegion(config);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/IBasicsStationConfigurationService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/IBasicsStationConfigurationService.cs
@@ -5,9 +5,11 @@ namespace LoRaWan.NetworkServer.BasicsStation
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using LoRaTools.Regions;
 
     internal interface IBasicsStationConfigurationService
     {
         Task<string> GetRouterConfigMessageAsync(StationEui stationEui, CancellationToken cancellationToken);
+        Task<Region> GetRegionFromBasicsStationConfiguration(StationEui stationEui, CancellationToken cancellationToken);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/IBasicsStationConfigurationService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/IBasicsStationConfigurationService.cs
@@ -10,6 +10,6 @@ namespace LoRaWan.NetworkServer.BasicsStation
     internal interface IBasicsStationConfigurationService
     {
         Task<string> GetRouterConfigMessageAsync(StationEui stationEui, CancellationToken cancellationToken);
-        Task<Region> GetRegionFromBasicsStationConfiguration(StationEui stationEui, CancellationToken cancellationToken);
+        Task<Region> GetRegionAsync(StationEui stationEui, CancellationToken cancellationToken);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/LoRaRegionType.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/LoRaRegionType.cs
@@ -8,6 +8,9 @@ namespace LoRaTools.Regions
         NotSet,
         EU868,
         US915,
-        CN470
+        CN470,
+        //Following regions are added in the enum for BasicsStation compatibility
+        EU863,
+        US902
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionManager.cs
@@ -21,10 +21,12 @@ namespace LoRaTools.Regions
             region = null;
             switch (value)
             {
+                case LoRaRegionType.EU863: //Case added for LoRa Basics Station compatibility
                 case LoRaRegionType.EU868:
                     region = EU868;
                     return true;
 
+                case LoRaRegionType.US902: //Case added for LoRa Basics Station compatibility
                 case LoRaRegionType.US915:
                     region = US915;
                     return true;

--- a/Tests/Unit/LoRaWanTests/RegionEU868TestData.cs
+++ b/Tests/Unit/LoRaWanTests/RegionEU868TestData.cs
@@ -72,6 +72,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
            new List<object[]>
            {
                 new object[] { region, LoRaRegionType.EU868 },
+                new object[] { region, LoRaRegionType.EU863 },
            };
 
         public static IEnumerable<object[]> TestTryGetJoinChannelIndexData =>

--- a/Tests/Unit/LoRaWanTests/RegionUS915TestData.cs
+++ b/Tests/Unit/LoRaWanTests/RegionUS915TestData.cs
@@ -130,6 +130,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
            new List<object[]>
            {
                 new object[] { region, LoRaRegionType.US915 },
+                new object[] { region, LoRaRegionType.US902 },
            };
 
         public static IEnumerable<object[]> TestTryGetJoinChannelIndexData =>

--- a/Tests/Unit/NetworkServerTests/JsonHandlers/LnsStationConfigurationTests.cs
+++ b/Tests/Unit/NetworkServerTests/JsonHandlers/LnsStationConfigurationTests.cs
@@ -16,6 +16,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests.JsonHandlers
     using static Bandwidth;
     using static SpreadingFactor;
     using static NetworkServer.BasicsStation.RouterConfigStationFlags;
+    using LoRaTools.Regions;
 
     public class LnsStationConfigurationTests
     {
@@ -455,6 +456,27 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests.JsonHandlers
                                  Serialize((flags & NoClearChannelAssessment) == NoClearChannelAssessment),
                                  Serialize((flags & NoDutyCycle) == NoDutyCycle),
                                  Serialize((flags & NoDwellTimeLimitations) == NoDwellTimeLimitations));
+        }
+
+        [Fact]
+        public void RegionConfigurationConverter_Succeeds()
+        {
+            var region = LnsStationConfiguration.GetRegion(ValidStationConfiguration);
+            Assert.Equal(RegionManager.EU868, region);
+        }
+
+        [Fact]
+        public void RegionConfigurationConverter_Throws_OnEmptyRegion()
+        {
+            var config = JsonUtil.Strictify(@"{'region':''}");
+            Assert.Throws<JsonException>(() => _ = LnsStationConfiguration.GetRegion(config));
+        }
+
+        [Fact]
+        public void RegionConfigurationConverter_Throws_OnNotSetRegion()
+        {
+            var config = JsonUtil.Strictify(@"{'region':'NotSet'}");
+            Assert.Throws<NotSupportedException>(() => _ = LnsStationConfiguration.GetRegion(config));
         }
     }
 }


### PR DESCRIPTION
# PR for issue #710 

## What is being addressed

This PR is including a way to get Region from a cached station configuration.
This is going to be useful for sending downlink messages properly in upcoming downlink communication support.

## How is this addressed

- [x] Added a RegionConfigurationConverter to LnsStationConfiguration for parsing a Region object
- [x] GetRegionFromBasicsStationConfiguration added to the interface and implemented for making use of the RegionConfigurationConverter from above
- [x] Unit tests added for new JsonReader