### PR TITLE
Revert "Bump Microsoft.Azure.Devices from 1.33.0 to 1.36.0 (#986)"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     </PropertyGroup>
     <PropertyGroup>
       <DockerDotNetX509Version>3.125.2</DockerDotNetX509Version>
-      <MicrosoftAzureDevicesVersion>1.36.0</MicrosoftAzureDevicesVersion>
+      <MicrosoftAzureDevicesVersion>1.33.0</MicrosoftAzureDevicesVersion>
       <MicrosoftAzureDevicesClientVersion>1.39.0</MicrosoftAzureDevicesClientVersion>
       <MicrosoftExtensionsCachingMemoryVersion>6.0.0</MicrosoftExtensionsCachingMemoryVersion>
       <MicrosoftAzureFunctionsExtensionsVersion>1.0.0</MicrosoftAzureFunctionsExtensionsVersion>


### PR DESCRIPTION
This reverts commit 3e2671520d14fe44503e102f17adda06c1803899 as it's causing some timeouts