### PR TITLE
Feature/565 remove generic catch exception

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -178,11 +178,9 @@ namespace LoRaWan.NetworkServer
                         {
                             decryptedPayloadData = loraPayload.GetDecryptedPayload(loRaDevice.AppSKey);
                         }
-#pragma warning disable CA1031 // Do not catch general exception types
-                        catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
+                        catch (LoRaProcessingException ex) when (ex.ErrorCode == LoRaProcessingErrorCode.PayloadDecryptionFailed)
                         {
-                            Logger.Log(loRaDevice.DevEUI, $"failed to decrypt message: {ex.Message}", LogLevel.Error);
+                            Logger.Log(loRaDevice.DevEUI, ex.ToString(), LogLevel.Error);
                         }
                     }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
@@ -158,11 +158,9 @@ namespace LoRaWan.NetworkServer
                 {
                     _ = await Task.WhenAll(initTasks);
                 }
-#pragma warning disable CA1031 // Do not catch general exception types. TODO Will be revisited in #565
-                catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
+                catch (LoRaProcessingException ex) when (ex.ErrorCode == LoRaProcessingErrorCode.DeviceInitializationFailed)
                 {
-                    Logger.Log(this.devAddr, $"one or more device initialization failed. {ex.Message}", LogLevel.Error);
+                    Logger.Log(this.devAddr, $"one or more device initializations failed: {ex}", LogLevel.Error);
                 }
             }
 
@@ -359,50 +357,55 @@ namespace LoRaWan.NetworkServer
 
         private async Task<LoRaDevice> InitializeDeviceAsync(LoRaDevice loRaDevice)
         {
-
-            // Our device if it does not have a gateway assigned or is assigned to our
-            var isOurDevice = string.IsNullOrEmpty(loRaDevice.GatewayID) || string.Equals(loRaDevice.GatewayID, this.configuration.GatewayID, StringComparison.OrdinalIgnoreCase);
-            // Only create client if the device is our
-            if (!isOurDevice)
+            try
             {
-                loRaDevice.IsOurDevice = false;
-                return loRaDevice;
-            }
-
-            // Calling initialize async here to avoid making async calls in the concurrent dictionary
-            // Since only one device will be added, we guarantee that initialization only happens once
-            if (await loRaDevice.InitializeAsync())
-            {
-                // revalidate based on device twin property
-                loRaDevice.IsOurDevice = string.IsNullOrEmpty(loRaDevice.GatewayID) || string.Equals(loRaDevice.GatewayID, this.configuration.GatewayID, StringComparison.OrdinalIgnoreCase);
-                if (loRaDevice.IsOurDevice)
+                // Our device if it does not have a gateway assigned or is assigned to our
+                var isOurDevice = string.IsNullOrEmpty(loRaDevice.GatewayID) || string.Equals(loRaDevice.GatewayID, this.configuration.GatewayID, StringComparison.OrdinalIgnoreCase);
+                // Only create client if the device is our
+                if (!isOurDevice)
                 {
-                    // once added, call initializers
-                    if (this.initializers != null)
-                    {
-                        foreach (var initializer in this.initializers)
-                            initializer.Initialize(loRaDevice);
-                    }
+                    loRaDevice.IsOurDevice = false;
+                    return loRaDevice;
                 }
 
-                // checking again in case one of the initializers change the value
-                if (!loRaDevice.IsOurDevice)
+                // Calling initialize async here to avoid making async calls in the concurrent dictionary
+                // Since only one device will be added, we guarantee that initialization only happens once
+                if (await loRaDevice.InitializeAsync())
                 {
-                    // Initialization does not use activity counters
-                    // This should not fail
-                    if (!loRaDevice.TryDisconnect())
+                    // revalidate based on device twin property
+                    loRaDevice.IsOurDevice = string.IsNullOrEmpty(loRaDevice.GatewayID) || string.Equals(loRaDevice.GatewayID, this.configuration.GatewayID, StringComparison.OrdinalIgnoreCase);
+                    if (loRaDevice.IsOurDevice)
                     {
-                        Logger.Log(loRaDevice.DevEUI, "failed to disconnect device from another gateway", LogLevel.Error);
+                        // once added, call initializers
+                        if (this.initializers != null)
+                        {
+                            foreach (var initializer in this.initializers)
+                                initializer.Initialize(loRaDevice);
+                        }
                     }
+
+                    // checking again in case one of the initializers change the value
+                    if (!loRaDevice.IsOurDevice)
+                    {
+                        // Initialization does not use activity counters
+                        // This should not fail
+                        if (!loRaDevice.TryDisconnect())
+                        {
+                            Logger.Log(loRaDevice.DevEUI, "failed to disconnect device from another gateway", LogLevel.Error);
+                        }
+                    }
+
+                    return loRaDevice;
                 }
 
-                return loRaDevice;
+                // instance not used, dispose the connection
+                loRaDevice.Dispose();
+                return null;
             }
-
-
-            // instance not used, dispose the connection
-            loRaDevice.Dispose();
-            return null;
+            catch (Exception ex)
+            {
+                throw new LoRaProcessingException($"Device initialization of device '{loRaDevice.DevEUI}' failed.", ex, LoRaProcessingErrorCode.DeviceInitializationFailed);
+            }
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/LoRaProcessingException.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/LoRaProcessingException.cs
@@ -58,6 +58,7 @@ namespace LoRaWan
         InvalidDeviceConfiguration,
         InvalidModuleConfiguration,
         DeviceClientCreationFailed,
-        PayloadDecryptionFailed
+        PayloadDecryptionFailed,
+        DeviceInitializationFailed
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/LoRaProcessingException.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/LoRaProcessingException.cs
@@ -58,5 +58,6 @@ namespace LoRaWan
         InvalidDeviceConfiguration,
         InvalidModuleConfiguration,
         DeviceClientCreationFailed,
+        PayloadDecryptionFailed
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Logger/Logger.cs
@@ -243,6 +243,8 @@ namespace LoRaWan
                 }
             }
 #pragma warning disable CA1031 // Do not catch general exception types
+            // To be handled with #456.
+            // https://github.com/Azure/iotedge-lorawan-starterkit/issues/456
             catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
             {

--- a/Tests/Integration/RedisFixture.cs
+++ b/Tests/Integration/RedisFixture.cs
@@ -98,7 +98,7 @@ namespace LoRaWan.Tests.Integration
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.ToString());
+                Console.WriteLine(ex);
                 throw;
             }
         }

--- a/Tests/Integration/RedisFixture.cs
+++ b/Tests/Integration/RedisFixture.cs
@@ -7,6 +7,7 @@ namespace LoRaWan.Tests.Integration
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using Docker.DotNet;
@@ -91,11 +92,14 @@ namespace LoRaWan.Tests.Integration
 
                 System.Console.WriteLine("Finish booting sequence container...");
             }
-#pragma warning disable CA1031 // Do not catch general exception types. This is for tests
-            catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
+            catch (DockerApiException e) when (e.StatusCode == HttpStatusCode.Conflict)
             {
-                System.Console.WriteLine(ex.ToString());
+                Console.WriteLine("Docker container is already running.");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.ToString());
+                throw;
             }
         }
 


### PR DESCRIPTION
# PR for issue #565

## What is being addressed

This PR addresses all remaining instances of generic catch blocks that will not go away with tasks that are tracked in the backlog.

## How is this addressed

Each commit addresses a different occurrence of a generic catch block. Generic catches in `UdpServer` are not being addressed since they will go away after we switch to our new LNS implementation.
