### PR TITLE
Reuse existing redis containers for integration tests

### DIFF
--- a/Tests/Integration/DevAddrCacheTest.cs
+++ b/Tests/Integration/DevAddrCacheTest.cs
@@ -17,6 +17,7 @@ namespace LoRaWan.Tests.Integration
     using StackExchange.Redis;
     using Xunit;
 
+    [Collection(RedisFixture.CollectionName)]
     public class DevAddrCacheTest : FunctionTestBase, IClassFixture<RedisFixture>
     {
         private const string FullUpdateKey = "fullUpdateKey";

--- a/Tests/Integration/PreferredGatewayTestWithRedis.cs
+++ b/Tests/Integration/PreferredGatewayTestWithRedis.cs
@@ -13,6 +13,7 @@ namespace LoRaWan.Tests.Integration
     /// <summary>
     /// Tests to run against a real redis instance.
     /// </summary>
+    [Collection(RedisFixture.CollectionName)]
     public class PreferredGatewayTestWithRedis : IClassFixture<RedisFixture>
     {
         private readonly ILoRaDeviceCacheStore cache;

--- a/Tests/Integration/RedisFixture.cs
+++ b/Tests/Integration/RedisFixture.cs
@@ -95,7 +95,7 @@ namespace LoRaWan.Tests.Integration
             catch (DockerApiException e) when (e.StatusCode == HttpStatusCode.Conflict)
             {
                 var container = containers.FirstOrDefault(c => c.Names.Contains("/" + GetContainerName(RedisPort)));
-                if (container.State.Equals("exited", StringComparison.OrdinalIgnoreCase))
+                if (container is { } c && c.State.Equals("exited", StringComparison.OrdinalIgnoreCase))
                 {
                     Console.WriteLine("Starting existing container.");
                     await client.Containers.StartContainerAsync(container.ID, new ContainerStartParameters());

--- a/Tests/Integration/RedisFixture.cs
+++ b/Tests/Integration/RedisFixture.cs
@@ -25,6 +25,7 @@ namespace LoRaWan.Tests.Integration
         private const string ImageName = "redis";
         private const string ImageTag = "5.0.4-alpine";
         private const int RedisPort = 6001;
+        private static readonly string TestContainerName = ContainerName + RedisPort;
 
         private ConnectionMultiplexer redis;
 
@@ -76,7 +77,7 @@ namespace LoRaWan.Tests.Integration
                 var response = await client.Containers.CreateContainerAsync(new CreateContainerParameters(config)
                 {
                     Image = ImageName + ":" + ImageTag,
-                    Name = GetContainerName(RedisPort),
+                    Name = TestContainerName,
                     Tty = false,
                     HostConfig = hostConfig
                 });
@@ -94,7 +95,7 @@ namespace LoRaWan.Tests.Integration
             }
             catch (DockerApiException e) when (e.StatusCode == HttpStatusCode.Conflict)
             {
-                var container = containers.FirstOrDefault(c => c.Names.Contains("/" + GetContainerName(RedisPort)));
+                var container = containers.FirstOrDefault(c => c.Names.Contains("/" + TestContainerName));
                 if (container is { } c && c.State.Equals("exited", StringComparison.OrdinalIgnoreCase))
                 {
                     Console.WriteLine("Starting existing container.");
@@ -110,8 +111,6 @@ namespace LoRaWan.Tests.Integration
                 Console.WriteLine(ex);
                 throw;
             }
-
-            static string GetContainerName(int port) => ContainerName + port;
         }
 
         public async Task InitializeAsync()


### PR DESCRIPTION
# PR for issue #914

## What is being addressed

With the existing test setup against Redis, there was interference between existing docker Redis containers and test redis containers. With this PR we reuse already existing Redis containers and make sure that all tests classes relying on Redis run in sequence.
