### PR TITLE
Count processing errors and raise as metric

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
@@ -41,7 +41,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
             this.loRaDeviceAPIService = loRaDeviceAPIService ?? throw new ArgumentNullException(nameof(loRaDeviceAPIService));
             this.loRaModuleClientFactory = loRaModuleClientFactory ?? throw new ArgumentNullException(nameof(loRaModuleClientFactory));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            this.processingErrorCounter = meter?.CreateCounter<int>(MetricRegistry.ProcessingErrors);
+            this.processingErrorCounter = meter.CreateCounter<int>(MetricRegistry.ProcessingErrors);
         }
 
         public async Task CreateAsync(CancellationToken cancellationToken)
@@ -103,7 +103,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
                 return new MethodResponse((int)HttpStatusCode.BadRequest);
             }
             catch (Exception ex) when (ExceptionFilterUtility.False(() => this.logger.LogError(ex, $"An exception occurred on a direct method call: {ex}"),
-                                                                    () => this.processingErrorCounter?.Add(1)))
+                                                                    () => this.processingErrorCounter.Add(1)))
             {
                 throw;
             }
@@ -162,7 +162,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
                 this.logger.LogWarning($"A desired properties update was detected but the parameters are out of range with exception :  {ex}");
             }
             catch (Exception ex) when (ExceptionFilterUtility.False(() => this.logger.LogError(ex, $"An exception occurred on desired property update: {ex}"),
-                                                                    () => this.processingErrorCounter?.Add(1)))
+                                                                    () => this.processingErrorCounter.Add(1)))
             {
                 throw;
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
@@ -8,8 +8,6 @@ using System.Runtime.CompilerServices;
 namespace LoRaWan.NetworkServer.BasicsStation.Processors
 {
     using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Diagnostics.Metrics;
     using System.Linq;
     using System.Net.NetworkInformation;
@@ -38,7 +36,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
         private readonly RegistryMetricTagBag registryMetricTagBag;
         private readonly Counter<int> joinRequestCounter;
         private readonly Counter<int> uplinkMessageCounter;
-        private readonly Counter<int> processingErrorCounter;
+        private readonly Counter<int> unhandledExceptionCount;
 
         public LnsProtocolMessageProcessor(IBasicsStationConfigurationService basicsStationConfigurationService,
                                            WebSocketWriterRegistry<StationEui, string> socketWriterRegistry,
@@ -60,7 +58,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
             this.registryMetricTagBag = registryMetricTagBag;
             this.joinRequestCounter = meter?.CreateCounter<int>(MetricRegistry.JoinRequests);
             this.uplinkMessageCounter = meter?.CreateCounter<int>(MetricRegistry.D2CMessagesReceived);
-            this.processingErrorCounter = meter?.CreateCounter<int>(MetricRegistry.ProcessingErrors);
+            this.unhandledExceptionCount = meter?.CreateCounter<int>(MetricRegistry.UnhandledExceptions);
         }
 
         internal async Task<HttpContext> ProcessIncomingRequestAsync(HttpContext httpContext,
@@ -95,7 +93,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
                 }
             }
             catch (Exception ex) when (ExceptionFilterUtility.False(() => this.logger.LogError(ex, "An exception occurred while processing requests: {Exception}.", ex),
-                                                                    () => this.processingErrorCounter?.Add(1)))
+                                                                    () => this.unhandledExceptionCount?.Add(1)))
             {
                 throw;
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -30,7 +30,7 @@ namespace LoRaWan.NetworkServer
         private readonly Counter<int> receiveWindowHits;
         private readonly Histogram<int> d2cPayloadSizeHistogram;
         private readonly Counter<int> c2dMessageTooLong;
-        private readonly Counter<int> processingErrorCount;
+        private readonly Counter<int> unhandledExceptionCount;
         private IClassCDeviceMessageSender classCDeviceMessageSender;
 
         public DefaultLoRaDataRequestHandler(
@@ -56,7 +56,7 @@ namespace LoRaWan.NetworkServer
             this.receiveWindowHits = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowHits);
             this.d2cPayloadSizeHistogram = meter?.CreateHistogram<int>(MetricRegistry.D2CMessageSize);
             this.c2dMessageTooLong = meter?.CreateCounter<int>(MetricRegistry.C2DMessageTooLong);
-            this.processingErrorCount = meter?.CreateCounter<int>(MetricRegistry.ProcessingErrors);
+            this.unhandledExceptionCount = meter?.CreateCounter<int>(MetricRegistry.UnhandledExceptions);
         }
 
         public async Task<LoRaDeviceRequestProcessResult> ProcessRequestAsync(LoRaRequest request, LoRaDevice loRaDevice)
@@ -499,7 +499,7 @@ namespace LoRaWan.NetworkServer
                                              ex =>
                                              {
                                                  this.logger.LogError(ex, $"[class-c] error sending class C cloud to device message. {ex.Message}");
-                                                 this.processingErrorCount?.Add(1);
+                                                 this.unhandledExceptionCount?.Add(1);
                                              });
             }
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -496,11 +496,8 @@ namespace LoRaWan.NetworkServer
             if (this.classCDeviceMessageSender != null)
             {
                 _ = TaskUtil.RunOnThreadPool(() => this.classCDeviceMessageSender.SendAsync(cloudToDeviceMessage),
-                                             ex =>
-                                             {
-                                                 this.logger.LogError(ex, $"[class-c] error sending class C cloud to device message. {ex.Message}");
-                                                 this.unhandledExceptionCount?.Add(1);
-                                             });
+                                             ex => this.logger.LogError(ex, $"[class-c] error sending class C cloud to device message. {ex.Message}"),
+                                             this.unhandledExceptionCount);
             }
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -30,6 +30,7 @@ namespace LoRaWan.NetworkServer
         private readonly Counter<int> receiveWindowHits;
         private readonly Histogram<int> d2cPayloadSizeHistogram;
         private readonly Counter<int> c2dMessageTooLong;
+        private readonly Counter<int> processingErrorCount;
         private IClassCDeviceMessageSender classCDeviceMessageSender;
 
         public DefaultLoRaDataRequestHandler(
@@ -55,6 +56,7 @@ namespace LoRaWan.NetworkServer
             this.receiveWindowHits = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowHits);
             this.d2cPayloadSizeHistogram = meter?.CreateHistogram<int>(MetricRegistry.D2CMessageSize);
             this.c2dMessageTooLong = meter?.CreateCounter<int>(MetricRegistry.C2DMessageTooLong);
+            this.processingErrorCount = meter?.CreateCounter<int>(MetricRegistry.ProcessingErrors);
         }
 
         public async Task<LoRaDeviceRequestProcessResult> ProcessRequestAsync(LoRaRequest request, LoRaDevice loRaDevice)
@@ -494,7 +496,11 @@ namespace LoRaWan.NetworkServer
             if (this.classCDeviceMessageSender != null)
             {
                 _ = TaskUtil.RunOnThreadPool(() => this.classCDeviceMessageSender.SendAsync(cloudToDeviceMessage),
-                                             ex => this.logger.LogError($"[class-c] error sending class C cloud to device message. {ex.Message}"));
+                                             ex =>
+                                             {
+                                                 this.logger.LogError(ex, $"[class-c] error sending class C cloud to device message. {ex.Message}");
+                                                 this.processingErrorCount?.Add(1);
+                                             });
             }
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
@@ -75,7 +75,7 @@ namespace LoRaWan.NetworkServer
             this.loadingDevicesFailed = false;
             this.queueLock = new object();
             this.queuedRequests = new List<LoRaRequest>();
-            var processingErrorCount = meter?.CreateCounter<int>(MetricRegistry.ProcessingErrors);
+            var unhandledExceptionCount = meter?.CreateCounter<int>(MetricRegistry.UnhandledExceptions);
             _ = TaskUtil.RunOnThreadPool(async () =>
             {
                 using var scope = this.logger.BeginDeviceAddressScope(this.devAddr);
@@ -93,8 +93,8 @@ namespace LoRaWan.NetworkServer
             },
             ex =>
             {
-                this.logger.LogError($"Error while loading: {ex}.");
-                processingErrorCount?.Add(1);
+                this.logger.LogError(ex, $"Error while loading: {ex}.");
+                unhandledExceptionCount?.Add(1);
             });
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
@@ -75,7 +75,6 @@ namespace LoRaWan.NetworkServer
             this.loadingDevicesFailed = false;
             this.queueLock = new object();
             this.queuedRequests = new List<LoRaRequest>();
-            var unhandledExceptionCount = meter?.CreateCounter<int>(MetricRegistry.UnhandledExceptions);
             _ = TaskUtil.RunOnThreadPool(async () =>
             {
                 using var scope = this.logger.BeginDeviceAddressScope(this.devAddr);
@@ -91,11 +90,8 @@ namespace LoRaWan.NetworkServer
                     continuationAction(t, this);
                 }
             },
-            ex =>
-            {
-                this.logger.LogError(ex, $"Error while loading: {ex}.");
-                unhandledExceptionCount?.Add(1);
-            });
+            ex => this.logger.LogError(ex, $"Error while loading: {ex}."),
+            meter?.CreateCounter<int>(MetricRegistry.UnhandledExceptions));
         }
 
         private async Task Load()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -20,7 +20,7 @@ namespace LoRaWan.NetworkServer
         private readonly ILogger<JoinRequestMessageHandler> logger;
         private readonly Counter<int> receiveWindowHits;
         private readonly Counter<int> receiveWindowMisses;
-        private readonly Counter<int> processingErrorCounter;
+        private readonly Counter<int> unhandledExceptionCount;
         private readonly NetworkServerConfiguration configuration;
 
         public JoinRequestMessageHandler(NetworkServerConfiguration configuration,
@@ -33,7 +33,7 @@ namespace LoRaWan.NetworkServer
             this.logger = logger;
             this.receiveWindowHits = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowHits);
             this.receiveWindowMisses = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowMisses);
-            this.processingErrorCounter = meter?.CreateCounter<int>(MetricRegistry.ProcessingErrors);
+            this.unhandledExceptionCount = meter?.CreateCounter<int>(MetricRegistry.UnhandledExceptions);
         }
 
         public void DispatchRequest(LoRaRequest request)
@@ -300,7 +300,7 @@ namespace LoRaWan.NetworkServer
                 }
                 catch (Exception ex) when
                     (ExceptionFilterUtility.True(() => this.logger.LogError(ex, $"failed to handle join request. {ex.Message}", LogLevel.Error),
-                                                 () => this.processingErrorCounter?.Add(1)))
+                                                 () => this.unhandledExceptionCount?.Add(1)))
                 {
                     request.NotifyFailed(loRaDevice, ex);
                     throw;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -20,6 +20,7 @@ namespace LoRaWan.NetworkServer
         private readonly ILogger<JoinRequestMessageHandler> logger;
         private readonly Counter<int> receiveWindowHits;
         private readonly Counter<int> receiveWindowMisses;
+        private readonly Counter<int> processingErrorCounter;
         private readonly NetworkServerConfiguration configuration;
 
         public JoinRequestMessageHandler(NetworkServerConfiguration configuration,
@@ -32,6 +33,7 @@ namespace LoRaWan.NetworkServer
             this.logger = logger;
             this.receiveWindowHits = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowHits);
             this.receiveWindowMisses = meter?.CreateCounter<int>(MetricRegistry.ReceiveWindowMisses);
+            this.processingErrorCounter = meter?.CreateCounter<int>(MetricRegistry.ProcessingErrors);
         }
 
         public void DispatchRequest(LoRaRequest request)
@@ -297,8 +299,8 @@ namespace LoRaWan.NetworkServer
                     }
                 }
                 catch (Exception ex) when
-                    (ExceptionFilterUtility.True(() => this.logger.LogError($"failed to handle join request. {ex.Message}",
-                                                                            LogLevel.Error)))
+                    (ExceptionFilterUtility.True(() => this.logger.LogError(ex, $"failed to handle join request. {ex.Message}", LogLevel.Error),
+                                                 () => this.processingErrorCounter?.Add(1)))
                 {
                     request.NotifyFailed(loRaDevice, ex);
                     throw;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -1090,11 +1090,8 @@ namespace LoRaWan.NetworkServer
         private Task RunAndQueueNext(LoRaRequest request)
         {
             return TaskUtil.RunOnThreadPool(() => CoreAsync(),
-                                            ex =>
-                                            {
-                                                this.logger.LogError(ex, $"error processing request: {ex.Message}");
-                                                this.unhandledExceptionCount?.Add(1);
-                                            });
+                                            ex => this.logger.LogError(ex, $"error processing request: {ex.Message}"),
+                                            this.unhandledExceptionCount);
 
             async Task CoreAsync()
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -81,7 +81,7 @@ namespace LoRaWan.NetworkServer
         private readonly ChangeTrackingProperty<int> txPower = new ChangeTrackingProperty<int>(TwinProperty.TxPower);
         private readonly ILoRaDeviceClientConnectionManager connectionManager;
         private readonly ILogger<LoRaDevice> logger;
-        private readonly Counter<int> processingErrorCount;
+        private readonly Counter<int> unhandledExceptionCount;
 
         public int TxPower => this.txPower.Get();
 
@@ -209,7 +209,7 @@ namespace LoRaWan.NetworkServer
             this.confirmationResubmitCount = 0;
             this.queuedRequests = new Queue<LoRaRequest>();
             ClassType = LoRaDeviceClassType.A;
-            this.processingErrorCount = meter?.CreateCounter<int>(MetricRegistry.ProcessingErrors);
+            this.unhandledExceptionCount = meter?.CreateCounter<int>(MetricRegistry.UnhandledExceptions);
         }
 
         /// <summary>
@@ -1093,7 +1093,7 @@ namespace LoRaWan.NetworkServer
                                             ex =>
                                             {
                                                 this.logger.LogError(ex, $"error processing request: {ex.Message}");
-                                                this.processingErrorCount?.Add(1);
+                                                this.unhandledExceptionCount?.Add(1);
                                             });
 
             async Task CoreAsync()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.NetworkServer
 {
     using System;
+    using System.Diagnostics.Metrics;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Extensions.Logging;
 
@@ -14,18 +15,21 @@ namespace LoRaWan.NetworkServer
         private readonly ILoRaDeviceClientConnectionManager connectionManager;
         private readonly ILoggerFactory loggerFactory;
         private readonly ILogger<LoRaDeviceFactory> logger;
+        private readonly Meter meter;
 
         public LoRaDeviceFactory(NetworkServerConfiguration configuration,
                                  ILoRaDataRequestHandler dataRequestHandler,
                                  ILoRaDeviceClientConnectionManager connectionManager,
                                  ILoggerFactory loggerFactory,
-                                 ILogger<LoRaDeviceFactory> logger)
+                                 ILogger<LoRaDeviceFactory> logger,
+                                 Meter meter)
         {
             this.configuration = configuration;
             this.dataRequestHandler = dataRequestHandler;
             this.connectionManager = connectionManager;
             this.loggerFactory = loggerFactory;
             this.logger = logger;
+            this.meter = meter;
         }
 
         public LoRaDevice Create(IoTHubDeviceInfo deviceInfo)
@@ -36,7 +40,8 @@ namespace LoRaWan.NetworkServer
                 deviceInfo.DevAddr,
                 deviceInfo.DevEUI,
                 this.connectionManager,
-                this.loggerFactory.CreateLogger<LoRaDevice>())
+                this.loggerFactory.CreateLogger<LoRaDevice>(),
+                meter)
             {
                 GatewayID = deviceInfo.GatewayId,
                 NwkSKey = deviceInfo.NwkSKey

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceRegistry.cs
@@ -5,6 +5,7 @@ namespace LoRaWan.NetworkServer
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.Metrics;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -32,7 +33,7 @@ namespace LoRaWan.NetworkServer
         private readonly object getOrCreateLoadingDevicesRequestQueueLock;
         private readonly object getOrCreateJoinDeviceLoaderLock;
         private readonly object devEUIToLoRaDeviceDictionaryLock;
-
+        private readonly Meter meter;
         private readonly IMemoryCache cache;
 
         private CancellationChangeToken resetCacheChangeToken;
@@ -50,7 +51,8 @@ namespace LoRaWan.NetworkServer
             LoRaDeviceAPIServiceBase loRaDeviceAPIService,
             ILoRaDeviceFactory deviceFactory,
             ILoggerFactory loggerFactory,
-            ILogger<LoRaDeviceRegistry> logger)
+            ILogger<LoRaDeviceRegistry> logger,
+            Meter meter)
         {
             this.configuration = configuration;
             this.resetCacheToken = new CancellationTokenSource();
@@ -65,6 +67,7 @@ namespace LoRaWan.NetworkServer
             this.getOrCreateLoadingDevicesRequestQueueLock = new object();
             this.getOrCreateJoinDeviceLoaderLock = new object();
             this.devEUIToLoRaDeviceDictionaryLock = new object();
+            this.meter = meter;
         }
 
         /// <summary>
@@ -75,7 +78,7 @@ namespace LoRaWan.NetworkServer
                                     LoRaDeviceAPIServiceBase loRaDeviceAPIService,
                                     ILoRaDeviceFactory deviceFactory)
             : this(configuration, cache, loRaDeviceAPIService, deviceFactory,
-                   NullLoggerFactory.Instance, NullLogger<LoRaDeviceRegistry>.Instance)
+                   NullLoggerFactory.Instance, NullLogger<LoRaDeviceRegistry>.Instance, null)
         { }
 
         /// <summary>
@@ -148,7 +151,8 @@ namespace LoRaWan.NetworkServer
                                 }
                             },
                             (l) => UpdateDeviceRegistration(l),
-                            this.loggerFactory.CreateLogger<DeviceLoaderSynchronizer>());
+                            this.loggerFactory.CreateLogger<DeviceLoaderSynchronizer>(),
+                            meter);
 
                         return loader;
                     });

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -23,7 +23,7 @@ namespace LoRaWan.NetworkServer
         public static readonly CustomMetric StationConnectivityLost = new CustomMetric("StationConnectivityLost", "Counts the number of station connectivities that were lost", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric ReceiveWindowHits = new CustomMetric("ReceiveWindowHits", "Receive window hits", MetricType.Counter, new[] { GatewayIdTagName, ReceiveWindowTagName });
         public static readonly CustomMetric ReceiveWindowMisses = new CustomMetric("ReceiveWindowMisses", "Receive window misses", MetricType.Counter, new[] { GatewayIdTagName });
-        public static readonly CustomMetric ProcessingErrors = new CustomMetric("ProcessingErrors", "Number of processing errors", MetricType.Counter, Array.Empty<string>());
+        public static readonly CustomMetric UnhandledExceptions = new CustomMetric("UnhandledExceptions", "Number of unhandled exceptions", MetricType.Counter, Array.Empty<string>());
         public static readonly CustomMetric D2CMessageDeliveryLatency = new CustomHistogram("D2CMessageDeliveryLatency", "D2C delivery latency (in milliseconds)", MetricType.Histogram, new[] { GatewayIdTagName },
                                                                                             BucketStart: 100, BucketWidth: 50, BucketCount: 45);
         public static readonly CustomMetric D2CMessagesReceived = new CustomMetric("D2CMessagesReceived", "Number of D2C messages received", MetricType.Counter, new[] { GatewayIdTagName });
@@ -38,7 +38,7 @@ namespace LoRaWan.NetworkServer
             StationConnectivityLost,
             ReceiveWindowHits,
             ReceiveWindowMisses,
-            ProcessingErrors,
+            UnhandledExceptions,
             D2CMessageDeliveryLatency,
             D2CMessagesReceived,
             D2CMessageSize,

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -23,6 +23,7 @@ namespace LoRaWan.NetworkServer
         public static readonly CustomMetric StationConnectivityLost = new CustomMetric("StationConnectivityLost", "Counts the number of station connectivities that were lost", MetricType.Counter, new[] { GatewayIdTagName });
         public static readonly CustomMetric ReceiveWindowHits = new CustomMetric("ReceiveWindowHits", "Receive window hits", MetricType.Counter, new[] { GatewayIdTagName, ReceiveWindowTagName });
         public static readonly CustomMetric ReceiveWindowMisses = new CustomMetric("ReceiveWindowMisses", "Receive window misses", MetricType.Counter, new[] { GatewayIdTagName });
+        public static readonly CustomMetric ProcessingErrors = new CustomMetric("ProcessingErrors", "Number of processing errors", MetricType.Counter, Array.Empty<string>());
         public static readonly CustomMetric D2CMessageDeliveryLatency = new CustomHistogram("D2CMessageDeliveryLatency", "D2C delivery latency (in milliseconds)", MetricType.Histogram, new[] { GatewayIdTagName },
                                                                                             BucketStart: 100, BucketWidth: 50, BucketCount: 45);
         public static readonly CustomMetric D2CMessagesReceived = new CustomMetric("D2CMessagesReceived", "Number of D2C messages received", MetricType.Counter, new[] { GatewayIdTagName });
@@ -37,6 +38,7 @@ namespace LoRaWan.NetworkServer
             StationConnectivityLost,
             ReceiveWindowHits,
             ReceiveWindowMisses,
+            ProcessingErrors,
             D2CMessageDeliveryLatency,
             D2CMessagesReceived,
             D2CMessageSize,

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/TaskUtil.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/TaskUtil.cs
@@ -1,21 +1,24 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 namespace LoRaWan.NetworkServer
 {
     using System;
+    using System.Diagnostics.Metrics;
     using System.Threading.Tasks;
 
     internal static class TaskUtil
     {
-        public static Task RunOnThreadPool(Func<Task> task, Action<Exception> log) =>
+        public static Task RunOnThreadPool(Func<Task> task, Action<Exception> log, Counter<int>? exceptionCount) =>
             Task.Run(async () =>
             {
                 try
                 {
                     await task();
                 }
-                catch (Exception ex) when (ExceptionFilterUtility.False(() => log(ex)))
+                catch (Exception ex) when (ExceptionFilterUtility.False(() => log(ex), () => exceptionCount?.Add(1)))
                 {
                     throw;
                 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/ExceptionFilterUtility.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/ExceptionFilterUtility.cs
@@ -7,15 +7,23 @@ namespace LoRaWan
 
     public static class ExceptionFilterUtility
     {
-        public static bool True(Action action)
+        public static bool True(params Action[] actions)
         {
-            (action ?? throw new ArgumentNullException(nameof(action)))();
+            if (actions is null) throw new ArgumentNullException(nameof(actions));
+
+            foreach (var a in actions)
+                a();
+
             return true;
         }
 
-        public static bool False(Action action)
+        public static bool False(params Action[] actions)
         {
-            (action ?? throw new ArgumentNullException(nameof(action)))();
+            if (actions is null) throw new ArgumentNullException(nameof(actions));
+
+            foreach (var a in actions)
+                a();
+
             return false;
         }
     }

--- a/Tests/Unit/LoRaWan/ExceptionFilterUtilityTests.cs
+++ b/Tests/Unit/LoRaWan/ExceptionFilterUtilityTests.cs
@@ -24,6 +24,20 @@ namespace LoRaWan.Tests.Unit
         }
 
         [Fact]
+        public void True_Two_Arguments_SuccessCase()
+        {
+            // arrange
+            var action = new Mock<Action>();
+
+            // act
+            var result = ExceptionFilterUtility.True(action.Object, action.Object);
+
+            // assert
+            Assert.True(result);
+            action.Verify(a => a.Invoke(), Times.Exactly(2));
+        }
+
+        [Fact]
         public void False_SuccessCase()
         {
             // arrange
@@ -35,6 +49,20 @@ namespace LoRaWan.Tests.Unit
             // assert
             Assert.False(result);
             action.Verify(a => a.Invoke(), Times.Once);
+        }
+
+        [Fact]
+        public void False_Two_Arguments_SuccessCase()
+        {
+            // arrange
+            var action = new Mock<Action>();
+
+            // act
+            var result = ExceptionFilterUtility.False(action.Object, action.Object);
+
+            // assert
+            Assert.False(result);
+            action.Verify(a => a.Invoke(), Times.Exactly(2));
         }
     }
 }

--- a/Tests/Unit/NetworkServer/DeviceLoaderSynchronizerTest.cs
+++ b/Tests/Unit/NetworkServer/DeviceLoaderSynchronizerTest.cs
@@ -51,7 +51,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.serverConfiguration,
                 (_, l) => { finished.Release(); },
                 (d) => { destinationDictionary.TryAdd(d.DevEUI, d); },
-                NullLogger<DeviceLoaderSynchronizer>.Instance);
+                NullLogger<DeviceLoaderSynchronizer>.Instance,
+                TestMeter.Instance);
 
             await finished.WaitAsync();
 
@@ -95,7 +96,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.serverConfiguration,
                 (_, l) => { finished.Release(); },
                 (d) => destinationDictionary.TryAdd(d.DevEUI, d),
-                NullLogger<DeviceLoaderSynchronizer>.Instance);
+                NullLogger<DeviceLoaderSynchronizer>.Instance,
+                TestMeter.Instance);
 
             using var req1 = WaitableLoRaRequest.Create(payload1);
             target.Queue(req1);
@@ -150,7 +152,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.serverConfiguration,
                 (_, l) => { finished.Release(); },
                 (d) => destinationDictionary.TryAdd(d.DevEUI, d),
-                NullLogger<DeviceLoaderSynchronizer>.Instance);
+                NullLogger<DeviceLoaderSynchronizer>.Instance,
+                TestMeter.Instance);
 
             using var request = WaitableLoRaRequest.Create(payload);
             target.Queue(request);
@@ -194,7 +197,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.serverConfiguration,
                 (_, l) => { finished.Release(); },
                 (d) => destinationDictionary.TryAdd(d.DevEUI, d),
-                NullLogger<DeviceLoaderSynchronizer>.Instance);
+                NullLogger<DeviceLoaderSynchronizer>.Instance,
+                TestMeter.Instance);
 
             using var request = WaitableLoRaRequest.Create(payload);
             target.Queue(request);
@@ -245,7 +249,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 this.serverConfiguration,
                 (_, l) => { finished.Release(); },
                 (d) => destinationDictionary.TryAdd(d.DevEUI, d),
-                NullLogger<DeviceLoaderSynchronizer>.Instance);
+                NullLogger<DeviceLoaderSynchronizer>.Instance,
+                TestMeter.Instance);
 
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234");
             payload.SerializeUplink(simulatedDevice.AppSKey, "00000000000000000000000000EEAAFF");

--- a/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
+++ b/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
@@ -6,6 +6,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
     using Bogus;
     using LoRaWan.NetworkServer;
     using LoRaWan.NetworkServer.BasicsStation.ModuleConnection;
+    using LoRaWan.Tests.Common;
     using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Logging.Abstractions;
@@ -43,15 +44,15 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             // ASSERT
             ArgumentNullException ex;
-            ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(null, classCMessageSender, loRaModuleClientFactory, loRaDeviceRegistry, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance));
+            ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(null, classCMessageSender, loRaModuleClientFactory, loRaDeviceRegistry, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance));
             Assert.Equal("networkServerConfiguration", ex.ParamName);
-            ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, null, loRaModuleClientFactory, loRaDeviceRegistry, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance));
+            ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, null, loRaModuleClientFactory, loRaDeviceRegistry, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance));
             Assert.Equal("defaultClassCDevicesMessageSender", ex.ParamName);
-            ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, null, loRaDeviceRegistry, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance));
+            ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, null, loRaDeviceRegistry, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance));
             Assert.Equal("loRaModuleClientFactory", ex.ParamName);
-            ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, loRaModuleClientFactory, null, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance));
+            ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, loRaModuleClientFactory, null, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance));
             Assert.Equal("loRaDeviceRegistry", ex.ParamName);
-            ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, loRaModuleClientFactory, loRaDeviceRegistry, null, NullLogger<ModuleConnectionHost>.Instance));
+            ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, loRaModuleClientFactory, loRaDeviceRegistry, null, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance));
             Assert.Equal("loRaDeviceAPIService", ex.ParamName);
         }
 
@@ -63,7 +64,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var loRaDeviceRegistry = Mock.Of<ILoRaDeviceRegistry>();
             var loRaModuleClientFactory = Mock.Of<ILoRaModuleClientFactory>();
 
-            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, loRaModuleClientFactory, loRaDeviceRegistry, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance);
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, loRaModuleClientFactory, loRaDeviceRegistry, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance);
             var url1 = this.faker.Internet.Url();
             var authCode = this.faker.Internet.Password();
 
@@ -106,7 +107,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var loRaDeviceRegistry = Mock.Of<ILoRaDeviceRegistry>();
             var loRaModuleClientFactory = Mock.Of<ILoRaModuleClientFactory>();
 
-            await using var moduleClientFactory = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, loRaModuleClientFactory, loRaDeviceRegistry, localLoRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance);
+            await using var moduleClientFactory = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender, loRaModuleClientFactory, loRaDeviceRegistry, localLoRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance);
 
             await moduleClientFactory.OnDesiredPropertiesUpdate(new TwinCollection(twinUpdate), null);
             Assert.Equal(facadeUri + "/", localLoRaDeviceApiServiceBase.URL.ToString());
@@ -136,7 +137,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             
             loRaModuleClient.Setup(x => x.GetTwinAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new Twin(twinProperty));
 
-            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance);
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance);
             await moduleClient.CreateAsync(CancellationToken.None);
             Assert.Equal(facadeUri + "/", loRaDeviceApiServiceBase.URL.ToString());
             Assert.Equal(facadeCode, loRaDeviceApiServiceBase.AuthCode);
@@ -162,7 +163,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             };
             loRaModuleClient.Setup(x => x.GetTwinAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new Twin(twinProperty));
 
-            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance);
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance);
             await Assert.ThrowsAsync<ConfigurationErrorsException>(() => moduleClient.CreateAsync(CancellationToken.None));
         }
 
@@ -178,7 +179,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             loRaModuleClient.Setup(x => x.GetTwinAsync(It.IsAny<CancellationToken>())).Throws<IotHubCommunicationException>();
 
-            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance);
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance);
             var ex = await Assert.ThrowsAsync<LoRaProcessingException>(() => moduleClient.CreateAsync(CancellationToken.None));
             Assert.Equal(LoRaProcessingErrorCode.TwinFetchFailed, ex.ErrorCode);
         }
@@ -194,7 +195,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // Change the iot edge timeout.
             networkServerConfiguration.IoTEdgeTimeout = 5;
 
-            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance);
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance);
             await moduleClient.OnDirectMethodCalled(new Microsoft.Azure.Devices.Client.MethodRequest(Constants.CloudToDeviceClearCache), null);
             loRaDeviceRegistry.VerifyAll();
         }
@@ -210,7 +211,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // Change the iot edge timeout.
             networkServerConfiguration.IoTEdgeTimeout = 5;
 
-            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance);
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance);
 
             var c2d = "{\"test\":\"asd\"}";
 
@@ -229,7 +230,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // Change the iot edge timeout.
             networkServerConfiguration.IoTEdgeTimeout = 5;
 
-            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance);
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance);
 
             await Assert.ThrowsAnyAsync<ArgumentNullException>(async () => await moduleClient.OnDirectMethodCalled(null, null));
         }
@@ -245,7 +246,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // Change the iot edge timeout.
             networkServerConfiguration.IoTEdgeTimeout = 5;
 
-            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance);
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance);
             var c2d = "{\"test\":\"asd\"}";
 
             var response = await moduleClient.OnDirectMethodCalled(new Microsoft.Azure.Devices.Client.MethodRequest(this.faker.Random.String2(8), Encoding.UTF8.GetBytes(c2d)), null);
@@ -263,7 +264,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             loRaModuleClient.Setup(x => x.DisposeAsync());
             // Change the iot edge timeout.
             networkServerConfiguration.IoTEdgeTimeout = 5;
-            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance);
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance);
 
             var response = await moduleClient.OnDirectMethodCalled(new Microsoft.Azure.Devices.Client.MethodRequest(Constants.CloudToDeviceDecoderElementName, null), null);
             Assert.Equal((int)HttpStatusCode.BadRequest, response.Status);
@@ -282,7 +283,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             // Change the iot edge timeout.
             networkServerConfiguration.IoTEdgeTimeout = 5;
-            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance);
+            await using var moduleClient = new ModuleConnectionHost(networkServerConfiguration, classCMessageSender.Object, this.loRaModuleClientFactory.Object, loRaDeviceRegistry.Object, loRaDeviceApiServiceBase, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance);
 
             var response = await moduleClient.OnDirectMethodCalled(new Microsoft.Azure.Devices.Client.MethodRequest(Constants.CloudToDeviceDecoderElementName, Encoding.UTF8.GetBytes(faker.Random.String2(10))), null);
             Assert.Equal((int)HttpStatusCode.BadRequest, response.Status);

--- a/Tests/Unit/NetworkServer/TaskUtilTests.cs
+++ b/Tests/Unit/NetworkServer/TaskUtilTests.cs
@@ -21,7 +21,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 #pragma warning restore CA2201 // Do not raise reserved exception types
 
             // act
-            Task Act() => TaskUtil.RunOnThreadPool(() => throw ex, log.Object);
+            Task Act() => TaskUtil.RunOnThreadPool(() => throw ex, log.Object, null);
 
             // assert
             var actual = await Assert.ThrowsAsync<Exception>(Act);
@@ -36,7 +36,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var log = new Mock<Action<Exception>>();
 
             // act
-            await TaskUtil.RunOnThreadPool(() => Task.CompletedTask, log.Object);
+            await TaskUtil.RunOnThreadPool(() => Task.CompletedTask, log.Object, null);
 
             // assert
             log.Verify(l => l.Invoke(It.IsAny<Exception>()), Times.Never);


### PR DESCRIPTION
# PR for issue #747 

## What is being addressed

With this PR we start counting processing errors and raise them as metrics. This helps users that do not use Azure Monitor to still get insights into the number of errors occurred.

## How is this addressed

When logging (fallback) error messages, we increase the count for processing errors. In addition, we make sure to use the correct overload of the logger to ensure that the exceptions get raised properly in Application Insights
