### PR TITLE
Feature/876 certificate rotation cli

### DIFF
--- a/Tools/Cli-LoRa-Device-Provisioning/Cli-LoRa-Device-Provisioning.csproj
+++ b/Tools/Cli-LoRa-Device-Provisioning/Cli-LoRa-Device-Provisioning.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.36.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RevokeOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RevokeOptions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tools.CLI.CommandLineOptions
+{
+    using CommandLine;
+
+    [Verb("revoke", HelpText = "Revokes a client certificate thumbprint for a station.")]
+    public class RevokeOptions
+    {
+        public RevokeOptions(string stationEui, string clientCertificateThumbprint)
+        {
+            StationEui = stationEui;
+            ClientCertificateThumbprint = clientCertificateThumbprint;
+        }
+
+        [Option("stationeui",
+                Required = true,
+                HelpText = "Station EUI: Required id '--concentrator' switch is set. A 16 bit hex string ('AABBCCDDEEFFGGHH').")]
+        public string StationEui { get; }
+
+        [Option("client-certificate-thumbprint",
+                Required = true,
+                HelpText = "Client certificate thumbprint: A client certificate thumbprint that should be accepted by the CUPS/LNS endpoints.")]
+        public string ClientCertificateThumbprint { get; }
+    }
+}

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RotateCertificateOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RotateCertificateOptions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tools.CLI.CommandLineOptions
+{
+    using CommandLine;
+
+    [Verb("rotate-certificate", HelpText = "Rotates the certificates for a station.")]
+    public class RotateCertificateOptions
+    {
+        [Option("stationeui",
+                Required = true,
+                HelpText = "Station EUI: Required id '--concentrator' switch is set. A 16 bit hex string ('AABBCCDDEEFFGGHH').")]
+        public string StationEui { get; set; }
+
+        [Option("certificate-bundle-location",
+                Required = true,
+                HelpText = "Certificate bundle location: Points to the location of the (UTF-8-encoded) certificate bundle file.")]
+        public string CertificateBundleLocation { get; set; }
+
+        [Option("client-certificate-thumbprint",
+                Required = true,
+                HelpText = "Client certificate thumbprint: A client certificate thumbprint that should be accepted by the CUPS/LNS endpoints.")]
+        public string ClientCertificateThumbprint { get; set; }
+    }
+}

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RotateCertificateOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RotateCertificateOptions.cs
@@ -8,19 +8,26 @@ namespace LoRaWan.Tools.CLI.CommandLineOptions
     [Verb("rotate-certificate", HelpText = "Rotates the certificates for a station.")]
     public class RotateCertificateOptions
     {
+        public RotateCertificateOptions(string stationEui, string certificateBundleLocation, string clientCertificateThumbprint)
+        {
+            StationEui = stationEui;
+            CertificateBundleLocation = certificateBundleLocation;
+            ClientCertificateThumbprint = clientCertificateThumbprint;
+        }
+
         [Option("stationeui",
                 Required = true,
                 HelpText = "Station EUI: Required id '--concentrator' switch is set. A 16 bit hex string ('AABBCCDDEEFFGGHH').")]
-        public string StationEui { get; set; }
+        public string StationEui { get; }
 
         [Option("certificate-bundle-location",
                 Required = true,
                 HelpText = "Certificate bundle location: Points to the location of the (UTF-8-encoded) certificate bundle file.")]
-        public string CertificateBundleLocation { get; set; }
+        public string CertificateBundleLocation { get; }
 
         [Option("client-certificate-thumbprint",
                 Required = true,
                 HelpText = "Client certificate thumbprint: A client certificate thumbprint that should be accepted by the CUPS/LNS endpoints.")]
-        public string ClientCertificateThumbprint { get; set; }
+        public string ClientCertificateThumbprint { get; }
     }
 }

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -954,19 +954,22 @@ namespace LoRaWan.Tools.CLI.Helpers
             var propObject = JsonConvert.DeserializeObject<JObject>(jsonString);
             twinProperties.Desired[TwinProperty.RouterConfig] = propObject;
 
-            // Add CUPS configuration
-            twinProperties.Desired[TwinProperty.Cups] = new JObject
+            if (!opts.NoCups)
             {
-                [TwinProperty.TcCredentialUrl] = certificateBundleLocation,
-                [TwinProperty.TcCredentialCrc] = crcChecksum,
-                [TwinProperty.CupsCredentialUrl] = certificateBundleLocation,
-                [TwinProperty.CupsCredentialCrc] = crcChecksum,
-                [TwinProperty.CupsUri] = opts.CupsUri,
-                [TwinProperty.TcUri] = opts.TcUri,
-            };
+                // Add CUPS configuration
+                twinProperties.Desired[TwinProperty.Cups] = new JObject
+                {
+                    [TwinProperty.TcCredentialUrl] = certificateBundleLocation,
+                    [TwinProperty.TcCredentialCrc] = crcChecksum,
+                    [TwinProperty.CupsCredentialUrl] = certificateBundleLocation,
+                    [TwinProperty.CupsCredentialCrc] = crcChecksum,
+                    [TwinProperty.CupsUri] = opts.CupsUri,
+                    [TwinProperty.TcUri] = opts.TcUri,
+                };
 
-            // Add client certificate thumbprints
-            twinProperties.Desired[TwinProperty.ClientThumbprint] = new JArray(opts.ClientCertificateThumbprints);
+                // Add client certificate thumbprints
+                twinProperties.Desired[TwinProperty.ClientThumbprint] = new JArray(opts.ClientCertificateThumbprints);
+            }
 
             return new Twin
             {

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -907,8 +907,12 @@ namespace LoRaWan.Tools.CLI.Helpers
             var isValid = true;
             TrackErrorIf(string.IsNullOrEmpty(opts.StationEui), "'Concentrator' device type has been specified but StationEui option is missing.");
             TrackErrorIf(string.IsNullOrEmpty(opts.Region), "'Concentrator' device type has been specified but Region option is missing.");
-            TrackErrorIf(opts.Region is { } region && !File.Exists(Path.Combine(DefaultRouterConfigFolder, $"{region.ToUpperInvariant()}.json")),
-                         $"'Concentrator' device type has been specified with Region '{opts.Region.ToUpperInvariant()}' but no default router config file was found.");
+            if (opts.Region is { } region)
+            {
+                TrackErrorIf(!File.Exists(Path.Combine(DefaultRouterConfigFolder, $"{region.ToUpperInvariant()}.json")),
+                             $"'Concentrator' device type has been specified with Region '{region.ToUpperInvariant()}' but no default router config file was found.");
+            }
+
             if (opts.NoCups)
             {
                 TrackErrorIf(opts.TcUri is not null, "TC URI must not be defined if --no-cups is set.");

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -7,9 +7,7 @@ namespace LoRaWan.Tools.CLI.Helpers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using System.Text;
     using System.Threading.Tasks;
-    using Azure.Storage.Blobs;
     using LoRaWan.Tools.CLI.Options;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Shared;

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -174,11 +174,19 @@ namespace LoRaWan.Tools.CLI
                     return false;
                 }
 
-                return await UploadCertificateBundleAsync(opts.CertificateBundleLocation, opts.StationEui, async (crcHash, bundleStorageUri) =>
+                if (opts.NoCups)
                 {
-                    var twin = iotDeviceHelper.CreateConcentratorTwin(opts, crcHash, bundleStorageUri);
+                    var twin = iotDeviceHelper.CreateConcentratorTwin(opts, 0, null);
                     return await iotDeviceHelper.WriteDeviceTwin(twin, opts.StationEui, configurationHelper, true);
-                });
+                }
+                else
+                {
+                    return await UploadCertificateBundleAsync(opts.CertificateBundleLocation, opts.StationEui, async (crcHash, bundleStorageUri) =>
+                    {
+                        var twin = iotDeviceHelper.CreateConcentratorTwin(opts, crcHash, bundleStorageUri);
+                        return await iotDeviceHelper.WriteDeviceTwin(twin, opts.StationEui, configurationHelper, true);
+                    });
+                }
             }
 
             opts = iotDeviceHelper.CompleteMissingAddOptions(opts, configurationHelper);

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -283,12 +283,6 @@ namespace LoRaWan.Tools.CLI
 
             bool isSuccess = false;
 
-            if (string.IsNullOrEmpty(opts.DevEui))
-            {
-                StatusConsole.WriteLogLine(MessageType.Error, "Dev EUI must be defined.");
-                return false;
-            }
-
             opts = iotDeviceHelper.CleanOptions(opts as object, false) as UpdateOptions;
             opts = iotDeviceHelper.CompleteMissingUpdateOptions(opts, configurationHelper);
 

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -279,6 +279,10 @@ namespace LoRaWan.Tools.CLI
             var twinJObject = JsonConvert.DeserializeObject<JObject>(twin.Properties.Desired.ToJson());
             var clientThumprints = twinJObject[TwinProperty.ClientThumbprint];
             var t = clientThumprints.FirstOrDefault(t => t.ToString().Equals(opts.ClientCertificateThumbprint, StringComparison.OrdinalIgnoreCase));
+
+            if (t is null)
+                StatusConsole.WriteLogLine(MessageType.Error, "Specified thumbprint not found.");
+
             t?.Remove();
             twin.Properties.Desired[TwinProperty.ClientThumbprint] = clientThumprints;
             return await iotDeviceHelper.WriteDeviceTwin(twin, opts.StationEui, configurationHelper, isNewDevice: false);


### PR DESCRIPTION
# PR for issue #876

## What is being addressed

With this PR we introduce support for certificate rotation. This includes uploading new certificates, and revoking old client thumbprints

## How is this addressed

We add two new verbs to the CLI. One can be used to upload a new client certificate, while the other can be used to revoke an accepted thumbprint.
