### PR TITLE
Optimize `WebSocketTextChannel` for single reader

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/WebSocketTextChannel.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/WebSocketTextChannel.cs
@@ -39,7 +39,7 @@ namespace LoRaWan.NetworkServer
             this.sendTimeout = sendTimeout == Timeout.InfiniteTimeSpan || sendTimeout >= TimeSpan.Zero
                              ? sendTimeout
                              : throw new ArgumentOutOfRangeException(nameof(sendTimeout), sendTimeout, null);
-            this.channel = Channel.CreateUnbounded<Output>();
+            this.channel = Channel.CreateUnbounded<Output>(new UnboundedChannelOptions { SingleReader = true });
         }
 
         /// <summary>


### PR DESCRIPTION
# PR adds to story #676

## What is being addressed

The `WebSocketTextChannel` will only have a single reader at any given time and its internal channel can be optimised for the case.

## How is this addressed

Create the internal channel with the single-reader optimisation options.
