### PR TITLE
Bug/697 lbs device no hyphens

### DIFF
--- a/Docs/Operations/station-configuration.md
+++ b/Docs/Operations/station-configuration.md
@@ -4,17 +4,17 @@ Following the LoRaWAN  Network Server (LNS) specification, each Basics Station (
 
 In the following we describe how to register an LBS in IoT Hub and how to store its configuration.
 
-1. Create an IoT Hub device that has a name equal to the LBS EUI in hex-representation, e.g. `DC-A6-32-FF-FE-B3-2F-C6`.
+1. Create an IoT Hub device that has a name equal to the LBS EUI in hex-representation, e.g. `DCA632FFFEB32FC6`.
 2. The LBS configuration needs to be stored as a desired twin property of the newly created LBS device. Make sure to store the configuration under `properties.desired.routerConfig`.
    1. The configuration follows the `router_config` format from the LNS protocol as closely as possible. However, since device twins encode numbers as 32-bit values and given some configuration properties (such as EUIs) are 64-bit numbers, there are some minor differences.
-   2. The `JoinEui` nested array must consist of hexadecimal-encoded strings. The property should look similar to: `"JoinEui": [["DC-A6-32-FF-FE-B3-2F-C5","DC-A6-32-FF-FE-B3-2F-C7"]]`
+   2. The `JoinEui` nested array must consist of hexadecimal-encoded strings. The property should look similar to: `"JoinEui": [["DCA632FFFEB32FC5","DCA632FFFEB32FC7"]]`
    3. A full configuration example might look like this, relative to the desired twin property path `properties.desired`:
 
       ```json
       {
         "routerConfig": {
           "NetID": [1],
-          "JoinEui": [["DC-A6-32-FF-FE-B3-2F-C5", "DC-A6-32-FF-FE-B3-2F-C7"]],
+          "JoinEui": [["DCA632FFFEB32FC5", "DCA632FFFEB32FC7"]],
           "region": "EU863",
           "hwspec": "sx1301/1",
           "freq_range": [863000000, 870000000],

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationConfigurationService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationConfigurationService.cs
@@ -65,7 +65,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
 
         private async Task<string> GetRouterConfigMessageInternalAsync(StationEui stationEui)
         {
-            var queryResult = await this.loRaDeviceApiService.SearchByDevEUIAsync(stationEui.ToString());
+            var queryResult = await this.loRaDeviceApiService.SearchByEuiAsync(stationEui);
             if (queryResult.Count != 1)
             {
                 throw new LoRaProcessingException($"The configuration request of station '{stationEui}' did not match any configuration in IoT Hub. If you expect this connection request to succeed, make sure to provision the Basics Station in the device registry.",

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
@@ -181,7 +181,7 @@ namespace LoRaWan.NetworkServer
                     return new SearchDevicesResult();
                 }
 
-                Logger.Log(eui, $"error calling get device by devEUI api: {response.ReasonPhrase}, status: {response.StatusCode}, check the azure function log", LogLevel.Error);
+                Logger.Log(eui, $"error calling get device/station by EUI api: {response.ReasonPhrase}, status: {response.StatusCode}, check the azure function log", LogLevel.Error);
 
                 return new SearchDevicesResult();
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
@@ -157,13 +157,20 @@ namespace LoRaWan.NetworkServer
         }
 
         /// <inheritdoc />
-        public override async Task<SearchDevicesResult> SearchByDevEUIAsync(string devEUI)
+        public override Task<SearchDevicesResult> SearchByEuiAsync(DevEui eui) =>
+            SearchByEuiAsync(eui.ToString("N", null));
+
+        /// <inheritdoc />
+        public override Task<SearchDevicesResult> SearchByEuiAsync(StationEui eui) =>
+            SearchByEuiAsync(eui.ToString("N", null));
+
+        private async Task<SearchDevicesResult> SearchByEuiAsync(string eui)
         {
             var client = this.serviceFacadeHttpClientProvider.GetHttpClient();
             var url = BuildUri("GetDeviceByDevEUI", new Dictionary<string, string>
             {
                 ["code"] = AuthCode,
-                ["DevEUI"] = devEUI
+                ["DevEUI"] = eui
             });
 
             var response = await client.GetAsync(new Uri(url.ToString()));
@@ -174,7 +181,7 @@ namespace LoRaWan.NetworkServer
                     return new SearchDevicesResult();
                 }
 
-                Logger.Log(devEUI, $"error calling get device by devEUI api: {response.ReasonPhrase}, status: {response.StatusCode}, check the azure function log", LogLevel.Error);
+                Logger.Log(eui, $"error calling get device by devEUI api: {response.ReasonPhrase}, status: {response.StatusCode}, check the azure function log", LogLevel.Error);
 
                 return new SearchDevicesResult();
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIServiceBase.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIServiceBase.cs
@@ -38,7 +38,17 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         public abstract Task<SearchDevicesResult> SearchAndLockForJoinAsync(string gatewayID, string devEUI, string devNonce);
 
-        public abstract Task<SearchDevicesResult> SearchByDevEUIAsync(string devEUI);
+        /// <summary>
+        /// Searches station devices in IoT Hub.
+        /// </summary>
+        /// <param name="eui">EUI of the station.</param>
+        public abstract Task<SearchDevicesResult> SearchByEuiAsync(StationEui eui);
+
+        /// <summary>
+        /// Searches LoRa devices in IoT Hub.
+        /// </summary>
+        /// <param name="eui">EUI of the LoRa device.</param>
+        public abstract Task<SearchDevicesResult> SearchByEuiAsync(DevEui eui);
 
         /// <summary>
         /// Sets the authorization code for the URL.

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
@@ -194,7 +194,7 @@ namespace LoRaWan.NetworkServer
             if (this.cache.TryGetValue<LoRaDevice>(CacheKeyForDevEUIDevice(devEUI), out var cachedDevice))
                 return cachedDevice;
 
-            var searchResult = await this.loRaDeviceAPIService.SearchByEuiAsync(DevEui.Parse(devEUI, "N"));
+            var searchResult = await this.loRaDeviceAPIService.SearchByEuiAsync(DevEui.Parse(devEUI));
             if (searchResult == null || searchResult.Count == 0)
                 return null;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
@@ -194,7 +194,7 @@ namespace LoRaWan.NetworkServer
             if (this.cache.TryGetValue<LoRaDevice>(CacheKeyForDevEUIDevice(devEUI), out var cachedDevice))
                 return cachedDevice;
 
-            var searchResult = await this.loRaDeviceAPIService.SearchByDevEUIAsync(devEUI);
+            var searchResult = await this.loRaDeviceAPIService.SearchByEuiAsync(DevEui.Parse(devEUI, "N"));
             if (searchResult == null || searchResult.Count == 0)
                 return null;
 

--- a/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
+++ b/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
@@ -81,7 +81,7 @@ namespace LoRaWan.Tests.Integration
 
             var devEUI = simulatedDevice.DevEUI;
 
-            this.deviceApi.Setup(x => x.SearchByDevEUIAsync(devEUI))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
                 .ReturnsAsync(new SearchDevicesResult(
                     new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
@@ -169,7 +169,7 @@ namespace LoRaWan.Tests.Integration
 
             var devEUI = simulatedDevice.DevEUI;
 
-            this.deviceApi.Setup(x => x.SearchByDevEUIAsync(devEUI))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
             this.deviceClient.Setup(x => x.GetTwinAsync())

--- a/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
+++ b/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
@@ -81,7 +81,7 @@ namespace LoRaWan.Tests.Integration
 
             var devEUI = simulatedDevice.DevEUI;
 
-            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI)))
                 .ReturnsAsync(new SearchDevicesResult(
                     new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
@@ -169,7 +169,7 @@ namespace LoRaWan.Tests.Integration
 
             var devEUI = simulatedDevice.DevEUI;
 
-            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI)))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
             this.deviceClient.Setup(x => x.GetTwinAsync())

--- a/Tests/Unit/NetworkServerTests/BasicsStation/BasicsStationConfigurationServiceTests.cs
+++ b/Tests/Unit/NetworkServerTests/BasicsStation/BasicsStationConfigurationServiceTests.cs
@@ -42,7 +42,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests.BasicsStation
             SetupDeviceKeyLookup(stationEui, new[] { new IoTHubDeviceInfo { DevEUI = this.stationEui.ToString(), PrimaryKey = primaryKey } });
 
         private void SetupDeviceKeyLookup(StationEui stationEui, params IoTHubDeviceInfo[] ioTHubDeviceInfos) =>
-            loRaDeviceApiServiceMock.Setup(ldas => ldas.SearchByDevEUIAsync(stationEui.ToString()))
+            loRaDeviceApiServiceMock.Setup(ldas => ldas.SearchByEuiAsync(stationEui))
                                     .Returns(Task.FromResult(new SearchDevicesResult(ioTHubDeviceInfos)));
 
         private void SetupTwinResponse(StationEui stationEui, string primaryKey) =>
@@ -123,7 +123,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests.BasicsStation
                 // assert
                 Assert.Equal(result.Length, numberOfConcurrentAccess);
                 this.loRaDeviceFactoryMock.Verify(ldf => ldf.CreateDeviceClient(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-                this.loRaDeviceApiServiceMock.Verify(ldf => ldf.SearchByDevEUIAsync(It.IsAny<string>()), Times.Once);
+                this.loRaDeviceApiServiceMock.Verify(ldf => ldf.SearchByEuiAsync(It.IsAny<StationEui>()), Times.Once);
                 foreach (var r in result)
                     Assert.Equal(JsonUtil.Minify(LnsStationConfigurationTests.ValidRouterConfigMessage), r);
             }
@@ -147,7 +147,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests.BasicsStation
                 // arrange
                 const string primaryKey = "foo";
                 SetupTwinResponse(this.stationEui, primaryKey);
-                this.loRaDeviceApiServiceMock.SetupSequence(ldas => ldas.SearchByDevEUIAsync(It.IsAny<string>()))
+                this.loRaDeviceApiServiceMock.SetupSequence(ldas => ldas.SearchByEuiAsync(It.IsAny<StationEui>()))
                                              .Throws(new InvalidOperationException())
                                              .Returns(Task.FromResult(new SearchDevicesResult(new[]
                                              {
@@ -160,7 +160,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests.BasicsStation
                 var result = await Act();
 
                 // assert
-                this.loRaDeviceApiServiceMock.Verify(ldf => ldf.SearchByDevEUIAsync(It.IsAny<string>()), Times.Exactly(2));
+                this.loRaDeviceApiServiceMock.Verify(ldf => ldf.SearchByEuiAsync(It.IsAny<StationEui>()), Times.Exactly(2));
                 Assert.Equal(JsonUtil.Minify(LnsStationConfigurationTests.ValidRouterConfigMessage), result);
             }
         }

--- a/Tests/Unit/NetworkServerTests/DefaultClassCDevicesMessageSenderTest.cs
+++ b/Tests/Unit/NetworkServerTests/DefaultClassCDevicesMessageSenderTest.cs
@@ -74,7 +74,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, deviceClassType: 'c', gatewayID: deviceGatewayID));
             var devEUI = simDevice.DevEUI;
 
-            this.deviceApi.Setup(x => x.SearchByDevEUIAsync(devEUI))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
             var twin = simDevice.CreateABPTwin(reportedProperties: new Dictionary<string, object>
@@ -128,7 +128,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: ServerGatewayID));
             var devEUI = simDevice.DevEUI;
 
-            this.deviceApi.Setup(x => x.SearchByDevEUIAsync(devEUI))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
             this.deviceClient.Setup(x => x.GetTwinAsync())
@@ -184,7 +184,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: 'c', gatewayID: ServerGatewayID));
             var devEUI = simDevice.DevEUI;
 
-            this.deviceApi.Setup(x => x.SearchByDevEUIAsync(devEUI))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
             this.deviceClient.Setup(x => x.GetTwinAsync())
@@ -217,7 +217,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, deviceClassType: 'c'));
             var devEUI = simDevice.DevEUI;
 
-            this.deviceApi.Setup(x => x.SearchByDevEUIAsync(devEUI))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
             var twin = simDevice.CreateABPTwin(reportedProperties: new Dictionary<string, object>
@@ -317,7 +317,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var devEUI = simDevice.DevEUI;
             simDevice.SetupJoin(appSKey, nwkSKey, devAddr);
 
-            this.deviceApi.Setup(x => x.SearchByDevEUIAsync(devEUI))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
             var twin = simDevice.CreateOTAATwin(

--- a/Tests/Unit/NetworkServerTests/DefaultClassCDevicesMessageSenderTest.cs
+++ b/Tests/Unit/NetworkServerTests/DefaultClassCDevicesMessageSenderTest.cs
@@ -74,7 +74,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, deviceClassType: 'c', gatewayID: deviceGatewayID));
             var devEUI = simDevice.DevEUI;
 
-            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI)))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
             var twin = simDevice.CreateABPTwin(reportedProperties: new Dictionary<string, object>
@@ -128,7 +128,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: ServerGatewayID));
             var devEUI = simDevice.DevEUI;
 
-            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI)))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
             this.deviceClient.Setup(x => x.GetTwinAsync())
@@ -184,7 +184,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: 'c', gatewayID: ServerGatewayID));
             var devEUI = simDevice.DevEUI;
 
-            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI)))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
             this.deviceClient.Setup(x => x.GetTwinAsync())
@@ -217,7 +217,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, deviceClassType: 'c'));
             var devEUI = simDevice.DevEUI;
 
-            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI)))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
             var twin = simDevice.CreateABPTwin(reportedProperties: new Dictionary<string, object>
@@ -317,7 +317,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var devEUI = simDevice.DevEUI;
             simDevice.SetupJoin(appSKey, nwkSKey, devAddr);
 
-            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI, "N")))
+            this.deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(devEUI)))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(string.Empty, devEUI, "123").AsList()));
 
             var twin = simDevice.CreateOTAATwin(

--- a/Tests/Unit/NetworkServerTests/LoRaDeviceRegistryTest.cs
+++ b/Tests/Unit/NetworkServerTests/LoRaDeviceRegistryTest.cs
@@ -471,7 +471,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
 
             var deviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(simDevice.DevEUI, "N")))
+            deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(simDevice.DevEUI)))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(simDevice.DevAddr, simDevice.DevEUI, "123").AsList()));
 
             var deviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);

--- a/Tests/Unit/NetworkServerTests/LoRaDeviceRegistryTest.cs
+++ b/Tests/Unit/NetworkServerTests/LoRaDeviceRegistryTest.cs
@@ -471,7 +471,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
             var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
 
             var deviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            deviceApi.Setup(x => x.SearchByDevEUIAsync(simDevice.DevEUI))
+            deviceApi.Setup(x => x.SearchByEuiAsync(DevEui.Parse(simDevice.DevEUI, "N")))
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(simDevice.DevAddr, simDevice.DevEUI, "123").AsList()));
 
             var deviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
@@ -513,7 +513,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
         public async Task GetDeviceByDevEUIAsync_When_Api_Returns_Null_Should_Return_Null()
         {
             var deviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            deviceApi.Setup(x => x.SearchByDevEUIAsync(It.IsNotNull<string>()))
+            deviceApi.Setup(x => x.SearchByEuiAsync(It.IsNotNull<DevEui>()))
                 .ReturnsAsync((SearchDevicesResult)null);
 
             var deviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
@@ -537,7 +537,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
         public async Task GetDeviceByDevEUIAsync_When_Api_Returns_Empty_Should_Return_Null()
         {
             var deviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
-            deviceApi.Setup(x => x.SearchByDevEUIAsync(It.IsNotNull<string>()))
+            deviceApi.Setup(x => x.SearchByEuiAsync(It.IsNotNull<DevEui>()))
                 .ReturnsAsync(new SearchDevicesResult());
 
             var deviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);

--- a/Tests/Unit/NetworkServerTests/LoRaDeviceRegistryTest.cs
+++ b/Tests/Unit/NetworkServerTests/LoRaDeviceRegistryTest.cs
@@ -526,7 +526,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
                 deviceApi.Object,
                 deviceFactory);
 
-            var actual = await deviceRegistry.GetDeviceByDevEUIAsync("1");
+            var actual = await deviceRegistry.GetDeviceByDevEUIAsync(new DevEui(1).ToString("N", null));
             Assert.Null(actual);
 
             deviceApi.VerifyAll();
@@ -550,7 +550,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerTests
                 deviceApi.Object,
                 deviceFactory);
 
-            var actual = await deviceRegistry.GetDeviceByDevEUIAsync("1");
+            var actual = await deviceRegistry.GetDeviceByDevEUIAsync(new DevEui(1).ToString("N", null));
             Assert.Null(actual);
 
             deviceApi.VerifyAll();


### PR DESCRIPTION
# PR for issue #697

## What is being addressed

This PR makes sure that when fetching the station device twin, we use the same device ID format as we do for LoRa devices.

## How is this addressed

Uses the primitives and a specific formatting to fetch the device by ID.

Depends on #752 