### PR TITLE
Bug/995 Gateway ID Tags

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApplicationInsightsMetricExporter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApplicationInsightsMetricExporter.cs
@@ -60,7 +60,7 @@ namespace LoRaWan.NetworkServer
                 case 2: _ = metric.TrackValue(measurement, dimensions[0], dimensions[1]); break;
                 case 3: _ = metric.TrackValue(measurement, dimensions[0], dimensions[1], dimensions[2]); break;
                 case 4: _ = metric.TrackValue(measurement, dimensions[0], dimensions[1], dimensions[2], dimensions[3]); break;
-                default: throw new NotImplementedException("Metrics tracking in Application Insights for more than three dimensions it not supported");
+                default: throw new NotImplementedException("We do not support tracking more than four custom dimensions.");
             }
         }
     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApplicationInsightsMetricExporter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApplicationInsightsMetricExporter.cs
@@ -19,10 +19,12 @@ namespace LoRaWan.NetworkServer
     /// </summary>
     internal class ApplicationInsightsMetricExporter : RegistryMetricExporter
     {
-        private readonly IDictionary<string, (Metric, MetricIdentifier)> metricRegistry;
+        private readonly IDictionary<string, (Metric, string[])> metricRegistry;
         private readonly RegistryMetricTagBag metricTagBag;
 
-        public ApplicationInsightsMetricExporter(TelemetryClient telemetryClient, RegistryMetricTagBag metricTagBag, ILogger<ApplicationInsightsMetricExporter> logger)
+        public ApplicationInsightsMetricExporter(TelemetryClient telemetryClient,
+                                                 RegistryMetricTagBag metricTagBag,
+                                                 ILogger<ApplicationInsightsMetricExporter> logger)
             : this(telemetryClient, MetricRegistry.RegistryLookup, metricTagBag, logger)
         { }
 
@@ -35,7 +37,7 @@ namespace LoRaWan.NetworkServer
             this.metricRegistry = registryLookup.ToDictionary(m => m.Key, m =>
             {
                 var id = new MetricIdentifier(MetricRegistry.Namespace, m.Value.Name, m.Value.Tags);
-                return (telemetryClient.GetMetric(id), id);
+                return (telemetryClient.GetMetric(id), id.GetDimensionNames().ToArray());
             });
             this.metricTagBag = metricTagBag;
         }
@@ -44,9 +46,8 @@ namespace LoRaWan.NetworkServer
         {
             if (this.metricRegistry.TryGetValue(instrument.Name, out var value))
             {
-                var (metric, identifier) = value;
-                var tagNames = identifier.GetDimensionNames().ToArray() ?? Array.Empty<string>();
-                TrackValue(metric, measurement, MetricExporterHelper.GetTagsInOrder(tagNames, tags, this.metricTagBag));
+                var (metric, dimensions) = value;
+                TrackValue(metric, measurement, MetricExporterHelper.GetTagsInOrder(dimensions, tags, this.metricTagBag));
             }
         }
 
@@ -58,6 +59,7 @@ namespace LoRaWan.NetworkServer
                 case 1: _ = metric.TrackValue(measurement, dimensions[0]); break;
                 case 2: _ = metric.TrackValue(measurement, dimensions[0], dimensions[1]); break;
                 case 3: _ = metric.TrackValue(measurement, dimensions[0], dimensions[1], dimensions[2]); break;
+                case 4: _ = metric.TrackValue(measurement, dimensions[0], dimensions[1], dimensions[2], dimensions[3]); break;
                 default: throw new NotImplementedException("Metrics tracking in Application Insights for more than three dimensions it not supported");
             }
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -96,7 +96,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         .AddTransient<ILnsProtocolMessageProcessor, LnsProtocolMessageProcessor>()
                         .AddTransient<ICupsProtocolMessageProcessor, CupsProtocolMessageProcessor>()
                         .AddSingleton(typeof(IConcentratorDeduplication<>), typeof(ConcentratorDeduplication<>))
-                        .AddSingleton(new RegistryMetricTagBag())
+                        .AddSingleton(new RegistryMetricTagBag(NetworkServerConfiguration))
                         .AddSingleton(_ => new Meter(MetricRegistry.Namespace, MetricRegistry.Version))
                         .AddHostedService(sp =>
                             new MetricExporterHostedService(

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -125,11 +125,11 @@ namespace LoRaWan.NetworkServer
                 string? tagValue = null;
 
                 // nested loop since we will only ever have less than approximately five custom dimensions
-                foreach (var tagKeyValuePair in tags)
+                for (var j = 0; j < tags.Length; ++j)
                 {
-                    if (tagName == tagKeyValuePair.Key)
+                    if (tagName == tags[j].Key)
                     {
-                        tagValue = tagKeyValuePair.Value?.ToString();
+                        tagValue = tags[j].Value?.ToString();
                         break;
                     }
                 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -118,6 +118,7 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         public static string[] GetTagsInOrder(IReadOnlyList<string> tagNames, ReadOnlySpan<KeyValuePair<string, object?>> tags, RegistryMetricTagBag metricTagBag)
         {
+            var tagsMatchedCount = 0; // Used to validate that all tag values that are raised are defined in the custom metric registry.
             var result = new string[tagNames.Count];
             for (var i = 0; i < tagNames.Count; ++i)
             {
@@ -130,6 +131,7 @@ namespace LoRaWan.NetworkServer
                     if (tagName == tags[j].Key)
                     {
                         tagValue = tags[j].Value?.ToString();
+                        ++tagsMatchedCount;
                         break;
                     }
                 }
@@ -150,6 +152,9 @@ namespace LoRaWan.NetworkServer
 
                 result[i] = tagValue;
             }
+
+            if (tagsMatchedCount != tags.Length)
+                throw new InvalidOperationException("Some tags raised are not defined in custom metric registry. Make sure that all tags that you raise are defined in the metric registry.");
 
             return result;
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -103,7 +103,7 @@ namespace LoRaWan.NetworkServer
     {
         public RegistryMetricTagBag(NetworkServerConfiguration networkServerConfiguration)
         {
-            GatewayId = networkServerConfiguration.GatewayID;
+            GatewayId = string.IsNullOrEmpty(networkServerConfiguration.GatewayID) ? "unknown" : networkServerConfiguration.GatewayID;
         }
 
         public AsyncLocal<StationEui?> StationEui { get; } = new AsyncLocal<StationEui?>();

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/RegistryMetricExporter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/RegistryMetricExporter.cs
@@ -59,11 +59,6 @@ namespace LoRaWan.NetworkServer
                     {
                         this.listener.RecordObservableInstruments();
                     }
-                    catch (TaskCanceledException)
-                    {
-                        // exception raised after disposal.
-                        return;
-                    }
 #pragma warning disable CA1031 // Do not catch general exception types (continue observing metrics even on error)
                     catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
@@ -71,7 +66,15 @@ namespace LoRaWan.NetworkServer
                         this.logger.LogInformation(ex, "Exception when recording observable metrics.");
                     }
 
-                    await Task.Delay(ObserveInterval, this.cancellationTokenSource.Token);
+                    try
+                    {
+                        await Task.Delay(ObserveInterval, this.cancellationTokenSource.Token);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        // exception raised after disposal.
+                        return;
+                    }
                 }
             });
         }

--- a/Tests/Unit/NetworkServer/ApplicationInsightsMetricExporterTests.cs
+++ b/Tests/Unit/NetworkServer/ApplicationInsightsMetricExporterTests.cs
@@ -31,13 +31,13 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         {
             this.registry = new[]
             {
-                new CustomMetric(Guid.NewGuid().ToString(), "Counter", MetricType.Counter, new[] { MetricRegistry.GatewayIdTagName }),
-                new CustomMetric(Guid.NewGuid().ToString(), "Histogram", MetricType.Histogram, new[] { MetricRegistry.GatewayIdTagName }),
-                new CustomMetric(Guid.NewGuid().ToString(), "ObservableGauge", MetricType.ObservableGauge, new[] { MetricRegistry.GatewayIdTagName })
+                new CustomMetric(Guid.NewGuid().ToString(), "Counter", MetricType.Counter, new[] { MetricRegistry.ConcentratorIdTagName }),
+                new CustomMetric(Guid.NewGuid().ToString(), "Histogram", MetricType.Histogram, new[] { MetricRegistry.ConcentratorIdTagName }),
+                new CustomMetric(Guid.NewGuid().ToString(), "ObservableGauge", MetricType.ObservableGauge, new[] { MetricRegistry.ConcentratorIdTagName })
             };
             this.telemetryConfiguration = new TelemetryConfiguration { TelemetryChannel = new Mock<ITelemetryChannel>().Object };
             this.trackValueMock = new Mock<Action<Metric, double, string[]>>();
-            this.registryMetricTagBag = new RegistryMetricTagBag();
+            this.registryMetricTagBag = new RegistryMetricTagBag(new NetworkServerConfiguration { GatewayID = "foogateway" });
             this.applicationInsightsMetricExporter = new TestableApplicationInsightsExporter(new TelemetryClient(this.telemetryConfiguration),
                                                                                              this.trackValueMock.Object,
                                                                                              this.registry.ToDictionary(m => m.Name, m => m),
@@ -91,7 +91,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // act
             applicationInsightsMetricExporter.Start();
             foreach (var val in metricValues)
-                counter.Add(val, KeyValuePair.Create(MetricRegistry.GatewayIdTagName, (object)gateway));
+                counter.Add(val, KeyValuePair.Create(MetricRegistry.ConcentratorIdTagName, (object)gateway));
 
             // assert
             foreach (var expectedReportedValue in expectedReportedValues)
@@ -116,7 +116,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             // act
             this.applicationInsightsMetricExporter.Start();
-            histogram.Record(value, KeyValuePair.Create(MetricRegistry.GatewayIdTagName, (object)gateway));
+            histogram.Record(value, KeyValuePair.Create(MetricRegistry.ConcentratorIdTagName, (object)gateway));
 
             // assert
             this.trackValueMock.Verify(me => me.Invoke(It.Is<Metric>(m => m.Identifier.MetricNamespace == MetricRegistry.Namespace
@@ -132,7 +132,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // arrange
             var observeValue = new Mock<Func<Measurement<int>>>();
             var stationEui = new StationEui(1);
-            var measurement = new Measurement<int>(1, KeyValuePair.Create(MetricRegistry.GatewayIdTagName, (object)stationEui));
+            var measurement = new Measurement<int>(1, KeyValuePair.Create(MetricRegistry.ConcentratorIdTagName, (object)stationEui));
             _ = observeValue.Setup(ov => ov.Invoke()).Returns(measurement);
             using var meter = new Meter("LoRaWan", "1.0");
             _ = meter.CreateObservableGauge(ObservableGaugeMetric.Name, observeValue.Object);
@@ -189,7 +189,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             // act
             applicationInsightsMetricExporter.Start();
-            counter.Add(1, new KeyValuePair<string, object>(MetricRegistry.GatewayIdTagName.ToUpperInvariant(), gateway));
+            counter.Add(1, new KeyValuePair<string, object>(MetricRegistry.ConcentratorIdTagName.ToUpperInvariant(), gateway));
 
             // assert
             this.trackValueMock.Verify(me => me.Invoke(It.IsAny<Metric>(), 1, new[] { gateway }), Times.Once);

--- a/Tests/Unit/NetworkServer/ApplicationInsightsMetricExporterTests.cs
+++ b/Tests/Unit/NetworkServer/ApplicationInsightsMetricExporterTests.cs
@@ -180,22 +180,6 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         }
 
         [Fact]
-        public void When_Raising_Metric_Dimensions_Should_Be_Case_Insensitive()
-        {
-            // arrange
-            const string gateway = "foogateway";
-            using var meter = new Meter(MetricRegistry.Namespace, MetricRegistry.Version);
-            var counter = meter.CreateCounter<int>(CounterMetric.Name);
-
-            // act
-            applicationInsightsMetricExporter.Start();
-            counter.Add(1, new KeyValuePair<string, object>(MetricRegistry.ConcentratorIdTagName.ToUpperInvariant(), gateway));
-
-            // assert
-            this.trackValueMock.Verify(me => me.Invoke(It.IsAny<Metric>(), 1, new[] { gateway }), Times.Once);
-        }
-
-        [Fact]
         public void When_Tag_Not_Specified_Should_Fallback_To_Tag_Bag()
         {
             // arrange

--- a/Tests/Unit/NetworkServer/LnsProtocolMessageProcessorTests.cs
+++ b/Tests/Unit/NetworkServer/LnsProtocolMessageProcessorTests.cs
@@ -52,7 +52,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                                                                            this.messageDispatcher.Object,
                                                                            upstreamDeduplicationMock.Object,
                                                                            joinRequestDeduplicationMock.Object,
-                                                                           loggerMock, new RegistryMetricTagBag(),
+                                                                           loggerMock, new RegistryMetricTagBag(new NetworkServerConfiguration { GatewayID = "foogateway" }),
                                                                            // Do not pass meter since metric testing will be unreliable due to interference from test classes running in parallel.
                                                                            null);
         }

--- a/Tests/Unit/NetworkServer/MetricRegistryTests.cs
+++ b/Tests/Unit/NetworkServer/MetricRegistryTests.cs
@@ -15,12 +15,14 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
     public sealed class MetricRegistryTests : IDisposable
     {
+        private const string GatewayId = "foogateway";
+
         private readonly RegistryMetricTagBag metricTagBag;
         private readonly Meter meter;
 
         public MetricRegistryTests()
         {
-            this.metricTagBag = new RegistryMetricTagBag();
+            this.metricTagBag = new RegistryMetricTagBag(new NetworkServerConfiguration { GatewayID = GatewayId });
             this.meter = new Meter(MetricRegistry.Namespace, MetricRegistry.Version);
         }
 
@@ -154,10 +156,20 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             this.metricTagBag.StationEui.Value = stationEui;
 
             // act
-            var result = MetricExporterHelper.GetTagsInOrder(new[] { MetricRegistry.GatewayIdTagName }, Array.Empty<KeyValuePair<string, object?>>(), this.metricTagBag);
+            var result = MetricExporterHelper.GetTagsInOrder(new[] { MetricRegistry.ConcentratorIdTagName }, Array.Empty<KeyValuePair<string, object?>>(), this.metricTagBag);
 
             // assert
             Assert.Equal(new[] { stationEui.ToString() }, result);
+        }
+
+        [Fact]
+        public void GetTagsInOrder_Should_Fall_Back_To_Tag_Bag_For_GatewayId()
+        {
+            // arrange + act
+            var result = MetricExporterHelper.GetTagsInOrder(new[] { MetricRegistry.GatewayIdTagName }, Array.Empty<KeyValuePair<string, object?>>(), this.metricTagBag);
+
+            // assert
+            Assert.Equal(new[] { GatewayId }, result);
         }
 
         [Fact]

--- a/Tests/Unit/NetworkServer/MetricRegistryTests.cs
+++ b/Tests/Unit/NetworkServer/MetricRegistryTests.cs
@@ -173,6 +173,18 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         }
 
         [Fact]
+        public void GetTagsInOrder_Should_Indicate_Gateway_Id_Unknown_When_GatewayId_Not_Set()
+        {
+            // arrange + act
+            var result = MetricExporterHelper.GetTagsInOrder(new[] { MetricRegistry.GatewayIdTagName },
+                                                             Array.Empty<KeyValuePair<string, object?>>(),
+                                                             new RegistryMetricTagBag(new NetworkServerConfiguration()));
+
+            // assert
+            Assert.Equal(new[] { "unknown" }, result);
+        }
+
+        [Fact]
         public void CompositeMetricExporter_Works_If_One_Exporter_Null()
         {
             // arrange

--- a/Tests/Unit/NetworkServer/MetricRegistryTests.cs
+++ b/Tests/Unit/NetworkServer/MetricRegistryTests.cs
@@ -140,6 +140,21 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.Equal(LoRaProcessingErrorCode.TagNotSet, result.ErrorCode);
         }
 
+        public static object[][] Tag_Value_Is_Not_In_Tag_Names() => new[]
+        {
+            new object[] { Array.Empty<string>(), KeyValuePair.Create("foo", (object?)"bar") },
+            new object[] { new[] { "foo" }, KeyValuePair.Create("foo", (object?)"bar"), KeyValuePair.Create("baz", (object?)"bar") },
+            new object[] { new[] { MetricRegistry.GatewayIdTagName }, KeyValuePair.Create("foo", (object?)"bar") },
+            new object[] { new[] { MetricRegistry.GatewayIdTagName, "foo" }, KeyValuePair.Create("foo", (object?)"bar"), KeyValuePair.Create("baz", (object?)"bar") }
+        };
+
+        [Theory]
+        [MemberData(nameof(Tag_Value_Is_Not_In_Tag_Names))]
+        public void GetTagsInOrder_Throws_When_Tag_Value_Is_Not_In_Tag_Names(string[] tagNames, params KeyValuePair<string, object?>[] tagValues)
+        {
+            _ = Assert.Throws<InvalidOperationException>(() => MetricExporterHelper.GetTagsInOrder(tagNames, tagValues, this.metricTagBag));
+        }
+
         [Fact]
         public void GetTagsInOrder_Throws_When_Tag_Is_Empty()
         {

--- a/Tests/Unit/NetworkServer/PrometheusMetricExporterTests.cs
+++ b/Tests/Unit/NetworkServer/PrometheusMetricExporterTests.cs
@@ -33,14 +33,14 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         {
             this.registry = new[]
             {
-                new CustomMetric($"counter{Guid.NewGuid():N}", "Counter", MetricType.Counter, new[] { MetricRegistry.GatewayIdTagName }),
-                new CustomMetric($"histogram{Guid.NewGuid():N}", "Histogram", MetricType.Histogram, new[] { MetricRegistry.GatewayIdTagName }),
-                new CustomMetric($"observablegauge{Guid.NewGuid():N}", "Observable Gauge", MetricType.ObservableGauge, new[] { MetricRegistry.GatewayIdTagName })
+                new CustomMetric($"counter{Guid.NewGuid():N}", "Counter", MetricType.Counter, new[] { MetricRegistry.ConcentratorIdTagName }),
+                new CustomMetric($"histogram{Guid.NewGuid():N}", "Histogram", MetricType.Histogram, new[] { MetricRegistry.ConcentratorIdTagName }),
+                new CustomMetric($"observablegauge{Guid.NewGuid():N}", "Observable Gauge", MetricType.ObservableGauge, new[] { MetricRegistry.ConcentratorIdTagName })
             };
             this.incCounterMock = new Mock<Action<string, string[], double>>();
             this.recordHistogramMock = new Mock<Action<string, string[], double>>();
             this.recordObservableGaugeMock = new Mock<Action<string, string[], double>>();
-            this.metricTagBag = new RegistryMetricTagBag();
+            this.metricTagBag = new RegistryMetricTagBag(new NetworkServerConfiguration { GatewayID = "foogateway" });
             this.prometheusMetricExporter = new TestablePrometheusMetricExporter(this.incCounterMock.Object,
                                                                                  this.recordHistogramMock.Object,
                                                                                  this.recordObservableGaugeMock.Object,
@@ -99,7 +99,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             using var meter = new Meter("LoRaWan", "1.0");
             var counter = meter.CreateCounter<T>(Counter.Name);
             foreach (var value in values)
-                counter.Add(value, KeyValuePair.Create(MetricRegistry.GatewayIdTagName, (object?)gatewayId));
+                counter.Add(value, KeyValuePair.Create(MetricRegistry.ConcentratorIdTagName, (object?)gatewayId));
 
             // assert
             foreach (var value in expectedReportedValues)
@@ -118,7 +118,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             using var meter = new Meter("LoRaWan", "1.0");
             var histogram = meter.CreateHistogram<int>(Histogram.Name);
             foreach (var value in values)
-                histogram.Record(value, KeyValuePair.Create(MetricRegistry.GatewayIdTagName, (object?)gatewayId));
+                histogram.Record(value, KeyValuePair.Create(MetricRegistry.ConcentratorIdTagName, (object?)gatewayId));
 
             // assert
             foreach (var value in values)
@@ -131,7 +131,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // arrange
             var observeValue = new Mock<Func<Measurement<int>>>();
             var stationEui = new StationEui(1);
-            var measurement = new Measurement<int>(1, KeyValuePair.Create(MetricRegistry.GatewayIdTagName, (object?)stationEui));
+            var measurement = new Measurement<int>(1, KeyValuePair.Create(MetricRegistry.ConcentratorIdTagName, (object?)stationEui));
             observeValue.Setup(ov => ov.Invoke()).Returns(measurement);
             using var meter = new Meter("LoRaWan", "1.0");
             _ = meter.CreateObservableGauge(ObservableGauge.Name, observeValue.Object);


### PR DESCRIPTION
# PR for issue #995

## What is being addressed

With this PR we add the Gateway ID to all custom metrics that we raise. To support easier extensibility for (potential) future tags from the tag bag, we first refactor the logic to fetch tags in order to be more efficient by creating less allocations.
