### PR TITLE
Support CUPS when provisioning a concentrator device via CLI

### DIFF
--- a/Tools/Cli-LoRa-Device-Provisioning/Cli-LoRa-Device-Provisioning.csproj
+++ b/Tools/Cli-LoRa-Device-Provisioning/Cli-LoRa-Device-Provisioning.csproj
@@ -32,7 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Crc32.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.22.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/AddOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/AddOptions.cs
@@ -10,6 +10,9 @@ namespace LoRaWan.Tools.CLI.Options
     [Verb("add", HelpText = "Add a new device to IoT Hub.")]
     public class AddOptions
     {
+        private const string ConcentratorSetName = "Contentrator";
+        private const string LoRaDeviceSetName = "LoRaDevice";
+
         [Option(
             "type",
             Required = true,
@@ -19,175 +22,204 @@ namespace LoRaWan.Tools.CLI.Options
         [Option(
             "region",
             Required = false,
-            HelpText = "Region: Required for 'Concentrator' type devices. Must be the name of one of the regions in the DefaultRouterConfig folder.")]
+            HelpText = "Region: Required for 'Concentrator' type devices. Must be the name of one of the regions in the DefaultRouterConfig folder.",
+            SetName = ConcentratorSetName)]
         public string Region { get; set; }
 
         [Option(
             "stationeui",
             Required = false,
-            HelpText = "Station EUI: Required for 'Concentrator' type devices. A 16 bit hex string ('AABBCCDDEEFFGGHH').")]
+            HelpText = "Station EUI: Required for 'Concentrator' type devices. A 16 bit hex string ('AABBCCDDEEFFGGHH').",
+            SetName = ConcentratorSetName)]
         public string StationEui { get; set; }
 
         [Option(
             "no-cups",
             Required = false,
-            HelpText = "No CUPS: Only applicable to 'Concentrator' type devices. If set to true indicates that the concentrator does not use CUPS.")]
+            HelpText = "No CUPS: Only applicable to 'Concentrator' type devices. If set to true indicates that the concentrator does not use CUPS.",
+            SetName = ConcentratorSetName)]
         public bool NoCups { get; set; }
 
         [Option(
             "certificate-bundle-location",
             Required = false,
-            HelpText = "Certificate bundle location: Required if --no-cups set to false. Points to the location of the (UTF-8-encoded) certificate bundle file.")]
+            HelpText = "Certificate bundle location: Required if --no-cups set to false. Points to the location of the (UTF-8-encoded) certificate bundle file.",
+            SetName = ConcentratorSetName)]
         public string CertificateBundleLocation { get; set; }
 
         [Option(
             "client-certificate-thumbprint",
             Required = false,
-            HelpText = "Client certificate thumbprint: Required if --no-cups set to false. A list of client certificate thumbprints (separated by a space) that should be accepted by the CUPS/LNS endpoints.")]
+            HelpText = "Client certificate thumbprint: Required if --no-cups set to false. A list of client certificate thumbprints (separated by a space) that should be accepted by the CUPS/LNS endpoints.",
+            SetName = ConcentratorSetName)]
         public IEnumerable<string> ClientCertificateThumbprints { get; set; }
 
         [Option(
             "tc-uri",
             Required = false,
-            HelpText = "LoRaWAN Network Server URI: Required if --no-cups set to false. The URI of the LNS endpoint. Protocol must be set to wss://")]
+            HelpText = "LoRaWAN Network Server URI: Required if --no-cups set to false. The URI of the LNS endpoint. Protocol must be set to wss://",
+            SetName = ConcentratorSetName)]
         public Uri TcUri { get; set; }
 
         [Option(
-           "cups-uri",
-           Required = false,
-           HelpText = "LoRaWAN Network Server URI: Required if --no-cups set to false. The URI of the CUPS endpoint. Protocol must be set to https://")]
+            "cups-uri",
+            Required = false,
+            HelpText = "LoRaWAN Network Server URI: Required if --no-cups set to false. The URI of the CUPS endpoint. Protocol must be set to https://",
+            SetName = ConcentratorSetName)]
         public Uri CupsUri { get; set; }
 
         [Option(
             "deveui",
             Required = false,
-            HelpText = "DevEUI / Device Id: A 16 bit hex string. Will be randomly generated if left blank.")]
+            HelpText = "DevEUI / Device Id: A 16 bit hex string. Will be randomly generated if left blank.",
+            SetName = LoRaDeviceSetName)]
         public string DevEui { get; set; }
 
         [Option(
             "appskey",
             Required = false,
-            HelpText = "AppSKey (Only for ABP devices): A 16 bit hex string. Will be randomly generated if left blank.")]
+            HelpText = "AppSKey (Only for ABP devices): A 16 bit hex string. Will be randomly generated if left blank.",
+            SetName = LoRaDeviceSetName)]
         public string AppSKey { get; set; }
 
         [Option(
             "nwkskey",
             Required = false,
-            HelpText = "NwkSKey (Only for ABP devices): A 16 bit hex string. Will be randomly generated if left blank.")]
+            HelpText = "NwkSKey (Only for ABP devices): A 16 bit hex string. Will be randomly generated if left blank.",
+            SetName = LoRaDeviceSetName)]
         public string NwkSKey { get; set; }
 
         [Option(
             "devaddr",
             Required = false,
-            HelpText = "DevAddr (Only for ABP devices): A 4 bit hex string. Will be randomly generated if left blank.")]
+            HelpText = "DevAddr (Only for ABP devices): A 4 bit hex string. Will be randomly generated if left blank.",
+            SetName = LoRaDeviceSetName)]
         public string DevAddr { get; set; }
 
         [Option(
             "netid",
             Required = false,
-            HelpText = "Network ID (Only for ABP devices): A 3 bit hex string. Will default to 000001 or NetId set in settings file if left blank. (optional)")]
+            HelpText = "Network ID (Only for ABP devices): A 3 bit hex string. Will default to 000001 or NetId set in settings file if left blank. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string NetId { get; set; }
 
         [Option(
             "abprelaxmode",
             Required = false,
-            HelpText = "ABPRelaxMode (ABP relaxed framecounter, only for ABP devices): True or false. (optional)")]
+            HelpText = "ABPRelaxMode (ABP relaxed framecounter, only for ABP devices): True or false. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string ABPRelaxMode { get; set; }
 
         [Option(
             "appeui",
             Required = false,
-            HelpText = "AppEUI (only for OTAA devices): A 16 bit hex string. Will be randomly generated if left blank.")]
+            HelpText = "AppEUI (only for OTAA devices): A 16 bit hex string. Will be randomly generated if left blank.",
+            SetName = LoRaDeviceSetName)]
         public string AppEui { get; set; }
 
         [Option(
             "appkey",
             Required = false,
-            HelpText = "AppKey (only for OTAA devices): A 16 bit hex string. Will be randomly generated if left blank.")]
+            HelpText = "AppKey (only for OTAA devices): A 16 bit hex string. Will be randomly generated if left blank.",
+            SetName = LoRaDeviceSetName)]
         public string AppKey { get; set; }
 
         [Option(
             "gatewayid",
             Required = false,
-            HelpText = "GatewayID: A hostname. (optional)")]
+            HelpText = "GatewayID: A hostname. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string GatewayId { get; set; }
 
         [Option(
             "decoder",
             Required = false,
-            HelpText = "SensorDecoder: The name of an integrated decoder function or the URI to a decoder in a custom decoder module in the format: http://modulename/api/decodername. (optional)")]
+            HelpText = "SensorDecoder: The name of an integrated decoder function or the URI to a decoder in a custom decoder module in the format: http://modulename/api/decodername. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string SensorDecoder { get; set; }
 
         [Option(
             "classtype",
             Required = false,
-            HelpText = "ClassType: \"A\" (default) or \"C\". (optional)")]
+            HelpText = "ClassType: \"A\" (default) or \"C\". (optional)",
+            SetName = LoRaDeviceSetName)]
         public string ClassType { get; set; }
 
         [Option(
             "downlinkenabled",
             Required = false,
-            HelpText = "DownlinkEnabled: True or false. (optional)")]
+            HelpText = "DownlinkEnabled: True or false. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string DownlinkEnabled { get; set; }
 
         [Option(
             "preferredwindow",
             Required = false,
-            HelpText = "PreferredWindow (Preferred receive window): 1 or 2. (optional)")]
+            HelpText = "PreferredWindow (Preferred receive window): 1 or 2. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string PreferredWindow { get; set; }
 
         [Option(
             "deduplication",
             Required = false,
-            HelpText = "Deduplication: None (default), Drop or Mark. (optional)")]
+            HelpText = "Deduplication: None (default), Drop or Mark. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string Deduplication { get; set; }
 
         [Option(
             "rx2datarate",
             Required = false,
-            HelpText = "Rx2DataRate (Receive window 2 data rate, currently only supported for OTAA devices): Any of the allowed data rates. EU: SF12BW125, SF11BW125, SF10BW125, SF8BW125, SF7BW125, SF7BW250 or 50. US: SF10BW125, SF9BW125, SF8BW125, SF7BW125, SF8BW500, SF12BW500, SF11BW500, SF10BW500, SF9BW500, SF8BW500, SF8BW500. (optional).")]
+            HelpText = "Rx2DataRate (Receive window 2 data rate, currently only supported for OTAA devices): Any of the allowed data rates. EU: SF12BW125, SF11BW125, SF10BW125, SF8BW125, SF7BW125, SF7BW250 or 50. US: SF10BW125, SF9BW125, SF8BW125, SF7BW125, SF8BW500, SF12BW500, SF11BW500, SF10BW500, SF9BW500, SF8BW500, SF8BW500. (optional).",
+            SetName = LoRaDeviceSetName)]
         public string Rx2DataRate { get; set; }
 
         [Option(
             "rx1droffset",
             Required = false,
-            HelpText = "Rx1DrOffset (Receive window 1 data rate offset, currently only supported for OTAA devices): 0 through 15. (optional)")]
+            HelpText = "Rx1DrOffset (Receive window 1 data rate offset, currently only supported for OTAA devices): 0 through 15. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string Rx1DrOffset { get; set; }
 
         [Option(
             "rxdelay",
             Required = false,
-            HelpText = "RxDelay (Delay in seconds for sending downstream messages, currently only supported for OTAA devices): 0 through 15. (optional)")]
+            HelpText = "RxDelay (Delay in seconds for sending downstream messages, currently only supported for OTAA devices): 0 through 15. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string RxDelay { get; set; }
 
         [Option(
             "keepalivetimeout",
             Required = false,
-            HelpText = "KeepAliveTimeout (Timeout in seconds before device client connection is closed): 0 or 60 and above. (optional)")]
+            HelpText = "KeepAliveTimeout (Timeout in seconds before device client connection is closed): 0 or 60 and above. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string KeepAliveTimeout { get; set; }
 
         [Option(
             "supports32bitfcnt",
             Required = false,
-            HelpText = "Supports32BitFCnt (Support for 32bit frame counter): True or false. (optional)")]
+            HelpText = "Supports32BitFCnt (Support for 32bit frame counter): True or false. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string Supports32BitFCnt { get; set; }
 
         [Option(
             "fcntupstart",
             Required = false,
-            HelpText = "FCntUpStart (Frame counter up start value): 0 through 4294967295. (optional)")]
+            HelpText = "FCntUpStart (Frame counter up start value): 0 through 4294967295. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string FCntUpStart { get; set; }
 
         [Option(
             "fcntdownstart",
             Required = false,
-            HelpText = "FCntDownStart (Frame counter down start value): 0 through 4294967295. (optional)")]
+            HelpText = "FCntDownStart (Frame counter down start value): 0 through 4294967295. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string FCntDownStart { get; set; }
 
         [Option(
             "fcntresetcounter",
             Required = false,
-            HelpText = "FCntResetCounter (Frame counter reset counter value): 0 through 4294967295. (optional)")]
+            HelpText = "FCntResetCounter (Frame counter reset counter value): 0 through 4294967295. (optional)",
+            SetName = LoRaDeviceSetName)]
         public string FCntResetCounter { get; set; }
     }
 }

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/AddOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/AddOptions.cs
@@ -3,6 +3,8 @@
 
 namespace LoRaWan.Tools.CLI.Options
 {
+    using System;
+    using System.Collections.Generic;
     using CommandLine;
 
     [Verb("add", HelpText = "Add a new device to IoT Hub.")]
@@ -17,14 +19,44 @@ namespace LoRaWan.Tools.CLI.Options
         [Option(
             "region",
             Required = false,
-            HelpText = "Region: Only required for 'Concentrator' type devices. Must be the name of one of the regions in the DefaultRouterConfig folder.")]
+            HelpText = "Region: Required for 'Concentrator' type devices. Must be the name of one of the regions in the DefaultRouterConfig folder.")]
         public string Region { get; set; }
 
         [Option(
             "stationeui",
             Required = false,
-            HelpText = "Station EUI: A 16 bit hex string ('AABBCCDDEEFFGGHH'). Required if 'Concentrator' device.")]
+            HelpText = "Station EUI: Required for 'Concentrator' type devices. A 16 bit hex string ('AABBCCDDEEFFGGHH').")]
         public string StationEui { get; set; }
+
+        [Option(
+            "no-cups",
+            Required = false,
+            HelpText = "No CUPS: Only applicable to 'Concentrator' type devices. If set to true indicates that the concentrator does not use CUPS.")]
+        public bool NoCups { get; set; }
+
+        [Option(
+            "certificate-bundle-location",
+            Required = false,
+            HelpText = "Certificate bundle location: Required if --no-cups set to false. Points to the location of the (UTF-8-encoded) certificate bundle file.")]
+        public string CertificateBundleLocation { get; set; }
+
+        [Option(
+            "client-certificate-thumbprint",
+            Required = false,
+            HelpText = "Client certificate thumbprint: Required if --no-cups set to false. A list of client certificate thumbprints (separated by a space) that should be accepted by the CUPS/LNS endpoints.")]
+        public IEnumerable<string> ClientCertificateThumbprints { get; set; }
+
+        [Option(
+            "tc-uri",
+            Required = false,
+            HelpText = "LoRaWAN Network Server URI: Required if --no-cups set to false. The URI of the LNS endpoint. Protocol must be set to wss://")]
+        public Uri TcUri { get; set; }
+
+        [Option(
+           "cups-uri",
+           Required = false,
+           HelpText = "LoRaWAN Network Server URI: Required if --no-cups set to false. The URI of the CUPS endpoint. Protocol must be set to https://")]
+        public Uri CupsUri { get; set; }
 
         [Option(
             "deveui",

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
@@ -11,6 +11,7 @@ namespace LoRaWan.Tools.CLI.Helpers
 
     public class ConfigurationHelper
     {
+        private const string CredentialsStorageContainerName = "stationcredentials";
         public string NetId { get; set; }
 
         public RegistryManager RegistryManager { get; set; }
@@ -18,7 +19,7 @@ namespace LoRaWan.Tools.CLI.Helpers
 
         public bool ReadConfig()
         {
-            string connectionString, netId, credentialStorageConnectionString, credentialStorageContainerName;
+            string connectionString, netId, credentialStorageConnectionString;
 
             Console.WriteLine("Reading configuration file \"appsettings.json\"...");
 
@@ -33,7 +34,6 @@ namespace LoRaWan.Tools.CLI.Helpers
 
                 connectionString = configurationBuilder["IoTHubConnectionString"];
                 credentialStorageConnectionString = configurationBuilder["CredentialStorageConnectionString"];
-                credentialStorageContainerName = configurationBuilder["CredentialStorageContainerName"];
                 netId = configurationBuilder["NetId"];
             }
             catch (Exception ex)
@@ -103,7 +103,7 @@ namespace LoRaWan.Tools.CLI.Helpers
 
             try
             {
-                CertificateStorageContainerClient = new BlobContainerClient(credentialStorageConnectionString, credentialStorageContainerName);
+                CertificateStorageContainerClient = new BlobContainerClient(credentialStorageConnectionString, CredentialsStorageContainerName);
             }
             catch (FormatException)
             {

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -923,8 +923,10 @@ namespace LoRaWan.Tools.CLI.Helpers
                 TrackErrorIf(!opts.ClientCertificateThumbprints.Any(), "CUPS is enabled but no client certificate thumbprints were specified.");
                 TrackErrorIf(opts.TcUri is null, "CUPS is enabled but TC URI is not defined.");
                 TrackErrorIf(opts.TcUri is { } tcUri && !tcUri.Scheme.Equals("wss", StringComparison.OrdinalIgnoreCase), "CUPS is enabled but TC URI is not in wss:// protocol.");
+                TrackErrorIf(opts.TcUri is { } tu && tu.Port != 5001, "CUPS is enabled but TC URI does not point to port 5001.");
                 TrackErrorIf(opts.CupsUri is null, "CUPS is enabled but CUPS URI is not defined");
                 TrackErrorIf(opts.CupsUri is { } cupsUri && !cupsUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase), "CUPS is enabled but CUPS URI is not in https:// protocol.");
+                TrackErrorIf(opts.CupsUri is { } cu && cu.Port != 443, "CUPS is enabled but CUPS URI does not point to port 443.");
             }
 
             void TrackErrorIf(bool hasError, string message)

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -909,51 +909,48 @@ namespace LoRaWan.Tools.CLI.Helpers
             var isValid = true;
             if (string.IsNullOrEmpty(opts.StationEui))
             {
-                StatusConsole.WriteLogLine(MessageType.Error, "'Concentrator' device type has been specified but StationEui option is missing.");
-                isValid = false;
+                TrackError("'Concentrator' device type has been specified but StationEui option is missing.");
             }
             if (string.IsNullOrEmpty(opts.Region))
             {
-                StatusConsole.WriteLogLine(MessageType.Error, "'Concentrator' device type has been specified but Region option is missing.");
-                isValid = false;
+                TrackError("'Concentrator' device type has been specified but Region option is missing.");
             }
             else if (!File.Exists(Path.Combine(DefaultRouterConfigFolder, $"{opts.Region.ToUpperInvariant()}.json")))
             {
-                StatusConsole.WriteLogLine(MessageType.Error, $"'Concentrator' device type has been specified with Region '{opts.Region.ToUpperInvariant()}' but no default router config file was found.");
-                isValid = false;
+                TrackError($"'Concentrator' device type has been specified with Region '{opts.Region.ToUpperInvariant()}' but no default router config file was found.");
             }
             if (!opts.NoCups)
             {
                 if (!File.Exists(opts.CertificateBundleLocation))
                 {
-                    StatusConsole.WriteLogLine(MessageType.Error, $"CUPS is enabled but no certificate bundle was found at the specified location.");
-                    isValid = false;
+                    TrackError("CUPS is enabled but no certificate bundle was found at the specified location.");
                 }
                 if (!opts.ClientCertificateThumbprints.Any())
                 {
-                    StatusConsole.WriteLogLine(MessageType.Error, $"CUPS is enabled but no client certificate thumbprints were specified.");
-                    isValid = false;
+                    TrackError("CUPS is enabled but no client certificate thumbprints were specified.");
                 }
                 if (opts.TcUri is null)
                 {
-                    StatusConsole.WriteLogLine(MessageType.Error, $"CUPS is enabled but TC URI is not defined.");
-                    isValid = false;
+                    TrackError("CUPS is enabled but TC URI is not defined.");
                 }
                 else if (!opts.TcUri.Scheme.Equals("wss", StringComparison.OrdinalIgnoreCase))
                 {
-                    StatusConsole.WriteLogLine(MessageType.Error, $"CUPS is enabled but TC URI is not in wss:// protocol.");
-                    isValid = false;
+                    TrackError("CUPS is enabled but TC URI is not in wss:// protocol.");
                 }
                 if (opts.CupsUri is null)
                 {
-                    StatusConsole.WriteLogLine(MessageType.Error, $"CUPS is enabled but CUPS URI is not defined.");
-                    isValid = false;
+                    TrackError($"CUPS is enabled but CUPS URI is not defined.");
                 }
                 else if (!opts.CupsUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
                 {
-                    StatusConsole.WriteLogLine(MessageType.Error, $"CUPS is enabled but CUPS URI is not in https:// protocol.");
-                    isValid = false;
+                    TrackError("CUPS is enabled but CUPS URI is not in https:// protocol.");
                 }
+            }
+
+            void TrackError(string message)
+            {
+                StatusConsole.WriteLogLine(MessageType.Error, message);
+                isValid = false;
             }
 
             return isValid;

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -939,7 +939,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             return isValid;
         }
 
-        public Twin CreateConcentratorTwin(AddOptions opts, int crcChecksum, Uri certificateBundleLocation)
+        public Twin CreateConcentratorTwin(AddOptions opts, uint crcChecksum, Uri certificateBundleLocation)
         {
             var twinProperties = new TwinProperties();
             Console.WriteLine();

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.Tools.CLI
 {
     using System;
+    using System.Buffers.Binary;
     using System.IO;
     using System.Text;
     using System.Text.RegularExpressions;
@@ -185,7 +186,7 @@ namespace LoRaWan.Tools.CLI
                 try
                 {
                     var crc = new Force.Crc32.Crc32Algorithm();
-                    var crcHash = BitConverter.ToInt32(crc.ComputeHash(Encoding.UTF8.GetBytes(certificateContent)));
+                    var crcHash = BinaryPrimitives.ReadUInt32BigEndian(crc.ComputeHash(Encoding.UTF8.GetBytes(certificateContent)));
                     var twin = iotDeviceHelper.CreateConcentratorTwin(opts, crcHash, blobClient.Uri);
                     return await iotDeviceHelper.WriteDeviceTwin(twin, opts.StationEui, configurationHelper, true);
                 }

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -174,7 +174,7 @@ namespace LoRaWan.Tools.CLI
                 }
                 catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobAlreadyExists)
                 {
-                    StatusConsole.WriteLogLine(MessageType.Error, $"Uploading certificate bundle failed because bundle already exists. Please use the 'update' verb to update an existing certificate.");
+                    StatusConsole.WriteLogLine(MessageType.Error, $"Uploading certificate bundle failed because bundle already exists. Please use the 'update' verb to update existing concentrator configuration.");
                     return false;
                 }
                 catch (RequestFailedException ex)

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -13,9 +13,7 @@ namespace LoRaWan.Tools.CLI
     using CommandLine;
     using LoRaWan.Tools.CLI.Helpers;
     using LoRaWan.Tools.CLI.Options;
-    using Microsoft.Azure.Devices.Common.Exceptions;
     using Microsoft.Azure.Devices.Shared;
-    using Newtonsoft.Json.Linq;
 
     public class Program
     {

--- a/Tools/Cli-LoRa-Device-Provisioning/TwinProperty.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/TwinProperty.cs
@@ -39,7 +39,16 @@ namespace LoRaWan.Tools.CLI
 
         public const string RXDelay = "RXDelay";
 
+        // Station twin
         public const string RouterConfig = "routerConfig";
+        public const string ClientThumbprint = "clientThumbprint";
+        public const string Cups = "cups";
+        public const string CupsUri = "cupsUri";
+        public const string TcUri = "tcUri";
+        public const string CupsCredentialCrc = "cupsCredCrc";
+        public const string TcCredentialCrc = "tcCredCrc";
+        public const string TcCredentialUrl = "tcCredentialUrl";
+        public const string CupsCredentialUrl = "cupsCredentialUrl";
 
         /// <summary>
         /// Defines the connection keep alive timeout

--- a/Tools/Cli-LoRa-Device-Provisioning/appsettings.json
+++ b/Tools/Cli-LoRa-Device-Provisioning/appsettings.json
@@ -1,6 +1,5 @@
 {
   "IoTHubConnectionString": "Your IoT Hub Connection String (iothubowner) here.",
   "NetId": "1",
-  "CredentialStorageContainerName": "stationcredentials",
   "CredentialStorageConnectionString": "Your Storage Account connection string here."
 }

--- a/Tools/Cli-LoRa-Device-Provisioning/appsettings.json
+++ b/Tools/Cli-LoRa-Device-Provisioning/appsettings.json
@@ -1,4 +1,6 @@
 {
   "IoTHubConnectionString": "Your IoT Hub Connection String (iothubowner) here.",
-  "NetId": "1"
+  "NetId": "1",
+  "CredentialStorageContainerName": "stationcredentials",
+  "CredentialStorageConnectionString": "Your Storage Account connection string here."
 }


### PR DESCRIPTION
# PR for issue #874

## What is being addressed

With this PR we add support to the device provisioning CLI to support CUPS when creating a concentrator device.

## How is this addressed

We add the necessary CLI options, validate them, upload the certs bundle to a storage container and set the device twin configuration as described in [the ADR](https://azure.github.io/iotedge-lorawan-starterkit/dev/adr/006_cups/)

An example command might look like this: `cli.exe add --type concentrator --stationeui 11F5A90000000012 --region EU863 --client-certificate-thumbprint somethumbprint --certificate-bundle-location "C:/someclientcert.bundle" --cups-uri https://aka.ms --tc-uri wss://aka.ms` or `cli.exe add --type concentrator --stationeui 11F5A90000000012 --region EU863 --no-cups`