### PR TITLE
Feature/747 custom metrics updates

### DIFF
--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -83,10 +83,8 @@ In addition to this, we will support Application Insights metrics on an opt-in b
 | ActiveStationConnections   | Active connections to stations                               | LNS    | LoRaWan   | Gateway Id                 |
 | D2CMessagesReceived        | Number of messages received from device                      | LNS    | LoRaWan   | Gateway Id                 |
 | D2CMessageDeliveryLatency  | Time from when we received the message from the concentrator until we are done processing it | LNS    | LoRaWan   | Gateway Id                 |
-| D2CMessagesError | Number of errors processing downstream messages | LNS    | LoRaWan   | Gateway Id            |
 | D2CMessageSize             | Message size in bytes received from device                   | LNS    | LoRaWan   | Gateway Id                 |
 | C2DMessagesAbandoned       | Number of C2D messages abandoned                             | LNS    | LoRaWan   | Gateway Id                 |
-| C2DMessagesError           | Number of errors in sending messages to downstream           | LNS    | LoRaWan   | Gateway Id, To             |
 | C2DMessageSizeDownstream   | Message size in bytes sent downstream                        | LNS    | LoRaWan   | Gateway Id, To             |
 
 ### Alerts

--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -81,6 +81,7 @@ In addition to this, we will support Application Insights metrics on an opt-in b
 | JoinRequests               | Number of join requests                                      | LNS    | LoRaWan   | Gateway Id                 |
 | StationConnectivityLost    | Connection to LBS lost                                       | LNS    | LoRaWan   | Gateway Id                 |
 | ActiveStationConnections   | Active connections to stations                               | LNS    | LoRaWan   | Gateway Id                 |
+| ProcessingErrors           | Number of errors in LNS processing                           | LNS    | LoRaWan   | Gateway Id                 |
 | D2CMessagesReceived        | Number of messages received from device                      | LNS    | LoRaWan   | Gateway Id                 |
 | D2CMessageDeliveryLatency  | Time from when we dispatched the message sent from the concentrator until we are done processing it | LNS | LoRaWan | Gateway Id |
 | D2CMessageSize             | Message size in bytes received from device                   | LNS    | LoRaWan   | Gateway Id                 |
@@ -93,7 +94,7 @@ We support the following alerts when the user opts in to use Application Insight
 | Name                            | Description                                               | Source                                   | Condition |
 | ------------------------------- | --------------------------------------------------------- | ---------------------------------------- | --------- |
 | HighUpstreamMessageLatency      | High device message processing time (throughput)          | D2CMessageDeliveryLatency                | Dynamic   |
-| Exceptions                      | High exception raised count (correctness)                 | Exceptions                               | Dynamic   |
+| HighErrorCount                  | High error count (correctness)                            | Unhandled Exceptions / ProcessingErrors  | Dynamic   |
 | HighUpstreamMessagesLostRatio   | High device messages lost ratio (correctness, throughput) | D2CMessagesReceived/D2CMessagesDelivered | Dynamic   |
 | HighReceiveWindowMisses         | High device message processing time (throughput)          | ReceiveWindowMisses                      | Dynamic   |
 | HighDownstreamMessagesLostRatio | High device messages lost ratio (correctness, throughput) | Abandoned messages (IoT Hub metric)      | Dynamic   |

--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -82,8 +82,7 @@ In addition to this, we will support Application Insights metrics on an opt-in b
 | StationConnectivityLost    | Connection to LBS lost                                       | LNS    | LoRaWan   | Gateway Id                 |
 | ActiveStationConnections   | Active connections to stations                               | LNS    | LoRaWan   | Gateway Id                 |
 | D2CMessagesReceived        | Number of messages received from device                      | LNS    | LoRaWan   | Gateway Id                 |
-| DataMessageDeliveryLatency | Time from when we dispatched the message sent from the concentrator until we are done processing it | LNS    | LoRaWan   | Gateway Id                 |
-| DataMessageDispatchLatency | Time from when we received the message from the concentrator until we dispatch the message to be handled (internal metric) | LNS | LoRaWan | Gateway Id, Message Type |
+| D2CMessageDeliveryLatency | Time from when we dispatched the message sent from the concentrator until we are done processing it | LNS    | LoRaWan   | Gateway Id                 |
 | D2CMessageSize             | Message size in bytes received from device                   | LNS    | LoRaWan   | Gateway Id                 |
 | C2DMessagesAbandoned       | Number of C2D messages abandoned                             | LNS    | LoRaWan   | Gateway Id                 |
 | C2DMessageSizeDownstream   | Message size in bytes sent downstream                        | LNS    | LoRaWan   | Gateway Id             |

--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -86,6 +86,7 @@ In addition to this, we will support Application Insights metrics on an opt-in b
 | D2CMessageSize             | Message size in bytes received from device                   | LNS    | LoRaWan   | Gateway Id                 |
 | C2DMessagesAbandoned       | Number of C2D messages abandoned                             | LNS    | LoRaWan   | Gateway Id                 |
 | C2DMessageSizeDownstream   | Message size in bytes sent downstream                        | LNS    | LoRaWan   | Gateway Id                 |
+| C2DMessageTooLong          | Number of C2D messages that were too long to be sent downstream | LNS | LoRaWan 	 | Gateway Id 		      |
 
 ### Alerts
 

--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -95,7 +95,7 @@ We support the following alerts when the user opts in to use Application Insight
 | HighUpstreamMessageLatency      | High device message processing time (throughput)          | D2CMessageDeliveryLatency                | Dynamic   |
 | Exceptions                      | High exception raised count (correctness)                 | Exceptions                               | Dynamic   |
 | HighUpstreamMessagesLostRatio   | High device messages lost ratio (correctness, throughput) | D2CMessagesReceived/D2CMessagesDelivered | Dynamic   |
-| HighDownstreamMessageLatency    | High device message processing time (throughput)          | ReceiveWindowMisses                      | Dynamic   |
+| HighReceiveWindowMisses         | High device message processing time (throughput)          | ReceiveWindowMisses                      | Dynamic   |
 | HighDownstreamMessagesLostRatio | High device messages lost ratio (correctness, throughput) | Abandoned messages (IoT Hub metric)      | Dynamic   |
 
 ## Alternatives considered

--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -93,10 +93,9 @@ We support the following alerts when the user opts in to use Application Insight
 | Name                            | Description                                               | Source                                   | Condition |
 | ------------------------------- | --------------------------------------------------------- | ---------------------------------------- | --------- |
 | HighUpstreamMessageLatency      | High device message processing time (throughput)          | D2CMessageDeliveryLatency                | Dynamic   |
-| HighUpstreamMessageErrorRatio   | High device messages error ratio (correctness)            | D2CMessagesError                         | Dynamic   |
+| Exceptions                      | High exception raised count (correctness)                 | Exceptions                               | Dynamic   |
 | HighUpstreamMessagesLostRatio   | High device messages lost ratio (correctness, throughput) | D2CMessagesReceived/D2CMessagesDelivered | Dynamic   |
 | HighDownstreamMessageLatency    | High device message processing time (throughput)          | ReceiveWindowMisses                      | Dynamic   |
-| HighDownstreamMessageErrorRatio | High device messages error ratio (correctness)            | D2CMessagesError                         | Dynamic   |
 | HighDownstreamMessagesLostRatio | High device messages lost ratio (correctness, throughput) | Abandoned messages (IoT Hub metric)      | Dynamic   |
 
 ## Alternatives considered

--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -84,8 +84,6 @@ In addition to this, we will support Application Insights metrics on an opt-in b
 | D2CMessagesReceived        | Number of messages received from device                      | LNS    | LoRaWan   | Gateway Id                 |
 | D2CMessageDeliveryLatency  | Time from when we dispatched the message sent from the concentrator until we are done processing it | LNS | LoRaWan | Gateway Id |
 | D2CMessageSize             | Message size in bytes received from device                   | LNS    | LoRaWan   | Gateway Id                 |
-| C2DMessagesAbandoned       | Number of C2D messages abandoned                             | LNS    | LoRaWan   | Gateway Id                 |
-| C2DMessageSizeDownstream   | Message size in bytes sent downstream                        | LNS    | LoRaWan   | Gateway Id                 |
 | C2DMessageTooLong          | Number of C2D messages that were too long to be sent downstream | LNS | LoRaWan   | Gateway Id                 |
 
 ### Alerts
@@ -97,9 +95,9 @@ We support the following alerts when the user opts in to use Application Insight
 | HighUpstreamMessageLatency      | High device message processing time (throughput)          | D2CMessageDeliveryLatency                | Dynamic   |
 | HighUpstreamMessageErrorRatio   | High device messages error ratio (correctness)            | D2CMessagesError                         | Dynamic   |
 | HighUpstreamMessagesLostRatio   | High device messages lost ratio (correctness, throughput) | D2CMessagesReceived/D2CMessagesDelivered | Dynamic   |
-| HighDownstreamMessageLatency    | High device message processing time (throughput)          | RxWndMiss                                | Dynamic   |
+| HighDownstreamMessageLatency    | High device message processing time (throughput)          | ReceiveWindowMisses                      | Dynamic   |
 | HighDownstreamMessageErrorRatio | High device messages error ratio (correctness)            | D2CMessagesError                         | Dynamic   |
-| HighDownstreamMessagesLostRatio | High device messages lost ratio (correctness, throughput) | C2DMessagesAbandoned                     | Dynamic   |
+| HighDownstreamMessagesLostRatio | High device messages lost ratio (correctness, throughput) | Abandoned messages (IoT Hub metric)      | Dynamic   |
 
 ## Alternatives considered
 

--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -74,18 +74,19 @@ In addition to this, we will support Application Insights metrics on an opt-in b
 
 | Name                       | Description                                                  | Source | Namespace | Dimensions                 |
 | -------------------------- | ------------------------------------------------------------ | ------ | --------- | -------------------------- |
-| RxWndRate                  | Number of times we hit the different receive windows.        | LNS    | LoRaWan   | Gateway Id, (estimated) Receive Window |
-| RxWndMiss                  | Number of missed on downstream windows                       | LNS    | LoRaWan   | Gateway Id                 |
+| ReceiveWindowHits | Number of times we hit the different receive windows.        | LNS    | LoRaWan   | Gateway Id, (estimated) Receive Window |
+| ReceiveWindowMisses | Number of missed on downstream windows                       | LNS    | LoRaWan   | Gateway Id                 |
 | DeviceCacheHit             | Number of device cache hit                                   | LNS    | LoRaWan   | Gateway Id                 |
 | DeviceLoadRequests         | Number of device load requests                               | LNS    | LoRaWan   | Gateway Id                 |
 | JoinRequests               | Number of join requests                                      | LNS    | LoRaWan   | Gateway Id                 |
 | StationConnectivityLost    | Connection to LBS lost                                       | LNS    | LoRaWan   | Gateway Id                 |
 | ActiveStationConnections   | Active connections to stations                               | LNS    | LoRaWan   | Gateway Id                 |
 | D2CMessagesReceived        | Number of messages received from device                      | LNS    | LoRaWan   | Gateway Id                 |
-| D2CMessageDeliveryLatency  | Time from when we received the message from the concentrator until we are done processing it | LNS    | LoRaWan   | Gateway Id                 |
+| DataMessageDeliveryLatency | Time from when we dispatched the message sent from the concentrator until we are done processing it | LNS    | LoRaWan   | Gateway Id                 |
+| DataMessageDispatchLatency | Time from when we received the message from the concentrator until we dispatch the message to be handled (internal metric) | LNS | LoRaWan | Gateway Id, Message Type |
 | D2CMessageSize             | Message size in bytes received from device                   | LNS    | LoRaWan   | Gateway Id                 |
 | C2DMessagesAbandoned       | Number of C2D messages abandoned                             | LNS    | LoRaWan   | Gateway Id                 |
-| C2DMessageSizeDownstream   | Message size in bytes sent downstream                        | LNS    | LoRaWan   | Gateway Id, To             |
+| C2DMessageSizeDownstream   | Message size in bytes sent downstream                        | LNS    | LoRaWan   | Gateway Id             |
 
 ### Alerts
 

--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -86,7 +86,7 @@ In addition to this, we will support Application Insights metrics on an opt-in b
 | D2CMessageSize             | Message size in bytes received from device                   | LNS    | LoRaWan   | Gateway Id                 |
 | C2DMessagesAbandoned       | Number of C2D messages abandoned                             | LNS    | LoRaWan   | Gateway Id                 |
 | C2DMessageSizeDownstream   | Message size in bytes sent downstream                        | LNS    | LoRaWan   | Gateway Id                 |
-| C2DMessageTooLong          | Number of C2D messages that were too long to be sent downstream | LNS | LoRaWan 	 | Gateway Id 		      |
+| C2DMessageTooLong          | Number of C2D messages that were too long to be sent downstream | LNS | LoRaWan   | Gateway Id                 |
 
 ### Alerts
 

--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -81,7 +81,7 @@ In addition to this, we will support Application Insights metrics on an opt-in b
 | JoinRequests               | Number of join requests                                      | LNS    | LoRaWan   | Gateway Id                 |
 | StationConnectivityLost    | Connection to LBS lost                                       | LNS    | LoRaWan   | Gateway Id                 |
 | ActiveStationConnections   | Active connections to stations                               | LNS    | LoRaWan   | Gateway Id                 |
-| ProcessingErrors           | Number of errors in LNS processing                           | LNS    | LoRaWan   | Gateway Id                 |
+| ProcessingErrors           | Number of errors in LNS processing                           | LNS    | LoRaWan   |                          |
 | D2CMessagesReceived        | Number of messages received from device                      | LNS    | LoRaWan   | Gateway Id                 |
 | D2CMessageDeliveryLatency  | Time from when we dispatched the message sent from the concentrator until we are done processing it | LNS | LoRaWan | Gateway Id |
 | D2CMessageSize             | Message size in bytes received from device                   | LNS    | LoRaWan   | Gateway Id                 |

--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -74,7 +74,7 @@ In addition to this, we will support Application Insights metrics on an opt-in b
 
 | Name                       | Description                                                  | Source | Namespace | Dimensions                 |
 | -------------------------- | ------------------------------------------------------------ | ------ | --------- | -------------------------- |
-| RxWndRate                  | Number of times we hit the different receive windows.        | LNS    | LoRaWan   | Gateway Id, Receive Window |
+| RxWndRate                  | Number of times we hit the different receive windows.        | LNS    | LoRaWan   | Gateway Id, (estimated) Receive Window |
 | RxWndMiss                  | Number of missed on downstream windows                       | LNS    | LoRaWan   | Gateway Id                 |
 | DeviceCacheHit             | Number of device cache hit                                   | LNS    | LoRaWan   | Gateway Id                 |
 | DeviceLoadRequests         | Number of device load requests                               | LNS    | LoRaWan   | Gateway Id                 |
@@ -83,13 +83,9 @@ In addition to this, we will support Application Insights metrics on an opt-in b
 | ActiveStationConnections   | Active connections to stations                               | LNS    | LoRaWan   | Gateway Id                 |
 | D2CMessagesReceived        | Number of messages received from device                      | LNS    | LoRaWan   | Gateway Id                 |
 | D2CMessageDeliveryLatency  | Time from when we received the message from the concentrator until we are done processing it | LNS    | LoRaWan   | Gateway Id                 |
-| D2CMessagesDelivered       | Number of messages sent to upstream                          | LNS    | LoRaWan   | Gateway Id, To             |
-| D2CMessagesError           | Number of errors in sending messages to upstream             | LNS    | LoRaWan   | Gateway Id, To            |
-| D2CMessagesProcessingError | Number of errors processing (decoding, decrypting) messages  | LNS    | LoRaWan   | Gateway Id, To            |
+| D2CMessagesError | Number of errors processing downstream messages | LNS    | LoRaWan   | Gateway Id            |
 | D2CMessageSize             | Message size in bytes received from device                   | LNS    | LoRaWan   | Gateway Id                 |
-| D2CMessageSizeUpstream     | Message size in bytes sent upstream                          | LNS    | LoRaWan   | Gateway Id, To            |
 | C2DMessagesAbandoned       | Number of C2D messages abandoned                             | LNS    | LoRaWan   | Gateway Id                 |
-| C2DMessagesDelivered       | Number of messages sent downstream                           | LNS    | LoRaWan   | Gateway Id, To             |
 | C2DMessagesError           | Number of errors in sending messages to downstream           | LNS    | LoRaWan   | Gateway Id, To             |
 | C2DMessageSizeDownstream   | Message size in bytes sent downstream                        | LNS    | LoRaWan   | Gateway Id, To             |
 

--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -74,18 +74,18 @@ In addition to this, we will support Application Insights metrics on an opt-in b
 
 | Name                       | Description                                                  | Source | Namespace | Dimensions                 |
 | -------------------------- | ------------------------------------------------------------ | ------ | --------- | -------------------------- |
-| ReceiveWindowHits | Number of times we hit the different receive windows.        | LNS    | LoRaWan   | Gateway Id, (estimated) Receive Window |
-| ReceiveWindowMisses | Number of missed on downstream windows                       | LNS    | LoRaWan   | Gateway Id                 |
+| ReceiveWindowHits          | Number of times we hit the different receive windows.        | LNS    | LoRaWan   | Gateway Id, (estimated) Receive Window |
+| ReceiveWindowMisses        | Number of missed on downstream windows                       | LNS    | LoRaWan   | Gateway Id                 |
 | DeviceCacheHit             | Number of device cache hit                                   | LNS    | LoRaWan   | Gateway Id                 |
 | DeviceLoadRequests         | Number of device load requests                               | LNS    | LoRaWan   | Gateway Id                 |
 | JoinRequests               | Number of join requests                                      | LNS    | LoRaWan   | Gateway Id                 |
 | StationConnectivityLost    | Connection to LBS lost                                       | LNS    | LoRaWan   | Gateway Id                 |
 | ActiveStationConnections   | Active connections to stations                               | LNS    | LoRaWan   | Gateway Id                 |
 | D2CMessagesReceived        | Number of messages received from device                      | LNS    | LoRaWan   | Gateway Id                 |
-| D2CMessageDeliveryLatency | Time from when we dispatched the message sent from the concentrator until we are done processing it | LNS    | LoRaWan   | Gateway Id                 |
+| D2CMessageDeliveryLatency  | Time from when we dispatched the message sent from the concentrator until we are done processing it | LNS | LoRaWan | Gateway Id |
 | D2CMessageSize             | Message size in bytes received from device                   | LNS    | LoRaWan   | Gateway Id                 |
 | C2DMessagesAbandoned       | Number of C2D messages abandoned                             | LNS    | LoRaWan   | Gateway Id                 |
-| C2DMessageSizeDownstream   | Message size in bytes sent downstream                        | LNS    | LoRaWan   | Gateway Id             |
+| C2DMessageSizeDownstream   | Message size in bytes sent downstream                        | LNS    | LoRaWan   | Gateway Id                 |
 
 ### Alerts
 

--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -81,7 +81,7 @@ In addition to this, we will support Application Insights metrics on an opt-in b
 | JoinRequests               | Number of join requests                                      | LNS    | LoRaWan   | Gateway Id                 |
 | StationConnectivityLost    | Connection to LBS lost                                       | LNS    | LoRaWan   | Gateway Id                 |
 | ActiveStationConnections   | Active connections to stations                               | LNS    | LoRaWan   | Gateway Id                 |
-| ProcessingErrors           | Number of errors in LNS processing                           | LNS    | LoRaWan   |                          |
+| UnhandledExceptions        | Number of unhandled exceptions in LNS processing             | LNS    | LoRaWan   |                            |
 | D2CMessagesReceived        | Number of messages received from device                      | LNS    | LoRaWan   | Gateway Id                 |
 | D2CMessageDeliveryLatency  | Time from when we dispatched the message sent from the concentrator until we are done processing it | LNS | LoRaWan | Gateway Id |
 | D2CMessageSize             | Message size in bytes received from device                   | LNS    | LoRaWan   | Gateway Id                 |
@@ -94,7 +94,7 @@ We support the following alerts when the user opts in to use Application Insight
 | Name                            | Description                                               | Source                                   | Condition |
 | ------------------------------- | --------------------------------------------------------- | ---------------------------------------- | --------- |
 | HighUpstreamMessageLatency      | High device message processing time (throughput)          | D2CMessageDeliveryLatency                | Dynamic   |
-| HighErrorCount                  | High error count (correctness)                            | Unhandled Exceptions / ProcessingErrors  | Dynamic   |
+| HighErrorCount                  | High error count (correctness)                            | Unhandled Exceptions                     | Dynamic   |
 | HighUpstreamMessagesLostRatio   | High device messages lost ratio (correctness, throughput) | D2CMessagesReceived/D2CMessagesDelivered | Dynamic   |
 | HighReceiveWindowMisses         | High device message processing time (throughput)          | ReceiveWindowMisses                      | Dynamic   |
 | HighDownstreamMessagesLostRatio | High device messages lost ratio (correctness, throughput) | Abandoned messages (IoT Hub metric)      | Dynamic   |


### PR DESCRIPTION
# PR for issue #747

## What is being addressed

With this update to the observability ADR, which is based on #935, we remove some metrics that are hard to track (and not worth the effort) and some that are automatically tracked by IoT Hub and we don't need to manually track. 
