### PR TITLE
Add method that attempts to retrieve handle from registry

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/WebSocketWriterRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/WebSocketWriterRegistry.cs
@@ -8,6 +8,7 @@ namespace LoRaWan.NetworkServer
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Net.WebSockets;
     using System.Threading;
@@ -62,6 +63,26 @@ namespace LoRaWan.NetworkServer
 
         public WebSocketWriterRegistry(ILogger<WebSocketWriterRegistry<TKey, TMessage>>? logger) =>
             this.logger = logger;
+
+        /// <summary>
+        /// Attempts to retrieve the socket writer handle for the given key.
+        /// </summary>
+        public bool TryGetHandle(TKey key, [NotNullWhen(true)] out IWebSocketWriterHandle<TMessage>? handle)
+        {
+            lock (this.sockets)
+            {
+                if (this.sockets.TryGetValue(key, out var entry))
+                {
+                    handle = entry.Handle;
+                    return true;
+                }
+                else
+                {
+                    handle = default;
+                    return false;
+                }
+            }
+        }
 
         /// <summary>
         /// Registers a socket writer under a key, returning a handle to the writer.

--- a/Tests/Unit/NetworkServerTests/WebSocketWriterRegistryTests.cs
+++ b/Tests/Unit/NetworkServerTests/WebSocketWriterRegistryTests.cs
@@ -167,6 +167,27 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             await CustomAssert.WriterIsRegistered(activeHandle, activeWriter);
         }
 
+        [Fact]
+        public void TryGetHandle_Returns_False_With_Null_Handle_When_Not_Registered_Under_Given_Key()
+        {
+            var succeeded = this.sut.TryGetHandle("foo", out var handle);
+
+            Assert.False(succeeded);
+            Assert.Null(handle);
+        }
+
+        [Fact]
+        public void TryGetHandle_Returns_True_With_Handle_Registered_Under_Key()
+        {
+            const string key = "key";
+            var (initialHandle, _) = CreateAndRegisterWebSocketWriterMock(key);
+
+            var succeeded = this.sut.TryGetHandle(key, out var handle);
+
+            Assert.True(succeeded);
+            Assert.Same(initialHandle, handle);
+        }
+
         private (IWebSocketWriterHandle<string> Handle, Mock<IWebSocketWriter<string>> WriterMock)
             CreateAndRegisterWebSocketWriterMock(string key)
         {


### PR DESCRIPTION
# PR for issue #725

## What is being addressed

For sending cloud-to-device messages to class C devices, the registry lacks a method to retrieve the handle for a given key.

## How is this addressed

A new method called `TryGetHandle` has been added to `WebSocketWriterRegistry`.
