### PR TITLE
Ensures sockets are disposed properly.

### DIFF
--- a/Tests/Integration/LnsProtocolMessageProcessorConcentratorDeduplicationIntegrationTests.cs
+++ b/Tests/Integration/LnsProtocolMessageProcessorConcentratorDeduplicationIntegrationTests.cs
@@ -28,11 +28,11 @@ namespace LoRaWan.Tests.Integration
     {
         private const string TestDataFrame =
             @"{msgtype: 'updf', MHdr: 128, DevAddr: 58772467, FCtrl: 0, FCnt: 164, FOpts: '', FPort: 8, FRMPayload: '5ABBBA', MIC: -1943282916, RefTime: 0.0, DR: 4, Freq: 868100000, upinfo: {rctx: 0, xtime: 40250921680313459, gpstime: 0, fts: -1, rssi: -60, snr: 9, rxtime: 1635347491.917289}}";
-
         private const string TestJoinRequest =
             @"{msgtype: 'jreq', MHdr:0, JoinEui: '47-62-78-C8-E5-D2-C4-B5', DevEui:'85-27-C1-DF-EE-A4-16-9E', DevNonce: 54360, MIC: -1056607131, RefTime: 0.000000, DR: 5, Freq: 868500000, upinfo: { rctx: 0, xtime: 68116944372333395, gpstime: 0, fts: -1, rssi: -54, snr: 7.25, rxtime: 1636131668.725738}}";
 
         private IHost testHost;
+        private WebSocket socket1, socket2;
 
         public Task InitializeAsync() => Task.CompletedTask;
 
@@ -75,15 +75,15 @@ namespace LoRaWan.Tests.Integration
 
             // act
             var validJsonMessage = JsonUtil.Strictify(message);
-            var socket1 = await wsClient.ConnectAsync(wsUri1, CancellationToken.None);
-            var socket2 = await wsClient.ConnectAsync(wsUri2, CancellationToken.None);
+            this.socket1 = await wsClient.ConnectAsync(wsUri1, CancellationToken.None);
+            this.socket2 = await wsClient.ConnectAsync(wsUri2, CancellationToken.None);
 
-            await socket1.SendAsync(Encoding.UTF8.GetBytes(validJsonMessage), WebSocketMessageType.Text, true, default);
-            await socket2.SendAsync(Encoding.UTF8.GetBytes(validJsonMessage), WebSocketMessageType.Text, true, default);
+            await this.socket1.SendAsync(Encoding.UTF8.GetBytes(validJsonMessage), WebSocketMessageType.Text, true, default);
+            await this.socket2.SendAsync(Encoding.UTF8.GetBytes(validJsonMessage), WebSocketMessageType.Text, true, default);
 
             await Task.Delay(10); // adding a small delay to ensure messages are sent before closing the socket
-            await socket1.CloseAsync(WebSocketCloseStatus.NormalClosure, "Byebye", default);
-            await socket2.CloseAsync(WebSocketCloseStatus.NormalClosure, "Byebye", default);
+            await this.socket1.CloseAsync(WebSocketCloseStatus.NormalClosure, "Byebye", default);
+            await this.socket2.CloseAsync(WebSocketCloseStatus.NormalClosure, "Byebye", default);
 
             // assert
             Assert.Equal(expectedMessagesUpstream, dispatcherCounter);
@@ -91,6 +91,9 @@ namespace LoRaWan.Tests.Integration
 
         public async Task DisposeAsync()
         {
+            this.socket1?.Dispose();
+            this.socket2?.Dispose();
+
             await this.testHost?.StopAsync();
             this.testHost?.Dispose();
         }


### PR DESCRIPTION
# PR for issue #827

## What is being addressed

This PR ensures that the web sockets we are opening are properly disposed at the end of the test.

The original issue #827  is about stabilizing the test in the CI, however I was not able to reproduce the failure anymore after multiple tries in dev. I also was not able to reproduce this locally running in a loop up to 50 test runs. Potentially the underlying issue was fixed already in #847 

## How is this addressed

By calling `Dispose()` on the sockets.
