### PR TITLE
Ensures IHost is stopped and disposed.

### DIFF
--- a/Tests/Integration/LnsProtocolMessageProcessorConcentratorDeduplicationIntegrationTests.cs
+++ b/Tests/Integration/LnsProtocolMessageProcessorConcentratorDeduplicationIntegrationTests.cs
@@ -22,9 +22,12 @@ namespace LoRaWan.Tests.Integration
     /// <summary>
     /// These tests test the integration between <see cref="LnsProtocolMessageProcessor"/> and <see cref="ConcentratorDeduplication"/>.
     /// </summary>
-    public sealed class LnsProtocolMessageProcessorConcentratorDeduplicationIntegrationTests : IDisposable
+    public sealed class LnsProtocolMessageProcessorConcentratorDeduplicationIntegrationTests
+        : IAsyncLifetime
     {
         private IHost testHost;
+
+        public Task InitializeAsync() => Task.CompletedTask;
 
         private async Task CreateTestHostAsync(Mock<IMessageDispatcher> messageDispatcherMock)
         {
@@ -109,9 +112,9 @@ namespace LoRaWan.Tests.Integration
             Assert.Equal(expected, dispatcherCounter);
         }
 
-        public void Dispose()
+        public async Task DisposeAsync()
         {
-            _ = this.testHost?.StopAsync();
+            await this.testHost?.StopAsync();
             this.testHost?.Dispose();
         }
     }

--- a/Tests/Integration/LnsProtocolMessageProcessorConcentratorDeduplicationIntegrationTests.cs
+++ b/Tests/Integration/LnsProtocolMessageProcessorConcentratorDeduplicationIntegrationTests.cs
@@ -22,11 +22,13 @@ namespace LoRaWan.Tests.Integration
     /// <summary>
     /// These tests test the integration between <see cref="LnsProtocolMessageProcessor"/> and <see cref="ConcentratorDeduplication"/>.
     /// </summary>
-    public sealed class LnsProtocolMessageProcessorConcentratorDeduplicationIntegrationTests
+    public sealed class LnsProtocolMessageProcessorConcentratorDeduplicationIntegrationTests : IDisposable
     {
-        private static async Task<TestServer> TestServerAsyncFactory(Mock<IMessageDispatcher> messageDispatcherMock)
+        private IHost testHost;
+
+        private async Task CreateTestHostAsync(Mock<IMessageDispatcher> messageDispatcherMock)
         {
-            var host = await new HostBuilder()
+            this.testHost = await new HostBuilder()
                 .ConfigureWebHost(builder =>
                     builder.UseTestServer()
                             .UseStartup<BasicsStationNetworkServerStartup>()
@@ -41,8 +43,6 @@ namespace LoRaWan.Tests.Integration
                             })
                             .UseEnvironment("Development"))
                 .StartAsync();
-
-            return host.GetTestServer();
         }
 
         [Theory]
@@ -54,8 +54,8 @@ namespace LoRaWan.Tests.Integration
             var dispatcherCounter = 0;
             var messageDispatcherMock = new Mock<IMessageDispatcher>();
             _ = messageDispatcherMock.Setup(x => x.DispatchRequest(It.IsAny<LoRaRequest>())).Callback(() => dispatcherCounter++);
-            var testServer = await TestServerAsyncFactory(messageDispatcherMock);
-            var wsClient = testServer.CreateWebSocketClient();
+            await CreateTestHostAsync(messageDispatcherMock);
+            var wsClient = this.testHost.GetTestServer().CreateWebSocketClient();
 
             var station1 = StationEui.Parse("a8-27-eb-ff-fe-e1-e3-9a");
             var station2 = isSameStation ? station1 : StationEui.Parse("b8-27-eb-ff-fe-e1-e3-9a");
@@ -107,6 +107,12 @@ namespace LoRaWan.Tests.Integration
             // assert
             var expected = isSameStation ? 2 : 1;
             Assert.Equal(expected, dispatcherCounter);
+        }
+
+        public void Dispose()
+        {
+            _ = this.testHost?.StopAsync();
+            this.testHost?.Dispose();
         }
     }
 }


### PR DESCRIPTION
# PR for issue #828

## What is being addressed

The `IHost` for the `LnsProtocolMessageProcessorConcentratorDeduplicationIntegrationTests` was not properly stopped and disposed, causing the Resharper runner to hang.

## How is this addressed

By implementing the `IAsyncLifetime` interface. 
ReSharper no longer complains when running these tests and execution completes.
