### PR TITLE
Remove unused `LoRaDeviceAPIService.CheckDuplicateMsgAsync`

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIService.cs
@@ -49,23 +49,6 @@ namespace LoRaWan.NetworkServer
             return 0;
         }
 
-        public override async Task<DeduplicationResult> CheckDuplicateMsgAsync(string devEUI, uint fcntUp, string gatewayId, uint fcntDown)
-        {
-            var client = this.serviceFacadeHttpClientProvider.GetHttpClient();
-            var url = GetFullUri($"DuplicateMsgCheck/{devEUI}?code={AuthCode}&FCntUp={fcntUp}&GatewayId={gatewayId}&FCntDown={fcntDown}");
-
-            var response = await client.GetAsync(url);
-            if (!response.IsSuccessStatusCode)
-            {
-                this.logger.LogError($"error calling the DuplicateMsgCheck function, check the function log. {response.ReasonPhrase}");
-                return null;
-            }
-
-            var payload = await response.Content.ReadAsStringAsync();
-            this.logger.LogDebug($"deduplication response: '{payload}'");
-            return JsonConvert.DeserializeObject<DeduplicationResult>(payload);
-        }
-
         public override async Task<FunctionBundlerResult> ExecuteFunctionBundlerAsync(string devEUI, FunctionBundlerRequest request)
         {
             var client = this.serviceFacadeHttpClientProvider.GetHttpClient();

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIServiceBase.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceAPIServiceBase.cs
@@ -55,16 +55,6 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         public void SetAuthCode(string value) => AuthCode = value;
 
-        /// <summary>
-        /// Validates if the specified message from the device
-        /// was already processed by any gateway in the system.
-        /// </summary>
-        /// <param name="devEUI">Device identifier.</param>
-        /// <param name="fcntUp">frame count of the message we received.</param>
-        /// <param name="gatewayId">The current processing gateway.</param>
-        /// <param name="fcntDown">The frame count down of the client.</returns>
-        public abstract Task<DeduplicationResult> CheckDuplicateMsgAsync(string devEUI, uint fcntUp, string gatewayId, uint fcntDown);
-
         public abstract Task<FunctionBundlerResult> ExecuteFunctionBundlerAsync(string devEUI, FunctionBundlerRequest request);
 
         protected LoRaDeviceAPIServiceBase()


### PR DESCRIPTION
# PR for issue #866

## What is being addressed

`LoRaDeviceAPIService.CheckDuplicateMsgAsync` is never called anywhere.

## How is this addressed

`LoRaDeviceAPIService.CheckDuplicateMsgAsync` is removed.
