### PR TITLE
Fix charset of project files to avoid UTF-8 BOM

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ trim_trailing_whitespace = true
 charset = utf-8
 
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+charset = utf-8
 indent_size = 2
 
 [*.{sln}]

--- a/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
+++ b/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>

--- a/Tests/Integration/LoRaWan.Tests.Integration.csproj
+++ b/Tests/Integration/LoRaWan.Tests.Integration.csproj
@@ -25,5 +25,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Common\LoRaWan.Tests.Common.csproj" />
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
## What is being addressed

Inconsistency in C# project files because the `charset` configuration was missing.

## How is this addressed

Added the missing setting in `.editorconfig` and fixed inconsistencies in project files.