### PR TITLE
Add prometheus default metrics to LNS

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -16,6 +16,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
+    using Prometheus;
 
     internal sealed class BasicsStationNetworkServerStartup
     {
@@ -100,6 +101,8 @@ namespace LoRaWan.NetworkServer.BasicsStation
                                await lnsProtocolMessageProcessor.HandleDataAsync(context, context.RequestAborted);
                            });
                    });
+
+            _ = app.UseMetricServer();
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaWan.NetworkServer.csproj
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaWan.NetworkServer.csproj
@@ -19,6 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="prometheus-net.AspNetCore" Version="5.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
 


### PR DESCRIPTION
# PR for issue #255

## What is being addressed

With this PR we expose default metrics on the LNS in Prometheus format.

## How is this addressed

`prometheus-net.AspNetCore` is an MIT-licensed package that builds on top of `prometheus-net` to expose default metrics on `<basUrl>/metrics`. With #747 we will also start raising custom metrics on this endpoint.

Example default metrics:

```bash
❯ http GET http://localhost:5000/metrics
HTTP/1.1 200 OK
Content-Type: text/plain; version=0.0.4; charset=utf-8
Date: Thu, 11 Nov 2021 07:13:45 GMT
Server: Kestrel
Transfer-Encoding: chunked

# HELP process_num_threads Total number of threads
# TYPE process_num_threads gauge
process_num_threads 32
# HELP dotnet_total_memory_bytes Total known allocated memory
# TYPE dotnet_total_memory_bytes gauge
dotnet_total_memory_bytes 3111376
# HELP process_open_handles Number of open handles
# TYPE process_open_handles gauge
process_open_handles 636
# HELP dotnet_collection_count_total GC collection count
# TYPE dotnet_collection_count_total counter
dotnet_collection_count_total{generation="1"} 0
dotnet_collection_count_total{generation="2"} 0
dotnet_collection_count_total{generation="0"} 1
# HELP process_private_memory_bytes Process private memory size
# TYPE process_private_memory_bytes gauge
process_private_memory_bytes 42663936
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 2203984539648
# HELP process_working_set_bytes Process working set
# TYPE process_working_set_bytes gauge
process_working_set_bytes 85037056
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1636614611.8996582
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 3.515625
```