### PR TITLE
Fix formatting exceptions and reenable format analyzer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -77,9 +77,6 @@ dotnet_diagnostic.IDE0021.severity=suggestion
 # IDE0061: Use block body for local functions
 dotnet_diagnostic.IDE0061.severity=suggestion
 
-# IDE0055: Fix formatting
-dotnet_diagnostic.IDE0055.severity=suggestion
-
 # IDE0052: Unused private member
 dotnet_diagnostic.IDE0052.severity=suggestion
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicStationToRxpk.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicStationToRxpk.cs
@@ -14,7 +14,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
         {
             if (radioMetadata is null) throw new ArgumentNullException(nameof(radioMetadata));
             if (region is null) throw new ArgumentNullException(nameof(region));
-            
+
             Freq = radioMetadata.Frequency.Mega;
             Datr = region.DRtoConfiguration[(ushort)radioMetadata.DataRate.AsInt32].configuration;
             Rssi = Convert.ToInt32(radioMetadata.UpInfo.ReceivedSignalStrengthIndication);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationConfigurationService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationConfigurationService.cs
@@ -16,7 +16,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
     {
         private const string RouterConfigPropertyName = "routerConfig";
         private const string CachePrefixName = "routerConfig:";
-        
+
         private static readonly TimeSpan CacheTimeout = TimeSpan.FromHours(2);
         private readonly SemaphoreSlim cacheSemaphore = new SemaphoreSlim(1);
         private readonly LoRaDeviceAPIServiceBase loRaDeviceApiService;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/JsonHandlers/LnsStationConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/JsonHandlers/LnsStationConfiguration.cs
@@ -183,21 +183,21 @@ namespace LoRaWan.NetworkServer.BasicsStation.JsonHandlers
                                       return region;
                                   });
 
-/*
-    {
-      "msgtype"    : "router_config"
-      "NetID"      : [ INT, .. ]
-      "JoinEui"    : [ [INT,INT], .. ]  // ranges: beg,end inclusive
-      "region"     : STRING             // e.g. "EU863", "US902", ..
-      "hwspec"     : STRING
-      "freq_range" : [ INT, INT ]       // min, max (hz)
-      "DRs"        : [ [INT,INT,INT], .. ]   // sf,bw,dnonly
-      "sx1301_conf": [ SX1301CONF, .. ]
-      "nocca"      : BOOL
-      "nodc"       : BOOL
-      "nodwell"    : BOOL
-    }
- */
+        /*
+            {
+              "msgtype"    : "router_config"
+              "NetID"      : [ INT, .. ]
+              "JoinEui"    : [ [INT,INT], .. ]  // ranges: beg,end inclusive
+              "region"     : STRING             // e.g. "EU863", "US902", ..
+              "hwspec"     : STRING
+              "freq_range" : [ INT, INT ]       // min, max (hz)
+              "DRs"        : [ [INT,INT,INT], .. ]   // sf,bw,dnonly
+              "sx1301_conf": [ SX1301CONF, .. ]
+              "nocca"      : BOOL
+              "nodc"       : BOOL
+              "nodwell"    : BOOL
+            }
+        */
 
         public static string GetConfiguration(string jsonInput) => RouterConfigurationConverter.Read(jsonInput);
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/LnsMessageType.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/LnsMessageType.cs
@@ -29,12 +29,14 @@ namespace LoRaWan.NetworkServer.BasicsStation
     {
         internal static string ToBasicStationString(this LnsMessageType lnsMessageType) => lnsMessageType switch
         {
+#pragma warning disable format
             LnsMessageType.Version              => "version",
             LnsMessageType.RouterConfig         => "router_config",
             LnsMessageType.JoinRequest          => "jreq",
             LnsMessageType.UplinkDataFrame      => "updf",
             LnsMessageType.TransmitConfirmation => "dntxed",
             LnsMessageType.DownlinkMessage      => "dnmsg",
+#pragma warning restore format
             _ => throw new ArgumentOutOfRangeException(nameof(lnsMessageType), lnsMessageType, null),
         };
     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinDeviceLoader.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinDeviceLoader.cs
@@ -52,5 +52,5 @@ namespace LoRaWan.NetworkServer
 
             return null;
         }
-}
+    }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -38,7 +38,7 @@ namespace LoRaWan.NetworkServer
                 {
                     var timeWatcher = new LoRaOperationTimeWatcher(loraRegion, request.StartTime);
 
-                var joinReq = (LoRaPayloadJoinRequest)request.Payload;
+                    var joinReq = (LoRaPayloadJoinRequest)request.Payload;
 
                     devEUI = joinReq.GetDevEUIAsString();
                     var appEUI = joinReq.GetAppEUIAsString();
@@ -175,12 +175,12 @@ namespace LoRaWan.NetworkServer
                         return;
                     }
 
-                double freq = 0;
-                string datr = null;
-                uint tmst = 0;
-                ushort lnsRxDelay = 0;
-                if (windowToUse == Constants.ReceiveWindow1)
-                {
+                    double freq = 0;
+                    string datr = null;
+                    uint tmst = 0;
+                    ushort lnsRxDelay = 0;
+                    if (windowToUse == Constants.ReceiveWindow1)
+                    {
 #pragma warning disable CS0618 // #655 - This Rxpk based implementation will go away as soon as the complete LNS implementation is done
                         datr = loraRegion.GetDownstreamDataRate(request.Rxpk);
                         if (!loraRegion.TryGetDownstreamChannelFrequency(request.Rxpk, out freq) || datr == null)
@@ -191,15 +191,15 @@ namespace LoRaWan.NetworkServer
                             return;
                         }
 
-                    // set tmst for the normal case
-                    tmst = request.Rxpk.Tmst + (loraRegion.JoinAcceptDelay1 * 1000000);
-                    lnsRxDelay = (ushort)loraRegion.JoinAcceptDelay1;
-                }
-                else
-                {
-                    Logger.Log(devEUI, $"processing of the join request took too long, using second join accept receive window", LogLevel.Debug);
-                    tmst = request.Rxpk.Tmst + (loraRegion.JoinAcceptDelay2 * 1000000);
-                    lnsRxDelay = (ushort)loraRegion.JoinAcceptDelay2;
+                        // set tmst for the normal case
+                        tmst = request.Rxpk.Tmst + (loraRegion.JoinAcceptDelay1 * 1000000);
+                        lnsRxDelay = (ushort)loraRegion.JoinAcceptDelay1;
+                    }
+                    else
+                    {
+                        Logger.Log(devEUI, $"processing of the join request took too long, using second join accept receive window", LogLevel.Debug);
+                        tmst = request.Rxpk.Tmst + (loraRegion.JoinAcceptDelay2 * 1000000);
+                        lnsRxDelay = (ushort)loraRegion.JoinAcceptDelay2;
 
                         freq = loraRegion.GetDownstreamRX2Freq(devEUI, this.configuration.Rx2Frequency);
 #pragma warning disable CS0618 // #655 - This Rxpk based implementation will go away as soon as the complete LNS implementation is done
@@ -240,33 +240,33 @@ namespace LoRaWan.NetworkServer
                         Logger.Log(devEUI, $"twin RX1 offset DR value is not within acceptable values", LogLevel.Error);
                     }
 
-                // The following DesiredRxDelay is different than the RxDelay to be passed to Serialize function
-                // This one is a delay between TX and RX for any message to be processed by joining device
-                // The field accepted by Serialize method is an indication of the delay (compared to receive time of join request)
-                // of when the message Join Accept message should be sent
-                ushort loraSpecDesiredRxDelay = 0;
-                if (Region.IsValidRXDelay(loRaDevice.DesiredRXDelay))
-                {
-                    loraSpecDesiredRxDelay = loRaDevice.DesiredRXDelay;
-                }
-                else
-                {
-                    Logger.Log(devEUI, $"twin RX delay value is not within acceptable values", LogLevel.Error);
-                }
+                    // The following DesiredRxDelay is different than the RxDelay to be passed to Serialize function
+                    // This one is a delay between TX and RX for any message to be processed by joining device
+                    // The field accepted by Serialize method is an indication of the delay (compared to receive time of join request)
+                    // of when the message Join Accept message should be sent
+                    ushort loraSpecDesiredRxDelay = 0;
+                    if (Region.IsValidRXDelay(loRaDevice.DesiredRXDelay))
+                    {
+                        loraSpecDesiredRxDelay = loRaDevice.DesiredRXDelay;
+                    }
+                    else
+                    {
+                        Logger.Log(devEUI, $"twin RX delay value is not within acceptable values", LogLevel.Error);
+                    }
 
-                var loRaPayloadJoinAccept = new LoRaPayloadJoinAccept(
-                    ConversionHelper.ByteArrayToString(netId), // NETID 0 / 1 is default test
-                    ConversionHelper.StringToByteArray(devAddr), // todo add device address management
-                    appNonceBytes,
-                    dlSettings,
-                    loraSpecDesiredRxDelay,
-                    null);
+                    var loRaPayloadJoinAccept = new LoRaPayloadJoinAccept(
+                        ConversionHelper.ByteArrayToString(netId), // NETID 0 / 1 is default test
+                        ConversionHelper.StringToByteArray(devAddr), // todo add device address management
+                        appNonceBytes,
+                        dlSettings,
+                        loraSpecDesiredRxDelay,
+                        null);
 
-                var joinAccept = loRaPayloadJoinAccept.Serialize(loRaDevice.AppKey, datr, freq, devEUI, tmst, lnsRxDelay, request.Rxpk.Rfch, request.Rxpk.Time, request.StationEui);
-                if (joinAccept != null)
-                {
-                    _ = request.PacketForwarder.SendDownstreamAsync(joinAccept);
-                    request.NotifySucceeded(loRaDevice, joinAccept);
+                    var joinAccept = loRaPayloadJoinAccept.Serialize(loRaDevice.AppKey, datr, freq, devEUI, tmst, lnsRxDelay, request.Rxpk.Rfch, request.Rxpk.Time, request.StationEui);
+                    if (joinAccept != null)
+                    {
+                        _ = request.PacketForwarder.SendDownstreamAsync(joinAccept);
+                        request.NotifySucceeded(loRaDevice, joinAccept);
 
                         if (Logger.LoggerLevel <= LogLevel.Debug)
                         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -494,7 +494,7 @@ namespace LoRaWan.NetworkServer
             {
                 return Convert.ToInt32(value);
             }
-            catch(FormatException)
+            catch (FormatException)
             {
             }
             catch (OverflowException)
@@ -525,7 +525,7 @@ namespace LoRaWan.NetworkServer
             }
             catch (OverflowException)
             {
-                Logger.Log("value represents a number that is less than MinValue or greater than MaxValue." ,LogLevel.Error);
+                Logger.Log("value represents a number that is less than MinValue or greater than MaxValue.", LogLevel.Error);
             }
             catch (FormatException)
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/FrameControl.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/FrameControl.cs
@@ -12,11 +12,13 @@ namespace LoRaWan
     public enum FCtrlFlags : byte
 #pragma warning restore CA1711, CA1028
     {
+#pragma warning disable format
         None      = 0,
         Adr       = 0x80,
         AdrAckReq = 0x40,
         Ack       = 0x20,
         FPending  = 0x10,
+#pragma warning restore format
     }
 
     /// <summary>
@@ -34,7 +36,8 @@ namespace LoRaWan
 
         public FrameControl(FCtrlFlags flags, int optionsLength = 0) :
             this(unchecked((byte)((byte)(((byte)flags & FOptsLenMask) == 0 ? flags : throw new ArgumentException(null, nameof(flags)))
-                                         | (optionsLength is >= 0 and <= 15 ? optionsLength : throw new ArgumentOutOfRangeException(nameof(optionsLength), optionsLength, null))))) { }
+                                         | (optionsLength is >= 0 and <= 15 ? optionsLength : throw new ArgumentOutOfRangeException(nameof(optionsLength), optionsLength, null)))))
+        { }
 
         private bool HasFlags(FCtrlFlags flags) => ((FCtrlFlags)this.value & flags) == flags;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Id6.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Id6.cs
@@ -75,7 +75,7 @@ namespace LoRaWan
                 (colon, state) = state switch
 #pragma warning restore IDE0072 // Add missing cases
                 {
-                    var s and (FormatterState.Word or FormatterState.Blank or FormatterState.ColonColonWord)  => (true, s),
+                    var s and (FormatterState.Word or FormatterState.Blank or FormatterState.ColonColonWord) => (true, s),
                     FormatterState.WordColonBlank or FormatterState.BlankColonBlank => (true, FormatterState.ColonColon),
                     var s => (false, s)
                 };
@@ -174,7 +174,7 @@ namespace LoRaWan
             {
                 var ch = chars[0];
 
-                restate:
+            restate:
                 switch (state)
                 {
                     case ParserState.BeforeColonColon:

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/MacMessageType.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/MacMessageType.cs
@@ -9,6 +9,7 @@ namespace LoRaWan
 
     public enum MacMessageType
     {
+#pragma warning disable format
         JoinRequest         = 0, // 000
         JoinAccept          = 1, // 001
         UnconfirmedDataUp   = 2, // 010
@@ -17,5 +18,6 @@ namespace LoRaWan
         ConfirmedDataDown   = 5, // 101
         RejoinRequest       = 6, // 110 (was reserved/FRU before 1.1)
         Proprietary         = 7, // 111
+#pragma warning restore format
     }
 }

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -26,3 +26,6 @@ dotnet_diagnostic.CA1034.severity = none
 
 # CA1031: Do not catch general exception types
 dotnet_diagnostic.CA1031.severity=suggestion
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity=suggestion


### PR DESCRIPTION
# PR for issue #691 

## What is being addressed

With this PR we reenable format analyzers for malformed code.

## How is this addressed

`IDE0055` is reenabled on the main repo and all breaking occurrences are fixed. This does not fix the bug that even though we have `dotnet_sort_system_directives_first` set to `true` and `IDE0055` breaking the build (typically), wrongly sorted using statements do not break the build (tested also on .NET 6).

Follow-up work:
- [x] Create an issue in the roslyn project to figure out why `dotnet_sort_system_directives_first` does not break the build -> https://github.com/dotnet/roslyn/issues/57644
