### PR TITLE
Add downstream join frequencies for region CN470

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
@@ -15,6 +15,8 @@ namespace LoRaTools.Regions
     {
         private const ushort MAX_RX_DELAY = 15;
 
+        protected const double EPSILON = 0.00001;
+
         public LoRaRegionType LoRaRegion { get; set; }
 
         /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionAS923.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionAS923.cs
@@ -14,7 +14,6 @@ namespace LoRaTools.Regions
     {
         private const double Channel0Frequency = 923.2;
         private const double Channel1Frequency = 923.4;
-        private const double Epsilon = 0.001;
 
         private readonly bool useDwellTimeLimit;
 
@@ -108,7 +107,7 @@ namespace LoRaTools.Regions
             FrequencyOffset = Math.Round(frequencyChannel0.Mega - Channel0Frequency, 2, MidpointRounding.AwayFromZero);
 
             var channel1Offset = Math.Round(frequencyChannel1.Mega - Channel1Frequency, 2, MidpointRounding.AwayFromZero);
-            if (Math.Abs(channel1Offset - FrequencyOffset) > Epsilon)
+            if (Math.Abs(channel1Offset - FrequencyOffset) > EPSILON)
             {
                 throw new ConfigurationErrorsException($"Provided channel frequencies {frequencyChannel0}, {frequencyChannel1} for Region {LoRaRegion} are inconsistent.");
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionCN470.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionCN470.cs
@@ -20,7 +20,7 @@ namespace LoRaTools.Regions
 
         // Dictionary mapping upstream join frequencies to a tuple containing
         // the corresponding downstream join frequency and the channel index
-        public Dictionary<double, (double, int)> UpstreamJoinFrequenciesToDownstreamAndChannelIndex { get; }
+        public Dictionary<double, (double downstreamFreq, int joinChannelIndex)> UpstreamJoinFrequenciesToDownstreamAndChannelIndex { get; }
 
         public RegionCN470()
             : base(LoRaRegionType.CN470)
@@ -107,7 +107,7 @@ namespace LoRaTools.Regions
 
             if (UpstreamJoinFrequenciesToDownstreamAndChannelIndex.TryGetValue(joinChannel.Freq, out var elem))
             {
-                channelIndex = elem.Item2;
+                channelIndex = elem.joinChannelIndex;
             }
 
             return channelIndex != -1;
@@ -122,7 +122,7 @@ namespace LoRaTools.Regions
 
             if (UpstreamJoinFrequenciesToDownstreamAndChannelIndex.TryGetValue(frequency, out var elem))
             {
-                channelIndex = elem.Item2;
+                channelIndex = elem.joinChannelIndex;
             }
 
             return channelIndex != -1;

--- a/Tests/Unit/LoRaTools/RegionCN470TestData.cs
+++ b/Tests/Unit/LoRaTools/RegionCN470TestData.cs
@@ -138,12 +138,19 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
            new List<object[]>
            {
                 new object[] { region, 470.9, 0 },
+                new object[] { region, 472.5, 1 },
                 new object[] { region, 475.7, 3 },
                 new object[] { region, 507.3, 6 },
+                new object[] { region, 479.9, 8 },
                 new object[] { region, 499.9, 9 },
                 new object[] { region, 478.3, 14 },
                 new object[] { region, 482.3, 16 },
+                new object[] { region, 486.3, 18 },
                 new object[] { region, 488.3, 19 },
+                new object[] { region, 470.900000000001, 0 },
+                new object[] { region, 499.90000005, 9 },
+                new object[] { region, 472.4999999, 1 },
+                new object[] { region, 488.29999999, 19 },
            };
 
         public static IEnumerable<object[]> TestIsValidRX1DROffsetData =>

--- a/Tests/Unit/LoRaTools/RegionCN470TestData.cs
+++ b/Tests/Unit/LoRaTools/RegionCN470TestData.cs
@@ -147,10 +147,6 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                 new object[] { region, 482.3, 16 },
                 new object[] { region, 486.3, 18 },
                 new object[] { region, 488.3, 19 },
-                new object[] { region, 470.900000000001, 0 },
-                new object[] { region, 499.90000005, 9 },
-                new object[] { region, 472.4999999, 1 },
-                new object[] { region, 488.29999999, 19 },
            };
 
         public static IEnumerable<object[]> TestIsValidRX1DROffsetData =>

--- a/Tests/Unit/LoRaTools/RegionCN470TestWithRxpk.cs
+++ b/Tests/Unit/LoRaTools/RegionCN470TestWithRxpk.cs
@@ -17,12 +17,19 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
 
         [Theory]
         [InlineData(470.9, 0)]
+        [InlineData(472.5, 1)]
         [InlineData(475.7, 3)]
         [InlineData(507.3, 6)]
+        [InlineData(479.9, 8)]
         [InlineData(499.9, 9)]
         [InlineData(478.3, 14)]
         [InlineData(482.3, 16)]
+        [InlineData(486.3, 18)]
         [InlineData(488.3, 19)]
+        [InlineData(470.900000000001, 0)]
+        [InlineData(499.90000005, 9)]
+        [InlineData(472.4999999, 1)]
+        [InlineData(488.29999999, 19)]
         public void TestTryGetJoinChannelIndex_ReturnsValidIndex(double freq, int expectedIndex)
         {
             var rxpk = GenerateRxpk("SF12BW125", freq);

--- a/Tests/Unit/LoRaTools/RegionCN470TestWithRxpk.cs
+++ b/Tests/Unit/LoRaTools/RegionCN470TestWithRxpk.cs
@@ -26,10 +26,6 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
         [InlineData(482.3, 16)]
         [InlineData(486.3, 18)]
         [InlineData(488.3, 19)]
-        [InlineData(470.900000000001, 0)]
-        [InlineData(499.90000005, 9)]
-        [InlineData(472.4999999, 1)]
-        [InlineData(488.29999999, 19)]
         public void TestTryGetJoinChannelIndex_ReturnsValidIndex(double freq, int expectedIndex)
         {
             var rxpk = GenerateRxpk("SF12BW125", freq);


### PR DESCRIPTION
# PR for issue #881 

## What is being addressed

Only upstream join frequencies were previously supported for region CN470.

## How is this addressed

- Upstream join frequencies were replaces with a list of tuples using format: (upstream join freq, downstream join freq).
- Unit tests for join channels in China were expanded.

The changes were previously added in a different branch and tested manually: https://github.com/Azure/iotedge-lorawan-starterkit/commit/01b8ddac19275879ff81908f9a53e43010eadffb