### PR TITLE
Make function bundler's context read-only

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FunctionBundler/FunctionBundlerExecutionContext.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FunctionBundler/FunctionBundlerExecutionContext.cs
@@ -7,18 +7,31 @@ namespace LoRaWan.NetworkServer
 
     public class FunctionBundlerExecutionContext
     {
-        public string GatewayId { get; set; }
+        public FunctionBundlerExecutionContext(string gatewayId, uint fCntUp, uint fCntDown,
+                                               LoRaPayloadData loRaPayload, LoRaDevice loRaDevice,
+                                               IDeduplicationStrategyFactory deduplicationFactory, LoRaRequest request)
+        {
+            GatewayId = gatewayId;
+            FCntUp = fCntUp;
+            FCntDown = fCntDown;
+            LoRaPayload = loRaPayload;
+            LoRaDevice = loRaDevice;
+            DeduplicationFactory = deduplicationFactory;
+            Request = request;
+        }
 
-        public uint FCntUp { get; set; }
+        public string GatewayId { get; }
 
-        public uint FCntDown { get; set; }
+        public uint FCntUp { get; }
 
-        public LoRaPayloadData LoRaPayload { get; set; }
+        public uint FCntDown { get; }
 
-        public LoRaDevice LoRaDevice { get; set; }
+        public LoRaPayloadData LoRaPayload { get; }
 
-        public IDeduplicationStrategyFactory DeduplicationFactory { get; set; }
+        public LoRaDevice LoRaDevice { get; }
 
-        public LoRaRequest Request { get; set; }
+        public IDeduplicationStrategyFactory DeduplicationFactory { get; }
+
+        public LoRaRequest Request { get; }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FunctionBundler/FunctionBundlerProvider.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FunctionBundler/FunctionBundlerProvider.cs
@@ -45,16 +45,8 @@ namespace LoRaWan.NetworkServer
                 return null;
             }
 
-            var context = new FunctionBundlerExecutionContext
-            {
-                DeduplicationFactory = deduplicationFactory,
-                FCntDown = loRaDevice.FCntDown,
-                FCntUp = loRaPayload.GetFcnt(),
-                GatewayId = gatewayId,
-                LoRaDevice = loRaDevice,
-                LoRaPayload = loRaPayload,
-                Request = request
-            };
+            var context = new FunctionBundlerExecutionContext(gatewayId, loRaPayload.GetFcnt(), loRaDevice.FCntDown,
+                                                              loRaPayload, loRaDevice, deduplicationFactory, request);
 
             var qualifyingExecutionItems = new List<IFunctionBundlerExecutionItem>(functionItems.Count);
             for (var i = 0; i < functionItems.Count; i++)


### PR DESCRIPTION
## What is being addressed

Required properties of `FunctionBundlerExecutionContext` and whether it is modifiable after creation/initialisation.

## How is this addressed

Renders `FunctionBundlerExecutionContext` read-only by removing property setters and requires initialisation of the context through a constructor.

This makes the initialisation requirements clear and whether the context can ever be modified after creation/initialisation.