### PR TITLE
Update docs on local E2E setup 

### DIFF
--- a/LoRaEngine/deployment.lbs.template.json
+++ b/LoRaEngine/deployment.lbs.template.json
@@ -107,9 +107,6 @@
                 },
                 "APPINSIGHTS_INSTRUMENTATIONKEY": {
                   "value": "$APPINSIGHTS_INSTRUMENTATIONKEY"
-                },
-                "REGION": {
-                  "value": "EU868"
                 }
               },
               "status": "running",

--- a/LoRaEngine/deployment.lbs.template.json
+++ b/LoRaEngine/deployment.lbs.template.json
@@ -107,6 +107,9 @@
                 },
                 "APPINSIGHTS_INSTRUMENTATIONKEY": {
                   "value": "$APPINSIGHTS_INSTRUMENTATIONKEY"
+                },
+                "REGION": {
+                  "value": "EU868"
                 }
               },
               "status": "running",

--- a/Tests/E2E/README.md
+++ b/Tests/E2E/README.md
@@ -50,13 +50,6 @@ Configure LoRa Basics Station and Network Server to run on your local LoRa gatew
 
     In VS Code: Ctrl+Shift+P -> Azure IoT Edge: Bild and Push IoT Edge Solution -> select template file. 
 
-3. Make sure the generated deployment template (`LoRaEngine/config/deployment.lbs.json`) contains the correct region configuration in the `LoRaWanNetworkSrvModule` section, e.g.:
-    ```
-    "REGION": {
-        "value": "EU868"
-    }
-    ```
-
 3. Create deployment for a single device using generated deployment template.
 
     In VS Code, right-click on `LoRaEngine/config/deployment.lbs.json` and select Create Deployment for Single Device.

--- a/Tests/E2E/README.md
+++ b/Tests/E2E/README.md
@@ -30,7 +30,7 @@ This guide helps you to execute and author E2E tests on your local environment.
 
 ### LoRa Basics Station and LNS setup
 
-Configure LoRa Basics Station and Network Server to run on your local LoRa gateway:
+Configure LoRa Basics Station and Network Server to run on your concentrator:
 
 1. Copy `LoRaEngine/example.env` file and name it `.env`.
 


### PR DESCRIPTION
# PR for issue #751 

## What is being addressed

While trying to set up the E2E tests to run locally on my LoRa gateway and leaf device, I found a few gaps that in my view are missing from the current E2E readme, focusing on the requirements to get the tests to run locally (LBS and LNS).

## How is this addressed

E2E tests readme was updated with the steps I found out about while working on running the tests locally.
