### PR TITLE
LNS - Loading server certificate from file

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServer.cs
@@ -25,22 +25,15 @@ namespace LoRaWan.NetworkServer.BasicsStation
         {
             if (configuration is null) throw new ArgumentNullException(nameof(configuration));
 
-            var endpoints = new List<string>()
-            {
-                FormattableString.Invariant($"http://0.0.0.0:{Port}")
-            };
-
-            if (!string.IsNullOrEmpty(configuration.LnsServerPfxPath))
-            {
-                endpoints.Add(FormattableString.Invariant($"https://0.0.0.0:{SecurePort}"));
-            }
+            var shouldUseCertificate = string.IsNullOrEmpty(configuration.LnsServerPfxPath);
 
             using var webHost = WebHost.CreateDefaultBuilder()
-                                       .UseUrls(endpoints.ToArray())
+                                       .UseUrls(shouldUseCertificate ? FormattableString.Invariant($"https://0.0.0.0:{SecurePort}")
+                                                                     : FormattableString.Invariant($"http://0.0.0.0:{Port}"))
                                        .UseStartup<BasicsStationNetworkServerStartup>()
                                        .UseKestrel(config =>
                                        {
-                                           if (!string.IsNullOrEmpty(configuration.LnsServerPfxPath))
+                                           if (shouldUseCertificate)
                                            {
                                                config.ConfigureHttpsDefaults(https =>
                                                {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -112,6 +112,16 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         public bool UseBasicsStation { get; private set; }
 
+        /// <summary>
+        /// Path of the .pfx certificate to be used for LNS Server endpoint
+        /// </summary>
+        public string LnsServerPfxPath { get; private set; }
+
+        /// <summary>
+        /// Password of the .pfx certificate to be used for LNS Server endpoint
+        /// </summary>
+        public string LnsServerPfxPassword { get; private set; }
+
         // Creates a new instance of NetworkServerConfiguration by reading values from environment variables
         public static NetworkServerConfiguration CreateFromEnvironmentVariables()
         {
@@ -143,6 +153,8 @@ namespace LoRaWan.NetworkServer
             config.NetId = envVars.GetEnvVar("NETID", config.NetId);
             config.AllowedDevAddresses = new HashSet<string>(envVars.GetEnvVar("AllowedDevAddresses", string.Empty).Split(";"));
             config.UseBasicsStation = envVars.GetEnvVar("USE_BASIC_STATION", false);
+            config.LnsServerPfxPath = envVars.GetEnvVar("LNS_SERVER_PFX_PATH", string.Empty);
+            config.LnsServerPfxPassword = envVars.GetEnvVar("LNS_SERVER_PFX_PASSWORD", string.Empty);
 
             return config;
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule/Program.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule/Program.cs
@@ -29,6 +29,6 @@ Console.CancelKeyPress += (_, args) =>
 };
 
 var configuration = NetworkServerConfiguration.CreateFromEnvironmentVariables();
-var runnerTask = configuration.UseBasicsStation ? BasicsStationNetworkServer.RunServerAsync(cancellationToken)
+var runnerTask = configuration.UseBasicsStation ? BasicsStationNetworkServer.RunServerAsync(configuration, cancellationToken)
                                                 : UdpServer.RunServerAsync();
 await runnerTask;


### PR DESCRIPTION
# PR for issue #639 

## What is being addressed

This PR is introducing two NetworkStationConfiguration variables for allowing to import a .pfx to be used as server-side certificate.