### PR TITLE
Bug/697 different EUI formats

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.cs
@@ -45,6 +45,8 @@ namespace LoRaWan
 
     internal static class Eui
     {
+        private const int HexadecimalEuiCharacterCount = 23;
+
         public static string Format(ulong value, string? format)
         {
             return format switch
@@ -68,6 +70,29 @@ namespace LoRaWan
                 Span<char> chars = stackalloc char[nChars];
                 Hexadecimal.Write(bytes, chars, separator, letterCase);
                 return new string(chars);
+            }
+        }
+
+        public static bool TryParse(ReadOnlySpan<char> input, out ulong result)
+        {
+            if (input.Contains('-'))
+            {
+                return Hexadecimal.TryParse(input, out result, '-');
+            }
+            else if (input.Contains(':'))
+            {
+                if (input.Length == HexadecimalEuiCharacterCount)
+                {
+                    return Hexadecimal.TryParse(input, out result, ':');
+                }
+                else
+                {
+                    return Id6.TryParse(input, out result);
+                }
+            }
+            else
+            {
+                return Hexadecimal.TryParse(input, out result, null);
             }
         }
     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.cs
@@ -75,27 +75,13 @@ namespace LoRaWan
             }
         }
 
-        public static bool TryParse(ReadOnlySpan<char> input, out ulong result)
-        {
-            if (input.Contains('-'))
+        public static bool TryParse(ReadOnlySpan<char> input, out ulong result) =>
+            input.Length switch
             {
-                return Hexadecimal.TryParse(input, out result, '-');
-            }
-            else if (input.Contains(':'))
-            {
-                if (input.Length == HexadecimalEuiCharacterCount)
-                {
-                    return Hexadecimal.TryParse(input, out result, ':');
-                }
-                else
-                {
-                    return Id6.TryParse(input, out result);
-                }
-            }
-            else
-            {
-                return Hexadecimal.TryParse(input, out result, null);
-            }
-        }
+                23 => Hexadecimal.TryParse(input, out result, '-')  // e.g. "88:99:AA:BB:CC:DD:EE:FF"
+                   || Hexadecimal.TryParse(input, out result, ':'), // e.g. "88-99-AA-BB-CC-DD-EE-FF"
+                16 => Hexadecimal.TryParse(input, out result),      // e.g. "8899AABBCCDDEEFF"
+                _ => Id6.TryParse(input, out result)                // e.g. "8899:AABB:CCDD:EEFF"
+            };
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.cs
@@ -3,6 +3,9 @@
 
 namespace LoRaWan
 {
+    using System;
+    using System.Buffers.Binary;
+
     /// <summary>
     /// Global end-device ID in IEEE EUI-64 (64-bit Extended Unique Identifier) address space
     /// that uniquely identifies the end-device.
@@ -39,4 +42,33 @@ namespace LoRaWan
     /// EUI are 8 bytes multi-octet fields and are transmitted as little endian.
     /// </remarks>
     public partial struct StationEui { }
+
+    internal static class Eui
+    {
+        public static string Format(ulong value, string? format)
+        {
+            return format switch
+            {
+                null or "G" or "D" => ToHex(value, '-', LetterCase.Upper),
+                "g" or "d"         => ToHex(value, '-', LetterCase.Lower),
+                "E"                => ToHex(value, ':', LetterCase.Upper),
+                "e"                => ToHex(value, ':', LetterCase.Lower),
+                "N"                => ToHex(value, null, LetterCase.Upper),
+                "n"                => ToHex(value, null, LetterCase.Lower),
+                "I"                => Id6.Format(value, Id6.FormatOptions.FixedWidth),
+                "i"                => Id6.Format(value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
+                _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
+            };
+
+            static string ToHex(ulong value, char? separator, LetterCase letterCase)
+            {
+                Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+                BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
+                var nChars = separator is null ? bytes.Length * 2 : (bytes.Length * 3) - 1;
+                Span<char> chars = stackalloc char[nChars];
+                Hexadecimal.Write(bytes, chars, separator, letterCase);
+                return new string(chars);
+            }
+        }
+    }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.cs
@@ -45,8 +45,6 @@ namespace LoRaWan
 
     internal static class Eui
     {
-        private const int HexadecimalEuiCharacterCount = 23;
-
         public static string Format(ulong value, string? format)
         {
             return format switch

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
@@ -51,17 +51,50 @@ namespace LoRaWan
         public static DevEui Parse(ReadOnlySpan<char> input) =>
             TryParse(input, out var result) ? result : throw new FormatException();
 
-        public static bool TryParse(ReadOnlySpan<char> input, out DevEui result)
+        public static DevEui Parse(ReadOnlySpan<char> input, string? format) =>
+            TryParse(input, format, out var result) ? result : throw new FormatException();
+
+        public static bool TryParse(ReadOnlySpan<char> input, out DevEui result) => TryParse(input, "G", out result);
+
+        public static bool TryParse(ReadOnlySpan<char> input, string? format, out DevEui result)
         {
-            if (Hexadecimal.TryParse(input, out var raw, '-'))
+            result = default;
+
+            return format?.ToLowerInvariant() switch
             {
-                result = new DevEui(raw);
-                return true;
+                null or "g" or "d"  => TryParseHex(input, '-', out result),
+                "e"                 => TryParseHex(input, ':', out result),
+                "n"                 => TryParseHex(input, null, out result),
+                "i"                 => TryParseId6(input, out result),
+                _                   => false
+            };
+
+            static bool TryParseHex(ReadOnlySpan<char> input, char? separator, out DevEui result)
+            {
+                if (Hexadecimal.TryParse(input, out var raw, separator))
+                {
+                    result = new DevEui(raw);
+                    return true;
+                }
+                else
+                {
+                    result = default;
+                    return false;
+                }
             }
-            else
+
+            static bool TryParseId6(ReadOnlySpan<char> input, out DevEui result)
             {
-                result = default;
-                return false;
+                if (Id6.TryParse(input, out var raw))
+                {
+                    result = new DevEui(raw);
+                    return true;
+                }
+                else
+                {
+                    result = default;
+                    return false;
+                }
             }
         }
 
@@ -126,17 +159,50 @@ namespace LoRaWan
         public static JoinEui Parse(ReadOnlySpan<char> input) =>
             TryParse(input, out var result) ? result : throw new FormatException();
 
-        public static bool TryParse(ReadOnlySpan<char> input, out JoinEui result)
+        public static JoinEui Parse(ReadOnlySpan<char> input, string? format) =>
+            TryParse(input, format, out var result) ? result : throw new FormatException();
+
+        public static bool TryParse(ReadOnlySpan<char> input, out JoinEui result) => TryParse(input, "G", out result);
+
+        public static bool TryParse(ReadOnlySpan<char> input, string? format, out JoinEui result)
         {
-            if (Hexadecimal.TryParse(input, out var raw, '-'))
+            result = default;
+
+            return format?.ToLowerInvariant() switch
             {
-                result = new JoinEui(raw);
-                return true;
+                null or "g" or "d"  => TryParseHex(input, '-', out result),
+                "e"                 => TryParseHex(input, ':', out result),
+                "n"                 => TryParseHex(input, null, out result),
+                "i"                 => TryParseId6(input, out result),
+                _                   => false
+            };
+
+            static bool TryParseHex(ReadOnlySpan<char> input, char? separator, out JoinEui result)
+            {
+                if (Hexadecimal.TryParse(input, out var raw, separator))
+                {
+                    result = new JoinEui(raw);
+                    return true;
+                }
+                else
+                {
+                    result = default;
+                    return false;
+                }
             }
-            else
+
+            static bool TryParseId6(ReadOnlySpan<char> input, out JoinEui result)
             {
-                result = default;
-                return false;
+                if (Id6.TryParse(input, out var raw))
+                {
+                    result = new JoinEui(raw);
+                    return true;
+                }
+                else
+                {
+                    result = default;
+                    return false;
+                }
             }
         }
 
@@ -201,17 +267,50 @@ namespace LoRaWan
         public static StationEui Parse(ReadOnlySpan<char> input) =>
             TryParse(input, out var result) ? result : throw new FormatException();
 
-        public static bool TryParse(ReadOnlySpan<char> input, out StationEui result)
+        public static StationEui Parse(ReadOnlySpan<char> input, string? format) =>
+            TryParse(input, format, out var result) ? result : throw new FormatException();
+
+        public static bool TryParse(ReadOnlySpan<char> input, out StationEui result) => TryParse(input, "G", out result);
+
+        public static bool TryParse(ReadOnlySpan<char> input, string? format, out StationEui result)
         {
-            if (Hexadecimal.TryParse(input, out var raw, '-'))
+            result = default;
+
+            return format?.ToLowerInvariant() switch
             {
-                result = new StationEui(raw);
-                return true;
+                null or "g" or "d"  => TryParseHex(input, '-', out result),
+                "e"                 => TryParseHex(input, ':', out result),
+                "n"                 => TryParseHex(input, null, out result),
+                "i"                 => TryParseId6(input, out result),
+                _                   => false
+            };
+
+            static bool TryParseHex(ReadOnlySpan<char> input, char? separator, out StationEui result)
+            {
+                if (Hexadecimal.TryParse(input, out var raw, separator))
+                {
+                    result = new StationEui(raw);
+                    return true;
+                }
+                else
+                {
+                    result = default;
+                    return false;
+                }
             }
-            else
+
+            static bool TryParseId6(ReadOnlySpan<char> input, out StationEui result)
             {
-                result = default;
-                return false;
+                if (Id6.TryParse(input, out var raw))
+                {
+                    result = new StationEui(raw);
+                    return true;
+                }
+                else
+                {
+                    result = default;
+                    return false;
+                }
             }
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
@@ -77,31 +77,7 @@ namespace LoRaWan
                 Id6.TryParse(input, out var raw) ? (true, new DevEui(raw)) : (false, default);
         }
 
-        public string ToString(string? format, IFormatProvider? formatProvider)
-        {
-            return format switch
-            {
-                null or "G" or "D"  => ToHex(this.value, '-', LetterCase.Upper),
-                "g" or "d"          => ToHex(this.value, '-', LetterCase.Lower),
-                "E"                 => ToHex(this.value, ':', LetterCase.Upper),
-                "e"                 => ToHex(this.value, ':', LetterCase.Lower),
-                "N"                 => ToHex(this.value, null, LetterCase.Upper),
-                "n"                 => ToHex(this.value, null, LetterCase.Lower),
-                "I"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth),
-                "i"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
-                _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
-            };
-
-            static string ToHex(ulong value, char? separator, LetterCase letterCase)
-            {
-                Span<byte> bytes = stackalloc byte[sizeof(ulong)];
-                var nChars = separator is null ? bytes.Length * 2 : bytes.Length * 3 - 1;
-                Span<char> chars = stackalloc char[nChars];
-                BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
-                Hexadecimal.Write(bytes, chars, separator, letterCase);
-                return new string(chars);
-            }
-        }
+        public string ToString(string? format, IFormatProvider? formatProvider) => Eui.Format(this.value, format);
     }
 
     readonly partial struct JoinEui : IEquatable<JoinEui>, IFormattable
@@ -168,31 +144,7 @@ namespace LoRaWan
                 Id6.TryParse(input, out var raw) ? (true, new JoinEui(raw)) : (false, default);
         }
 
-        public string ToString(string? format, IFormatProvider? formatProvider)
-        {
-            return format switch
-            {
-                null or "G" or "D"  => ToHex(this.value, '-', LetterCase.Upper),
-                "g" or "d"          => ToHex(this.value, '-', LetterCase.Lower),
-                "E"                 => ToHex(this.value, ':', LetterCase.Upper),
-                "e"                 => ToHex(this.value, ':', LetterCase.Lower),
-                "N"                 => ToHex(this.value, null, LetterCase.Upper),
-                "n"                 => ToHex(this.value, null, LetterCase.Lower),
-                "I"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth),
-                "i"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
-                _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
-            };
-
-            static string ToHex(ulong value, char? separator, LetterCase letterCase)
-            {
-                Span<byte> bytes = stackalloc byte[sizeof(ulong)];
-                var nChars = separator is null ? bytes.Length * 2 : bytes.Length * 3 - 1;
-                Span<char> chars = stackalloc char[nChars];
-                BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
-                Hexadecimal.Write(bytes, chars, separator, letterCase);
-                return new string(chars);
-            }
-        }
+        public string ToString(string? format, IFormatProvider? formatProvider) => Eui.Format(this.value, format);
     }
 
     readonly partial struct StationEui : IEquatable<StationEui>, IFormattable
@@ -259,30 +211,6 @@ namespace LoRaWan
                 Id6.TryParse(input, out var raw) ? (true, new StationEui(raw)) : (false, default);
         }
 
-        public string ToString(string? format, IFormatProvider? formatProvider)
-        {
-            return format switch
-            {
-                null or "G" or "D"  => ToHex(this.value, '-', LetterCase.Upper),
-                "g" or "d"          => ToHex(this.value, '-', LetterCase.Lower),
-                "E"                 => ToHex(this.value, ':', LetterCase.Upper),
-                "e"                 => ToHex(this.value, ':', LetterCase.Lower),
-                "N"                 => ToHex(this.value, null, LetterCase.Upper),
-                "n"                 => ToHex(this.value, null, LetterCase.Lower),
-                "I"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth),
-                "i"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
-                _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
-            };
-
-            static string ToHex(ulong value, char? separator, LetterCase letterCase)
-            {
-                Span<byte> bytes = stackalloc byte[sizeof(ulong)];
-                var nChars = separator is null ? bytes.Length * 2 : bytes.Length * 3 - 1;
-                Span<char> chars = stackalloc char[nChars];
-                BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
-                Hexadecimal.Write(bytes, chars, separator, letterCase);
-                return new string(chars);
-            }
-        }
+        public string ToString(string? format, IFormatProvider? formatProvider) => Eui.Format(this.value, format);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
@@ -13,7 +13,7 @@ namespace LoRaWan
     using System;
     using System.Buffers.Binary;
 
-    readonly partial struct DevEui : IEquatable<DevEui>
+    readonly partial struct DevEui : IEquatable<DevEui>, IFormattable
     {
         public const int Size = sizeof(ulong);
 
@@ -27,14 +27,7 @@ namespace LoRaWan
         public override bool Equals(object? obj) => obj is DevEui other && this.Equals(other);
         public override int GetHashCode() => this.value.GetHashCode();
 
-        public override string ToString()
-        {
-            Span<byte> bytes = stackalloc byte[sizeof(ulong)];
-            Span<char> chars = stackalloc char[bytes.Length * 3 - 1];
-            BinaryPrimitives.WriteUInt64BigEndian(bytes, this.value);
-            Hexadecimal.Write(bytes, chars, '-');
-            return new string(chars);
-        }
+        public override string ToString() => ToString("G", null);
 
         public static bool operator ==(DevEui left, DevEui right) => left.Equals(right);
         public static bool operator !=(DevEui left, DevEui right) => !left.Equals(right);
@@ -71,9 +64,31 @@ namespace LoRaWan
                 return false;
             }
         }
+
+        public string ToString(string? format, IFormatProvider? formatProvider)
+        {
+            return format?.ToLowerInvariant() switch
+            {
+                null or "g" or "d"  => ToHex(this.value, '-'),
+                "e"                 => ToHex(this.value, ':'),
+                "n"                 => ToHex(value, null),
+                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
+                _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
+            };
+
+            static string ToHex(ulong value, char? separator)
+            {
+                Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+                var nChars = separator is null ? bytes.Length * 2 : bytes.Length * 3 - 1;
+                Span<char> chars = stackalloc char[nChars];
+                BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
+                Hexadecimal.Write(bytes, chars, separator);
+                return new string(chars);
+            }
+        }
     }
 
-    readonly partial struct JoinEui : IEquatable<JoinEui>
+    readonly partial struct JoinEui : IEquatable<JoinEui>, IFormattable
     {
         public const int Size = sizeof(ulong);
 
@@ -87,14 +102,7 @@ namespace LoRaWan
         public override bool Equals(object? obj) => obj is JoinEui other && this.Equals(other);
         public override int GetHashCode() => this.value.GetHashCode();
 
-        public override string ToString()
-        {
-            Span<byte> bytes = stackalloc byte[sizeof(ulong)];
-            Span<char> chars = stackalloc char[bytes.Length * 3 - 1];
-            BinaryPrimitives.WriteUInt64BigEndian(bytes, this.value);
-            Hexadecimal.Write(bytes, chars, '-');
-            return new string(chars);
-        }
+        public override string ToString() => ToString("G", null);
 
         public static bool operator ==(JoinEui left, JoinEui right) => left.Equals(right);
         public static bool operator !=(JoinEui left, JoinEui right) => !left.Equals(right);
@@ -131,9 +139,31 @@ namespace LoRaWan
                 return false;
             }
         }
+
+        public string ToString(string? format, IFormatProvider? formatProvider)
+        {
+            return format?.ToLowerInvariant() switch
+            {
+                null or "g" or "d"  => ToHex(this.value, '-'),
+                "e"                 => ToHex(this.value, ':'),
+                "n"                 => ToHex(value, null),
+                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
+                _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
+            };
+
+            static string ToHex(ulong value, char? separator)
+            {
+                Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+                var nChars = separator is null ? bytes.Length * 2 : bytes.Length * 3 - 1;
+                Span<char> chars = stackalloc char[nChars];
+                BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
+                Hexadecimal.Write(bytes, chars, separator);
+                return new string(chars);
+            }
+        }
     }
 
-    readonly partial struct StationEui : IEquatable<StationEui>
+    readonly partial struct StationEui : IEquatable<StationEui>, IFormattable
     {
         public const int Size = sizeof(ulong);
 
@@ -147,14 +177,7 @@ namespace LoRaWan
         public override bool Equals(object? obj) => obj is StationEui other && this.Equals(other);
         public override int GetHashCode() => this.value.GetHashCode();
 
-        public override string ToString()
-        {
-            Span<byte> bytes = stackalloc byte[sizeof(ulong)];
-            Span<char> chars = stackalloc char[bytes.Length * 3 - 1];
-            BinaryPrimitives.WriteUInt64BigEndian(bytes, this.value);
-            Hexadecimal.Write(bytes, chars, '-');
-            return new string(chars);
-        }
+        public override string ToString() => ToString("G", null);
 
         public static bool operator ==(StationEui left, StationEui right) => left.Equals(right);
         public static bool operator !=(StationEui left, StationEui right) => !left.Equals(right);
@@ -189,6 +212,28 @@ namespace LoRaWan
             {
                 result = default;
                 return false;
+            }
+        }
+
+        public string ToString(string? format, IFormatProvider? formatProvider)
+        {
+            return format?.ToLowerInvariant() switch
+            {
+                null or "g" or "d"  => ToHex(this.value, '-'),
+                "e"                 => ToHex(this.value, ':'),
+                "n"                 => ToHex(value, null),
+                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
+                _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
+            };
+
+            static string ToHex(ulong value, char? separator)
+            {
+                Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+                var nChars = separator is null ? bytes.Length * 2 : bytes.Length * 3 - 1;
+                Span<char> chars = stackalloc char[nChars];
+                BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
+                Hexadecimal.Write(bytes, chars, separator);
+                return new string(chars);
             }
         }
     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
@@ -98,24 +98,30 @@ namespace LoRaWan
             }
         }
 
+        public string ToString(string? format) => ToString(format, null);
+
         public string ToString(string? format, IFormatProvider? formatProvider)
         {
-            return format?.ToLowerInvariant() switch
+            return format switch
             {
-                null or "g" or "d"  => ToHex(this.value, '-'),
-                "e"                 => ToHex(this.value, ':'),
-                "n"                 => ToHex(value, null),
-                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
+                null or "G" or "D"  => ToHex(this.value, '-', LetterCase.Upper),
+                "g" or "d"          => ToHex(this.value, '-', LetterCase.Lower),
+                "E"                 => ToHex(this.value, ':', LetterCase.Upper),
+                "e"                 => ToHex(this.value, ':', LetterCase.Lower),
+                "N"                 => ToHex(value, null, LetterCase.Upper),
+                "n"                 => ToHex(value, null, LetterCase.Lower),
+                "I"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
+                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
                 _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
             };
 
-            static string ToHex(ulong value, char? separator)
+            static string ToHex(ulong value, char? separator, LetterCase letterCase)
             {
                 Span<byte> bytes = stackalloc byte[sizeof(ulong)];
                 var nChars = separator is null ? bytes.Length * 2 : bytes.Length * 3 - 1;
                 Span<char> chars = stackalloc char[nChars];
                 BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
-                Hexadecimal.Write(bytes, chars, separator);
+                Hexadecimal.Write(bytes, chars, separator, letterCase);
                 return new string(chars);
             }
         }
@@ -206,24 +212,30 @@ namespace LoRaWan
             }
         }
 
+        public string ToString(string? format) => ToString(format, null);
+
         public string ToString(string? format, IFormatProvider? formatProvider)
         {
-            return format?.ToLowerInvariant() switch
+            return format switch
             {
-                null or "g" or "d"  => ToHex(this.value, '-'),
-                "e"                 => ToHex(this.value, ':'),
-                "n"                 => ToHex(value, null),
-                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
+                null or "G" or "D"  => ToHex(this.value, '-', LetterCase.Upper),
+                "g" or "d"          => ToHex(this.value, '-', LetterCase.Lower),
+                "E"                 => ToHex(this.value, ':', LetterCase.Upper),
+                "e"                 => ToHex(this.value, ':', LetterCase.Lower),
+                "N"                 => ToHex(value, null, LetterCase.Upper),
+                "n"                 => ToHex(value, null, LetterCase.Lower),
+                "I"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
+                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
                 _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
             };
 
-            static string ToHex(ulong value, char? separator)
+            static string ToHex(ulong value, char? separator, LetterCase letterCase)
             {
                 Span<byte> bytes = stackalloc byte[sizeof(ulong)];
                 var nChars = separator is null ? bytes.Length * 2 : bytes.Length * 3 - 1;
                 Span<char> chars = stackalloc char[nChars];
                 BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
-                Hexadecimal.Write(bytes, chars, separator);
+                Hexadecimal.Write(bytes, chars, separator, letterCase);
                 return new string(chars);
             }
         }
@@ -314,24 +326,30 @@ namespace LoRaWan
             }
         }
 
+        public string ToString(string? format) => ToString(format, null);
+
         public string ToString(string? format, IFormatProvider? formatProvider)
         {
-            return format?.ToLowerInvariant() switch
+            return format switch
             {
-                null or "g" or "d"  => ToHex(this.value, '-'),
-                "e"                 => ToHex(this.value, ':'),
-                "n"                 => ToHex(value, null),
-                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
+                null or "G" or "D"  => ToHex(this.value, '-', LetterCase.Upper),
+                "g" or "d"          => ToHex(this.value, '-', LetterCase.Lower),
+                "E"                 => ToHex(this.value, ':', LetterCase.Upper),
+                "e"                 => ToHex(this.value, ':', LetterCase.Lower),
+                "N"                 => ToHex(value, null, LetterCase.Upper),
+                "n"                 => ToHex(value, null, LetterCase.Lower),
+                "I"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
+                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
                 _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
             };
 
-            static string ToHex(ulong value, char? separator)
+            static string ToHex(ulong value, char? separator, LetterCase letterCase)
             {
                 Span<byte> bytes = stackalloc byte[sizeof(ulong)];
                 var nChars = separator is null ? bytes.Length * 2 : bytes.Length * 3 - 1;
                 Span<char> chars = stackalloc char[nChars];
                 BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
-                Hexadecimal.Write(bytes, chars, separator);
+                Hexadecimal.Write(bytes, chars, separator, letterCase);
                 return new string(chars);
             }
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
@@ -58,44 +58,23 @@ namespace LoRaWan
 
         public static bool TryParse(ReadOnlySpan<char> input, string? format, out DevEui result)
         {
-            result = default;
-
-            return format?.ToLowerInvariant() switch
+            var (success, tempResult) = format?.ToLowerInvariant() switch
             {
-                null or "g" or "d"  => TryParseHex(input, '-', out result),
-                "e"                 => TryParseHex(input, ':', out result),
-                "n"                 => TryParseHex(input, null, out result),
-                "i"                 => TryParseId6(input, out result),
-                _                   => false
+                null or "g" or "d"  => TryParseHex(input, '-'),
+                "e"                 => TryParseHex(input, ':'),
+                "n"                 => TryParseHex(input, null),
+                "i"                 => TryParseId6(input),
+                _                   => (false, default)
             };
 
-            static bool TryParseHex(ReadOnlySpan<char> input, char? separator, out DevEui result)
-            {
-                if (Hexadecimal.TryParse(input, out var raw, separator))
-                {
-                    result = new DevEui(raw);
-                    return true;
-                }
-                else
-                {
-                    result = default;
-                    return false;
-                }
-            }
+            result = tempResult;
+            return success;
 
-            static bool TryParseId6(ReadOnlySpan<char> input, out DevEui result)
-            {
-                if (Id6.TryParse(input, out var raw))
-                {
-                    result = new DevEui(raw);
-                    return true;
-                }
-                else
-                {
-                    result = default;
-                    return false;
-                }
-            }
+            static (bool, DevEui) TryParseHex(ReadOnlySpan<char> input, char? separator) =>
+                Hexadecimal.TryParse(input, out var raw, separator) ? (true, new DevEui(raw)) : (false, default);
+
+            static (bool, DevEui) TryParseId6(ReadOnlySpan<char> input) =>
+                Id6.TryParse(input, out var raw) ? (true, new DevEui(raw)) : (false, default);
         }
 
         public string ToString(string? format, IFormatProvider? formatProvider)
@@ -170,44 +149,23 @@ namespace LoRaWan
 
         public static bool TryParse(ReadOnlySpan<char> input, string? format, out JoinEui result)
         {
-            result = default;
-
-            return format?.ToLowerInvariant() switch
+            var (success, tempResult) = format?.ToLowerInvariant() switch
             {
-                null or "g" or "d"  => TryParseHex(input, '-', out result),
-                "e"                 => TryParseHex(input, ':', out result),
-                "n"                 => TryParseHex(input, null, out result),
-                "i"                 => TryParseId6(input, out result),
-                _                   => false
+                null or "g" or "d"  => TryParseHex(input, '-'),
+                "e"                 => TryParseHex(input, ':'),
+                "n"                 => TryParseHex(input, null),
+                "i"                 => TryParseId6(input),
+                _                   => (false, default)
             };
 
-            static bool TryParseHex(ReadOnlySpan<char> input, char? separator, out JoinEui result)
-            {
-                if (Hexadecimal.TryParse(input, out var raw, separator))
-                {
-                    result = new JoinEui(raw);
-                    return true;
-                }
-                else
-                {
-                    result = default;
-                    return false;
-                }
-            }
+            result = tempResult;
+            return success;
 
-            static bool TryParseId6(ReadOnlySpan<char> input, out JoinEui result)
-            {
-                if (Id6.TryParse(input, out var raw))
-                {
-                    result = new JoinEui(raw);
-                    return true;
-                }
-                else
-                {
-                    result = default;
-                    return false;
-                }
-            }
+            static (bool, JoinEui) TryParseHex(ReadOnlySpan<char> input, char? separator) =>
+                Hexadecimal.TryParse(input, out var raw, separator) ? (true, new JoinEui(raw)) : (false, default);
+
+            static (bool, JoinEui) TryParseId6(ReadOnlySpan<char> input) =>
+                Id6.TryParse(input, out var raw) ? (true, new JoinEui(raw)) : (false, default);
         }
 
         public string ToString(string? format, IFormatProvider? formatProvider)
@@ -282,44 +240,23 @@ namespace LoRaWan
 
         public static bool TryParse(ReadOnlySpan<char> input, string? format, out StationEui result)
         {
-            result = default;
-
-            return format?.ToLowerInvariant() switch
+            var (success, tempResult) = format?.ToLowerInvariant() switch
             {
-                null or "g" or "d"  => TryParseHex(input, '-', out result),
-                "e"                 => TryParseHex(input, ':', out result),
-                "n"                 => TryParseHex(input, null, out result),
-                "i"                 => TryParseId6(input, out result),
-                _                   => false
+                null or "g" or "d"  => TryParseHex(input, '-'),
+                "e"                 => TryParseHex(input, ':'),
+                "n"                 => TryParseHex(input, null),
+                "i"                 => TryParseId6(input),
+                _                   => (false, default)
             };
 
-            static bool TryParseHex(ReadOnlySpan<char> input, char? separator, out StationEui result)
-            {
-                if (Hexadecimal.TryParse(input, out var raw, separator))
-                {
-                    result = new StationEui(raw);
-                    return true;
-                }
-                else
-                {
-                    result = default;
-                    return false;
-                }
-            }
+            result = tempResult;
+            return success;
 
-            static bool TryParseId6(ReadOnlySpan<char> input, out StationEui result)
-            {
-                if (Id6.TryParse(input, out var raw))
-                {
-                    result = new StationEui(raw);
-                    return true;
-                }
-                else
-                {
-                    result = default;
-                    return false;
-                }
-            }
+            static (bool, StationEui) TryParseHex(ReadOnlySpan<char> input, char? separator) =>
+                Hexadecimal.TryParse(input, out var raw, separator) ? (true, new StationEui(raw)) : (false, default);
+
+            static (bool, StationEui) TryParseId6(ReadOnlySpan<char> input) =>
+                Id6.TryParse(input, out var raw) ? (true, new StationEui(raw)) : (false, default);
         }
 
         public string ToString(string? format, IFormatProvider? formatProvider)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
@@ -27,7 +27,7 @@ namespace LoRaWan
         public override bool Equals(object? obj) => obj is DevEui other && this.Equals(other);
         public override int GetHashCode() => this.value.GetHashCode();
 
-        public override string ToString() => ToString("G", null);
+        public override string ToString() => ToString(null, null);
 
         public static bool operator ==(DevEui left, DevEui right) => left.Equals(right);
         public static bool operator !=(DevEui left, DevEui right) => !left.Equals(right);
@@ -82,7 +82,7 @@ namespace LoRaWan
         public override bool Equals(object? obj) => obj is JoinEui other && this.Equals(other);
         public override int GetHashCode() => this.value.GetHashCode();
 
-        public override string ToString() => ToString("G", null);
+        public override string ToString() => ToString(null, null);
 
         public static bool operator ==(JoinEui left, JoinEui right) => left.Equals(right);
         public static bool operator !=(JoinEui left, JoinEui right) => !left.Equals(right);
@@ -137,7 +137,7 @@ namespace LoRaWan
         public override bool Equals(object? obj) => obj is StationEui other && this.Equals(other);
         public override int GetHashCode() => this.value.GetHashCode();
 
-        public override string ToString() => ToString("G", null);
+        public override string ToString() => ToString(null, null);
 
         public static bool operator ==(StationEui left, StationEui right) => left.Equals(right);
         public static bool operator !=(StationEui left, StationEui right) => !left.Equals(right);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
@@ -51,30 +51,18 @@ namespace LoRaWan
         public static DevEui Parse(ReadOnlySpan<char> input) =>
             TryParse(input, out var result) ? result : throw new FormatException();
 
-        public static DevEui Parse(ReadOnlySpan<char> input, string? format) =>
-            TryParse(input, format, out var result) ? result : throw new FormatException();
-
-        public static bool TryParse(ReadOnlySpan<char> input, out DevEui result) => TryParse(input, "G", out result);
-
-        public static bool TryParse(ReadOnlySpan<char> input, string? format, out DevEui result)
+        public static bool TryParse(ReadOnlySpan<char> input, out DevEui result)
         {
-            var (success, tempResult) = format?.ToLowerInvariant() switch
+            if (Eui.TryParse(input, out var raw))
             {
-                null or "g" or "d"  => TryParseHex(input, '-'),
-                "e"                 => TryParseHex(input, ':'),
-                "n"                 => TryParseHex(input, null),
-                "i"                 => TryParseId6(input),
-                _                   => (false, default)
-            };
-
-            result = tempResult;
-            return success;
-
-            static (bool, DevEui) TryParseHex(ReadOnlySpan<char> input, char? separator) =>
-                Hexadecimal.TryParse(input, out var raw, separator) ? (true, new DevEui(raw)) : (false, default);
-
-            static (bool, DevEui) TryParseId6(ReadOnlySpan<char> input) =>
-                Id6.TryParse(input, out var raw) ? (true, new DevEui(raw)) : (false, default);
+                result = new DevEui(raw);
+                return true;
+            }
+            else
+            {
+                result = default;
+                return false;
+            }
         }
 
         public string ToString(string? format, IFormatProvider? formatProvider) => Eui.Format(this.value, format);
@@ -118,30 +106,18 @@ namespace LoRaWan
         public static JoinEui Parse(ReadOnlySpan<char> input) =>
             TryParse(input, out var result) ? result : throw new FormatException();
 
-        public static JoinEui Parse(ReadOnlySpan<char> input, string? format) =>
-            TryParse(input, format, out var result) ? result : throw new FormatException();
-
-        public static bool TryParse(ReadOnlySpan<char> input, out JoinEui result) => TryParse(input, "G", out result);
-
-        public static bool TryParse(ReadOnlySpan<char> input, string? format, out JoinEui result)
+        public static bool TryParse(ReadOnlySpan<char> input, out JoinEui result)
         {
-            var (success, tempResult) = format?.ToLowerInvariant() switch
+            if (Eui.TryParse(input, out var raw))
             {
-                null or "g" or "d"  => TryParseHex(input, '-'),
-                "e"                 => TryParseHex(input, ':'),
-                "n"                 => TryParseHex(input, null),
-                "i"                 => TryParseId6(input),
-                _                   => (false, default)
-            };
-
-            result = tempResult;
-            return success;
-
-            static (bool, JoinEui) TryParseHex(ReadOnlySpan<char> input, char? separator) =>
-                Hexadecimal.TryParse(input, out var raw, separator) ? (true, new JoinEui(raw)) : (false, default);
-
-            static (bool, JoinEui) TryParseId6(ReadOnlySpan<char> input) =>
-                Id6.TryParse(input, out var raw) ? (true, new JoinEui(raw)) : (false, default);
+                result = new JoinEui(raw);
+                return true;
+            }
+            else
+            {
+                result = default;
+                return false;
+            }
         }
 
         public string ToString(string? format, IFormatProvider? formatProvider) => Eui.Format(this.value, format);
@@ -185,30 +161,18 @@ namespace LoRaWan
         public static StationEui Parse(ReadOnlySpan<char> input) =>
             TryParse(input, out var result) ? result : throw new FormatException();
 
-        public static StationEui Parse(ReadOnlySpan<char> input, string? format) =>
-            TryParse(input, format, out var result) ? result : throw new FormatException();
-
-        public static bool TryParse(ReadOnlySpan<char> input, out StationEui result) => TryParse(input, "G", out result);
-
-        public static bool TryParse(ReadOnlySpan<char> input, string? format, out StationEui result)
+        public static bool TryParse(ReadOnlySpan<char> input, out StationEui result)
         {
-            var (success, tempResult) = format?.ToLowerInvariant() switch
+            if (Eui.TryParse(input, out var raw))
             {
-                null or "g" or "d"  => TryParseHex(input, '-'),
-                "e"                 => TryParseHex(input, ':'),
-                "n"                 => TryParseHex(input, null),
-                "i"                 => TryParseId6(input),
-                _                   => (false, default)
-            };
-
-            result = tempResult;
-            return success;
-
-            static (bool, StationEui) TryParseHex(ReadOnlySpan<char> input, char? separator) =>
-                Hexadecimal.TryParse(input, out var raw, separator) ? (true, new StationEui(raw)) : (false, default);
-
-            static (bool, StationEui) TryParseId6(ReadOnlySpan<char> input) =>
-                Id6.TryParse(input, out var raw) ? (true, new StationEui(raw)) : (false, default);
+                result = new StationEui(raw);
+                return true;
+            }
+            else
+            {
+                result = default;
+                return false;
+            }
         }
 
         public string ToString(string? format, IFormatProvider? formatProvider) => Eui.Format(this.value, format);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.cs
@@ -98,8 +98,6 @@ namespace LoRaWan
             }
         }
 
-        public string ToString(string? format) => ToString(format, null);
-
         public string ToString(string? format, IFormatProvider? formatProvider)
         {
             return format switch
@@ -108,10 +106,10 @@ namespace LoRaWan
                 "g" or "d"          => ToHex(this.value, '-', LetterCase.Lower),
                 "E"                 => ToHex(this.value, ':', LetterCase.Upper),
                 "e"                 => ToHex(this.value, ':', LetterCase.Lower),
-                "N"                 => ToHex(value, null, LetterCase.Upper),
-                "n"                 => ToHex(value, null, LetterCase.Lower),
-                "I"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
-                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
+                "N"                 => ToHex(this.value, null, LetterCase.Upper),
+                "n"                 => ToHex(this.value, null, LetterCase.Lower),
+                "I"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth),
+                "i"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
                 _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
             };
 
@@ -212,8 +210,6 @@ namespace LoRaWan
             }
         }
 
-        public string ToString(string? format) => ToString(format, null);
-
         public string ToString(string? format, IFormatProvider? formatProvider)
         {
             return format switch
@@ -222,10 +218,10 @@ namespace LoRaWan
                 "g" or "d"          => ToHex(this.value, '-', LetterCase.Lower),
                 "E"                 => ToHex(this.value, ':', LetterCase.Upper),
                 "e"                 => ToHex(this.value, ':', LetterCase.Lower),
-                "N"                 => ToHex(value, null, LetterCase.Upper),
-                "n"                 => ToHex(value, null, LetterCase.Lower),
-                "I"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
-                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
+                "N"                 => ToHex(this.value, null, LetterCase.Upper),
+                "n"                 => ToHex(this.value, null, LetterCase.Lower),
+                "I"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth),
+                "i"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
                 _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
             };
 
@@ -326,8 +322,6 @@ namespace LoRaWan
             }
         }
 
-        public string ToString(string? format) => ToString(format, null);
-
         public string ToString(string? format, IFormatProvider? formatProvider)
         {
             return format switch
@@ -336,10 +330,10 @@ namespace LoRaWan
                 "g" or "d"          => ToHex(this.value, '-', LetterCase.Lower),
                 "E"                 => ToHex(this.value, ':', LetterCase.Upper),
                 "e"                 => ToHex(this.value, ':', LetterCase.Lower),
-                "N"                 => ToHex(value, null, LetterCase.Upper),
-                "n"                 => ToHex(value, null, LetterCase.Lower),
-                "I"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
-                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
+                "N"                 => ToHex(this.value, null, LetterCase.Upper),
+                "n"                 => ToHex(this.value, null, LetterCase.Lower),
+                "I"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth),
+                "i"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
                 _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
             };
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
@@ -60,17 +60,50 @@ namespace LoRaWan
         public static <#= t #> Parse(ReadOnlySpan<char> input) =>
             TryParse(input, out var result) ? result : throw new FormatException();
 
-        public static bool TryParse(ReadOnlySpan<char> input, out <#= t #> result)
+        public static <#= t #> Parse(ReadOnlySpan<char> input, string? format) =>
+            TryParse(input, format, out var result) ? result : throw new FormatException();
+
+        public static bool TryParse(ReadOnlySpan<char> input, out <#= t #> result) => TryParse(input, "G", out result);
+
+        public static bool TryParse(ReadOnlySpan<char> input, string? format, out <#= t #> result)
         {
-            if (Hexadecimal.TryParse(input, out var raw, '-'))
+            result = default;
+
+            return format?.ToLowerInvariant() switch
             {
-                result = new <#= t #>(raw);
-                return true;
+                null or "g" or "d"  => TryParseHex(input, '-', out result),
+                "e"                 => TryParseHex(input, ':', out result),
+                "n"                 => TryParseHex(input, null, out result),
+                "i"                 => TryParseId6(input, out result),
+                _                   => false
+            };
+
+            static bool TryParseHex(ReadOnlySpan<char> input, char? separator, out <#= t #> result)
+            {
+                if (Hexadecimal.TryParse(input, out var raw, separator))
+                {
+                    result = new <#= t #>(raw);
+                    return true;
+                }
+                else
+                {
+                    result = default;
+                    return false;
+                }
             }
-            else
+
+            static bool TryParseId6(ReadOnlySpan<char> input, out <#= t #> result)
             {
-                result = default;
-                return false;
+                if (Id6.TryParse(input, out var raw))
+                {
+                    result = new <#= t #>(raw);
+                    return true;
+                }
+                else
+                {
+                    result = default;
+                    return false;
+                }
             }
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
@@ -107,24 +107,30 @@ namespace LoRaWan
             }
         }
 
+        public string ToString(string? format) => ToString(format, null);
+
         public string ToString(string? format, IFormatProvider? formatProvider)
         {
-            return format?.ToLowerInvariant() switch
+            return format switch
             {
-                null or "g" or "d"  => ToHex(this.value, '-'),
-                "e"                 => ToHex(this.value, ':'),
-                "n"                 => ToHex(value, null),
-                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
+                null or "G" or "D"  => ToHex(this.value, '-', LetterCase.Upper),
+                "g" or "d"          => ToHex(this.value, '-', LetterCase.Lower),
+                "E"                 => ToHex(this.value, ':', LetterCase.Upper),
+                "e"                 => ToHex(this.value, ':', LetterCase.Lower),
+                "N"                 => ToHex(value, null, LetterCase.Upper),
+                "n"                 => ToHex(value, null, LetterCase.Lower),
+                "I"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
+                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
                 _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
             };
 
-            static string ToHex(ulong value, char? separator)
+            static string ToHex(ulong value, char? separator, LetterCase letterCase)
             {
                 Span<byte> bytes = stackalloc byte[sizeof(ulong)];
                 var nChars = separator is null ? bytes.Length * 2 : bytes.Length * 3 - 1;
                 Span<char> chars = stackalloc char[nChars];
                 BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
-                Hexadecimal.Write(bytes, chars, separator);
+                Hexadecimal.Write(bytes, chars, separator, letterCase);
                 return new string(chars);
             }
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
@@ -36,7 +36,7 @@ namespace LoRaWan
         public override bool Equals(object? obj) => obj is <#= t #> other && this.Equals(other);
         public override int GetHashCode() => this.value.GetHashCode();
 
-        public override string ToString() => ToString("G", null);
+        public override string ToString() => ToString(null, null);
 
         public static bool operator ==(<#= t #> left, <#= t #> right) => left.Equals(right);
         public static bool operator !=(<#= t #> left, <#= t #> right) => !left.Equals(right);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
@@ -60,30 +60,18 @@ namespace LoRaWan
         public static <#= t #> Parse(ReadOnlySpan<char> input) =>
             TryParse(input, out var result) ? result : throw new FormatException();
 
-        public static <#= t #> Parse(ReadOnlySpan<char> input, string? format) =>
-            TryParse(input, format, out var result) ? result : throw new FormatException();
-
-        public static bool TryParse(ReadOnlySpan<char> input, out <#= t #> result) => TryParse(input, "G", out result);
-
-        public static bool TryParse(ReadOnlySpan<char> input, string? format, out <#= t #> result)
+        public static bool TryParse(ReadOnlySpan<char> input, out <#= t #> result)
         {
-            var (success, tempResult) = format?.ToLowerInvariant() switch
+            if (Eui.TryParse(input, out var raw))
             {
-                null or "g" or "d"  => TryParseHex(input, '-'),
-                "e"                 => TryParseHex(input, ':'),
-                "n"                 => TryParseHex(input, null),
-                "i"                 => TryParseId6(input),
-                _                   => (false, default)
-            };
-
-            result = tempResult;
-            return success;
-
-            static (bool, <#= t #>) TryParseHex(ReadOnlySpan<char> input, char? separator) =>
-                Hexadecimal.TryParse(input, out var raw, separator) ? (true, new <#= t #>(raw)) : (false, default);
-
-            static (bool, <#= t #>) TryParseId6(ReadOnlySpan<char> input) =>
-                Id6.TryParse(input, out var raw) ? (true, new <#= t #>(raw)) : (false, default);
+                result = new <#= t #>(raw);
+                return true;
+            }
+            else
+            {
+                result = default;
+                return false;
+            }
         }
 
         public string ToString(string? format, IFormatProvider? formatProvider) => Eui.Format(this.value, format);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
@@ -86,31 +86,7 @@ namespace LoRaWan
                 Id6.TryParse(input, out var raw) ? (true, new <#= t #>(raw)) : (false, default);
         }
 
-        public string ToString(string? format, IFormatProvider? formatProvider)
-        {
-            return format switch
-            {
-                null or "G" or "D"  => ToHex(this.value, '-', LetterCase.Upper),
-                "g" or "d"          => ToHex(this.value, '-', LetterCase.Lower),
-                "E"                 => ToHex(this.value, ':', LetterCase.Upper),
-                "e"                 => ToHex(this.value, ':', LetterCase.Lower),
-                "N"                 => ToHex(this.value, null, LetterCase.Upper),
-                "n"                 => ToHex(this.value, null, LetterCase.Lower),
-                "I"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth),
-                "i"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
-                _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
-            };
-
-            static string ToHex(ulong value, char? separator, LetterCase letterCase)
-            {
-                Span<byte> bytes = stackalloc byte[sizeof(ulong)];
-                var nChars = separator is null ? bytes.Length * 2 : bytes.Length * 3 - 1;
-                Span<char> chars = stackalloc char[nChars];
-                BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
-                Hexadecimal.Write(bytes, chars, separator, letterCase);
-                return new string(chars);
-            }
-        }
+        public string ToString(string? format, IFormatProvider? formatProvider) => Eui.Format(this.value, format);
     }
 <#  } #>
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
@@ -22,7 +22,7 @@ namespace LoRaWan
         })
     { #>
 
-    readonly partial struct <#= t #> : IEquatable<<#= t #>>
+    readonly partial struct <#= t #> : IEquatable<<#= t #>>, IFormattable
     {
         public const int Size = sizeof(ulong);
 
@@ -36,14 +36,7 @@ namespace LoRaWan
         public override bool Equals(object? obj) => obj is <#= t #> other && this.Equals(other);
         public override int GetHashCode() => this.value.GetHashCode();
 
-        public override string ToString()
-        {
-            Span<byte> bytes = stackalloc byte[sizeof(ulong)];
-            Span<char> chars = stackalloc char[bytes.Length * 3 - 1];
-            BinaryPrimitives.WriteUInt64BigEndian(bytes, this.value);
-            Hexadecimal.Write(bytes, chars, '-');
-            return new string(chars);
-        }
+        public override string ToString() => ToString("G", null);
 
         public static bool operator ==(<#= t #> left, <#= t #> right) => left.Equals(right);
         public static bool operator !=(<#= t #> left, <#= t #> right) => !left.Equals(right);
@@ -78,6 +71,28 @@ namespace LoRaWan
             {
                 result = default;
                 return false;
+            }
+        }
+
+        public string ToString(string? format, IFormatProvider? formatProvider)
+        {
+            return format?.ToLowerInvariant() switch
+            {
+                null or "g" or "d"  => ToHex(this.value, '-'),
+                "e"                 => ToHex(this.value, ':'),
+                "n"                 => ToHex(value, null),
+                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
+                _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
+            };
+
+            static string ToHex(ulong value, char? separator)
+            {
+                Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+                var nChars = separator is null ? bytes.Length * 2 : bytes.Length * 3 - 1;
+                Span<char> chars = stackalloc char[nChars];
+                BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
+                Hexadecimal.Write(bytes, chars, separator);
+                return new string(chars);
             }
         }
     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
@@ -67,44 +67,23 @@ namespace LoRaWan
 
         public static bool TryParse(ReadOnlySpan<char> input, string? format, out <#= t #> result)
         {
-            result = default;
-
-            return format?.ToLowerInvariant() switch
+            var (success, tempResult) = format?.ToLowerInvariant() switch
             {
-                null or "g" or "d"  => TryParseHex(input, '-', out result),
-                "e"                 => TryParseHex(input, ':', out result),
-                "n"                 => TryParseHex(input, null, out result),
-                "i"                 => TryParseId6(input, out result),
-                _                   => false
+                null or "g" or "d"  => TryParseHex(input, '-'),
+                "e"                 => TryParseHex(input, ':'),
+                "n"                 => TryParseHex(input, null),
+                "i"                 => TryParseId6(input),
+                _                   => (false, default)
             };
 
-            static bool TryParseHex(ReadOnlySpan<char> input, char? separator, out <#= t #> result)
-            {
-                if (Hexadecimal.TryParse(input, out var raw, separator))
-                {
-                    result = new <#= t #>(raw);
-                    return true;
-                }
-                else
-                {
-                    result = default;
-                    return false;
-                }
-            }
+            result = tempResult;
+            return success;
 
-            static bool TryParseId6(ReadOnlySpan<char> input, out <#= t #> result)
-            {
-                if (Id6.TryParse(input, out var raw))
-                {
-                    result = new <#= t #>(raw);
-                    return true;
-                }
-                else
-                {
-                    result = default;
-                    return false;
-                }
-            }
+            static (bool, <#= t #>) TryParseHex(ReadOnlySpan<char> input, char? separator) =>
+                Hexadecimal.TryParse(input, out var raw, separator) ? (true, new <#= t #>(raw)) : (false, default);
+
+            static (bool, <#= t #>) TryParseId6(ReadOnlySpan<char> input) =>
+                Id6.TryParse(input, out var raw) ? (true, new <#= t #>(raw)) : (false, default);
         }
 
         public string ToString(string? format, IFormatProvider? formatProvider)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Eui.g.tt
@@ -107,8 +107,6 @@ namespace LoRaWan
             }
         }
 
-        public string ToString(string? format) => ToString(format, null);
-
         public string ToString(string? format, IFormatProvider? formatProvider)
         {
             return format switch
@@ -117,10 +115,10 @@ namespace LoRaWan
                 "g" or "d"          => ToHex(this.value, '-', LetterCase.Lower),
                 "E"                 => ToHex(this.value, ':', LetterCase.Upper),
                 "e"                 => ToHex(this.value, ':', LetterCase.Lower),
-                "N"                 => ToHex(value, null, LetterCase.Upper),
-                "n"                 => ToHex(value, null, LetterCase.Lower),
-                "I"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth),
-                "i"                 => Id6.Format(value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
+                "N"                 => ToHex(this.value, null, LetterCase.Upper),
+                "n"                 => ToHex(this.value, null, LetterCase.Lower),
+                "I"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth),
+                "i"                 => Id6.Format(this.value, Id6.FormatOptions.FixedWidth | Id6.FormatOptions.Lowercase),
                 _ => throw new FormatException(@"Format string can only be null, ""G"", ""g"", ""D"", ""d"", ""I"", ""i"", ""N"", ""n"", ""E"" or ""e"".")
             };
 

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -179,11 +179,22 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
             Assert.Equal(default, result);
         }
 
-        [Fact]
-        public void String_Interpolation_Success_Case()
+        [Theory]
+        [InlineData("{0}", "01-23-45-67-89-AB-CD-EF")]
+        [InlineData("{0:G}", "01-23-45-67-89-AB-CD-EF")]
+        [InlineData("{0:D}", "01-23-45-67-89-AB-CD-EF")]
+        [InlineData("{0:g}", "01-23-45-67-89-ab-cd-ef")]
+        [InlineData("{0:d}", "01-23-45-67-89-ab-cd-ef")]
+        [InlineData("{0:E}", "01:23:45:67:89:AB:CD:EF")]
+        [InlineData("{0:e}", "01:23:45:67:89:ab:cd:ef")]
+        [InlineData("{0:I}", "0123:4567:89AB:CDEF")]
+        [InlineData("{0:i}", "0123:4567:89ab:cdef")]
+        [InlineData("{0:N}", "0123456789ABCDEF")]
+        [InlineData("{0:n}", "0123456789abcdef")]
+        public void String_Interpolation_Success_Case(string format, string expected)
         {
-            var result = $"N = {Subject:N}, I = {Subject:I}";
-            Assert.Equal("N = 0123456789ABCDEF, I = 0123:4567:89AB:CDEF", result);
+            var result = string.Format(CultureInfo.InvariantCulture, format, Subject);
+            Assert.Equal(expected, result);
         }
 
 #pragma warning disable CA1000 // Do not declare static members on generic types

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -110,10 +110,9 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
         {
             var ex = Assert.Throws<FormatException>(() => Subject.ToString("z", null));
 
-            foreach (var c in SupportedFormats)
+            foreach (var c in SupportedFormats.Where(c => c != null).Cast<char>())
             {
-                if (c is { } cp)
-                    Assert.True(ex.Message.Contains(cp, StringComparison.Ordinal));
+                Assert.True(ex.Message.Contains(c, StringComparison.Ordinal));
             }
         }
 

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -194,9 +194,9 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
         [Fact]
         public void TryParse_Returns_False_When_Input_Is_Invalid()
         {
-            var succeeded = DevEui.TryParse("foobar", out var result);
+            var succeeded = TryParse("foobar", out var result);
             Assert.False(succeeded);
-            Assert.True(result == default);
+            Assert.Equal(default, result);
         }
 
 #pragma warning disable CA1000 // Do not declare static members on generic types

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -8,6 +8,15 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
     using System.Linq;
     using LoRaWan;
     using Xunit;
+    using static LoRaWan.Tests.Unit.LoRaWanTests.EuiTests;
+
+    internal static class EuiTests
+    {
+        public static readonly char?[] SupportedFormats = { null, 'G', 'g', 'D', 'd', 'I', 'i', 'N', 'n', 'E', 'e' };
+
+        public static object[][] SupportedFormatsTheoryData() =>
+            SupportedFormats.Select(f => new object[] { f }).ToArray();
+    }
 
     public abstract class EuiTests<T> where T : struct, IEquatable<T>, IFormattable
     {
@@ -21,7 +30,6 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
         private static readonly Func<T, T, bool> Equal = Operators<T>.Equality;
         private static readonly Func<T, T, bool> NotEqual = Operators<T>.Inequality;
-        private static readonly char?[] SupportedFormats = { null, 'G', 'g', 'D', 'd', 'I', 'i', 'N', 'n', 'E', 'e' };
 
         [Fact]
         public void Size_Returns_Width_In_Bytes()
@@ -197,11 +205,6 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
             var result = string.Format(CultureInfo.InvariantCulture, format, Subject);
             Assert.Equal(expected, result);
         }
-
-#pragma warning disable CA1000 // Do not declare static members on generic types
-        public static object[][] SupportedFormatsTheoryData() =>
-#pragma warning restore CA1000 // Do not declare static members on generic types
-            SupportedFormats.Select(f => new object[] { f }).ToArray();
     }
 
     public class DevEuiTests : EuiTests<DevEui>

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -7,7 +7,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
     using LoRaWan;
     using Xunit;
 
-    public abstract class EuiTests<T> where T : struct, IEquatable<T>
+    public abstract class EuiTests<T> where T : struct, IEquatable<T>, IFormattable
     {
         private T Subject => Parse("01-23-45-67-89-AB-CD-EF");
 
@@ -19,6 +19,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
         private static readonly Func<T, T, bool> Equal = Operators<T>.Equality;
         private static readonly Func<T, T, bool> NotEqual = Operators<T>.Inequality;
+        private static readonly char[] SupportedFormats = new[] { 'G', 'g', 'D', 'd', 'I', 'i', 'N', 'n', 'E', 'e' };
 
         [Fact]
         public void Size_Returns_Width_In_Bytes()
@@ -82,6 +83,34 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
         public void ToString_Returns_Hexadecimal_String()
         {
             Assert.Equal("01-23-45-67-89-AB-CD-EF", this.Subject.ToString());
+        }
+
+        [Theory]
+        [InlineData(null, "01-23-45-67-89-AB-CD-EF")]
+        [InlineData("G", "01-23-45-67-89-AB-CD-EF")]
+        [InlineData("g", "01-23-45-67-89-AB-CD-EF")]
+        [InlineData("D", "01-23-45-67-89-AB-CD-EF")]
+        [InlineData("d", "01-23-45-67-89-AB-CD-EF")]
+        [InlineData("I", "0123:4567:89AB:CDEF")]
+        [InlineData("i", "0123:4567:89AB:CDEF")]
+        [InlineData("E", "01:23:45:67:89:AB:CD:EF")]
+        [InlineData("e", "01:23:45:67:89:AB:CD:EF")]
+        [InlineData("N", "0123456789ABCDEF")]
+        [InlineData("n", "0123456789ABCDEF")]
+        public void ToString_Returns_Correctly_Formatted_String(string format, string expectedRepresentation)
+        {
+            Assert.Equal(expectedRepresentation, Subject.ToString(format, null));
+        }
+
+        [Fact]
+        public void ToString_Throws_FormatException_When_Format_Is_Not_Supported()
+        {
+            var ex = Assert.Throws<FormatException>(() => Subject.ToString("z", null));
+
+            foreach (var c in SupportedFormats)
+            {
+                Assert.True(ex.Message.Contains(c, StringComparison.Ordinal));
+            }
         }
 
         [Fact]

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -13,9 +13,6 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
     internal static class EuiTests
     {
         public static readonly char?[] SupportedFormats = { null, 'G', 'g', 'D', 'd', 'I', 'i', 'N', 'n', 'E', 'e' };
-
-        public static object[][] SupportedFormatsTheoryData() =>
-            SupportedFormats.Select(f => new object[] { f }).ToArray();
     }
 
     public abstract class EuiTests<T> where T : struct, IEquatable<T>, IFormattable
@@ -129,6 +126,11 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
             var result = Parse(this.Subject.ToString());
             Assert.Equal(Subject, result);
         }
+
+#pragma warning disable CA1000 // Do not declare static members on generic types (necessary for unit tests)
+        public static object[][] SupportedFormatsTheoryData() =>
+#pragma warning restore CA1000 // Do not declare static members on generic types
+            SupportedFormats.Select(f => new object[] { f }).ToArray();
 
         [Theory]
         [MemberData(nameof(SupportedFormatsTheoryData))]

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -91,15 +91,15 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
         [Theory]
         [InlineData(null, "01-23-45-67-89-AB-CD-EF")]
         [InlineData("G", "01-23-45-67-89-AB-CD-EF")]
-        [InlineData("g", "01-23-45-67-89-AB-CD-EF")]
         [InlineData("D", "01-23-45-67-89-AB-CD-EF")]
-        [InlineData("d", "01-23-45-67-89-AB-CD-EF")]
-        [InlineData("I", "0123:4567:89AB:CDEF")]
-        [InlineData("i", "0123:4567:89AB:CDEF")]
+        [InlineData("g", "01-23-45-67-89-ab-cd-ef")]
+        [InlineData("d", "01-23-45-67-89-ab-cd-ef")]
         [InlineData("E", "01:23:45:67:89:AB:CD:EF")]
-        [InlineData("e", "01:23:45:67:89:AB:CD:EF")]
+        [InlineData("e", "01:23:45:67:89:ab:cd:ef")]
+        [InlineData("I", "0123:4567:89AB:CDEF")]
+        [InlineData("i", "0123:4567:89ab:cdef")]
         [InlineData("N", "0123456789ABCDEF")]
-        [InlineData("n", "0123456789ABCDEF")]
+        [InlineData("n", "0123456789abcdef")]
         public void ToString_Returns_Correctly_Formatted_String(string format, string expectedRepresentation)
         {
             Assert.Equal(expectedRepresentation, Subject.ToString(format, null));

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -135,8 +135,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
         [Fact]
         public void Parse_Throws_When_Format_Is_Unsupported()
         {
-            const string format = "z";
-            _ = Assert.Throws<FormatException>(() => Parse(Subject.ToString(null, null), format));
+            _ = Assert.Throws<FormatException>(() => Parse(Subject.ToString(null, null), "z"));
         }
 
         [Fact]
@@ -174,8 +173,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
         [Fact]
         public void TryParse_Returns_False_When_Format_Is_Unsupported()
         {
-            const string format = "z";
-            var succeeded = TryParse(Subject.ToString(null, null), format, out var result);
+            var succeeded = TryParse(Subject.ToString(null, null), "z", out var result);
 
             Assert.False(succeeded);
             Assert.Equal(default, result);

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -141,7 +141,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
         [Fact]
         public void Parse_Throws_When_Input_Is_Invalid()
         {
-            _ = Assert.Throws<FormatException>(() => DevEui.Parse("foobar"));
+            _ = Assert.Throws<FormatException>(() => Parse("foobar"));
         }
 
         [Fact]

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -16,9 +16,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
         protected abstract int Size { get; }
         protected abstract T Parse(string input);
-        protected abstract T Parse(string input, string format);
         protected abstract bool TryParse(string input, out T result);
-        protected abstract bool TryParse(string input, string format, out T result);
 
         private static readonly Func<T, T, bool> Equal = Operators<T>.Equality;
         private static readonly Func<T, T, bool> NotEqual = Operators<T>.Inequality;
@@ -127,14 +125,8 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
         [MemberData(nameof(SupportedFormatsTheoryData))]
         public void Parse_Returns_Parsed_Value_With_Valid_Format(string format)
         {
-            var result = Parse(Subject.ToString(format, null), format);
+            var result = Parse(Subject.ToString(format, null));
             Assert.Equal(Subject, result);
-        }
-
-        [Fact]
-        public void Parse_Throws_When_Format_Is_Unsupported()
-        {
-            _ = Assert.Throws<FormatException>(() => Parse(Subject.ToString(null, null), "z"));
         }
 
         [Fact]
@@ -164,18 +156,9 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
         [MemberData(nameof(SupportedFormatsTheoryData))]
         public void TryParse_Returns_Parsed_Value_With_Valid_Format(string format)
         {
-            var succeeded = TryParse(Subject.ToString(format, null), format, out var result);
+            var succeeded = TryParse(Subject.ToString(format, null), out var result);
             Assert.True(succeeded);
             Assert.Equal(Subject, result);
-        }
-
-        [Fact]
-        public void TryParse_Returns_False_When_Format_Is_Unsupported()
-        {
-            var succeeded = TryParse(Subject.ToString(null, null), "z", out var result);
-
-            Assert.False(succeeded);
-            Assert.Equal(default, result);
         }
 
         [Fact]
@@ -206,18 +189,14 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
     {
         protected override int Size => DevEui.Size;
         protected override DevEui Parse(string input) => DevEui.Parse(input);
-        protected override DevEui Parse(string input, string format) => DevEui.Parse(input, format);
         protected override bool TryParse(string input, out DevEui result) => DevEui.TryParse(input, out result);
-        protected override bool TryParse(string input, string format, out DevEui result) => DevEui.TryParse(input, format, out result);
     }
 
     public class JoinEuiTests : EuiTests<JoinEui>
     {
         protected override int Size => JoinEui.Size;
         protected override JoinEui Parse(string input) => JoinEui.Parse(input);
-        protected override JoinEui Parse(string input, string format) => JoinEui.Parse(input, format);
         protected override bool TryParse(string input, out JoinEui result) => JoinEui.TryParse(input, out result);
-        protected override bool TryParse(string input, string format, out JoinEui result) => JoinEui.TryParse(input, format, out result);
 
     }
 
@@ -225,8 +204,6 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
     {
         protected override int Size => StationEui.Size;
         protected override StationEui Parse(string input) => StationEui.Parse(input);
-        protected override StationEui Parse(string input, string format) => StationEui.Parse(input, format);
         protected override bool TryParse(string input, out StationEui result) => StationEui.TryParse(input, out result);
-        protected override bool TryParse(string input, string format, out StationEui result) => StationEui.TryParse(input, format, out result);
     }
 }

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.Tests.Unit.LoRaWanTests
 {
     using System;
+    using System.Globalization;
     using System.Linq;
     using LoRaWan;
     using Xunit;

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -20,7 +20,7 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
 
         private static readonly Func<T, T, bool> Equal = Operators<T>.Equality;
         private static readonly Func<T, T, bool> NotEqual = Operators<T>.Inequality;
-        private static readonly char?[] SupportedFormats = new char?[] { null, 'G', 'g', 'D', 'd', 'I', 'i', 'N', 'n', 'E', 'e' };
+        private static readonly char?[] SupportedFormats = { null, 'G', 'g', 'D', 'd', 'I', 'i', 'N', 'n', 'E', 'e' };
 
         [Fact]
         public void Size_Returns_Width_In_Bytes()

--- a/Tests/Unit/LoRaWanTests/EuiTests.cs
+++ b/Tests/Unit/LoRaWanTests/EuiTests.cs
@@ -179,6 +179,13 @@ namespace LoRaWan.Tests.Unit.LoRaWanTests
             Assert.Equal(default, result);
         }
 
+        [Fact]
+        public void String_Interpolation_Success_Case()
+        {
+            var result = $"N = {Subject:N}, I = {Subject:I}";
+            Assert.Equal("N = 0123456789ABCDEF, I = 0123:4567:89AB:CDEF", result);
+        }
+
 #pragma warning disable CA1000 // Do not declare static members on generic types
         public static object[][] SupportedFormatsTheoryData() =>
 #pragma warning restore CA1000 // Do not declare static members on generic types


### PR DESCRIPTION
# PR for issue #697

## What is being addressed

With this PR we introduce different formats for all the `Eui`.

- `G`, `D`, `null` format give us dashed Hex format (88-99-AA-BB-CC-DD-EE-FF)
- `N` gives us non-dashed (similar as for `Guid`)
- `I` gives us ID6 (8899:AABB:CCDD:EEFF)
- `E` gives us the ID6 format (88:99:AA:BB:CC:DD:EE:FF)
- `e`, `n`, `i`, `d` give their respective formats using lowercase alpha digits

## How is this addressed

We add a `TryParse(string format)`, `Parse(string format)` and `ToString(string format, IFormatProvider formatProvider)` implementation for all euis.
