### PR TITLE
Feature/747 raise custom metrics

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApplicationInsightsMetricExporter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApplicationInsightsMetricExporter.cs
@@ -11,6 +11,7 @@ namespace LoRaWan.NetworkServer
     using System.Linq;
     using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.Metrics;
+    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Exports System.Diagnostics.Metrics metrics which are registered in MetricRegistry to Application Insights.
@@ -21,14 +22,15 @@ namespace LoRaWan.NetworkServer
         private readonly IDictionary<string, (Metric, MetricIdentifier)> metricRegistry;
         private readonly RegistryMetricTagBag metricTagBag;
 
-        public ApplicationInsightsMetricExporter(TelemetryClient telemetryClient, RegistryMetricTagBag metricTagBag)
-            : this(telemetryClient, MetricRegistry.RegistryLookup, metricTagBag)
+        public ApplicationInsightsMetricExporter(TelemetryClient telemetryClient, RegistryMetricTagBag metricTagBag, ILogger<ApplicationInsightsMetricExporter> logger)
+            : this(telemetryClient, MetricRegistry.RegistryLookup, metricTagBag, logger)
         { }
 
         internal ApplicationInsightsMetricExporter(TelemetryClient telemetryClient,
                                                    IDictionary<string, CustomMetric> registryLookup,
-                                                   RegistryMetricTagBag metricTagBag)
-            : base(registryLookup)
+                                                   RegistryMetricTagBag metricTagBag,
+                                                   ILogger<ApplicationInsightsMetricExporter> logger)
+            : base(registryLookup, logger)
         {
             this.metricRegistry = registryLookup.ToDictionary(m => m.Key, m =>
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -96,8 +96,9 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         .AddHostedService(sp =>
                             new MetricExporterHostedService(
                                 new CompositeMetricExporter(useApplicationInsights ? new ApplicationInsightsMetricExporter(sp.GetRequiredService<TelemetryClient>(),
-                                                                                                                           sp.GetRequiredService<RegistryMetricTagBag>()) : null,
-                                                            new PrometheusMetricExporter(sp.GetRequiredService<RegistryMetricTagBag>()))))
+                                                                                                                           sp.GetRequiredService<RegistryMetricTagBag>(),
+                                                                                                                           sp.GetRequiredService<ILogger<ApplicationInsightsMetricExporter>>()) : null,
+                                                            new PrometheusMetricExporter(sp.GetRequiredService<RegistryMetricTagBag>(), sp.GetRequiredService<ILogger<PrometheusMetricExporter>>()))))
                         .AddSingleton(_ => new Meter(MetricRegistry.Namespace, MetricRegistry.Version));
 
             if (useApplicationInsights)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
@@ -35,6 +35,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
         private readonly ILogger<LnsProtocolMessageProcessor> logger;
         private readonly RegistryMetricTagBag registryMetricTagBag;
         private readonly Counter<int> joinRequestCounter;
+        private readonly Counter<int> uplinkMessageCounter;
 
         public LnsProtocolMessageProcessor(IBasicsStationConfigurationService basicsStationConfigurationService,
                                            WebSocketWriterRegistry<StationEui, string> socketWriterRegistry,
@@ -55,6 +56,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
             this.logger = logger;
             this.registryMetricTagBag = registryMetricTagBag;
             this.joinRequestCounter = meter?.CreateCounter<int>(MetricRegistry.JoinRequests);
+            this.uplinkMessageCounter = meter?.CreateCounter<int>(MetricRegistry.D2CMessagesReceived);
         }
 
         internal async Task<HttpContext> ProcessIncomingRequestAsync(HttpContext httpContext,
@@ -240,6 +242,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
                         }
 
                         using var scope = this.logger.BeginDeviceAddressScope(updf.DevAddr);
+                        this.uplinkMessageCounter.Add(1);
 
                         var routerRegion = await this.basicsStationConfigurationService.GetRegionAsync(stationEui, cancellationToken);
                         var rxpk = new BasicStationToRxpk(updf.RadioMetadata, routerRegion);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 namespace LoRaWan.NetworkServer.BasicsStation.Processors
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.Metrics;
     using System.Linq;
@@ -288,7 +289,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
                     throw new SwitchExpressionException();
             }
             stopwatch.Stop();
-            this.dataMessageDispatchLatency?.Record(stopwatch.ElapsedMilliseconds);
+            this.dataMessageDispatchLatency?.Record(stopwatch.ElapsedMilliseconds, KeyValuePair.Create(MetricRegistry.DataMessageTypeTagName, (object)messageType));
         }
 
         internal async Task CloseSocketAsync(WebSocket socket, CancellationToken cancellationToken)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
@@ -247,7 +247,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
                         }
 
                         using var scope = this.logger.BeginDeviceAddressScope(updf.DevAddr);
-                        this.uplinkMessageCounter.Add(1);
+                        this.uplinkMessageCounter?.Add(1);
 
                         var routerRegion = await this.basicsStationConfigurationService.GetRegionAsync(stationEui, cancellationToken);
                         var rxpk = new BasicStationToRxpk(updf.RadioMetadata, routerRegion);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 namespace LoRaWan.NetworkServer.BasicsStation.Processors
 {
     using System;
+    using System.Diagnostics;
     using System.Diagnostics.Metrics;
     using System.Linq;
     using System.Net.NetworkInformation;
@@ -36,6 +37,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
         private readonly RegistryMetricTagBag registryMetricTagBag;
         private readonly Counter<int> joinRequestCounter;
         private readonly Counter<int> uplinkMessageCounter;
+        private readonly Histogram<double> dataMessageDispatchLatency;
 
         public LnsProtocolMessageProcessor(IBasicsStationConfigurationService basicsStationConfigurationService,
                                            WebSocketWriterRegistry<StationEui, string> socketWriterRegistry,
@@ -57,6 +59,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
             this.registryMetricTagBag = registryMetricTagBag;
             this.joinRequestCounter = meter?.CreateCounter<int>(MetricRegistry.JoinRequests);
             this.uplinkMessageCounter = meter?.CreateCounter<int>(MetricRegistry.D2CMessagesReceived);
+            this.dataMessageDispatchLatency = meter?.CreateHistogram<double>(MetricRegistry.DataMessageDispatchLatency);
         }
 
         internal async Task<HttpContext> ProcessIncomingRequestAsync(HttpContext httpContext,
@@ -190,7 +193,9 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
                                                   string json,
                                                   CancellationToken cancellationToken)
         {
-            switch (LnsData.MessageTypeReader.Read(json))
+            var messageType = LnsData.MessageTypeReader.Read(json);
+            var stopwatch = Stopwatch.StartNew();
+            switch (messageType)
             {
                 case LnsMessageType.Version:
                     var stationVersion = LnsData.VersionMessageReader.Read(json);
@@ -269,18 +274,21 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
                 case LnsMessageType.TransmitConfirmation:
                     LogReceivedMessage(this.logger, "dntxed", json, null);
                     break;
-                case var messageType and (LnsMessageType.DownlinkMessage or LnsMessageType.RouterConfig):
+                case LnsMessageType.RouterConfig:
+                case LnsMessageType.DownlinkMessage:
                     throw new NotSupportedException($"'{messageType}' is not a valid message type for this endpoint and is only valid for 'downstream' messages.");
-                case var messageType and (LnsMessageType.ProprietaryDataFrame
-                                          or LnsMessageType.MulticastSchedule
-                                          or LnsMessageType.TimeSync
-                                          or LnsMessageType.RunCommand
-                                          or LnsMessageType.RemoteShell):
+                case LnsMessageType.ProprietaryDataFrame:
+                case LnsMessageType.MulticastSchedule:
+                case LnsMessageType.TimeSync:
+                case LnsMessageType.RunCommand:
+                case LnsMessageType.RemoteShell:
                     this.logger.LogWarning("'{MessageType}' ({MessageTypeBasicStationString}) is not handled in current LoRaWan Network Server implementation.", messageType, messageType.ToBasicStationString());
                     break;
                 default:
                     throw new SwitchExpressionException();
             }
+            stopwatch.Stop();
+            this.dataMessageDispatchLatency?.Record(stopwatch.ElapsedMilliseconds);
         }
 
         internal async Task CloseSocketAsync(WebSocket socket, CancellationToken cancellationToken)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -29,6 +29,7 @@ namespace LoRaWan.NetworkServer
         private readonly Counter<int> receiveWindowMissed;
         private readonly Counter<int> receiveWindowHits;
         private readonly Histogram<int> c2dPayloadSizeHistogram;
+        private readonly Histogram<int> d2cPayloadSizeHistogram;
         private IClassCDeviceMessageSender classCDeviceMessageSender;
 
         public DefaultLoRaDataRequestHandler(
@@ -53,6 +54,7 @@ namespace LoRaWan.NetworkServer
             this.receiveWindowMissed = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowMisses);
             this.receiveWindowHits = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowHits);
             this.c2dPayloadSizeHistogram = meter?.CreateHistogram<int>(MetricRegistry.C2DMessageSize);
+            this.d2cPayloadSizeHistogram = meter?.CreateHistogram<int>(MetricRegistry.D2CMessageSize);
         }
 
         public async Task<LoRaDeviceRequestProcessResult> ProcessRequestAsync(LoRaRequest request, LoRaDevice loRaDevice)
@@ -68,6 +70,7 @@ namespace LoRaWan.NetworkServer
             }
 
             var loraPayload = (LoRaPayloadData)request.Payload;
+            this.d2cPayloadSizeHistogram?.Record(loraPayload.Frmpayload.Length);
 
             var payloadFcnt = loraPayload.GetFcnt();
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -28,7 +28,6 @@ namespace LoRaWan.NetworkServer
         private readonly ILogger<DefaultLoRaDataRequestHandler> logger;
         private readonly Counter<int> receiveWindowMissed;
         private readonly Counter<int> receiveWindowHits;
-        private readonly Histogram<int> c2dPayloadSizeHistogram;
         private readonly Histogram<int> d2cPayloadSizeHistogram;
         private readonly Counter<int> c2dMessageTooLong;
         private IClassCDeviceMessageSender classCDeviceMessageSender;
@@ -54,7 +53,6 @@ namespace LoRaWan.NetworkServer
             this.logger = logger;
             this.receiveWindowMissed = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowMisses);
             this.receiveWindowHits = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowHits);
-            this.c2dPayloadSizeHistogram = meter?.CreateHistogram<int>(MetricRegistry.C2DMessageSize);
             this.d2cPayloadSizeHistogram = meter?.CreateHistogram<int>(MetricRegistry.D2CMessageSize);
             this.c2dMessageTooLong = meter?.CreateCounter<int>(MetricRegistry.C2DMessageTooLong);
         }
@@ -304,8 +302,7 @@ namespace LoRaWan.NetworkServer
                         false, // fpending
                         fcntDown.GetValueOrDefault(),
                         loRaADRResult,
-                        this.logger,
-                        this.c2dPayloadSizeHistogram);
+                        this.logger);
 
                     if (downlinkMessageBuilderResp.DownlinkPktFwdMessage != null)
                     {
@@ -411,8 +408,7 @@ namespace LoRaWan.NetworkServer
                     fpending,
                     fcntDown.GetValueOrDefault(),
                     loRaADRResult,
-                    this.logger,
-                    this.c2dPayloadSizeHistogram);
+                    this.logger);
 
                 if (cloudToDeviceMessage != null)
                 {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -433,7 +433,7 @@ namespace LoRaWan.NetworkServer
 
                 if (confirmDownlinkMessageBuilderResp.DownlinkPktFwdMessage != null)
                 {
-                    this.receiveWindowHits?.Add(1);
+                    this.receiveWindowHits?.Add(1, KeyValuePair.Create(MetricRegistry.ReceiveWindowTagName, (object)confirmDownlinkMessageBuilderResp.ReceiveWindow));
                     _ = request.PacketForwarder.SendDownstreamAsync(confirmDownlinkMessageBuilderResp.DownlinkPktFwdMessage);
                 }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -28,6 +28,7 @@ namespace LoRaWan.NetworkServer
         private readonly ILogger<DefaultLoRaDataRequestHandler> logger;
         private readonly Counter<int> receiveWindowMissed;
         private readonly Counter<int> receiveWindowHits;
+        private readonly Histogram<int> c2dPayloadSizeHistogram;
         private IClassCDeviceMessageSender classCDeviceMessageSender;
 
         public DefaultLoRaDataRequestHandler(
@@ -51,6 +52,7 @@ namespace LoRaWan.NetworkServer
             this.logger = logger;
             this.receiveWindowMissed = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowMisses);
             this.receiveWindowHits = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowHits);
+            this.c2dPayloadSizeHistogram = meter?.CreateHistogram<int>(MetricRegistry.C2DMessageSize);
         }
 
         public async Task<LoRaDeviceRequestProcessResult> ProcessRequestAsync(LoRaRequest request, LoRaDevice loRaDevice)
@@ -297,7 +299,8 @@ namespace LoRaWan.NetworkServer
                         false, // fpending
                         fcntDown.GetValueOrDefault(),
                         loRaADRResult,
-                        this.logger);
+                        this.logger,
+                        this.c2dPayloadSizeHistogram);
 
                     if (downlinkMessageBuilderResp.DownlinkPktFwdMessage != null)
                     {
@@ -402,7 +405,8 @@ namespace LoRaWan.NetworkServer
                     fpending,
                     fcntDown.GetValueOrDefault(),
                     loRaADRResult,
-                    this.logger);
+                    this.logger,
+                    this.c2dPayloadSizeHistogram);
 
                 if (cloudToDeviceMessage != null)
                 {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -421,7 +421,6 @@ namespace LoRaWan.NetworkServer
                     }
                     else if (confirmDownlinkMessageBuilderResp.IsMessageTooLong)
                     {
-                        this.receiveWindowMissed?.Add(1);
                         this.logger.LogError($"payload will not fit in current receive window, will abandon cloud to device message id: {cloudToDeviceMessage.MessageId ?? "undefined"}");
                         _ = cloudToDeviceMessage.AbandonAsync();
                     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
@@ -5,6 +5,7 @@ namespace LoRaWan.NetworkServer
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.Metrics;
     using System.Linq;
     using System.Security.Cryptography;
     using LoRaTools;
@@ -36,7 +37,8 @@ namespace LoRaWan.NetworkServer
             bool fpending,
             uint fcntDown,
             LoRaADRResult loRaADRResult,
-            ILogger logger)
+            ILogger logger,
+            Histogram<int> paylodSizeHistogram)
         {
             var fcntDownToSend = ValidateAndConvert16bitFCnt(fcntDown);
 
@@ -164,6 +166,7 @@ namespace LoRaWan.NetworkServer
                         fport = cloudToDeviceMessage.Fport;
                     }
 
+                    paylodSizeHistogram?.Record(frmPayload?.Length ?? 0);
                     logger.LogInformation($"cloud to device message: {((frmPayload?.Length ?? 0) == 0 ? "empty" : ConversionHelper.ByteArrayToString(frmPayload))}, id: {cloudToDeviceMessage.MessageId ?? "undefined"}, fport: {fport ?? 0}, confirmed: {requiresDeviceAcknowlegement}, cidType: {macCommandType}, macCommand: {macCommands.Count > 0}");
                     Array.Reverse(frmPayload);
                 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
@@ -61,7 +61,7 @@ namespace LoRaWan.NetworkServer
             {
                 // No valid receive window. Abandon the message
                 isMessageTooLong = true;
-                return new DownlinkMessageBuilderResponse(null, isMessageTooLong);
+                return new DownlinkMessageBuilderResponse(null, isMessageTooLong, receiveWindow);
             }
 
             var rndToken = new byte[2];
@@ -94,7 +94,7 @@ namespace LoRaWan.NetworkServer
                 if (datr == null)
                 {
                     logger.LogError("there was a problem in setting the data rate in the downstream message packet forwarder settings");
-                    return new DownlinkMessageBuilderResponse(null, false);
+                    return new DownlinkMessageBuilderResponse(null, false, receiveWindow);
                 }
 
                 // The logic for passing CN470 join channel will change as part of #561
@@ -103,7 +103,7 @@ namespace LoRaWan.NetworkServer
 #pragma warning restore CS0618 // #655 - This Rxpk based implementation will go away as soon as the complete LNS implementation is done
                 {
                     logger.LogError("there was a problem in setting the frequency in the downstream message packet forwarder settings");
-                    return new DownlinkMessageBuilderResponse(null, false);
+                    return new DownlinkMessageBuilderResponse(null, false, receiveWindow);
                 }
 
                 tmst = rxpk.Tmst + (timeWatcher.GetReceiveWindow1Delay(loRaDevice) * Constants.ConvertToPktFwdTime);
@@ -233,7 +233,7 @@ namespace LoRaWan.NetworkServer
             if (logger.IsEnabled(LogLevel.Debug))
                 logger.LogDebug($"{(LoRaMessageType)ackLoRaMessage.Mhdr.Span[0]} {JsonConvert.SerializeObject(downlinkPktFwdMessage)}");
 
-            return new DownlinkMessageBuilderResponse(downlinkPktFwdMessage, isMessageTooLong);
+            return new DownlinkMessageBuilderResponse(downlinkPktFwdMessage, isMessageTooLong, receiveWindow);
         }
 
         private static ushort ValidateAndConvert16bitFCnt(uint fcntDown)
@@ -297,7 +297,7 @@ namespace LoRaWan.NetworkServer
             if (availablePayloadSize < totalC2dSize)
             {
                 isMessageTooLong = true;
-                return new DownlinkMessageBuilderResponse(null, isMessageTooLong);
+                return new DownlinkMessageBuilderResponse(null, isMessageTooLong, Constants.ReceiveWindow2);
             }
 
             if (macCommands?.Count > 0)
@@ -352,7 +352,8 @@ namespace LoRaWan.NetworkServer
             if (logger.IsEnabled(LogLevel.Debug))
                 logger.LogDebug($"{(LoRaMessageType)ackLoRaMessage.Mhdr.Span[0]} {JsonConvert.SerializeObject(downlinkPktFwdMessage)}");
 
-            return new DownlinkMessageBuilderResponse(downlinkPktFwdMessage, isMessageTooLong);
+            // Class C always uses RX2.
+            return new DownlinkMessageBuilderResponse(downlinkPktFwdMessage, isMessageTooLong, Constants.ReceiveWindow2);
         }
 
         /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
@@ -37,8 +37,7 @@ namespace LoRaWan.NetworkServer
             bool fpending,
             uint fcntDown,
             LoRaADRResult loRaADRResult,
-            ILogger logger,
-            Histogram<int> paylodSizeHistogram)
+            ILogger logger)
         {
             var fcntDownToSend = ValidateAndConvert16bitFCnt(fcntDown);
 
@@ -166,7 +165,6 @@ namespace LoRaWan.NetworkServer
                         fport = cloudToDeviceMessage.Fport;
                     }
 
-                    paylodSizeHistogram?.Record(frmPayload?.Length ?? 0);
                     logger.LogInformation($"cloud to device message: {((frmPayload?.Length ?? 0) == 0 ? "empty" : ConversionHelper.ByteArrayToString(frmPayload))}, id: {cloudToDeviceMessage.MessageId ?? "undefined"}, fport: {fport ?? 0}, confirmed: {requiresDeviceAcknowlegement}, cidType: {macCommandType}, macCommand: {macCommands.Count > 0}");
                     Array.Reverse(frmPayload);
                 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilderResponse.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilderResponse.cs
@@ -10,11 +10,13 @@ namespace LoRaWan.NetworkServer
         internal DownlinkPktFwdMessage DownlinkPktFwdMessage { get; set; }
 
         internal bool IsMessageTooLong { get; set; }
+        public int ReceiveWindow { get; }
 
-        internal DownlinkMessageBuilderResponse(DownlinkPktFwdMessage downlinkPktFwdMessage, bool isMessageTooLong)
+        internal DownlinkMessageBuilderResponse(DownlinkPktFwdMessage downlinkPktFwdMessage, bool isMessageTooLong, int receiveWindow)
         {
             DownlinkPktFwdMessage = downlinkPktFwdMessage;
             IsMessageTooLong = isMessageTooLong;
+            ReceiveWindow = receiveWindow;
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -281,7 +281,7 @@ namespace LoRaWan.NetworkServer
                     var joinAccept = loRaPayloadJoinAccept.Serialize(loRaDevice.AppKey, datr, freq, devEUI, tmst, lnsRxDelay, request.Rxpk.Rfch, request.Rxpk.Time, request.StationEui);
                     if (joinAccept != null)
                     {
-                        this.receiveWindowHits?.Add(1);
+                        this.receiveWindowHits?.Add(1, KeyValuePair.Create(MetricRegistry.ReceiveWindowTagName, (object)windowToUse));
                         _ = request.PacketForwarder.SendDownstreamAsync(joinAccept);
                         request.NotifySucceeded(loRaDevice, joinAccept);
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -4,6 +4,8 @@
 namespace LoRaWan.NetworkServer
 {
     using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Metrics;
     using System.Threading.Tasks;
     using LoRaTools;
     using LoRaTools.LoRaMessage;
@@ -16,15 +18,20 @@ namespace LoRaWan.NetworkServer
     {
         private readonly ILoRaDeviceRegistry deviceRegistry;
         private readonly ILogger<JoinRequestMessageHandler> logger;
+        private readonly Counter<int> receiveWindowHits;
+        private readonly Counter<int> receiveWindowMisses;
         private readonly NetworkServerConfiguration configuration;
 
         public JoinRequestMessageHandler(NetworkServerConfiguration configuration,
                                          ILoRaDeviceRegistry deviceRegistry,
-                                         ILogger<JoinRequestMessageHandler> logger)
+                                         ILogger<JoinRequestMessageHandler> logger,
+                                         Meter meter)
         {
             this.configuration = configuration;
             this.deviceRegistry = deviceRegistry;
             this.logger = logger;
+            this.receiveWindowHits = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowHits);
+            this.receiveWindowMisses = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowMisses);
         }
 
         public void DispatchRequest(LoRaRequest request)
@@ -126,6 +133,7 @@ namespace LoRaWan.NetworkServer
 
                     if (!timeWatcher.InTimeForJoinAccept())
                     {
+                        this.receiveWindowMisses?.Add(1);
                         // in this case it's too late, we need to break and avoid saving twins
                         this.logger.LogInformation("join refused: processing of the join request took too long, sending no message");
                         request.NotifyFailed(loRaDevice, LoRaDeviceRequestFailedReason.ReceiveWindowMissed);
@@ -177,6 +185,7 @@ namespace LoRaWan.NetworkServer
                     var windowToUse = timeWatcher.ResolveJoinAcceptWindowToUse();
                     if (windowToUse == Constants.InvalidReceiveWindow)
                     {
+                        this.receiveWindowMisses?.Add(1);
                         this.logger.LogInformation("join refused: processing of the join request took too long, sending no message");
                         request.NotifyFailed(loRaDevice, LoRaDeviceRequestFailedReason.ReceiveWindowMissed);
                         return;
@@ -272,6 +281,7 @@ namespace LoRaWan.NetworkServer
                     var joinAccept = loRaPayloadJoinAccept.Serialize(loRaDevice.AppKey, datr, freq, devEUI, tmst, lnsRxDelay, request.Rxpk.Rfch, request.Rxpk.Time, request.StationEui);
                     if (joinAccept != null)
                     {
+                        this.receiveWindowHits?.Add(1);
                         _ = request.PacketForwarder.SendDownstreamAsync(joinAccept);
                         request.NotifySucceeded(loRaDevice, joinAccept);
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.NetworkServer
 {
     using System;
+    using System.Diagnostics.Metrics;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Extensions.Logging;
 
@@ -14,18 +15,21 @@ namespace LoRaWan.NetworkServer
         private readonly ILoRaDeviceClientConnectionManager connectionManager;
         private readonly ILoggerFactory loggerFactory;
         private readonly ILogger<LoRaDeviceFactory> logger;
+        private readonly Histogram<double> dataMessageDeliveryLatency;
 
         public LoRaDeviceFactory(NetworkServerConfiguration configuration,
                                  ILoRaDataRequestHandler dataRequestHandler,
                                  ILoRaDeviceClientConnectionManager connectionManager,
                                  ILoggerFactory loggerFactory,
-                                 ILogger<LoRaDeviceFactory> logger)
+                                 ILogger<LoRaDeviceFactory> logger,
+                                 Meter meter)
         {
             this.configuration = configuration;
             this.dataRequestHandler = dataRequestHandler;
             this.connectionManager = connectionManager;
             this.loggerFactory = loggerFactory;
             this.logger = logger;
+            this.dataMessageDeliveryLatency = meter?.CreateHistogram<double>(MetricRegistry.DataMessageDeliveryLatency);
         }
 
         public LoRaDevice Create(IoTHubDeviceInfo deviceInfo)
@@ -36,7 +40,8 @@ namespace LoRaWan.NetworkServer
                 deviceInfo.DevAddr,
                 deviceInfo.DevEUI,
                 this.connectionManager,
-                this.loggerFactory.CreateLogger<LoRaDevice>())
+                this.loggerFactory.CreateLogger<LoRaDevice>(),
+                dataMessageDeliveryLatency)
             {
                 GatewayID = deviceInfo.GatewayId,
                 NwkSKey = deviceInfo.NwkSKey

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
@@ -4,7 +4,6 @@
 namespace LoRaWan.NetworkServer
 {
     using System;
-    using System.Diagnostics.Metrics;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Extensions.Logging;
 
@@ -15,21 +14,18 @@ namespace LoRaWan.NetworkServer
         private readonly ILoRaDeviceClientConnectionManager connectionManager;
         private readonly ILoggerFactory loggerFactory;
         private readonly ILogger<LoRaDeviceFactory> logger;
-        private readonly Histogram<double> dataMessageDeliveryLatency;
 
         public LoRaDeviceFactory(NetworkServerConfiguration configuration,
                                  ILoRaDataRequestHandler dataRequestHandler,
                                  ILoRaDeviceClientConnectionManager connectionManager,
                                  ILoggerFactory loggerFactory,
-                                 ILogger<LoRaDeviceFactory> logger,
-                                 Meter meter)
+                                 ILogger<LoRaDeviceFactory> logger)
         {
             this.configuration = configuration;
             this.dataRequestHandler = dataRequestHandler;
             this.connectionManager = connectionManager;
             this.loggerFactory = loggerFactory;
             this.logger = logger;
-            this.dataMessageDeliveryLatency = meter?.CreateHistogram<double>(MetricRegistry.DataMessageDeliveryLatency);
         }
 
         public LoRaDevice Create(IoTHubDeviceInfo deviceInfo)
@@ -40,8 +36,7 @@ namespace LoRaWan.NetworkServer
                 deviceInfo.DevAddr,
                 deviceInfo.DevEUI,
                 this.connectionManager,
-                this.loggerFactory.CreateLogger<LoRaDevice>(),
-                dataMessageDeliveryLatency)
+                this.loggerFactory.CreateLogger<LoRaDevice>())
             {
                 GatewayID = deviceInfo.GatewayId,
                 NwkSKey = deviceInfo.NwkSKey

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
@@ -51,7 +51,7 @@ namespace LoRaWan.NetworkServer
                                    ILoRaDeviceRegistry deviceRegistry,
                                    ILoRaDeviceFrameCounterUpdateStrategyProvider frameCounterUpdateStrategyProvider)
             : this(configuration, deviceRegistry, frameCounterUpdateStrategyProvider,
-                   new JoinRequestMessageHandler(configuration, deviceRegistry, NullLogger<JoinRequestMessageHandler>.Instance),
+                   new JoinRequestMessageHandler(configuration, deviceRegistry, NullLogger<JoinRequestMessageHandler>.Instance, null),
                    NullLoggerFactory.Instance,
                    NullLogger<MessageDispatcher>.Instance)
         { }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.NetworkServer
 {
     using System;
+    using System.Diagnostics.Metrics;
     using LoRaTools.LoRaMessage;
     using LoRaTools.Regions;
     using LoRaTools.Utils;
@@ -22,6 +23,7 @@ namespace LoRaWan.NetworkServer
         private readonly IJoinRequestMessageHandler joinRequestHandler;
         private readonly ILoggerFactory loggerFactory;
         private readonly ILogger<MessageDispatcher> logger;
+        private readonly Histogram<double> d2cMessageDeliveryLatencyHistogram;
 
         public MessageDispatcher(
             NetworkServerConfiguration configuration,
@@ -29,7 +31,8 @@ namespace LoRaWan.NetworkServer
             ILoRaDeviceFrameCounterUpdateStrategyProvider frameCounterUpdateStrategyProvider,
             IJoinRequestMessageHandler joinRequestHandler,
             ILoggerFactory loggerFactory,
-            ILogger<MessageDispatcher> logger)
+            ILogger<MessageDispatcher> logger,
+            Meter meter)
         {
             this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             this.deviceRegistry = deviceRegistry;
@@ -42,6 +45,7 @@ namespace LoRaWan.NetworkServer
             this.joinRequestHandler = joinRequestHandler;
             this.loggerFactory = loggerFactory;
             this.logger = logger;
+            this.d2cMessageDeliveryLatencyHistogram = meter?.CreateHistogram<double>(MetricRegistry.D2CMessageDeliveryLatency);
         }
 
         /// <summary>
@@ -53,7 +57,8 @@ namespace LoRaWan.NetworkServer
             : this(configuration, deviceRegistry, frameCounterUpdateStrategyProvider,
                    new JoinRequestMessageHandler(configuration, deviceRegistry, NullLogger<JoinRequestMessageHandler>.Instance, null),
                    NullLoggerFactory.Instance,
-                   NullLogger<MessageDispatcher>.Instance)
+                   NullLogger<MessageDispatcher>.Instance,
+                   null)
         { }
 
         /// <summary>
@@ -93,7 +98,7 @@ namespace LoRaWan.NetworkServer
 
             request.SetRegion(this.loraRegion);
 
-            var loggingRequest = new LoggingLoRaRequest(request, this.loggerFactory.CreateLogger<LoggingLoRaRequest>());
+            var loggingRequest = new LoggingLoRaRequest(request, this.loggerFactory.CreateLogger<LoggingLoRaRequest>(), this.d2cMessageDeliveryLatencyHistogram);
 
             if (request.Payload.LoRaMessageType == LoRaMessageType.JoinRequest)
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -28,8 +28,6 @@ namespace LoRaWan.NetworkServer
         public static readonly CustomMetric D2CMessagesReceived = new CustomMetric("D2CMessagesReceived", "Number of D2C messages received", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric D2CMessageSize = new CustomHistogram("D2CMessageSize", "Size of D2C messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName },
                                                                                  BucketStart: 5, BucketWidth: 10, BucketCount: 26);
-        public static readonly CustomMetric C2DMessageSize = new CustomHistogram("C2DMessageSize", "Size of C2D messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName },
-                                                                                 BucketStart: 5, BucketWidth: 10, BucketCount: 26);
         public static readonly CustomMetric C2DMessageTooLong = new CustomMetric("C2DMessageTooLong", "Number of C2D messages that were too long to be sent downstream", MetricType.Counter, new[] { GatewayIdTagName });
 
         private static readonly ICollection<CustomMetric> Registry = new[]
@@ -42,7 +40,6 @@ namespace LoRaWan.NetworkServer
             D2CMessageDeliveryLatency,
             D2CMessagesReceived,
             D2CMessageSize,
-            C2DMessageSize,
             C2DMessageTooLong
         };
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -20,7 +20,7 @@ namespace LoRaWan.NetworkServer
         public const string ReceiveWindowTagName = "ReceiveWindow";
 
         public static readonly CustomMetric JoinRequests = new CustomMetric("JoinRequests", "Number of join requests", MetricType.Counter, new[] { GatewayIdTagName });
-        public static readonly CustomMetric ActiveStationConnections = new CustomMetric("ActiveStationConnections", "Number of active station connections", MetricType.Histogram, Array.Empty<string>());
+        public static readonly CustomMetric ActiveStationConnections = new CustomMetric("ActiveStationConnections", "Number of active station connections", MetricType.ObservableGauge, Array.Empty<string>());
         public static readonly CustomMetric StationConnectivityLost = new CustomMetric("StationConnectivityLost", "Counts the number of station connectivities that were lost", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric ReceiveWindowHits = new CustomMetric("ReceiveWindowHits", "Receive window hits", MetricType.Counter, new[] { GatewayIdTagName, ReceiveWindowTagName });
         public static readonly CustomMetric ReceiveWindowMisses = new CustomMetric("ReceiveWindowMisses", "Receive window misses", MetricType.Counter, new[] { GatewayIdTagName });
@@ -53,7 +53,8 @@ namespace LoRaWan.NetworkServer
     internal enum MetricType
     {
         Counter,
-        Histogram
+        Histogram,
+        ObservableGauge
     }
 
     internal interface IMetricExporter : IDisposable
@@ -134,6 +135,11 @@ namespace LoRaWan.NetworkServer
         public static Histogram<T> CreateHistogram<T>(this Meter meter, CustomMetric customMetric) where T : struct =>
             customMetric.Type == MetricType.Histogram
             ? meter.CreateHistogram<T>(customMetric.Name, description: customMetric.Description)
+            : throw new ArgumentException("Custom metric must of type Histogram", nameof(customMetric));
+
+        public static ObservableGauge<T> CreateObservableGauge<T>(this Meter meter, CustomMetric customMetric, Func<T> observeValue) where T : struct =>
+            customMetric.Type == MetricType.ObservableGauge
+            ? meter.CreateObservableGauge(customMetric.Name, observeValue, description: customMetric.Description)
             : throw new ArgumentException("Custom metric must of type Histogram", nameof(customMetric));
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -17,11 +17,12 @@ namespace LoRaWan.NetworkServer
         public const string Version = "1.0";
         public const string GatewayIdTagName = "GatewayId";
         public const string DataMessageTypeTagName = "MessageType";
+        public const string ReceiveWindowTagName = "ReceiveWindow";
 
         public static readonly CustomMetric JoinRequests = new CustomMetric("JoinRequests", "Number of join requests", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric ActiveStationConnections = new CustomMetric("ActiveStationConnections", "Number of active station connections", MetricType.Histogram, Array.Empty<string>());
         public static readonly CustomMetric StationConnectivityLost = new CustomMetric("StationConnectivityLost", "Counts the number of station connectivities that were lost", MetricType.Counter, new[] { GatewayIdTagName });
-        public static readonly CustomMetric ReceiveWindowHits = new CustomMetric("ReceiveWindowHits", "Receive window hits", MetricType.Counter, new[] { GatewayIdTagName });
+        public static readonly CustomMetric ReceiveWindowHits = new CustomMetric("ReceiveWindowHits", "Receive window hits", MetricType.Counter, new[] { GatewayIdTagName, ReceiveWindowTagName });
         public static readonly CustomMetric ReceiveWindowMisses = new CustomMetric("ReceiveWindowMisses", "Receive window misses", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric D2CMessagesReceived = new CustomMetric("D2CMessagesReceived", "Number of D2C messages received", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric D2CMessageSize = new CustomMetric("D2CMessageSize", "Size of D2C messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName });
@@ -39,7 +40,8 @@ namespace LoRaWan.NetworkServer
             D2CMessagesReceived,
             D2CMessageSize,
             C2DMessageSize,
-            DataMessageDispatchLatency
+            DataMessageDispatchLatency,
+            DataMessageDeliveryLatency
         };
 
         public static readonly IDictionary<string, CustomMetric> RegistryLookup =

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -22,6 +22,7 @@ namespace LoRaWan.NetworkServer
         public static readonly CustomMetric StationConnectivityLost = new CustomMetric("StationConnectivityLost", "Counts the number of station connectivities that were lost", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric ReceiveWindowHits = new CustomMetric("ReceiveWindowHits", "Receive window hits", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric ReceiveWindowMisses = new CustomMetric("ReceiveWindowMisses", "Receive window misses", MetricType.Counter, new[] { GatewayIdTagName });
+        public static readonly CustomMetric D2CMessagesReceived = new CustomMetric("D2CMessagesReceived", "Number of D2C messages received", MetricType.Counter, new[] { GatewayIdTagName });
 
         private static readonly ICollection<CustomMetric> Registry = new[]
         {
@@ -29,7 +30,8 @@ namespace LoRaWan.NetworkServer
             ActiveStationConnections,
             StationConnectivityLost,
             ReceiveWindowHits,
-            ReceiveWindowMisses
+            ReceiveWindowMisses,
+            D2CMessagesReceived
         };
 
         public static readonly IDictionary<string, CustomMetric> RegistryLookup =

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -23,6 +23,7 @@ namespace LoRaWan.NetworkServer
         public static readonly CustomMetric ReceiveWindowHits = new CustomMetric("ReceiveWindowHits", "Receive window hits", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric ReceiveWindowMisses = new CustomMetric("ReceiveWindowMisses", "Receive window misses", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric D2CMessagesReceived = new CustomMetric("D2CMessagesReceived", "Number of D2C messages received", MetricType.Counter, new[] { GatewayIdTagName });
+        public static readonly CustomMetric D2CMessageSize = new CustomMetric("D2CMessageSize", "Size of D2C messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName });
         public static readonly CustomMetric C2DMessageSize = new CustomMetric("C2DMessageSize", "Size of C2D messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName });
 
         private static readonly ICollection<CustomMetric> Registry = new[]

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -16,6 +16,7 @@ namespace LoRaWan.NetworkServer
         public const string Namespace = "LoRaWan";
         public const string Version = "1.0";
         public const string GatewayIdTagName = "GatewayId";
+        public const string DataMessageTypeTagName = "MessageType";
 
         public static readonly CustomMetric JoinRequests = new CustomMetric("JoinRequests", "Number of join requests", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric ActiveStationConnections = new CustomMetric("ActiveStationConnections", "Number of active station connections", MetricType.Histogram, Array.Empty<string>());
@@ -25,6 +26,8 @@ namespace LoRaWan.NetworkServer
         public static readonly CustomMetric D2CMessagesReceived = new CustomMetric("D2CMessagesReceived", "Number of D2C messages received", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric D2CMessageSize = new CustomMetric("D2CMessageSize", "Size of D2C messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName });
         public static readonly CustomMetric C2DMessageSize = new CustomMetric("C2DMessageSize", "Size of C2D messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName });
+        public static readonly CustomMetric DataMessageDispatchLatency = new CustomMetric("DataMessageDispatchLatency", "Indicates how long it took to dispatch the message", MetricType.Histogram, new[] { GatewayIdTagName, DataMessageTypeTagName });
+        public static readonly CustomMetric DataMessageDeliveryLatency = new CustomMetric("DataMessageDeliveryLatency", "Indicates how long it took to deliver a dispatched message", MetricType.Histogram, new[] { GatewayIdTagName });
 
         private static readonly ICollection<CustomMetric> Registry = new[]
         {
@@ -34,7 +37,9 @@ namespace LoRaWan.NetworkServer
             ReceiveWindowHits,
             ReceiveWindowMisses,
             D2CMessagesReceived,
-            C2DMessageSize
+            D2CMessageSize,
+            C2DMessageSize,
+            DataMessageDispatchLatency
         };
 
         public static readonly IDictionary<string, CustomMetric> RegistryLookup =

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -23,6 +23,7 @@ namespace LoRaWan.NetworkServer
         public static readonly CustomMetric StationConnectivityLost = new CustomMetric("StationConnectivityLost", "Counts the number of station connectivities that were lost", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric ReceiveWindowHits = new CustomMetric("ReceiveWindowHits", "Receive window hits", MetricType.Counter, new[] { GatewayIdTagName, ReceiveWindowTagName });
         public static readonly CustomMetric ReceiveWindowMisses = new CustomMetric("ReceiveWindowMisses", "Receive window misses", MetricType.Counter, new[] { GatewayIdTagName });
+        public static readonly CustomMetric D2CMessageDeliveryLatency = new CustomMetric("D2CMessageDeliveryLatency", "D2C delivery latency", MetricType.Histogram, new[] { GatewayIdTagName });
         public static readonly CustomMetric D2CMessagesReceived = new CustomMetric("D2CMessagesReceived", "Number of D2C messages received", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric D2CMessageSize = new CustomMetric("D2CMessageSize", "Size of D2C messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName });
         public static readonly CustomMetric C2DMessageSize = new CustomMetric("C2DMessageSize", "Size of C2D messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName });
@@ -34,6 +35,7 @@ namespace LoRaWan.NetworkServer
             StationConnectivityLost,
             ReceiveWindowHits,
             ReceiveWindowMisses,
+            D2CMessageDeliveryLatency,
             D2CMessagesReceived,
             D2CMessageSize,
             C2DMessageSize

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -24,12 +24,12 @@ namespace LoRaWan.NetworkServer
         public static readonly CustomMetric ReceiveWindowHits = new CustomMetric("ReceiveWindowHits", "Receive window hits", MetricType.Counter, new[] { GatewayIdTagName, ReceiveWindowTagName });
         public static readonly CustomMetric ReceiveWindowMisses = new CustomMetric("ReceiveWindowMisses", "Receive window misses", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric D2CMessageDeliveryLatency = new CustomHistogram("D2CMessageDeliveryLatency", "D2C delivery latency (in milliseconds)", MetricType.Histogram, new[] { GatewayIdTagName },
-                                                                                            BucketStart: 100, BucketWidth: 50, BucketCount: 30);
+                                                                                            BucketStart: 100, BucketWidth: 50, BucketCount: 45);
         public static readonly CustomMetric D2CMessagesReceived = new CustomMetric("D2CMessagesReceived", "Number of D2C messages received", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric D2CMessageSize = new CustomHistogram("D2CMessageSize", "Size of D2C messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName },
-                                                                                 BucketStart: 5, BucketWidth: 5, BucketCount: 30);
+                                                                                 BucketStart: 5, BucketWidth: 10, BucketCount: 26);
         public static readonly CustomMetric C2DMessageSize = new CustomHistogram("C2DMessageSize", "Size of C2D messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName },
-                                                                                 BucketStart: 5, BucketWidth: 5, BucketCount: 30);
+                                                                                 BucketStart: 5, BucketWidth: 10, BucketCount: 26);
         public static readonly CustomMetric C2DMessageTooLong = new CustomMetric("C2DMessageTooLong", "Number of C2D messages that were too long to be sent downstream", MetricType.Counter, new[] { GatewayIdTagName });
 
         private static readonly ICollection<CustomMetric> Registry = new[]

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -20,11 +20,16 @@ namespace LoRaWan.NetworkServer
         public static readonly CustomMetric JoinRequests = new CustomMetric("JoinRequests", "Number of join requests", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric ActiveStationConnections = new CustomMetric("ActiveStationConnections", "Number of active station connections", MetricType.Histogram, Array.Empty<string>());
         public static readonly CustomMetric StationConnectivityLost = new CustomMetric("StationConnectivityLost", "Counts the number of station connectivities that were lost", MetricType.Counter, new[] { GatewayIdTagName });
+        public static readonly CustomMetric ReceiveWindowHits = new CustomMetric("ReceiveWindowHits", "Receive window hits", MetricType.Counter, new[] { GatewayIdTagName });
+        public static readonly CustomMetric ReceiveWindowMisses = new CustomMetric("ReceiveWindowMisses", "Receive window misses", MetricType.Counter, new[] { GatewayIdTagName });
 
         private static readonly ICollection<CustomMetric> Registry = new[]
         {
             JoinRequests,
-            ActiveStationConnections
+            ActiveStationConnections,
+            StationConnectivityLost,
+            ReceiveWindowHits,
+            ReceiveWindowMisses
         };
 
         public static readonly IDictionary<string, CustomMetric> RegistryLookup =

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -16,7 +16,6 @@ namespace LoRaWan.NetworkServer
         public const string Namespace = "LoRaWan";
         public const string Version = "1.0";
         public const string GatewayIdTagName = "GatewayId";
-        public const string DataMessageTypeTagName = "MessageType";
         public const string ReceiveWindowTagName = "ReceiveWindow";
 
         public static readonly CustomMetric JoinRequests = new CustomMetric("JoinRequests", "Number of join requests", MetricType.Counter, new[] { GatewayIdTagName });
@@ -27,8 +26,6 @@ namespace LoRaWan.NetworkServer
         public static readonly CustomMetric D2CMessagesReceived = new CustomMetric("D2CMessagesReceived", "Number of D2C messages received", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric D2CMessageSize = new CustomMetric("D2CMessageSize", "Size of D2C messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName });
         public static readonly CustomMetric C2DMessageSize = new CustomMetric("C2DMessageSize", "Size of C2D messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName });
-        public static readonly CustomMetric DataMessageDispatchLatency = new CustomMetric("DataMessageDispatchLatency", "Indicates how long it took to dispatch the message", MetricType.Histogram, new[] { GatewayIdTagName, DataMessageTypeTagName });
-        public static readonly CustomMetric DataMessageDeliveryLatency = new CustomMetric("DataMessageDeliveryLatency", "Indicates how long it took to deliver a dispatched message", MetricType.Histogram, new[] { GatewayIdTagName });
 
         private static readonly ICollection<CustomMetric> Registry = new[]
         {
@@ -39,9 +36,7 @@ namespace LoRaWan.NetworkServer
             ReceiveWindowMisses,
             D2CMessagesReceived,
             D2CMessageSize,
-            C2DMessageSize,
-            DataMessageDispatchLatency,
-            DataMessageDeliveryLatency
+            C2DMessageSize
         };
 
         public static readonly IDictionary<string, CustomMetric> RegistryLookup =

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -23,10 +23,13 @@ namespace LoRaWan.NetworkServer
         public static readonly CustomMetric StationConnectivityLost = new CustomMetric("StationConnectivityLost", "Counts the number of station connectivities that were lost", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric ReceiveWindowHits = new CustomMetric("ReceiveWindowHits", "Receive window hits", MetricType.Counter, new[] { GatewayIdTagName, ReceiveWindowTagName });
         public static readonly CustomMetric ReceiveWindowMisses = new CustomMetric("ReceiveWindowMisses", "Receive window misses", MetricType.Counter, new[] { GatewayIdTagName });
-        public static readonly CustomMetric D2CMessageDeliveryLatency = new CustomMetric("D2CMessageDeliveryLatency", "D2C delivery latency", MetricType.Histogram, new[] { GatewayIdTagName });
+        public static readonly CustomMetric D2CMessageDeliveryLatency = new CustomHistogram("D2CMessageDeliveryLatency", "D2C delivery latency", MetricType.Histogram, new[] { GatewayIdTagName },
+                                                                                            BucketStart: 100, BucketWidth: 50, BucketCount: 30);
         public static readonly CustomMetric D2CMessagesReceived = new CustomMetric("D2CMessagesReceived", "Number of D2C messages received", MetricType.Counter, new[] { GatewayIdTagName });
-        public static readonly CustomMetric D2CMessageSize = new CustomMetric("D2CMessageSize", "Size of D2C messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName });
-        public static readonly CustomMetric C2DMessageSize = new CustomMetric("C2DMessageSize", "Size of C2D messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName });
+        public static readonly CustomMetric D2CMessageSize = new CustomHistogram("D2CMessageSize", "Size of D2C messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName },
+                                                                                 BucketStart: 5, BucketWidth: 5, BucketCount: 30);
+        public static readonly CustomMetric C2DMessageSize = new CustomHistogram("C2DMessageSize", "Size of C2D messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName },
+                                                                                 BucketStart: 5, BucketWidth: 5, BucketCount: 30);
 
         private static readonly ICollection<CustomMetric> Registry = new[]
         {
@@ -46,6 +49,10 @@ namespace LoRaWan.NetworkServer
     }
 
     internal record CustomMetric(string Name, string Description, MetricType Type, string[] Tags);
+
+    internal record CustomHistogram(string Name, string Description, MetricType Type, string[] Tags,
+                                    double BucketStart, double BucketWidth, int BucketCount)
+        : CustomMetric(Name, Description, Type, Tags);
 
     internal enum MetricType
     {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -23,13 +23,14 @@ namespace LoRaWan.NetworkServer
         public static readonly CustomMetric StationConnectivityLost = new CustomMetric("StationConnectivityLost", "Counts the number of station connectivities that were lost", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric ReceiveWindowHits = new CustomMetric("ReceiveWindowHits", "Receive window hits", MetricType.Counter, new[] { GatewayIdTagName, ReceiveWindowTagName });
         public static readonly CustomMetric ReceiveWindowMisses = new CustomMetric("ReceiveWindowMisses", "Receive window misses", MetricType.Counter, new[] { GatewayIdTagName });
-        public static readonly CustomMetric D2CMessageDeliveryLatency = new CustomHistogram("D2CMessageDeliveryLatency", "D2C delivery latency", MetricType.Histogram, new[] { GatewayIdTagName },
+        public static readonly CustomMetric D2CMessageDeliveryLatency = new CustomHistogram("D2CMessageDeliveryLatency", "D2C delivery latency (in milliseconds)", MetricType.Histogram, new[] { GatewayIdTagName },
                                                                                             BucketStart: 100, BucketWidth: 50, BucketCount: 30);
         public static readonly CustomMetric D2CMessagesReceived = new CustomMetric("D2CMessagesReceived", "Number of D2C messages received", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric D2CMessageSize = new CustomHistogram("D2CMessageSize", "Size of D2C messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName },
                                                                                  BucketStart: 5, BucketWidth: 5, BucketCount: 30);
         public static readonly CustomMetric C2DMessageSize = new CustomHistogram("C2DMessageSize", "Size of C2D messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName },
                                                                                  BucketStart: 5, BucketWidth: 5, BucketCount: 30);
+        public static readonly CustomMetric C2DMessageTooLong = new CustomMetric("C2DMessageTooLong", "Number of C2D messages that were too long to be sent downstream", MetricType.Counter, new[] { GatewayIdTagName });
 
         private static readonly ICollection<CustomMetric> Registry = new[]
         {
@@ -41,7 +42,8 @@ namespace LoRaWan.NetworkServer
             D2CMessageDeliveryLatency,
             D2CMessagesReceived,
             D2CMessageSize,
-            C2DMessageSize
+            C2DMessageSize,
+            C2DMessageTooLong
         };
 
         public static readonly IDictionary<string, CustomMetric> RegistryLookup =

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -23,6 +23,7 @@ namespace LoRaWan.NetworkServer
         public static readonly CustomMetric ReceiveWindowHits = new CustomMetric("ReceiveWindowHits", "Receive window hits", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric ReceiveWindowMisses = new CustomMetric("ReceiveWindowMisses", "Receive window misses", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric D2CMessagesReceived = new CustomMetric("D2CMessagesReceived", "Number of D2C messages received", MetricType.Counter, new[] { GatewayIdTagName });
+        public static readonly CustomMetric C2DMessageSize = new CustomMetric("C2DMessageSize", "Size of C2D messages (in bytes)", MetricType.Histogram, new[] { GatewayIdTagName });
 
         private static readonly ICollection<CustomMetric> Registry = new[]
         {
@@ -31,7 +32,8 @@ namespace LoRaWan.NetworkServer
             StationConnectivityLost,
             ReceiveWindowHits,
             ReceiveWindowMisses,
-            D2CMessagesReceived
+            D2CMessagesReceived,
+            C2DMessageSize
         };
 
         public static readonly IDictionary<string, CustomMetric> RegistryLookup =

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -18,9 +18,13 @@ namespace LoRaWan.NetworkServer
         public const string GatewayIdTagName = "GatewayId";
 
         public static readonly CustomMetric JoinRequests = new CustomMetric("JoinRequests", "Number of join requests", MetricType.Counter, new[] { GatewayIdTagName });
+        public static readonly CustomMetric ActiveStationConnections = new CustomMetric("ActiveStationConnections", "Number of active station connections", MetricType.Histogram, Array.Empty<string>());
+        public static readonly CustomMetric StationConnectivityLost = new CustomMetric("StationConnectivityLost", "Counts the number of station connectivities that were lost", MetricType.Counter, new[] { GatewayIdTagName });
+
         private static readonly ICollection<CustomMetric> Registry = new[]
         {
-            JoinRequests
+            JoinRequests,
+            ActiveStationConnections
         };
 
         public static readonly IDictionary<string, CustomMetric> RegistryLookup =

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/PrometheusMetricExporter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/PrometheusMetricExporter.cs
@@ -31,7 +31,14 @@ namespace LoRaWan.NetworkServer
             : base(registryLookup, logger)
         {
             this.counters = GetMetricsFromRegistry(MetricType.Counter, m => Metrics.CreateCounter(m.Name, m.Description, m.Tags));
-            this.histograms = GetMetricsFromRegistry(MetricType.Histogram, m => Metrics.CreateHistogram(m.Name, m.Description, m.Tags));
+            this.histograms = GetMetricsFromRegistry(MetricType.Histogram, m => m is CustomHistogram customHistogram
+                    ? Metrics.CreateHistogram(customHistogram.Name, customHistogram.Description,
+                                              new HistogramConfiguration
+                                              {
+                                                  Buckets = Histogram.LinearBuckets(customHistogram.BucketStart, customHistogram.BucketWidth, customHistogram.BucketCount),
+                                                  LabelNames = customHistogram.Tags
+                                              })
+                    : Metrics.CreateHistogram(m.Name, m.Description, m.Tags));
             this.gauges = GetMetricsFromRegistry(MetricType.ObservableGauge, m => Metrics.CreateGauge(m.Name, m.Description, m.Tags));
 
             IDictionary<string, T> GetMetricsFromRegistry<T>(MetricType metricType, Func<CustomMetric, T> factory) =>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/RegistryMetricExporter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/RegistryMetricExporter.cs
@@ -59,6 +59,11 @@ namespace LoRaWan.NetworkServer
                     {
                         this.listener.RecordObservableInstruments();
                     }
+                    catch (TaskCanceledException)
+                    {
+                        // exception raised after disposal.
+                        return;
+                    }
 #pragma warning disable CA1031 // Do not catch general exception types (continue observing metrics even on error)
                     catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/RegistryMetricExporter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/RegistryMetricExporter.cs
@@ -14,7 +14,7 @@ namespace LoRaWan.NetworkServer
 
     internal abstract class RegistryMetricExporter : IMetricExporter
     {
-        private static readonly TimeSpan ObserveInterval = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan ObserveInterval = TimeSpan.FromSeconds(30);
 
         private readonly CancellationTokenSource cancellationTokenSource;
         protected readonly IDictionary<string, CustomMetric> registryLookup;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/RegistryMetricExporter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/RegistryMetricExporter.cs
@@ -8,17 +8,25 @@ namespace LoRaWan.NetworkServer
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.Metrics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
 
     internal abstract class RegistryMetricExporter : IMetricExporter
     {
-        protected readonly IDictionary<string, CustomMetric> registryLookup;
+        private static readonly TimeSpan ObserveInterval = TimeSpan.FromSeconds(10);
 
+        private readonly CancellationTokenSource cancellationTokenSource;
+        protected readonly IDictionary<string, CustomMetric> registryLookup;
+        private readonly ILogger<RegistryMetricExporter> logger;
         private MeterListener? listener;
         private bool disposedValue;
 
-        public RegistryMetricExporter(IDictionary<string, CustomMetric> registryLookup)
+        public RegistryMetricExporter(IDictionary<string, CustomMetric> registryLookup, ILogger<RegistryMetricExporter> logger)
         {
             this.registryLookup = registryLookup;
+            this.logger = logger;
+            this.cancellationTokenSource = new CancellationTokenSource();
         }
 
         public void Start()
@@ -28,7 +36,9 @@ namespace LoRaWan.NetworkServer
                 InstrumentPublished = (instrument, meterListener) =>
                 {
                     if (instrument.Meter.Name == MetricRegistry.Namespace && this.registryLookup.ContainsKey(instrument.Name))
+                    {
                         meterListener.EnableMeasurementEvents(instrument);
+                    }
                 }
             };
 
@@ -40,6 +50,25 @@ namespace LoRaWan.NetworkServer
             this.listener.SetMeasurementEventCallback<double>(TrackValue);
             this.listener.SetMeasurementEventCallback<decimal>((i, m, t, s) => TrackValue(i, checked((double)m), t, s));
             this.listener.Start();
+
+            _ = Task.Run(async () =>
+            {
+                while (!this.cancellationTokenSource.IsCancellationRequested)
+                {
+                    try
+                    {
+                        this.listener.RecordObservableInstruments();
+                    }
+#pragma warning disable CA1031 // Do not catch general exception types (continue observing metrics even on error)
+                    catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+                    {
+                        this.logger.LogInformation(ex, "Exception when recording observable metrics.");
+                    }
+
+                    await Task.Delay(ObserveInterval, this.cancellationTokenSource.Token);
+                }
+            });
         }
 
         protected abstract void TrackValue(Instrument instrument,
@@ -54,6 +83,8 @@ namespace LoRaWan.NetworkServer
                 if (disposing)
                 {
                     this.listener?.Dispose();
+                    this.cancellationTokenSource.Cancel();
+                    this.cancellationTokenSource.Dispose();
                 }
 
                 this.disposedValue = true;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/WebSocketWriterRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/WebSocketWriterRegistry.cs
@@ -9,6 +9,7 @@ namespace LoRaWan.NetworkServer
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
+    using System.Diagnostics.Metrics;
     using System.Linq;
     using System.Net.WebSockets;
     using System.Threading;
@@ -51,9 +52,15 @@ namespace LoRaWan.NetworkServer
     {
         private readonly Dictionary<TKey, (IWebSocketWriter<TMessage> Object, Handle Handle)> sockets = new();
         private readonly ILogger? logger;
+        private readonly Histogram<int>? activeStationConnectionsHistogram;
+        private readonly Counter<int>? stationConnectivityLostCounter;
 
-        public WebSocketWriterRegistry(ILogger<WebSocketWriterRegistry<TKey, TMessage>>? logger) =>
+        public WebSocketWriterRegistry(ILogger<WebSocketWriterRegistry<TKey, TMessage>>? logger, Meter? meter)
+        {
             this.logger = logger;
+            this.activeStationConnectionsHistogram = meter?.CreateHistogram<int>(MetricRegistry.ActiveStationConnections);
+            this.stationConnectivityLostCounter = meter?.CreateCounter<int>(MetricRegistry.StationConnectivityLost);
+        }
 
         /// <summary>
         /// Attempts to retrieve the socket writer handle for the given key.
@@ -99,6 +106,7 @@ namespace LoRaWan.NetworkServer
                 }
 
                 this.sockets[key] = (socketWriter, handle);
+                this.activeStationConnectionsHistogram?.Record(this.sockets.Count);
                 return handle;
             }
         }
@@ -113,6 +121,7 @@ namespace LoRaWan.NetworkServer
             {
                 if (this.sockets.TryGetValue(key, out var current))
                 {
+                    this.stationConnectivityLostCounter?.Add(1);
                     _ = this.sockets.Remove(key);
                     return current.Object;
                 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/WebSocketWriterRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/WebSocketWriterRegistry.cs
@@ -52,13 +52,13 @@ namespace LoRaWan.NetworkServer
     {
         private readonly Dictionary<TKey, (IWebSocketWriter<TMessage> Object, Handle Handle)> sockets = new();
         private readonly ILogger? logger;
-        private readonly Histogram<int>? activeStationConnectionsHistogram;
+        private readonly ObservableGauge<int>? activeStationConnectionsHistogram;
         private readonly Counter<int>? stationConnectivityLostCounter;
 
         public WebSocketWriterRegistry(ILogger<WebSocketWriterRegistry<TKey, TMessage>>? logger, Meter? meter)
         {
             this.logger = logger;
-            this.activeStationConnectionsHistogram = meter?.CreateHistogram<int>(MetricRegistry.ActiveStationConnections);
+            this.activeStationConnectionsHistogram = meter?.CreateObservableGauge<int>(MetricRegistry.ActiveStationConnections.Name, () => this.sockets.Count, description: MetricRegistry.ActiveStationConnections.Description);
             this.stationConnectivityLostCounter = meter?.CreateCounter<int>(MetricRegistry.StationConnectivityLost);
         }
 
@@ -106,7 +106,6 @@ namespace LoRaWan.NetworkServer
                 }
 
                 this.sockets[key] = (socketWriter, handle);
-                this.activeStationConnectionsHistogram?.Record(this.sockets.Count);
                 return handle;
             }
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/WebSocketWriterRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/WebSocketWriterRegistry.cs
@@ -58,7 +58,7 @@ namespace LoRaWan.NetworkServer
         public WebSocketWriterRegistry(ILogger<WebSocketWriterRegistry<TKey, TMessage>>? logger, Meter? meter)
         {
             this.logger = logger;
-            this.activeStationConnectionsHistogram = meter?.CreateObservableGauge<int>(MetricRegistry.ActiveStationConnections.Name, () => this.sockets.Count, description: MetricRegistry.ActiveStationConnections.Description);
+            this.activeStationConnectionsHistogram = meter?.CreateObservableGauge(MetricRegistry.ActiveStationConnections, () => this.sockets.Count);
             this.stationConnectivityLostCounter = meter?.CreateCounter<int>(MetricRegistry.StationConnectivityLost);
         }
 

--- a/Tests/Common/MessageProcessorMultipleGatewayBase.cs
+++ b/Tests/Common/MessageProcessorMultipleGatewayBase.cs
@@ -51,7 +51,7 @@ namespace LoRaWan.Tests.Common
             var loRaAdrManagerFactory = new LoRAADRManagerFactory(SecondLoRaDeviceApi.Object, NullLoggerFactory.Instance);
             var adrStrategyProvider = new LoRaADRStrategyProvider(NullLoggerFactory.Instance);
             var functionBundlerProvider = new FunctionBundlerProvider(SecondLoRaDeviceApi.Object, NullLoggerFactory.Instance, NullLogger<FunctionBundlerProvider>.Instance);
-            SecondRequestHandlerImplementation = new DefaultLoRaDataRequestHandler(SecondServerConfiguration, SecondFrameCounterUpdateStrategyProvider, new LoRaPayloadDecoder(NullLogger<LoRaPayloadDecoder>.Instance), deduplicationStrategyFactory, adrStrategyProvider, loRaAdrManagerFactory, functionBundlerProvider, NullLogger<DefaultLoRaDataRequestHandler>.Instance);
+            SecondRequestHandlerImplementation = new DefaultLoRaDataRequestHandler(SecondServerConfiguration, SecondFrameCounterUpdateStrategyProvider, new LoRaPayloadDecoder(NullLogger<LoRaPayloadDecoder>.Instance), deduplicationStrategyFactory, adrStrategyProvider, loRaAdrManagerFactory, functionBundlerProvider, NullLogger<DefaultLoRaDataRequestHandler>.Instance, null);
             SecondLoRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
             this.cache = new MemoryCache(new MemoryCacheOptions() { ExpirationScanFrequency = TimeSpan.FromSeconds(5) });
             SecondConnectionManager = new LoRaDeviceClientConnectionManager(this.cache, NullLogger<LoRaDeviceClientConnectionManager>.Instance);

--- a/Tests/Common/MessageProcessorTestBase.cs
+++ b/Tests/Common/MessageProcessorTestBase.cs
@@ -65,7 +65,7 @@ namespace LoRaWan.Tests.Common
             var adrStrategyProvider = new LoRaADRStrategyProvider(NullLoggerFactory.Instance);
             var adrManagerFactory = new LoRAADRManagerFactory(LoRaDeviceApi.Object, NullLoggerFactory.Instance);
             var functionBundlerProvider = new FunctionBundlerProvider(LoRaDeviceApi.Object, NullLoggerFactory.Instance, NullLogger<FunctionBundlerProvider>.Instance);
-            RequestHandlerImplementation = new DefaultLoRaDataRequestHandler(ServerConfiguration, FrameCounterUpdateStrategyProvider, PayloadDecoder, deduplicationFactory, adrStrategyProvider, adrManagerFactory, functionBundlerProvider, NullLogger<DefaultLoRaDataRequestHandler>.Instance);
+            RequestHandlerImplementation = new DefaultLoRaDataRequestHandler(ServerConfiguration, FrameCounterUpdateStrategyProvider, PayloadDecoder, deduplicationFactory, adrStrategyProvider, adrManagerFactory, functionBundlerProvider, NullLogger<DefaultLoRaDataRequestHandler>.Instance, null);
             LoRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Strict);
             this.cache = new MemoryCache(new MemoryCacheOptions() { ExpirationScanFrequency = TimeSpan.FromSeconds(5) });
             ConnectionManager = new LoRaDeviceClientConnectionManager(this.cache, NullLogger<LoRaDeviceClientConnectionManager>.Instance);

--- a/Tests/Common/MoqExtensions.cs
+++ b/Tests/Common/MoqExtensions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Common
+{
+    using System;
+    using System.Linq.Expressions;
+    using System.Threading.Tasks;
+    using Moq;
+
+    public static class MoqExtensions
+    {
+        public static async Task RetryVerifyAsync<T>(this Mock<T> mock,
+                                                     Expression<Action<T>> expression,
+                                                     Func<Times> times,
+                                                     int numberOfRetries = 5,
+                                                     TimeSpan? delay = null)
+            where T : class
+        {
+            if (mock is null) throw new ArgumentNullException(nameof(mock));
+
+            var retryDelay = delay ?? TimeSpan.FromMilliseconds(50);
+            for (var i = 0; i < numberOfRetries + 1; ++i)
+            {
+                try
+                {
+                    mock.Verify(expression, times);
+                    break;
+                }
+                catch (MockException) when (i < numberOfRetries)
+                {
+                    // assertion does not yet pass, retry once more.
+                    await Task.Delay(retryDelay);
+                    continue;
+                }
+            }
+        }
+    }
+}

--- a/Tests/Common/TestLoRaDeviceFactory.cs
+++ b/Tests/Common/TestLoRaDeviceFactory.cs
@@ -84,7 +84,7 @@ namespace LoRaWan.Tests.Common
 
             this.connectionManager.Register(loRaDevice, deviceClientToAssign);
 
-            loRaDevice.SetRequestHandler(this.requestHandler ?? new DefaultLoRaDataRequestHandler(this.configuration, this.frameCounterUpdateStrategyProvider, new LoRaPayloadDecoder(NullLogger<LoRaPayloadDecoder>.Instance), this.deduplicationFactory, this.adrStrategyProvider, this.adrManagerFactory, this.functionBundlerProvider, NullLogger<DefaultLoRaDataRequestHandler>.Instance));
+            loRaDevice.SetRequestHandler(this.requestHandler ?? new DefaultLoRaDataRequestHandler(this.configuration, this.frameCounterUpdateStrategyProvider, new LoRaPayloadDecoder(NullLogger<LoRaPayloadDecoder>.Instance), this.deduplicationFactory, this.adrStrategyProvider, this.adrManagerFactory, this.functionBundlerProvider, NullLogger<DefaultLoRaDataRequestHandler>.Instance, null));
 
             this.deviceMap[deviceInfo.DevEUI] = loRaDevice;
 

--- a/Tests/Common/TestMeter.cs
+++ b/Tests/Common/TestMeter.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Common
+{
+    using System.Diagnostics.Metrics;
+
+    public sealed class TestMeter
+    {
+        /// <summary>
+        /// Gets a Meter instance that is not being listened on, which ensures that there is no non-deterministic interference on Metrics between tests running in parallel.
+        /// </summary>
+        public static readonly Meter Instance = new Meter("LoRaWanTest", "0.1");
+    }
+}

--- a/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
+++ b/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
@@ -5,6 +5,7 @@ namespace LoRaWan.Tests.Integration
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.Metrics;
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
@@ -121,7 +122,8 @@ namespace LoRaWan.Tests.Integration
                 this.loRaDeviceRegistry,
                 PacketForwarder,
                 this.frameCounterStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             // Expectations
             // Verify that C2D message is sent
@@ -206,7 +208,8 @@ namespace LoRaWan.Tests.Integration
                 this.loRaDeviceRegistry,
                 PacketForwarder,
                 this.frameCounterStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             // Expectations
             // Verify that C2D message is sent

--- a/Tests/Integration/ClassCIntegrationTests.cs
+++ b/Tests/Integration/ClassCIntegrationTests.cs
@@ -91,7 +91,8 @@ namespace LoRaWan.Tests.Integration
                 deviceRegistry,
                 PacketForwarder,
                 FrameCounterUpdateStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             var c2d = new ReceivedLoRaCloudToDeviceMessage()
             {
@@ -196,7 +197,8 @@ namespace LoRaWan.Tests.Integration
                 deviceRegistry,
                 PacketForwarder,
                 FrameCounterUpdateStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             var c2d = new ReceivedLoRaCloudToDeviceMessage()
             {

--- a/Tests/Integration/KeepAliveConnectionTests.cs
+++ b/Tests/Integration/KeepAliveConnectionTests.cs
@@ -360,7 +360,8 @@ namespace LoRaWan.Tests.Integration
                 deviceRegistry,
                 PacketForwarder,
                 FrameCounterUpdateStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             Assert.True(await target.SendAsync(c2dToDeviceMessage));
             Assert.Single(PacketForwarder.DownlinkMessages);

--- a/Tests/Unit/NetworkServer/ApplicationInsightsMetricExporterTests.cs
+++ b/Tests/Unit/NetworkServer/ApplicationInsightsMetricExporterTests.cs
@@ -136,7 +136,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var measurement = new Measurement<int>(1, KeyValuePair.Create(MetricRegistry.GatewayIdTagName, (object)stationEui));
             _ = observeValue.Setup(ov => ov.Invoke()).Returns(measurement);
             using var meter = new Meter("LoRaWan", "1.0");
-            var observableGauge = meter.CreateObservableGauge(ObservableGaugeMetric.Name, observeValue.Object);
+            _ = meter.CreateObservableGauge(ObservableGaugeMetric.Name, observeValue.Object);
 
             // act
             this.applicationInsightsMetricExporter.Start();

--- a/Tests/Unit/NetworkServer/ApplicationInsightsMetricExporterTests.cs
+++ b/Tests/Unit/NetworkServer/ApplicationInsightsMetricExporterTests.cs
@@ -7,7 +7,6 @@ namespace LoRaWan.Tests.Unit.NetworkServer
     using System.Collections.Generic;
     using System.Diagnostics.Metrics;
     using System.Linq;
-    using System.Threading.Tasks;
     using LoRaWan.NetworkServer;
     using LoRaWan.Tests.Common;
     using Microsoft.ApplicationInsights;

--- a/Tests/Unit/NetworkServer/BasicsStation/DownstreamSenderTests.cs
+++ b/Tests/Unit/NetworkServer/BasicsStation/DownstreamSenderTests.cs
@@ -26,7 +26,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
 
         public DownstreamSenderTests()
         {
-            var socketWriterRegistry = new WebSocketWriterRegistry<StationEui, string>(Mock.Of<ILogger<WebSocketWriterRegistry<StationEui, string>>>());
+            var socketWriterRegistry = new WebSocketWriterRegistry<StationEui, string>(Mock.Of<ILogger<WebSocketWriterRegistry<StationEui, string>>>(), null);
             this.webSocketWriter = new Mock<IWebSocketWriter<string>>();
 
             var basicStationConfigurationService = new Mock<IBasicsStationConfigurationService>();

--- a/Tests/Unit/NetworkServer/ConcentratorDeduplicationTest.cs
+++ b/Tests/Unit/NetworkServer/ConcentratorDeduplicationTest.cs
@@ -26,7 +26,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         public ConcentratorDeduplicationTest()
         {
             this.cache = new MemoryCache(new MemoryCacheOptions());
-            this.socketRegistry = new WebSocketWriterRegistry<StationEui, string>(NullLogger<WebSocketWriterRegistry<StationEui, string>>.Instance);
+            this.socketRegistry = new WebSocketWriterRegistry<StationEui, string>(NullLogger<WebSocketWriterRegistry<StationEui, string>>.Instance, null);
 
             this.concentratorDeduplication = new ConcentratorDeduplication<UpstreamDataFrame>(
                 this.cache,

--- a/Tests/Unit/NetworkServer/DefaultClassCDevicesMessageSenderTest.cs
+++ b/Tests/Unit/NetworkServer/DefaultClassCDevicesMessageSenderTest.cs
@@ -114,7 +114,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.loRaDeviceRegistry,
                 this.packetForwarder.Object,
                 this.frameCounterStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             Assert.True(await target.SendAsync(c2dToDeviceMessage));
 
@@ -150,7 +151,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.loRaDeviceRegistry,
                 this.packetForwarder.Object,
                 this.frameCounterStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             Assert.False(await target.SendAsync(c2dToDeviceMessage));
 
@@ -174,7 +176,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.loRaDeviceRegistry,
                 this.packetForwarder.Object,
                 this.frameCounterStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             Assert.False(await target.SendAsync(c2dToDeviceMessage));
 
@@ -208,7 +211,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.loRaDeviceRegistry,
                 this.packetForwarder.Object,
                 this.frameCounterStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             _ = await Assert.ThrowsAsync<ArgumentNullException>(() => target.SendAsync(c2dToDeviceMessage));
 
@@ -252,7 +256,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.loRaDeviceRegistry,
                 this.packetForwarder.Object,
                 this.frameCounterStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             _ = await Assert.ThrowsAsync<TimeoutException>(() => target.SendAsync(c2dToDeviceMessage));
 
@@ -280,7 +285,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.loRaDeviceRegistry,
                 this.packetForwarder.Object,
                 this.frameCounterStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             Assert.False(await target.SendAsync(c2dToDeviceMessage));
 
@@ -308,7 +314,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.loRaDeviceRegistry,
                 this.packetForwarder.Object,
                 this.frameCounterStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             Assert.False(await target.SendAsync(c2dToDeviceMessage));
 
@@ -373,7 +380,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.loRaDeviceRegistry,
                 this.packetForwarder.Object,
                 this.frameCounterStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             Assert.True(await target.SendAsync(c2dToDeviceMessage));
 
@@ -428,7 +436,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.loRaDeviceRegistry,
                 this.packetForwarder.Object,
                 this.frameCounterStrategyProvider,
-                NullLogger<DefaultClassCDevicesMessageSender>.Instance);
+                NullLogger<DefaultClassCDevicesMessageSender>.Instance,
+                TestMeter.Instance);
 
             Assert.False(await target.SendAsync(c2dToDeviceMessage));
 

--- a/Tests/Unit/NetworkServer/LnsProtocolMessageProcessorTests.cs
+++ b/Tests/Unit/NetworkServer/LnsProtocolMessageProcessorTests.cs
@@ -47,7 +47,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var joinRequestDeduplicationMock = new Mock<IConcentratorDeduplication<JoinRequestFrame>>();
 
             this.lnsMessageProcessorMock = new LnsProtocolMessageProcessor(this.basicsStationConfigurationMock.Object,
-                                                                           new WebSocketWriterRegistry<StationEui, string>(Mock.Of<ILogger<WebSocketWriterRegistry<StationEui, string>>>()),
+                                                                           new WebSocketWriterRegistry<StationEui, string>(Mock.Of<ILogger<WebSocketWriterRegistry<StationEui, string>>>(), null),
                                                                            this.packetForwarder.Object,
                                                                            this.messageDispatcher.Object,
                                                                            upstreamDeduplicationMock.Object,

--- a/Tests/Unit/NetworkServer/MetricRegistryTests.cs
+++ b/Tests/Unit/NetworkServer/MetricRegistryTests.cs
@@ -80,6 +80,30 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         }
 
         [Fact]
+        public void CreateObservableGauge_Success_Case()
+        {
+            // arrange
+            var customMetric = new CustomMetric("foo", "bar", MetricType.ObservableGauge, Array.Empty<string>());
+
+            // act
+            var result = this.meter.CreateObservableGauge<int>(customMetric, () => 1);
+
+            // assert
+            Assert.Equal(customMetric.Name, result.Name);
+            Assert.Equal(customMetric.Description, result.Description);
+        }
+
+        [Fact]
+        public void CreateObservableGauge_Throws_When_Argument_Is_Counter()
+        {
+            // arrange
+            var customMetric = new CustomMetric("foo", "bar", MetricType.Counter, Array.Empty<string>());
+
+            // act + assert
+            Assert.Throws<ArgumentException>(() => this.meter.CreateObservableGauge(customMetric, () => 1));
+        }
+
+        [Fact]
         public void GetTagsInOrder_Returns_Tags_When_Invoked_With_Ordered_Tags()
         {
             // arrange

--- a/Tests/Unit/NetworkServer/PrometheusMetricExporterTests.cs
+++ b/Tests/Unit/NetworkServer/PrometheusMetricExporterTests.cs
@@ -134,7 +134,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var measurement = new Measurement<int>(1, KeyValuePair.Create(MetricRegistry.GatewayIdTagName, (object?)stationEui));
             observeValue.Setup(ov => ov.Invoke()).Returns(measurement);
             using var meter = new Meter("LoRaWan", "1.0");
-            var observableGauge = meter.CreateObservableGauge(ObservableGauge.Name, observeValue.Object);
+            _ = meter.CreateObservableGauge(ObservableGauge.Name, observeValue.Object);
 
             // act
             this.prometheusMetricExporter.Start();

--- a/Tests/Unit/NetworkServer/WebSocketWriterHandleTests.cs
+++ b/Tests/Unit/NetworkServer/WebSocketWriterHandleTests.cs
@@ -17,7 +17,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // arrange
             const string message = "bar";
             using var cts = new CancellationTokenSource();
-            var registry = new WebSocketWriterRegistry<string, string>(null);
+            var registry = new WebSocketWriterRegistry<string, string>(null, null);
             var writerMock = new Mock<IWebSocketWriter<string>>();
             var sut = registry.Register("foo", writerMock.Object);
 
@@ -33,8 +33,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         {
             var registry = new
             {
-                A = new WebSocketWriterRegistry<string, string>(null),
-                B = new WebSocketWriterRegistry<string, string>(null),
+                A = new WebSocketWriterRegistry<string, string>(null, null),
+                B = new WebSocketWriterRegistry<string, string>(null, null),
             };
 
             var sut = registry.A.Register("a", new Mock<IWebSocketWriter<string>>().Object);

--- a/Tests/Unit/NetworkServer/WebSocketWriterRegistryTests.cs
+++ b/Tests/Unit/NetworkServer/WebSocketWriterRegistryTests.cs
@@ -19,7 +19,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
         public WebSocketWriterRegistryTests()
         {
-            this.sut = new WebSocketWriterRegistry<string, string>(NullLogger<WebSocketWriterRegistry<string, string>>.Instance);
+            this.sut = new WebSocketWriterRegistry<string, string>(NullLogger<WebSocketWriterRegistry<string, string>>.Instance, null);
         }
 
         [Fact]


### PR DESCRIPTION
# PR for issue #887 

## What is being addressed

With this PR we raise custom metrics as described in the ADR. The PR goes together with #936, as we make some changes to some of the metrics we raise. Specifically,
- metrics around error rates were removed, since they are hard to distinguish in code which source they have.
- metrics around C2D deliveries and abandons were removed, since they are tracked by IoT Hub automatically. This will imply that these metrics will not be available on the Prometheus endpoint.

Metrics around caching were not yet added, since they depend on #904 to be merged first.

To support more kinds of metrics, we add support for `ObservableGauge<T>` type metrics for both Application Insights and Prometheus exporters.

## How is this addressed

Metrics are always added (optionally) via the DI `Meter`. For test code, we never raise metrics since they might interfere with each other (as they rely on callbacks for each listener and will get notified from other tests, potentially lacking the correct `AsyncLocal` state in the `RegistryMetricTagBag`).
