### PR TITLE
Feature/907 Azure Function for fetching concentrator credentials

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/ConcentratorCredentialsFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ConcentratorCredentialsFunction.cs
@@ -94,7 +94,7 @@ namespace LoraKeysManagerFacade
                 catch (Exception ex) when (ex is ArgumentOutOfRangeException or JsonReaderException)
                 {
                     log.LogError("'{PropertyName}' desired property was not found or misconfigured.", CupsPropertyName);
-                    throw;
+                    return new UnprocessableEntityResult();
                 }
             }
             else

--- a/LoRaEngine/LoraKeysManagerFacade/ConcentratorCredentialsFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ConcentratorCredentialsFunction.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoraKeysManagerFacade
+{
+    using System;
+    using System.IO;
+    using System.Security.Cryptography;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Storage.Blobs;
+    using Azure.Storage.Blobs.Models;
+    using LoRaTools.CommonAPI;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Azure.Devices;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.Http;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Primitives;
+    using Newtonsoft.Json.Linq;
+
+    public class ConcentratorCredentialsFunction
+    {
+        internal const string CupsPropertyName = "cups";
+        internal const string CupsCredentialsUrlPropertyName = "cupsCredentialUrl";
+        internal const string LnsCredentialsUrlPropertyName = "tcCredentialUrl";
+        private readonly RegistryManager registryManager;
+        private readonly BlobServiceClient blobServiceClient;
+
+        public ConcentratorCredentialsFunction(RegistryManager registryManager)
+        {
+            this.registryManager = registryManager;
+
+            var connectionStringVariableName = "AzureWebJobsStorage";
+            var connectionString = Environment.GetEnvironmentVariable(connectionStringVariableName);
+            this.blobServiceClient = new BlobServiceClient(connectionString);
+        }
+
+        [FunctionName(nameof(FetchConcentratorCredentials))]
+        public async Task<IActionResult> FetchConcentratorCredentials([HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequest req,
+                                                                      ILogger log,
+                                                                      CancellationToken cancellationToken)
+        {
+            if (req is null) throw new ArgumentNullException(nameof(req));
+
+            try
+            {
+                VersionValidator.Validate(req);
+            }
+            catch (IncompatibleVersionException ex)
+            {
+                log.LogError(ex, "Invalid version");
+                return new BadRequestObjectResult(ex.Message);
+            }
+
+            return await RunFetchConcentratorCredentials(req, log, cancellationToken);
+        }
+
+        private async Task<IActionResult> RunFetchConcentratorCredentials(HttpRequest req, ILogger log, CancellationToken cancellationToken)
+        {
+            var stationEui = req.Query["StationEui"];
+            if (StringValues.IsNullOrEmpty(stationEui))
+            {
+                log.LogError("StationEui missing in request");
+                return new BadRequestObjectResult("StationEui missing in request");
+            }
+
+            var credentialTypeQueryString = req.Query["CredentialType"];
+            if (StringValues.IsNullOrEmpty(credentialTypeQueryString))
+            {
+                log.LogError("CredentialType missing in request");
+                return new BadRequestObjectResult("CredentialType missing in request");
+            }
+            if (!Enum.TryParse<ConcentratorCredentialType>(credentialTypeQueryString.ToString(), out var credentialType))
+            {
+                log.LogError("Could not parse '{QueryString}' to a ConcentratorCredentialType.", credentialTypeQueryString.ToString());
+                return new BadRequestObjectResult($"Could not parse desired concentrator credential type '{credentialTypeQueryString}'.");
+            }
+
+            var twin = await this.registryManager.GetTwinAsync(stationEui, cancellationToken);
+            if (twin != null)
+            {
+                log.LogInformation("Retrieving '{CredentialType}' for '{StationEui}'.", credentialType.ToString(), stationEui.ToString());
+                var cupsProperty = (string)twin.Properties.Desired[CupsPropertyName].ToString();
+                var parsedJson = JObject.Parse(cupsProperty);
+                var url = credentialType is ConcentratorCredentialType.Lns ? parsedJson[LnsCredentialsUrlPropertyName].ToString()
+                                                                           : parsedJson[CupsCredentialsUrlPropertyName].ToString();
+                var result = await GetBase64EncodedBlobAsync(url, cancellationToken);
+                return new OkObjectResult(result);
+            }
+            else
+            {
+                log.LogInformation($"Searching for {stationEui} returned 0 devices");
+                return new NotFoundResult();
+            }
+        }
+
+        internal async Task<string> GetBase64EncodedBlobAsync(string blobUrl, CancellationToken cancellationToken)
+        {
+            var blobUri = new BlobUriBuilder(new Uri(blobUrl));
+            using var blobStream = await this.blobServiceClient.GetBlobContainerClient(blobUri.BlobContainerName)
+                                                               .GetBlobClient(blobUri.BlobName)
+                                                               .OpenReadAsync(new BlobOpenReadOptions(false), cancellationToken);
+            using var base64transform = new ToBase64Transform();
+            using var base64Stream = new CryptoStream(blobStream, base64transform, CryptoStreamMode.Read);
+            using var memoryStream = new MemoryStream();
+            using var reader = new StreamReader(memoryStream);
+            await base64Stream.CopyToAsync(memoryStream, cancellationToken);
+            _ = memoryStream.Seek(0, SeekOrigin.Begin);
+            return await reader.ReadToEndAsync();
+        }
+    }
+}

--- a/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
+++ b/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="$(MicrosoftAzureDevicesVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryVersion)" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="$(MicrosoftAzureFunctionsExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />

--- a/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
+++ b/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacade.csproj
@@ -4,6 +4,7 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="$(MicrosoftAzureDevicesVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryVersion)" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="$(MicrosoftAzureFunctionsExtensionsVersion)" />

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/CommonAPI/ConcentratorCredentialType.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/CommonAPI/ConcentratorCredentialType.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaTools.CommonAPI
+{
+    public enum ConcentratorCredentialType
+    {
+        Cups,
+        Lns
+    }
+}

--- a/Tests/Unit/LoraKeysManagerFacade/ConcentratorCredentialTests.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/ConcentratorCredentialTests.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure;
+    using Azure.Storage.Blobs;
+    using Azure.Storage.Blobs.Models;
+    using global::LoraKeysManagerFacade;
+    using global::LoRaTools.CommonAPI;
+    using LoRaTools.CommonAPI;
+    using LoRaWan.Tests.Common;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Azure.Devices;
+    using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Azure;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Primitives;
+    using Moq;
+    using Xunit;
+
+    public class ConcentratorCredentialTests
+    {
+        private readonly Mock<RegistryManager> registryManager;
+        private readonly Mock<IAzureClientFactory<BlobServiceClient>> azureClientFactory;
+        private readonly ConcentratorCredentialsFunction concentratorCredential;
+        private readonly Mock<ILogger> loggerMock;
+        private const string RawStringContent = "hello";
+        private const string Base64EncodedString = "aGVsbG8=";
+
+        public ConcentratorCredentialTests()
+        {
+            this.registryManager = new Mock<RegistryManager>();
+            this.azureClientFactory = new Mock<IAzureClientFactory<BlobServiceClient>>();
+            this.concentratorCredential = new ConcentratorCredentialsFunction(registryManager.Object, azureClientFactory.Object);
+            this.loggerMock = new Mock<ILogger>();
+        }
+
+        [Fact]
+        public async Task GetBase64EncodedBlobAsync_Succeeds()
+        {
+            var blobBytes = Encoding.UTF8.GetBytes(RawStringContent);
+            using var blobStream = new MemoryStream(blobBytes);
+            SetupBlobMock(blobStream);
+
+            var result = await this.concentratorCredential.GetBase64EncodedBlobAsync("https://storage.blob.core.windows.net/container/blobname", CancellationToken.None);
+
+            Assert.NotNull(result);
+            Assert.Equal(Base64EncodedString, result);
+        }
+
+        [Theory]
+        [InlineData(ConcentratorCredentialType.Lns)]
+        [InlineData(ConcentratorCredentialType.Cups)]
+        public async Task RunFetchConcentratorCredentials_Succeeds(ConcentratorCredentialType credentialType)
+        {
+            var blobBytes = Encoding.UTF8.GetBytes(RawStringContent);
+            using var blobStream = new MemoryStream(blobBytes);
+            SetupBlobMock(blobStream);
+
+            // http request
+            var httpRequest = new Mock<HttpRequest>();
+            var queryCollection = new QueryCollection(new Dictionary<string, StringValues>()
+            {
+                { "StationEui", new StringValues("001122FFFEAABBCC") },
+                { "CredentialType", credentialType.ToString() }
+            });
+            httpRequest.SetupGet(x => x.Query).Returns(queryCollection);
+
+            // twin mock
+            var twin = new Twin();
+            twin.Properties.Desired = new TwinCollection(JsonUtil.Strictify(@"{'cups': {
+                'cupsUri': 'https://localhost:443',
+                'tcUri': 'wss://localhost:5001',
+                'cupsCredCrc': 1234,
+                'tcCredCrc': 5678,
+                'cupsCredentialUrl': 'https://storage.blob.core.windows.net/container/blob',
+                'tcCredentialUrl': 'https://storage.blob.core.windows.net/container/blob'
+            }}"));
+            this.registryManager.Setup(m => m.GetTwinAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                                .Returns(Task.FromResult(twin));
+
+            var result = await this.concentratorCredential.RunFetchConcentratorCredentials(httpRequest.Object, this.loggerMock.Object, CancellationToken.None);
+
+            Assert.NotNull(result);
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task RunFetchConcentratorCredentials_Returns_NotFound_ForMissingTwin()
+        {
+            // http request
+            var httpRequest = new Mock<HttpRequest>();
+            var queryCollection = new QueryCollection(new Dictionary<string, StringValues>()
+            {
+                { "StationEui", new StringValues("001122FFFEAABBCC") },
+                { "CredentialType", ConcentratorCredentialType.Cups.ToString() }
+            });
+            httpRequest.SetupGet(x => x.Query).Returns(queryCollection);
+
+            // twin mock
+            var twin = new Twin();
+            twin.Properties.Desired = new TwinCollection(JsonUtil.Strictify(@"{'cups': {
+                'cupsUri': 'https://localhost:443',
+                'tcUri': 'wss://localhost:5001',
+                'cupsCredCrc': 1234,
+                'tcCredCrc': 5678,
+                'cupsCredentialUrl': 'https://storage.blob.core.windows.net/container/blob',
+                'tcCredentialUrl': 'https://storage.blob.core.windows.net/container/blob'
+            }}"));
+            this.registryManager.Setup(m => m.GetTwinAsync("AnotherTwin", It.IsAny<CancellationToken>()))
+                                .Returns(Task.FromResult(twin));
+
+            var result = await this.concentratorCredential.RunFetchConcentratorCredentials(httpRequest.Object, this.loggerMock.Object, CancellationToken.None);
+
+            Assert.NotNull(result);
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Theory]
+        [InlineData(true, false, false)]
+        [InlineData(true, true, true)]
+        [InlineData(false, true, false)]
+        public async Task RunFetchConcentratorCredentials_Returns_BadRequest_ForMissingQueryParams(bool stationEuiAvailable, bool credentialTypeAvailable, bool wrongCredentialType)
+        {
+            // http request
+            var httpRequest = new Mock<HttpRequest>();
+            var queryDictionary = new Dictionary<string, StringValues>();
+            if (stationEuiAvailable)
+            {
+                queryDictionary.Add("StationEui", new StringValues("001122FFFEAABBCC"));
+            }
+            if (credentialTypeAvailable)
+            {
+                queryDictionary.Add("CredentialType", wrongCredentialType ? "wrong" : ConcentratorCredentialType.Cups.ToString());
+            }
+            var queryCollection = new QueryCollection(queryDictionary);
+            httpRequest.SetupGet(x => x.Query).Returns(queryCollection);
+
+            var result = await this.concentratorCredential.RunFetchConcentratorCredentials(httpRequest.Object, this.loggerMock.Object, CancellationToken.None);
+
+            Assert.NotNull(result);
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        private void SetupBlobMock(MemoryStream blobStream)
+        {
+            var blobServiceClient = new Mock<BlobServiceClient>();
+            var blobContainerClient = new Mock<BlobContainerClient>();
+            var blobContainerClientResponseMock = new Mock<Response>();
+
+            var blobClient = new Mock<BlobClient>();
+            var blobClientResponseMock = new Mock<Response>();
+
+            blobClient.Setup(m => m.OpenReadAsync(It.IsAny<BlobOpenReadOptions>(), It.IsAny<CancellationToken>()))
+                      .Returns(Task.FromResult(blobStream as Stream));
+
+            blobServiceClient.Setup(m => m.GetBlobContainerClient(It.IsAny<string>()))
+                             .Returns(Response.FromValue(blobContainerClient.Object, blobContainerClientResponseMock.Object));
+
+            blobContainerClient.Setup(m => m.GetBlobClient(It.IsAny<string>()))
+                               .Returns(Response.FromValue(blobClient.Object, blobClientResponseMock.Object));
+
+            this.azureClientFactory.Setup(m => m.CreateClient(FacadeStartup.WebJobsStorageClientName))
+                                   .Returns(blobServiceClient.Object);
+        }
+    }
+}


### PR DESCRIPTION
# PR for issue #907 

## What is being addressed

This PR is introducing a new Azure Function for fetching the concentrator credentials for LNS and CUPS endpoints.

## How is this addressed

Accordingly to the flow in ADR 006:
- [x] A ConcentratorCredentialsFunction class has been created for retrieving credentials location from Twin and download the selected blob from storage
- [x] FacadeStartup was adjusted to inject the BlobServiceClient for accessing Blob Storage
- [x] A CommonAPI/ConcentratorCredentialType enum was created in LoRaTools for future sharing with NetworkServer
- [x] Unit tests were added for new Function endpoint

## Validation

<img width="1096" alt="image" src="https://user-images.githubusercontent.com/1955514/143573107-43b3453e-69da-4c74-a7d1-935ff1914abb.png">

## What is missing:

- [ ] FetchConcentratorCredentials should authenticate against sinks by using Managed Identity
- [ ] FetchConcentratorCredentials should be able to retrieve credentials from Key Vault

## Adjustments to ADR

While implementing this solution, I realized that some adjustments were needed to ADR. #915 is tracking the required changes
