### PR TITLE
Enable multi-concentrator E2E test in the CI

### DIFF
--- a/.github/workflows/e2e-ci.yaml
+++ b/.github/workflows/e2e-ci.yaml
@@ -11,7 +11,7 @@ on: # rebuild any PRs and main branch changes
         description: 'Run E2E tests only'
         default: false
       TestsToRun:
-        default: '[SensorDecodingTest,OTAAJoinTest,ABPTest,OTAATest,MacTest,ClassCTest,C2DMessageTest,MultiGatewayTest]'
+        default: '[SensorDecodingTest,OTAAJoinTest,ABPTest,OTAATest,MacTest,ClassCTest,C2DMessageTest,MultiGatewayTest,MultiConcentratorTest]'
         description: 'tests to run'
       TxPower:
         description: 'TXPower value to use in E2E tests'
@@ -55,10 +55,10 @@ jobs:
           echo "::set-output name=E2ETestsToRun::${{ github.event.inputs.TestsToRun }}"
         elif [ ${{ github.event_name }} == 'pull_request' ]; then
           echo "Set up for pull request"
-          echo "::set-output name=E2ETestsToRun::[SensorDecodingTest,OTAAJoinTest,ABPTest,OTAATest,MacTest,ClassCTest,C2DMessageTest,MultiGatewayTest]"
+          echo "::set-output name=E2ETestsToRun::[SensorDecodingTest,OTAAJoinTest,ABPTest,OTAATest,MacTest,ClassCTest,C2DMessageTest,MultiGatewayTest,MultiConcentratorTest]"
         else
           echo "Set up for cron trigger"
-          echo "::set-output name=E2ETestsToRun::[SensorDecodingTest,OTAAJoinTest,ABPTest,OTAATest,MacTest,ClassCTest,C2DMessageTest,MultiGatewayTest]"
+          echo "::set-output name=E2ETestsToRun::[SensorDecodingTest,OTAAJoinTest,ABPTest,OTAATest,MacTest,ClassCTest,C2DMessageTest,MultiGatewayTest,MultiConcentratorTest]"
         fi
 
     - id: check-if-run
@@ -397,6 +397,13 @@ jobs:
       id: e2e_tests_multigwtest
       with:
         test_name: 'MultiGatewayTest'
+
+    - name:  Runs multi-concentrator E2E tests
+      if: always() && contains(env.TestsToRun, 'MultiConcentratorTest') && !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'MultiConcentratorTest'))
+      uses: ./.github/actions/rune2etest
+      id: e2e_tests_multiconctest
+      with:
+        test_name: 'MultiConcentratorTest'
 
     # Upload test results as artifact
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/e2e-ci.yaml
+++ b/.github/workflows/e2e-ci.yaml
@@ -398,7 +398,7 @@ jobs:
       with:
         test_name: 'MultiGatewayTest'
 
-    - name:  Runs multi-concentrator E2E tests
+    - name:  Runs MultiConcentrator E2E tests
       if: always() && contains(env.TestsToRun, 'MultiConcentratorTest') && !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'MultiConcentratorTest'))
       uses: ./.github/actions/rune2etest
       id: e2e_tests_multiconctest


### PR DESCRIPTION
# PR for issue #871 

## What is being addressed

This PR enables the multi-concentrator E2E test to run in the CI. 
The test ran successfully in the CI on this branch: https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/1507801584

