### PR TITLE
Allow setting the log level in word form

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -3,6 +3,7 @@
 
 namespace LoRaWan.NetworkServer.BasicsStation
 {
+    using System;
     using System.Globalization;
     using LoRaTools.ADR;
     using LoRaWan;
@@ -40,7 +41,10 @@ namespace LoRaWan.NetworkServer.BasicsStation
             _ = services.AddLogging(loggingBuilder =>
                         {
                             _ = loggingBuilder.ClearProviders();
-                            var logLevel = (LogLevel)int.Parse(NetworkServerConfiguration.LogLevel, CultureInfo.InvariantCulture);
+                            var logLevel = int.TryParse(NetworkServerConfiguration.LogLevel, out var logLevelNum)
+                                ? (LogLevel)logLevelNum
+                                : Enum.Parse<LogLevel>(NetworkServerConfiguration.LogLevel, true);
+
                             _ = loggingBuilder.SetMinimumLevel(logLevel);
                             _ = loggingBuilder.AddLoRaConsoleLogger(c => c.LogLevel = logLevel);
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -41,8 +41,8 @@ namespace LoRaWan.NetworkServer.BasicsStation
             _ = services.AddLogging(loggingBuilder =>
                         {
                             _ = loggingBuilder.ClearProviders();
-                            var logLevel = int.TryParse(NetworkServerConfiguration.LogLevel, out var logLevelNum)
-                                ? (LogLevel)logLevelNum
+                            var logLevel = int.TryParse(NetworkServerConfiguration.LogLevel, NumberStyles.Integer, CultureInfo.InvariantCulture, out var logLevelNum)
+                                 ? (LogLevel)logLevelNum is var level && Enum.IsDefined(typeof(LogLevel), level) ? level : throw new InvalidCastException()
                                 : Enum.Parse<LogLevel>(NetworkServerConfiguration.LogLevel, true);
 
                             _ = loggingBuilder.SetMinimumLevel(logLevel);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -42,7 +42,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         {
                             _ = loggingBuilder.ClearProviders();
                             var logLevel = int.TryParse(NetworkServerConfiguration.LogLevel, NumberStyles.Integer, CultureInfo.InvariantCulture, out var logLevelNum)
-                                 ? (LogLevel)logLevelNum is var level && Enum.IsDefined(typeof(LogLevel), level) ? level : throw new InvalidCastException()
+                                ? (LogLevel)logLevelNum is var level && Enum.IsDefined(typeof(LogLevel), level) ? level : throw new InvalidCastException()
                                 : Enum.Parse<LogLevel>(NetworkServerConfiguration.LogLevel, true);
 
                             _ = loggingBuilder.SetMinimumLevel(logLevel);


### PR DESCRIPTION
# PR for issue #675 

## What is being addressed

LNS was crashing if it was configured to use log level expressed in a word (e.g. "Debug"). Only number representation of the `LogLevel` enum was allowed. 

## How is this addressed

The logic in `BasicsStationNetworkServerStartup.ConfigureServices()` was adjusted to also allow word representation (case insensitive) of the log level to be provided. The numerical version is still supported.

## How was the fix verified

The bug was first reproduced by setting the log level in `LOG_LEVEL` variable of the LNS module to "Debug".
The fix was verified by deploying the updated LNS module and checking that the LNS doesn't crash and the log contains statements from the expected level.
