### PR TITLE
Fix docker build in CI

### DIFF
--- a/.github/workflows/e2e-ci.yaml
+++ b/.github/workflows/e2e-ci.yaml
@@ -78,6 +78,9 @@ jobs:
     - env_var
     name: Build and Push Docker images
     runs-on: ubuntu-latest
+    env:
+      DEV_IMAGE_TAG: dev
+      MASTER_IMAGE_TAG: master
     if: needs.env_var.outputs.RunE2ETestsOnly != 'true'
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
THere were some missing environment variables in the steps preventing the nightly runs. E.g. this run  https://github.com/Azure/iotedge-lorawan-starterkit/runs/4184376968?check_suite_focus=true#step:6:18