### PR TITLE
Feature/921 Add option to send LinkADRReqest as C2D message

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
@@ -386,6 +386,15 @@ namespace LoRaWan.NetworkServer
                         case Cid.Zero:
                         case Cid.One:
                         case Cid.LinkADRCmd:
+                            if (rxpk != null)
+                            {
+                                var linkCheckAnswer = new LinkCheckAnswer(rxpk.GetModulationMargin(), 1);
+                                if (macCommands.TryAdd((int)Cid.LinkCheckCmd, linkCheckAnswer))
+                                {
+                                    logger.LogInformation($"answering to a MAC command request {linkCheckAnswer}");
+                                }
+                            }
+                            break;
                         case Cid.DutyCycleCmd:
                         case Cid.RXParamCmd:
                         case Cid.DevStatusCmd:

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaCloudToDeviceMessageWrapper.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaCloudToDeviceMessageWrapper.cs
@@ -42,7 +42,7 @@ namespace LoRaWan.NetworkServer
                 }
                 catch (Exception ex) when (ex is JsonReaderException or JsonSerializationException)
                 {
-                    this.invalidErrorMessage = $"could not parse cloud to device message: {json}";
+                    this.invalidErrorMessage = $"could not parse cloud to device message: {json}: {ex.Message}";
                 }
             }
             else

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/LinkADRRequest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/LinkADRRequest.cs
@@ -34,7 +34,7 @@ namespace LoRaTools
         /// <summary>
         /// Initializes a new instance of the <see cref="LinkADRRequest"/> class.
         /// </summary>
-        public LinkADRRequest(byte datarate, byte txPower, ushort chMask, byte chMaskCntl, byte nbTrans)
+        public LinkADRRequest(ushort datarate, ushort txPower, ushort chMask, ushort chMaskCntl, ushort nbTrans)
         {
             Cid = Cid.LinkADRCmd;
             DataRateTXPower = (byte)((datarate << 4) | txPower);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommandJsonConverter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommandJsonConverter.cs
@@ -4,8 +4,6 @@
 namespace LoRaTools
 {
     using System;
-    using System.Collections.Generic;
-    using System.Globalization;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
@@ -76,11 +74,18 @@ namespace LoRaTools
                     case Cid.LinkCheckCmd:
                     case Cid.LinkADRCmd:
                     {
-                        if (!IsValidLindADRCmd(item, out var errors))
-                        {
-                            throw new JsonReaderException(string.Format(CultureInfo.InvariantCulture, "Command {0} is invalid: {1}", item, string.Join(", ", errors)));
-                        }
-                        var cmd = new LinkADRRequest((ushort)item["datarate"], (ushort)item["txpower"], (ushort)item["chmask"], (byte)item["chmaskctl"], (byte)item["nbtrans"]);
+                        if (!item.TryGetValue("datarate", out var datarate))
+                            throw new JsonReaderException("Property 'datarate' is missing");
+                        if (!item.TryGetValue("txpower", out var txpower))
+                            throw new JsonReaderException("Property 'txpower' is missing");
+                        if (!item.TryGetValue("chmask", out var chmask))
+                            throw new JsonReaderException("Property 'chmask' is missing");
+                        if (!item.TryGetValue("chmaskctl", out var chmaskctl))
+                            throw new JsonReaderException("Property 'chmaskctl' is missing");
+                        if (!item.TryGetValue("nbtrans", out var nbtrans))
+                            throw new JsonReaderException("Property 'nbtrans' is missing");
+
+                        var cmd = new LinkADRRequest((ushort)datarate, (ushort)txpower, (ushort)chmask, (byte)chmaskctl, (byte)nbtrans);
                         serializer.Populate(item.CreateReader(), cmd);
                         return cmd;
                     }
@@ -95,19 +100,5 @@ namespace LoRaTools
         public override bool CanWrite => false;
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => throw new NotImplementedException();
-
-        private static bool IsValidLindADRCmd(JObject item, out List<string> errorMsgs)
-        {
-            errorMsgs = new List<string>();
-            var requiredProperties = new List<string> { "datarate", "txpower", "chmask", "chmaskctl", "nbtrans" };
-
-            foreach (var property in requiredProperties)
-            {
-                if (!item.ContainsKey(property))
-                    errorMsgs.Add($"Property '{property}' is missing");
-            }
-
-            return errorMsgs.Count == 0;
-        }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommandJsonConverter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommandJsonConverter.cs
@@ -4,6 +4,8 @@
 namespace LoRaTools
 {
     using System;
+    using System.Collections.Generic;
+    using System.Globalization;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
@@ -74,6 +76,10 @@ namespace LoRaTools
                     case Cid.LinkCheckCmd:
                     case Cid.LinkADRCmd:
                     {
+                        if (!IsValidLindADRCmd(item, out var errors))
+                        {
+                            throw new JsonReaderException(string.Format(CultureInfo.InvariantCulture, "Command {0} is invalid: {1}", item, string.Join(", ", errors)));
+                        }
                         var cmd = new LinkADRRequest((ushort)item["datarate"], (ushort)item["txpower"], (ushort)item["chmask"], (byte)item["chmaskctl"], (byte)item["nbtrans"]);
                         serializer.Populate(item.CreateReader(), cmd);
                         return cmd;
@@ -89,5 +95,19 @@ namespace LoRaTools
         public override bool CanWrite => false;
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => throw new NotImplementedException();
+
+        private static bool IsValidLindADRCmd(JObject item, out List<string> errorMsgs)
+        {
+            errorMsgs = new List<string>();
+            var requiredProperties = new List<string> { "datarate", "txpower", "chmask", "chmaskctl", "nbtrans" };
+
+            foreach (var property in requiredProperties)
+            {
+                if (!item.ContainsKey(property))
+                    errorMsgs.Add($"Property '{property}' is missing");
+            }
+
+            return errorMsgs.Count == 0;
+        }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommandJsonConverter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommandJsonConverter.cs
@@ -73,6 +73,11 @@ namespace LoRaTools
                     case Cid.One:
                     case Cid.LinkCheckCmd:
                     case Cid.LinkADRCmd:
+                    {
+                        var cmd = new LinkADRRequest((ushort)item["datarate"], (ushort)item["txpower"], (ushort)item["chmask"], (byte)item["chmaskctl"], (byte)item["nbtrans"]);
+                        serializer.Populate(item.CreateReader(), cmd);
+                        return cmd;
+                    }
                     default:
                         throw new JsonReaderException($"Unhandled command identifier: {macCommandType}");
                 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommandJsonConverter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Mac/MACCommandJsonConverter.cs
@@ -89,7 +89,7 @@ namespace LoRaTools
                 }
             }
 
-            throw new JsonReaderException($"Unkown MAC command identifier: {cidPropertyValue}");
+            throw new JsonReaderException($"Unknown MAC command identifier: {cidPropertyValue}");
         }
 
         public override bool CanWrite => false;

--- a/Tests/Unit/LoRaWan/MacCommandTest.cs
+++ b/Tests/Unit/LoRaWan/MacCommandTest.cs
@@ -53,14 +53,10 @@ namespace LoRaWan.Tests.Unit.LoRaTools
         [Fact]
         public void When_Serializing_Invalid_LinkAdrCmd_Should_Throw()
         {
-            var input = @"{ ""cid"": ""LinkAdrCmd"", ""datarate"": 2, ""chmaskctl"": 0 }";
+            var input = @"{ ""cid"": ""LinkAdrCmd"", ""datarate"": 2, ""chmask"": 25, ""chmaskctl"": 0, ""nbtrans"": 1 }";
             var ex = Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<MacCommand>(input));
 
-            var missingProperties = new string[] { "txpower", "chmask", "nbtrans" };
-            foreach (var property in missingProperties)
-            {
-                Assert.Contains($"Property '{property}' is missing", ex.Message, StringComparison.InvariantCulture);
-            }
+            Assert.Equal($"Property 'txpower' is missing", ex.Message);
         }
     }
 }

--- a/Tests/Unit/LoRaWan/MacCommandTest.cs
+++ b/Tests/Unit/LoRaWan/MacCommandTest.cs
@@ -47,6 +47,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools
             Assert.Equal(4, linkADRCmd.TxPower);
             Assert.Equal(25, linkADRCmd.ChMask);
             Assert.Equal(0, linkADRCmd.ChMaskCntl);
+            Assert.Equal(1, linkADRCmd.NbRep);
         }
 
         [Fact]

--- a/Tests/Unit/LoRaWan/MacCommandTest.cs
+++ b/Tests/Unit/LoRaWan/MacCommandTest.cs
@@ -7,7 +7,6 @@ namespace LoRaWan.Tests.Unit.LoRaTools
     using System.Collections.Generic;
     using global::LoRaTools;
     using Newtonsoft.Json;
-    using Org.BouncyCastle.Asn1.BC;
     using Xunit;
 
     public class MacCommandTest

--- a/Tests/Unit/LoRaWan/MacCommandTest.cs
+++ b/Tests/Unit/LoRaWan/MacCommandTest.cs
@@ -50,13 +50,15 @@ namespace LoRaWan.Tests.Unit.LoRaTools
             Assert.Equal(1, linkADRCmd.NbRep);
         }
 
-        [Fact]
-        public void When_Serializing_Invalid_LinkAdrCmd_Should_Throw()
+        [Theory]
+        [InlineData(@"{ ""cid"": ""LinkAdrCmd"", ""datarate"": 2, ""chmask"": 25, ""chmaskctl"": 0, ""nbtrans"": 1 }", "txpower")]
+        [InlineData(@"{ ""cid"": ""LinkAdrCmd"", ""chmask"": 20 }", "datarate")]
+        [InlineData(@"{ ""cid"": ""LinkAdrCmd"", ""datarate"": 6, ""txpower"": 4, ""chmask"": 0 }", "chmaskctl")]
+        [InlineData(@"{ ""cid"": ""LinkAdrCmd"", ""datarate"": 8, ""txpower"": 0, ""chmask"": 20, ""chmaskctl"": 1 }", "nbtrans")]
+        public void When_Serializing_Invalid_LinkAdrCmd_Should_Throw(string input, string missingProperty)
         {
-            var input = @"{ ""cid"": ""LinkAdrCmd"", ""datarate"": 2, ""chmask"": 25, ""chmaskctl"": 0, ""nbtrans"": 1 }";
             var ex = Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<MacCommand>(input));
-
-            Assert.Equal($"Property 'txpower' is missing", ex.Message);
+            Assert.Equal($"Property '{missingProperty}' is missing", ex.Message);
         }
     }
 }

--- a/Tests/Unit/LoRaWan/MacCommandTest.cs
+++ b/Tests/Unit/LoRaWan/MacCommandTest.cs
@@ -3,9 +3,11 @@
 
 namespace LoRaWan.Tests.Unit.LoRaTools
 {
+    using System;
     using System.Collections.Generic;
     using global::LoRaTools;
     using Newtonsoft.Json;
+    using Org.BouncyCastle.Asn1.BC;
     using Xunit;
 
     public class MacCommandTest
@@ -32,6 +34,33 @@ namespace LoRaWan.Tests.Unit.LoRaTools
             _ = Assert.IsType<DutyCycleRequest>(genericMACCommand);
             var dutyCycleCmd = (DutyCycleRequest)genericMACCommand;
             Assert.Equal(12, dutyCycleCmd.DutyCyclePL);
+        }
+
+        [Fact]
+        public void When_Serializing_LinkAdrCmd_Should_Create_Correct_Items()
+        {
+            var input = @"{ ""cid"": ""LinkAdrCmd"", ""datarate"": 2, ""txpower"": 4, ""chmask"": 25, ""chmaskctl"": 0, ""nbtrans"": 1 }";
+            var macCommand = JsonConvert.DeserializeObject<MacCommand>(input);
+            Assert.NotNull(macCommand);
+            Assert.IsType<LinkADRRequest>(macCommand);
+            var linkADRCmd = (LinkADRRequest)macCommand;
+            Assert.Equal(2, linkADRCmd.DataRate);
+            Assert.Equal(4, linkADRCmd.TxPower);
+            Assert.Equal(25, linkADRCmd.ChMask);
+            Assert.Equal(0, linkADRCmd.ChMaskCntl);
+        }
+
+        [Fact]
+        public void When_Serializing_Invalid_LinkAdrCmd_Should_Throw()
+        {
+            var input = @"{ ""cid"": ""LinkAdrCmd"", ""datarate"": 2, ""chmaskctl"": 0 }";
+            var ex = Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<MacCommand>(input));
+
+            var missingProperties = new string[] { "txpower", "chmask", "nbtrans" };
+            foreach (var property in missingProperties)
+            {
+                Assert.Contains($"Property '{property}' is missing", ex.Message, StringComparison.InvariantCulture);
+            }
         }
     }
 }

--- a/Tests/Unit/NetworkServer/LoRaCloudToDeviceMessageWrapperTest.cs
+++ b/Tests/Unit/NetworkServer/LoRaCloudToDeviceMessageWrapperTest.cs
@@ -49,7 +49,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             using var message = new Message(Encoding.UTF8.GetBytes(json));
             var target = new LoRaCloudToDeviceMessageWrapper(this.sampleDevice, message);
             Assert.False(target.IsValid(out var errorMessage));
-            Assert.Equal($"could not parse cloud to device message: {json}", errorMessage);
+            Assert.Contains($"could not parse cloud to device message: {json}", errorMessage, StringComparison.InvariantCulture);
         }
 
         [Theory]
@@ -60,7 +60,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             using var message = new Message(Encoding.UTF8.GetBytes(json));
             var target = new LoRaCloudToDeviceMessageWrapper(this.sampleDevice, message);
             Assert.False(target.IsValid(out var errorMessage));
-            Assert.Equal($"could not parse cloud to device message: {json}", errorMessage);
+            Assert.Contains($"could not parse cloud to device message: {json}: Unknown MAC command identifier", errorMessage, StringComparison.InvariantCulture);
         }
 
         [Theory]


### PR DESCRIPTION
# PR for issue #921 

## What is being addressed

- `LinkADRReq` MAC command was not being handled correctly in the LNS and would never reach the leaf device

## How is this addressed

- `LinkADRReq` is correctly parsed from a MAC command
- Validation of required properties of the command added
- Unit tests added to cover `LinkADRReq` command parsing and error handling

## Out of scope

- E2E test verifying data rate change following a LinkADRReq MAC command - this is tracked in #922 
- Integration tests verifying the automatic DR change after certain number of messages - tracked in #923 