### PR TITLE
Bug/798 Make tests using real timer more deterministic

### DIFF
--- a/Tests/Common/LoRaEnumerable.cs
+++ b/Tests/Common/LoRaEnumerable.cs
@@ -9,7 +9,8 @@ namespace LoRaWan.Tests.Common
     {
         public static IEnumerable<T> Repeat<T>(T value)
         {
-            yield return value;
+            while (true)
+                yield return value;
         }
     }
 }

--- a/Tests/Common/LoRaEnumerable.cs
+++ b/Tests/Common/LoRaEnumerable.cs
@@ -7,7 +7,7 @@ namespace LoRaWan.Tests.Common
 
     internal static class LoRaEnumerable
     {
-        public static IEnumerable<T> Repeat<T>(T value)
+        public static IEnumerable<T> RepeatInfinite<T>(T value)
         {
             while (true)
                 yield return value;

--- a/Tests/Common/LoRaEnumerable.cs
+++ b/Tests/Common/LoRaEnumerable.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Common
+{
+    using System.Collections.Generic;
+
+    internal static class LoRaEnumerable
+    {
+        public static IEnumerable<T> Repeat<T>(T value)
+        {
+            yield return value;
+        }
+    }
+}

--- a/Tests/Common/MessageProcessorTestBase.cs
+++ b/Tests/Common/MessageProcessorTestBase.cs
@@ -4,7 +4,6 @@
 namespace LoRaWan.Tests.Common
 {
     using System;
-    using System.Collections.Generic;
     using System.Globalization;
     using System.Threading.Tasks;
     using LoRaTools.ADR;

--- a/Tests/Common/MessageProcessorTestBase.cs
+++ b/Tests/Common/MessageProcessorTestBase.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.Tests.Common
 {
     using System;
+    using System.Collections.Generic;
     using System.Globalization;
     using System.Threading.Tasks;
     using LoRaTools.ADR;

--- a/Tests/Common/TestLoRaOperationTimeWatcher.cs
+++ b/Tests/Common/TestLoRaOperationTimeWatcher.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.Tests.Common
 {
     using System;
+    using System.Collections.Generic;
     using LoRaTools.Regions;
     using LoRaWan.NetworkServer;
 
@@ -12,17 +13,22 @@ namespace LoRaWan.Tests.Common
     /// </summary>
     internal class TestLoRaOperationTimeWatcher : LoRaOperationTimeWatcher
     {
-        private readonly TimeSpan constantElapsedTime;
+        private readonly IEnumerator<TimeSpan> elapsedTimes;
 
-        public TestLoRaOperationTimeWatcher(Region loraRegion, TimeSpan constantElapsedTime)
+        public TestLoRaOperationTimeWatcher(Region loraRegion, IEnumerable<TimeSpan> elapsedTimes)
             : base(loraRegion)
         {
-            this.constantElapsedTime = constantElapsedTime;
+            this.elapsedTimes = elapsedTimes.GetEnumerator();
         }
 
         /// <summary>
         /// Gets time passed since start.
         /// </summary>
-        protected internal override TimeSpan GetElapsedTime() => this.constantElapsedTime;
+        protected internal override TimeSpan GetElapsedTime()
+        {
+            if (!this.elapsedTimes.MoveNext())
+                throw new InvalidOperationException("More elapsed times requested than were set up.");
+            return this.elapsedTimes.Current;
+        }
     }
 }

--- a/Tests/Common/WaitableLoRaRequest.cs
+++ b/Tests/Common/WaitableLoRaRequest.cs
@@ -54,18 +54,29 @@ namespace LoRaWan.Tests.Common
             Create(rxpk, LoRaEnumerable.Repeat(constantElapsedTime ?? TimeSpan.Zero), packetForwarder, startTimeOffset, useRealTimer);
 
         /// <summary>
-        /// Creates a WaitableLoRaRequest that uses a deterministic time handler.
+        /// Creates a WwaitableLoRaRequest that is configured to miss certain receive windows.
         /// </summary>
         /// <param name="rxpk">Rxpk instance.</param>
-        /// <param name="elapsedTimes">Returns an elapsed time every time it is requested.</param>
         /// <param name="packetForwarder">PacketForwarder instance.</param>
-        /// <param name="startTimeOffset">Is subtracted from the current time to determine the start time for the deterministic time watcher. Default is TimeSpan.Zero.</param>
-        /// <param name="useRealTimer">Allows you to opt-in to use a real, non-deterministic time watcher.</param>
-        public static WaitableLoRaRequest Create(Rxpk rxpk,
-                                                 IEnumerable<TimeSpan> elapsedTimes,
-                                                 IPacketForwarder packetForwarder = null,
-                                                 TimeSpan? startTimeOffset = null,
-                                                 bool useRealTimer = false)
+        /// <param name="inTimeForC2DMessageCheck">If set to true it ensures that processing is fast enough that C2D messages can be checked.</param>
+        /// <param name="inTimeForAdditionalMessageCheck">If set to true it ensures that processing is fast enough that additional C2D messages can be checked.</param>
+        /// <param name="inTimeForDownlinkDelivery">If set to true it ensures that processing is fast enough that C2D messages can be checked.</param>
+        public static WaitableLoRaRequest Create(Rxpk rxpk, IPacketForwarder packetForwarder,
+                                                 bool inTimeForC2DMessageCheck,
+                                                 bool inTimeForAdditionalMessageCheck,
+                                                 bool inTimeForDownlinkDelivery)
+        {
+            var c2dMessageCheckTimeSpan = inTimeForC2DMessageCheck ? TimeSpan.FromMilliseconds(10) : TimeSpan.FromSeconds(10);
+            var additionalMessageCheckTimeSpan = inTimeForAdditionalMessageCheck ? TimeSpan.FromMilliseconds(10) : TimeSpan.FromSeconds(10);
+            var downlinkDeliveryTimeSpan = inTimeForDownlinkDelivery ? TimeSpan.FromMilliseconds(10) : TimeSpan.FromSeconds(10);
+            return Create(rxpk, new[] { c2dMessageCheckTimeSpan, c2dMessageCheckTimeSpan, additionalMessageCheckTimeSpan, downlinkDeliveryTimeSpan }, packetForwarder);
+        }
+
+        private static WaitableLoRaRequest Create(Rxpk rxpk,
+                                                  IEnumerable<TimeSpan> elapsedTimes,
+                                                  IPacketForwarder packetForwarder = null,
+                                                  TimeSpan? startTimeOffset = null,
+                                                  bool useRealTimer = false)
         {
             var request = new WaitableLoRaRequest(rxpk,
                                                   packetForwarder ?? new TestPacketForwarder(),

--- a/Tests/Common/WaitableLoRaRequest.cs
+++ b/Tests/Common/WaitableLoRaRequest.cs
@@ -51,7 +51,7 @@ namespace LoRaWan.Tests.Common
                                                  TimeSpan? startTimeOffset = null,
                                                  TimeSpan? constantElapsedTime = null,
                                                  bool useRealTimer = false) =>
-            Create(rxpk, LoRaEnumerable.Repeat(constantElapsedTime ?? TimeSpan.Zero), packetForwarder, startTimeOffset, useRealTimer);
+            Create(rxpk, LoRaEnumerable.RepeatInfinite(constantElapsedTime ?? TimeSpan.Zero), packetForwarder, startTimeOffset, useRealTimer);
 
         /// <summary>
         /// Creates a WwaitableLoRaRequest that is configured to miss certain receive windows.

--- a/Tests/Integration/CloudToDeviceMessageTests.cs
+++ b/Tests/Integration/CloudToDeviceMessageTests.cs
@@ -991,13 +991,10 @@ namespace LoRaWan.Tests.Integration
 
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            using var request = WaitableLoRaRequest.Create(rxpk, new[]
-            {
-                TimeSpan.FromMilliseconds(100),
-                TimeSpan.FromMilliseconds(100),
-                TimeSpan.FromSeconds(3),
-                TimeSpan.FromSeconds(3)
-            }, PacketForwarder);
+            using var request = WaitableLoRaRequest.Create(rxpk, PacketForwarder,
+                                                           inTimeForC2DMessageCheck: true,
+                                                           inTimeForAdditionalMessageCheck: false,
+                                                           inTimeForDownlinkDelivery: false);
             messageProcessor.DispatchRequest(request);
             Assert.True(await request.WaitCompleteAsync());
 

--- a/Tests/Integration/CloudToDeviceMessageTests.cs
+++ b/Tests/Integration/CloudToDeviceMessageTests.cs
@@ -972,7 +972,7 @@ namespace LoRaWan.Tests.Integration
                 .CreateMessage();
 
             LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsAny<TimeSpan>()))
-                .ReturnsAsync(cloudToDeviceMessage, TimeSpan.FromMilliseconds(2001));
+                .ReturnsAsync(cloudToDeviceMessage);
 
             LoRaDeviceClient.Setup(x => x.AbandonAsync(cloudToDeviceMessage))
                 .ReturnsAsync(true);
@@ -991,7 +991,13 @@ namespace LoRaWan.Tests.Integration
 
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
             var rxpk = payload.SerializeUplink(simulatedDevice.AppSKey, simulatedDevice.NwkSKey).Rxpk[0];
-            using var request = CreateWaitableRequest(rxpk, useRealTimer: true);
+            using var request = WaitableLoRaRequest.Create(rxpk, new[]
+            {
+                TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromSeconds(3),
+                TimeSpan.FromSeconds(3)
+            }, PacketForwarder);
             messageProcessor.DispatchRequest(request);
             Assert.True(await request.WaitCompleteAsync());
 


### PR DESCRIPTION
# PR for issue #798

## What is being addressed

With this PR we introduce deterministic timing for two tests that were so far using real timing.

## How is this addressed

We refactor the existing `TestLoRaOperationTimeWatcher` to accept enumerables instead of constant values as input for the elapsed time calls. By using deterministic `GetElapsedTime` calls, the intermittent integration test failure that occurred due to timing issues can be prevented.

Making the tests more deterministic also means that `When_Takes_Too_Long_Getting_FcntDown_Should_Abandon_Message` and `When_Takes_Too_Long_Receiving_First_C2D_Should_Abandon_Message` tested the exact same path, which is why we remove one test in favor of a deterministic test that always runs with the same "`elapsedTimes`".