### PR TITLE
Treat Code Analysis warnings as errors in CLI project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -119,3 +119,6 @@ dotnet_diagnostic.CA1848.severity = suggestion
 # Logging template should not vary between calls. To be revisited as part of
 # https://github.com/Azure/iotedge-lorawan-starterkit/issues/829
 dotnet_diagnostic.CA2254.severity = suggestion
+
+# Extract strings to resource table (the solution will not be localized).
+dotnet_diagnostic.CA1303.severity = none

--- a/Tools/Cli-LoRa-Device-Provisioning/Cli-LoRa-Device-Provisioning.csproj
+++ b/Tools/Cli-LoRa-Device-Provisioning/Cli-LoRa-Device-Provisioning.csproj
@@ -5,9 +5,6 @@
     <TargetFramework>$(TargetFramework)</TargetFramework>
     <RootNamespace>LoRaWan.Tools.CLI</RootNamespace>
     <AssemblyName>loradeviceprovisioning</AssemblyName>
-    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
     <Authors>Sascha Corti (saschac@microsoft.com)</Authors>
     <Version>2.0.0-alpha</Version>
     <Company>Microsoft</Company>

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.Tools.CLI.Helpers
 {
     using System;
+    using System.Globalization;
     using System.IO;
     using Azure.Storage.Blobs;
     using Microsoft.Azure.Devices;
@@ -71,7 +72,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             // Validate NetId setting
             if (string.IsNullOrEmpty(netId))
             {
-                netId = ValidationHelper.CleanNetId(Constants.DefaultNetId.ToString());
+                netId = ValidationHelper.CleanNetId(Constants.DefaultNetId.ToString(CultureInfo.InvariantCulture));
                 StatusConsole.WriteLogLine(MessageType.Info, $"NetId is not set in settings file. Using default {netId}.");
             }
             else
@@ -85,7 +86,7 @@ namespace LoRaWan.Tools.CLI.Helpers
                 else
                 {
                     var netIdBad = netId;
-                    netId = ValidationHelper.CleanNetId(Constants.DefaultNetId.ToString());
+                    netId = ValidationHelper.CleanNetId(Constants.DefaultNetId.ToString(CultureInfo.InvariantCulture));
                     StatusConsole.WriteLogLine(MessageType.Warning, $"NetId {netIdBad} in settings file is invalid. {customError}.");
                     StatusConsole.WriteLogLine(MessageType.Warning, $"Using default NetId {netId} instead.");
                 }
@@ -125,10 +126,10 @@ namespace LoRaWan.Tools.CLI.Helpers
         {
             hostName = string.Empty;
 
-            var from = connectionString.IndexOf("HostName=");
+            var from = connectionString.IndexOf("HostName=", StringComparison.OrdinalIgnoreCase);
             var fromOffset = "HostName=".Length;
 
-            var to = connectionString.IndexOf("azure-devices.net");
+            var to = connectionString.IndexOf("azure-devices.net", StringComparison.OrdinalIgnoreCase);
             var length = to - from - fromOffset + "azure-devices.net".Length;
 
             if (from == -1 || to == -1)

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
@@ -52,7 +52,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             else
             {
                 // Just show IoT Hub Hostname
-                if (this.GetHostFromConnectionString(connectionString, out string hostName))
+                if (this.GetHostFromConnectionString(connectionString, out var hostName))
                 {
                     StatusConsole.WriteLogLine(MessageType.Info, $"Using IoT Hub: {hostName}");
                 }
@@ -73,7 +73,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             {
                 netId = ValidationHelper.CleanNetId(netId);
 
-                if (ValidationHelper.ValidateHexStringTwinProperty(netId, 3, out string customError))
+                if (ValidationHelper.ValidateHexStringTwinProperty(netId, 3, out var customError))
                 {
                     StatusConsole.WriteLogLine(MessageType.Info, $"Using NetId {netId} from settings file.");
                 }

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
@@ -52,7 +52,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             else
             {
                 // Just show IoT Hub Hostname
-                if (this.GetHostFromConnectionString(connectionString, out var hostName))
+                if (GetHostFromConnectionString(connectionString, out var hostName))
                 {
                     StatusConsole.WriteLogLine(MessageType.Info, $"Using IoT Hub: {hostName}");
                 }
@@ -88,12 +88,12 @@ namespace LoRaWan.Tools.CLI.Helpers
 
             StatusConsole.WriteLogLine(MessageType.Info, $"To override, use --netid parameter.");
 
-            this.NetId = netId;
+            NetId = netId;
 
             // Create Registry Manager using connection string
             try
             {
-                this.RegistryManager = RegistryManager.CreateFromConnectionString(connectionString);
+                RegistryManager = RegistryManager.CreateFromConnectionString(connectionString);
             }
             catch (Exception ex)
             {

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
@@ -35,18 +35,23 @@ namespace LoRaWan.Tools.CLI.Helpers
                 connectionString = configurationBuilder["IoTHubConnectionString"];
                 credentialStorageConnectionString = configurationBuilder["CredentialStorageConnectionString"];
                 netId = configurationBuilder["NetId"];
+
+                if (connectionString is null || credentialStorageConnectionString is null || netId is null)
+                {
+                    StatusConsole.WriteLogLine(MessageType.Info, "The file should have the following structure: { \"IoTHubConnectionString\" : \"HostName=xxx.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=xxx\" }");
+                    return false;
+                }
             }
-            catch (Exception ex)
+            catch (FileNotFoundException)
             {
-                StatusConsole.WriteLogLine(MessageType.Error, $"{ex.Message}");
-                StatusConsole.WriteLogLine(MessageType.Info, "The file should have the following structure: { \"IoTHubConnectionString\" : \"HostName=xxx.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=xxx\" }");
+                StatusConsole.WriteLogLine(MessageType.Error, "Configuration file 'appsettings.json' was not found.");
                 return false;
             }
 
             // Validate connection setting
             if (string.IsNullOrEmpty(connectionString))
             {
-                StatusConsole.WriteLogLine(MessageType.Error, "Connection string not found in settings file. The format should be: { \"IoTHubConnectionString\" : \"HostName=xxx.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=xxx\" }.");
+                StatusConsole.WriteLogLine(MessageType.Error, "Connection string 'IoTHubConnectionString' may not be empty.");
                 return false;
             }
             else
@@ -95,9 +100,11 @@ namespace LoRaWan.Tools.CLI.Helpers
             {
                 RegistryManager = RegistryManager.CreateFromConnectionString(connectionString);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is ArgumentNullException
+                                          or FormatException
+                                          or ArgumentException)
             {
-                StatusConsole.WriteLogLine(MessageType.Error, $"Can not connect to IoT Hub (possible error in connection string): {ex.Message}.");
+                StatusConsole.WriteLogLine(MessageType.Error, $"Failed to create connection string: {ex.Message}.");
                 return false;
             }
 

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
@@ -9,7 +9,7 @@ namespace LoRaWan.Tools.CLI.Helpers
     using Microsoft.Azure.Devices;
     using Microsoft.Extensions.Configuration;
 
-    public class ConfigurationHelper
+    internal class ConfigurationHelper
     {
         private const string CredentialsStorageContainerName = "stationcredentials";
         public string NetId { get; set; }

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
@@ -121,7 +121,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             return true;
         }
 
-        public bool GetHostFromConnectionString(string connectionString, out string hostName)
+        public static bool GetHostFromConnectionString(string connectionString, out string hostName)
         {
             hostName = string.Empty;
 

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConversionHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConversionHelper.cs
@@ -34,8 +34,8 @@ namespace LoRaWan.Tools.CLI.Helpers
 
             for (var i = 0; i < bytes.Length; i++)
             {
-                result.Append(Constants.HexAlphabet[byteSpan[i] >> 4]);
-                result.Append(Constants.HexAlphabet[byteSpan[i] & 0xF]);
+                _ = result.Append(Constants.HexAlphabet[byteSpan[i] >> 4])
+                          .Append(Constants.HexAlphabet[byteSpan[i] & 0xF]);
             }
 
             return result.ToString();
@@ -48,21 +48,8 @@ namespace LoRaWan.Tools.CLI.Helpers
 
             for (var i = bytes.Length - 1; i >= 0; --i)
             {
-                result.Append(Constants.HexAlphabet[byteSpan[i] >> 4]);
-                result.Append(Constants.HexAlphabet[byteSpan[i] & 0xF]);
-            }
-
-            return result.ToString();
-        }
-
-        static string ByteArrayToString(byte[] bytes)
-        {
-            var result = new StringBuilder(bytes.Length * 2);
-
-            foreach (var b in bytes)
-            {
-                result.Append(Constants.HexAlphabet[b >> 4]);
-                result.Append(Constants.HexAlphabet[b & 0xF]);
+                _ = result.Append(Constants.HexAlphabet[byteSpan[i] >> 4])
+                          .Append(Constants.HexAlphabet[byteSpan[i] & 0xF]);
             }
 
             return result.ToString();

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConversionHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConversionHelper.cs
@@ -6,7 +6,7 @@ namespace LoRaWan.Tools.CLI.Helpers
     using System;
     using System.Text;
 
-    public static class ConversionHelper
+    internal static class ConversionHelper
     {
         /// <summary>
         /// Method enabling to convert a hex string to a byte array.

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConversionHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConversionHelper.cs
@@ -14,13 +14,13 @@ namespace LoRaWan.Tools.CLI.Helpers
         /// <param name="hex">Input hex string</param>
         public static byte[] StringToByteArray(string hex)
         {
-            int numberChars = hex.Length;
+            var numberChars = hex.Length;
 
-            byte[] bytes = new byte[numberChars >> 1];
+            var bytes = new byte[numberChars >> 1];
 
             if (numberChars % 2 == 0)
             {
-                for (int i = 0; i < numberChars; i += 2)
+                for (var i = 0; i < numberChars; i += 2)
                     bytes[i >> 1] = Convert.ToByte(hex.Substring(i, 2), 16);
             }
 
@@ -59,7 +59,7 @@ namespace LoRaWan.Tools.CLI.Helpers
         {
             var result = new StringBuilder(bytes.Length * 2);
 
-            foreach (byte b in bytes)
+            foreach (var b in bytes)
             {
                 result.Append(Constants.HexAlphabet[b >> 4]);
                 result.Append(Constants.HexAlphabet[b & 0xF]);

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -52,34 +52,34 @@ namespace LoRaWan.Tools.CLI.Helpers
 
             devEui = ValidationHelper.CleanString(devEui);
 
-            var appEui = this.ReadTwin(twin.Properties.Desired, TwinProperty.AppEUI);
-            var appKey = this.ReadTwin(twin.Properties.Desired, TwinProperty.AppKey);
+            var appEui = ReadTwin(twin.Properties.Desired, TwinProperty.AppEUI);
+            var appKey = ReadTwin(twin.Properties.Desired, TwinProperty.AppKey);
 
-            var nwkSKey = this.ReadTwin(twin.Properties.Desired, TwinProperty.NwkSKey);
-            var appSKey = this.ReadTwin(twin.Properties.Desired, TwinProperty.AppSKey);
-            var devAddr = this.ReadTwin(twin.Properties.Desired, TwinProperty.DevAddr);
-            var abpRelaxMode = this.ReadTwin(twin.Properties.Desired, TwinProperty.ABPRelaxMode);
+            var nwkSKey = ReadTwin(twin.Properties.Desired, TwinProperty.NwkSKey);
+            var appSKey = ReadTwin(twin.Properties.Desired, TwinProperty.AppSKey);
+            var devAddr = ReadTwin(twin.Properties.Desired, TwinProperty.DevAddr);
+            var abpRelaxMode = ReadTwin(twin.Properties.Desired, TwinProperty.ABPRelaxMode);
 
             netId = ValidationHelper.CleanNetId(netId);
 
-            var gatewayID = this.ReadTwin(twin.Properties.Desired, TwinProperty.GatewayID);
-            var sensorDecoder = this.ReadTwin(twin.Properties.Desired, TwinProperty.SensorDecoder);
-            var classType = this.ReadTwin(twin.Properties.Desired, TwinProperty.ClassType);
-            var downlinkEnabled = this.ReadTwin(twin.Properties.Desired, TwinProperty.DownlinkEnabled);
-            var preferredWindow = this.ReadTwin(twin.Properties.Desired, TwinProperty.PreferredWindow);
-            var deduplication = this.ReadTwin(twin.Properties.Desired, TwinProperty.Deduplication);
-            var rx2DataRate = this.ReadTwin(twin.Properties.Desired, TwinProperty.RX2DataRate);
-            var rx1DrOffset = this.ReadTwin(twin.Properties.Desired, TwinProperty.RX1DROffset);
-            var rxDelay = this.ReadTwin(twin.Properties.Desired, TwinProperty.RXDelay);
-            var keepAliveTimeout = this.ReadTwin(twin.Properties.Desired, TwinProperty.KeepAliveTimeout);
-            var supports32BitFCnt = this.ReadTwin(twin.Properties.Desired, TwinProperty.Supports32BitFCnt);
-            var fCntUpStart = this.ReadTwin(twin.Properties.Desired, TwinProperty.FCntUpStart);
-            var fCntDownStart = this.ReadTwin(twin.Properties.Desired, TwinProperty.FCntDownStart);
-            var fCntResetCounter = this.ReadTwin(twin.Properties.Desired, TwinProperty.FCntResetCounter);
+            var gatewayID = ReadTwin(twin.Properties.Desired, TwinProperty.GatewayID);
+            var sensorDecoder = ReadTwin(twin.Properties.Desired, TwinProperty.SensorDecoder);
+            var classType = ReadTwin(twin.Properties.Desired, TwinProperty.ClassType);
+            var downlinkEnabled = ReadTwin(twin.Properties.Desired, TwinProperty.DownlinkEnabled);
+            var preferredWindow = ReadTwin(twin.Properties.Desired, TwinProperty.PreferredWindow);
+            var deduplication = ReadTwin(twin.Properties.Desired, TwinProperty.Deduplication);
+            var rx2DataRate = ReadTwin(twin.Properties.Desired, TwinProperty.RX2DataRate);
+            var rx1DrOffset = ReadTwin(twin.Properties.Desired, TwinProperty.RX1DROffset);
+            var rxDelay = ReadTwin(twin.Properties.Desired, TwinProperty.RXDelay);
+            var keepAliveTimeout = ReadTwin(twin.Properties.Desired, TwinProperty.KeepAliveTimeout);
+            var supports32BitFCnt = ReadTwin(twin.Properties.Desired, TwinProperty.Supports32BitFCnt);
+            var fCntUpStart = ReadTwin(twin.Properties.Desired, TwinProperty.FCntUpStart);
+            var fCntDownStart = ReadTwin(twin.Properties.Desired, TwinProperty.FCntDownStart);
+            var fCntResetCounter = ReadTwin(twin.Properties.Desired, TwinProperty.FCntResetCounter);
 
-            var fCntUpStartReported = this.ReadTwin(twin.Properties.Reported, TwinProperty.FCntUpStart);
-            var fCntDownStartReported = this.ReadTwin(twin.Properties.Reported, TwinProperty.FCntDownStart);
-            var fCntResetCounterReported = this.ReadTwin(twin.Properties.Reported, TwinProperty.FCntResetCounter);
+            var fCntUpStartReported = ReadTwin(twin.Properties.Reported, TwinProperty.FCntUpStart);
+            var fCntDownStartReported = ReadTwin(twin.Properties.Reported, TwinProperty.FCntDownStart);
+            var fCntResetCounterReported = ReadTwin(twin.Properties.Reported, TwinProperty.FCntResetCounter);
 
             isOtaa = !string.IsNullOrEmpty(appEui) || !string.IsNullOrEmpty(appKey);
             isAbp = !string.IsNullOrEmpty(nwkSKey) || !string.IsNullOrEmpty(appSKey) || !string.IsNullOrEmpty(devAddr);
@@ -88,7 +88,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             if (isAbp && !isOtaa)
             {
                 StatusConsole.WriteLogLineIfVerbose(MessageType.Info, "ABP device configuration detected.", isVerbose);
-                isValid = this.VerifyDevice(
+                isValid = VerifyDevice(
                     new AddOptions()
                     {
                         Type = "ABP",
@@ -126,7 +126,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             else if (isOtaa && !isAbp)
             {
                 StatusConsole.WriteLogLineIfVerbose(MessageType.Info, "OTAA device configuration detected.", isVerbose);
-                isValid = this.VerifyDevice(
+                isValid = VerifyDevice(
                     new AddOptions()
                     {
                         Type = "OTAA",
@@ -1284,7 +1284,7 @@ namespace LoRaWan.Tools.CLI.Helpers
 
                 foreach (var twin in fullList)
                 {
-                    if (!this.VerifyDeviceTwin(twin.DeviceId, null, twin, configurationHelper, false))
+                    if (!VerifyDeviceTwin(twin.DeviceId, null, twin, configurationHelper, false))
                     {
                         isValid = false;
                         countInvalid++;

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -14,7 +14,7 @@ namespace LoRaWan.Tools.CLI.Helpers
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
-    public class IoTDeviceHelper
+    internal class IoTDeviceHelper
     {
         private static readonly string[] ClassTypes = { "A", "C" };
         private static readonly string[] DeduplicationModes = { "None", "Drop", "Mark" };

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -8,7 +8,6 @@ namespace LoRaWan.Tools.CLI.Helpers
     using System.Globalization;
     using System.IO;
     using System.Linq;
-    using System.Threading;
     using System.Threading.Tasks;
     using LoRaWan.Tools.CLI.Options;
     using Microsoft.Azure.Devices;

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -22,7 +22,7 @@ namespace LoRaWan.Tools.CLI.Helpers
         private static readonly string[] DeduplicationModes = { "None", "Drop", "Mark" };
         private static readonly string DefaultRouterConfigFolder = "DefaultRouterConfig";
 
-        public async Task<Twin> QueryDeviceTwin(string devEui, ConfigurationHelper configurationHelper)
+        public static async Task<Twin> QueryDeviceTwin(string devEui, ConfigurationHelper configurationHelper)
         {
             Console.WriteLine();
             Console.WriteLine($"Querying device {devEui} in IoT Hub...");
@@ -36,7 +36,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             return twin;
         }
 
-        public bool VerifyDeviceTwin(string devEui, string netId, Twin twin, ConfigurationHelper configurationHelper, bool isVerbose)
+        public static bool VerifyDeviceTwin(string devEui, string netId, Twin twin, ConfigurationHelper configurationHelper, bool isVerbose)
         {
             var isOtaa = false;
             var isAbp = false;
@@ -185,12 +185,12 @@ namespace LoRaWan.Tools.CLI.Helpers
             return isValid;
         }
 
-        public string ReadTwin(TwinCollection collection, string property)
+        public static string ReadTwin(TwinCollection collection, string property)
         {
             return collection.Contains(property) ? ValidationHelper.GetTwinPropertyValue(collection[property]) : null;
         }
 
-        public object CleanOptions(object optsObject, bool isNewDevice)
+        public static object CleanOptions(object optsObject, bool isNewDevice)
         {
             dynamic opts;
 
@@ -271,7 +271,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             return (object)opts;
         }
 
-        public AddOptions CompleteMissingAddOptions(AddOptions opts, ConfigurationHelper configurationHelper)
+        public static AddOptions CompleteMissingAddOptions(AddOptions opts, ConfigurationHelper configurationHelper)
         {
             Console.WriteLine();
             Console.WriteLine($"Completing missing options for device...");
@@ -347,7 +347,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             return opts;
         }
 
-        public UpdateOptions CompleteMissingUpdateOptions(UpdateOptions opts, ConfigurationHelper configurationHelper)
+        public static UpdateOptions CompleteMissingUpdateOptions(UpdateOptions opts, ConfigurationHelper configurationHelper)
         {
             Console.WriteLine();
             Console.WriteLine($"Completing missing options for device...");
@@ -380,7 +380,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             return opts;
         }
 
-        public bool VerifyDevice(AddOptions opts, string fCntUpStartReported, string fCntDownStartReported, string fCntResetCounterReported, ConfigurationHelper configurationHelper, bool isVerbose)
+        public static bool VerifyDevice(AddOptions opts, string fCntUpStartReported, string fCntDownStartReported, string fCntResetCounterReported, ConfigurationHelper configurationHelper, bool isVerbose)
         {
             var validationError = string.Empty;
             var isValid = true;
@@ -897,7 +897,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             return isValid;
         }
 
-        public bool VerifyConcentrator(AddOptions opts)
+        public static bool VerifyConcentrator(AddOptions opts)
         {
             var isValid = true;
             TrackErrorIf(string.IsNullOrEmpty(opts.StationEui), "'Concentrator' device type has been specified but StationEui option is missing.");
@@ -938,7 +938,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             return isValid;
         }
 
-        public Twin CreateConcentratorTwin(AddOptions opts, uint crcChecksum, Uri certificateBundleLocation)
+        public static Twin CreateConcentratorTwin(AddOptions opts, uint crcChecksum, Uri certificateBundleLocation)
         {
             var twinProperties = new TwinProperties();
             Console.WriteLine();
@@ -972,7 +972,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             };
         }
 
-        public Twin CreateDeviceTwin(AddOptions opts)
+        public static Twin CreateDeviceTwin(AddOptions opts)
         {
             var twinProperties = new TwinProperties();
             Console.WriteLine();
@@ -1051,7 +1051,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             };
         }
 
-        public Twin UpdateDeviceTwin(Twin twin, UpdateOptions opts)
+        public static Twin UpdateDeviceTwin(Twin twin, UpdateOptions opts)
         {
             Console.WriteLine();
             Console.WriteLine($"Applying changes to device {opts.DevEui} twin...");
@@ -1128,7 +1128,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             return twin;
         }
 
-        public async Task<bool> WriteDeviceTwin(Twin twin, string devEui, ConfigurationHelper configurationHelper, bool isNewDevice)
+        public static async Task<bool> WriteDeviceTwin(Twin twin, string devEui, ConfigurationHelper configurationHelper, bool isNewDevice)
         {
             var device = new Device(devEui);
             BulkRegistryOperationResult result;
@@ -1185,7 +1185,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             return true;
         }
 
-        public async Task<bool> QueryDevices(ConfigurationHelper configurationHelper, int page, int total)
+        public static async Task<bool> QueryDevices(ConfigurationHelper configurationHelper, int page, int total)
         {
             var count = 0;
             IEnumerable<string> currentPage;
@@ -1247,7 +1247,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             return true;
         }
 
-        public async Task<bool> QueryDevicesAndVerify(ConfigurationHelper configurationHelper, int page)
+        public static async Task<bool> QueryDevicesAndVerify(ConfigurationHelper configurationHelper, int page)
         {
             var countValid = 0;
             var countInvalid = 0;
@@ -1297,7 +1297,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             return isValid;
         }
 
-        public async Task<bool> RemoveDevice(string devEui, ConfigurationHelper configurationHelper)
+        public static async Task<bool> RemoveDevice(string devEui, ConfigurationHelper configurationHelper)
         {
             Console.WriteLine();
             Console.WriteLine($"Finding existing device {devEui} in IoT Hub...");

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -43,43 +43,43 @@ namespace LoRaWan.Tools.CLI.Helpers
 
         public bool VerifyDeviceTwin(string devEui, string netId, Twin twin, ConfigurationHelper configurationHelper, bool isVerbose)
         {
-            bool isOtaa = false;
-            bool isAbp = false;
-            bool isValid = true;
+            var isOtaa = false;
+            var isAbp = false;
+            var isValid = true;
 
             StatusConsole.WriteLineIfVerbose(null, isVerbose);
             StatusConsole.WriteLineIfVerbose($"Analyzing device {devEui}...", isVerbose);
 
             devEui = ValidationHelper.CleanString(devEui);
 
-            string appEui = this.ReadTwin(twin.Properties.Desired, TwinProperty.AppEUI);
-            string appKey = this.ReadTwin(twin.Properties.Desired, TwinProperty.AppKey);
+            var appEui = this.ReadTwin(twin.Properties.Desired, TwinProperty.AppEUI);
+            var appKey = this.ReadTwin(twin.Properties.Desired, TwinProperty.AppKey);
 
-            string nwkSKey = this.ReadTwin(twin.Properties.Desired, TwinProperty.NwkSKey);
-            string appSKey = this.ReadTwin(twin.Properties.Desired, TwinProperty.AppSKey);
-            string devAddr = this.ReadTwin(twin.Properties.Desired, TwinProperty.DevAddr);
-            string abpRelaxMode = this.ReadTwin(twin.Properties.Desired, TwinProperty.ABPRelaxMode);
+            var nwkSKey = this.ReadTwin(twin.Properties.Desired, TwinProperty.NwkSKey);
+            var appSKey = this.ReadTwin(twin.Properties.Desired, TwinProperty.AppSKey);
+            var devAddr = this.ReadTwin(twin.Properties.Desired, TwinProperty.DevAddr);
+            var abpRelaxMode = this.ReadTwin(twin.Properties.Desired, TwinProperty.ABPRelaxMode);
 
             netId = ValidationHelper.CleanNetId(netId);
 
-            string gatewayID = this.ReadTwin(twin.Properties.Desired, TwinProperty.GatewayID);
-            string sensorDecoder = this.ReadTwin(twin.Properties.Desired, TwinProperty.SensorDecoder);
-            string classType = this.ReadTwin(twin.Properties.Desired, TwinProperty.ClassType);
-            string downlinkEnabled = this.ReadTwin(twin.Properties.Desired, TwinProperty.DownlinkEnabled);
-            string preferredWindow = this.ReadTwin(twin.Properties.Desired, TwinProperty.PreferredWindow);
-            string deduplication = this.ReadTwin(twin.Properties.Desired, TwinProperty.Deduplication);
-            string rx2DataRate = this.ReadTwin(twin.Properties.Desired, TwinProperty.RX2DataRate);
-            string rx1DrOffset = this.ReadTwin(twin.Properties.Desired, TwinProperty.RX1DROffset);
-            string rxDelay = this.ReadTwin(twin.Properties.Desired, TwinProperty.RXDelay);
-            string keepAliveTimeout = this.ReadTwin(twin.Properties.Desired, TwinProperty.KeepAliveTimeout);
-            string supports32BitFCnt = this.ReadTwin(twin.Properties.Desired, TwinProperty.Supports32BitFCnt);
-            string fCntUpStart = this.ReadTwin(twin.Properties.Desired, TwinProperty.FCntUpStart);
-            string fCntDownStart = this.ReadTwin(twin.Properties.Desired, TwinProperty.FCntDownStart);
-            string fCntResetCounter = this.ReadTwin(twin.Properties.Desired, TwinProperty.FCntResetCounter);
+            var gatewayID = this.ReadTwin(twin.Properties.Desired, TwinProperty.GatewayID);
+            var sensorDecoder = this.ReadTwin(twin.Properties.Desired, TwinProperty.SensorDecoder);
+            var classType = this.ReadTwin(twin.Properties.Desired, TwinProperty.ClassType);
+            var downlinkEnabled = this.ReadTwin(twin.Properties.Desired, TwinProperty.DownlinkEnabled);
+            var preferredWindow = this.ReadTwin(twin.Properties.Desired, TwinProperty.PreferredWindow);
+            var deduplication = this.ReadTwin(twin.Properties.Desired, TwinProperty.Deduplication);
+            var rx2DataRate = this.ReadTwin(twin.Properties.Desired, TwinProperty.RX2DataRate);
+            var rx1DrOffset = this.ReadTwin(twin.Properties.Desired, TwinProperty.RX1DROffset);
+            var rxDelay = this.ReadTwin(twin.Properties.Desired, TwinProperty.RXDelay);
+            var keepAliveTimeout = this.ReadTwin(twin.Properties.Desired, TwinProperty.KeepAliveTimeout);
+            var supports32BitFCnt = this.ReadTwin(twin.Properties.Desired, TwinProperty.Supports32BitFCnt);
+            var fCntUpStart = this.ReadTwin(twin.Properties.Desired, TwinProperty.FCntUpStart);
+            var fCntDownStart = this.ReadTwin(twin.Properties.Desired, TwinProperty.FCntDownStart);
+            var fCntResetCounter = this.ReadTwin(twin.Properties.Desired, TwinProperty.FCntResetCounter);
 
-            string fCntUpStartReported = this.ReadTwin(twin.Properties.Reported, TwinProperty.FCntUpStart);
-            string fCntDownStartReported = this.ReadTwin(twin.Properties.Reported, TwinProperty.FCntDownStart);
-            string fCntResetCounterReported = this.ReadTwin(twin.Properties.Reported, TwinProperty.FCntResetCounter);
+            var fCntUpStartReported = this.ReadTwin(twin.Properties.Reported, TwinProperty.FCntUpStart);
+            var fCntDownStartReported = this.ReadTwin(twin.Properties.Reported, TwinProperty.FCntDownStart);
+            var fCntResetCounterReported = this.ReadTwin(twin.Properties.Reported, TwinProperty.FCntResetCounter);
 
             isOtaa = !string.IsNullOrEmpty(appEui) || !string.IsNullOrEmpty(appKey);
             isAbp = !string.IsNullOrEmpty(nwkSKey) || !string.IsNullOrEmpty(appSKey) || !string.IsNullOrEmpty(devAddr);
@@ -308,7 +308,7 @@ namespace LoRaWan.Tools.CLI.Helpers
                     StatusConsole.WriteLogLine(MessageType.Info, $"Generating missing DevAddr: {opts.DevAddr}");
                 }
 
-                if (ValidationHelper.ValidateHexStringTwinProperty(opts.DevAddr, 4, out string _))
+                if (ValidationHelper.ValidateHexStringTwinProperty(opts.DevAddr, 4, out var _))
                 {
                     var newDevAddr = NetIdHelper.SetNwkIdPart(opts.DevAddr, opts.NetId, configurationHelper);
                     if (!string.Equals(newDevAddr, opts.DevAddr, StringComparison.OrdinalIgnoreCase))
@@ -358,7 +358,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             Console.WriteLine($"Completing missing options for device...");
 
             // ABP device specific properties
-            if (!string.IsNullOrEmpty(opts.DevAddr) && ValidationHelper.ValidateHexStringTwinProperty(opts.DevAddr, 4, out string _))
+            if (!string.IsNullOrEmpty(opts.DevAddr) && ValidationHelper.ValidateHexStringTwinProperty(opts.DevAddr, 4, out var _))
             {
                 var newDevAddr = NetIdHelper.SetNwkIdPart(opts.DevAddr, opts.NetId, configurationHelper);
                 if (!string.Equals(newDevAddr, opts.DevAddr, StringComparison.OrdinalIgnoreCase))
@@ -387,8 +387,8 @@ namespace LoRaWan.Tools.CLI.Helpers
 
         public bool VerifyDevice(AddOptions opts, string fCntUpStartReported, string fCntDownStartReported, string fCntResetCounterReported, ConfigurationHelper configurationHelper, bool isVerbose)
         {
-            string validationError = string.Empty;
-            bool isValid = true;
+            var validationError = string.Empty;
+            var isValid = true;
 
             StatusConsole.WriteLineIfVerbose(null, isVerbose);
             StatusConsole.WriteLineIfVerbose($"Verifying device {opts.DevEui} twin data...", isVerbose);
@@ -949,8 +949,8 @@ namespace LoRaWan.Tools.CLI.Helpers
             Console.WriteLine();
 
             // Add routerConfig configuration
-            string fileName = Path.Combine(DefaultRouterConfigFolder, $"{opts.Region.ToUpperInvariant()}.json");
-            string jsonString = File.ReadAllText(fileName);
+            var fileName = Path.Combine(DefaultRouterConfigFolder, $"{opts.Region.ToUpperInvariant()}.json");
+            var jsonString = File.ReadAllText(fileName);
             var propObject = JsonConvert.DeserializeObject<JObject>(jsonString);
             twinProperties.Desired[TwinProperty.RouterConfig] = propObject;
 
@@ -1194,7 +1194,7 @@ namespace LoRaWan.Tools.CLI.Helpers
         {
             var count = 0;
             IEnumerable<string> currentPage;
-            string totalString = (total == -1) ? "all" : total.ToString();
+            var totalString = (total == -1) ? "all" : total.ToString();
 
             page = Math.Max(1, page);
 
@@ -1221,12 +1221,12 @@ namespace LoRaWan.Tools.CLI.Helpers
 
                 foreach (var jsonString in currentPage)
                 {
-                    JObject json = JObject.Parse(jsonString);
+                    var json = JObject.Parse(jsonString);
 
                     Console.WriteLine($"DevEUI: {(string)json["deviceId"]}");
 
                     Console.ForegroundColor = ConsoleColor.Yellow;
-                    JObject desired = json.SelectToken("$.properties.desired") as JObject;
+                    var desired = json.SelectToken("$.properties.desired") as JObject;
                     desired.Remove("$metadata");
                     desired.Remove("$version");
                     Console.WriteLine(desired);
@@ -1261,7 +1261,7 @@ namespace LoRaWan.Tools.CLI.Helpers
         {
             var countValid = 0;
             var countInvalid = 0;
-            bool isValid = true;
+            var isValid = true;
             IEnumerable<Twin> fullList;
 
             Console.WriteLine();

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -5,6 +5,7 @@ namespace LoRaWan.Tools.CLI.Helpers
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Threading;
@@ -18,9 +19,9 @@ namespace LoRaWan.Tools.CLI.Helpers
 
     internal class IoTDeviceHelper
     {
+        private const string DefaultRouterConfigFolder = "DefaultRouterConfig";
         private static readonly string[] ClassTypes = { "A", "C" };
         private static readonly string[] DeduplicationModes = { "None", "Drop", "Mark" };
-        private static readonly string DefaultRouterConfigFolder = "DefaultRouterConfig";
 
         public static async Task<Twin> QueryDeviceTwin(string devEui, ConfigurationHelper configurationHelper)
         {
@@ -472,14 +473,14 @@ namespace LoRaWan.Tools.CLI.Helpers
                 {
                     var devAddrCorrect = NetIdHelper.SetNwkIdPart(opts.DevAddr, opts.NetId, configurationHelper);
 
-                    if (string.Equals(devAddrCorrect, opts.DevAddr))
+                    if (string.Equals(devAddrCorrect, opts.DevAddr, StringComparison.OrdinalIgnoreCase))
                     {
                         StatusConsole.WriteLogLineIfVerbose(MessageType.Info, $"DevAddr {opts.DevAddr} is valid based on NetId {(string.IsNullOrEmpty(opts.NetId) ? configurationHelper.NetId : opts.NetId)}.", isVerbose);
                     }
                     else
                     {
                         StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Error, $"DevAddr {opts.DevAddr} is invalid based on NetId {(string.IsNullOrEmpty(opts.NetId) ? configurationHelper.NetId : opts.NetId)}.", opts.DevEui, isVerbose);
-                        StatusConsole.WriteLogLineIfVerbose(MessageType.Warning, $"DevAddr {opts.DevAddr} belongs to NetId ending in byte {NetIdHelper.GetNwkIdPart(opts.DevAddr).ToString("X2")}.", isVerbose);
+                        StatusConsole.WriteLogLineIfVerbose(MessageType.Warning, $"DevAddr {opts.DevAddr} belongs to NetId ending in byte {NetIdHelper.GetNwkIdPart(opts.DevAddr):X2}.", isVerbose);
                         StatusConsole.WriteLogLineIfVerbose(MessageType.Info, $"To stop seeing this error, provide the --netid parameter or set the NetId in the settings file.", isVerbose);
 
                         isValid = false;
@@ -786,7 +787,7 @@ namespace LoRaWan.Tools.CLI.Helpers
                 StatusConsole.WriteLogLineWithDevEuiWhenVerbose(MessageType.Error, $"GatewayId is missing.", opts.DevEui, isVerbose);
                 isValid = false;
             }
-            else if (opts.GatewayId == string.Empty)
+            else if (string.IsNullOrEmpty(opts.GatewayId))
             {
                 StatusConsole.WriteLogLineIfVerbose(MessageType.Info, $"GatewayId is empty. This is valid.", isVerbose);
             }
@@ -1189,7 +1190,7 @@ namespace LoRaWan.Tools.CLI.Helpers
         {
             var count = 0;
             IEnumerable<string> currentPage;
-            var totalString = (total == -1) ? "all" : total.ToString();
+            var totalString = (total == -1) ? "all" : total.ToString(CultureInfo.InvariantCulture);
 
             page = Math.Max(1, page);
 

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -1217,8 +1217,8 @@ namespace LoRaWan.Tools.CLI.Helpers
 
                     Console.ForegroundColor = ConsoleColor.Yellow;
                     var desired = json.SelectToken("$.properties.desired") as JObject;
-                    desired.Remove("$metadata");
-                    desired.Remove("$version");
+                    _ = desired.Remove("$metadata");
+                    _ = desired.Remove("$version");
                     Console.WriteLine(desired);
                     Console.ResetColor();
 
@@ -1234,7 +1234,7 @@ namespace LoRaWan.Tools.CLI.Helpers
                 if (count > 0)
                 {
                     Console.WriteLine("Press any key to continue.");
-                    Console.ReadKey();
+                    _ = Console.ReadKey();
                     Console.WriteLine();
                 }
                 else
@@ -1279,7 +1279,7 @@ namespace LoRaWan.Tools.CLI.Helpers
                             if (countInvalid % page == 0)
                             {
                                 Console.WriteLine("Press any key to continue...");
-                                Console.ReadKey();
+                                _ = Console.ReadKey();
                                 Console.WriteLine();
                             }
                         }

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -39,10 +39,6 @@ namespace LoRaWan.Tools.CLI.Helpers
 
         public static bool VerifyDeviceTwin(string devEui, string netId, Twin twin, ConfigurationHelper configurationHelper, bool isVerbose)
         {
-            var isOtaa = false;
-            var isAbp = false;
-            var isValid = true;
-
             StatusConsole.WriteLineIfVerbose(null, isVerbose);
             StatusConsole.WriteLineIfVerbose($"Analyzing device {devEui}...", isVerbose);
 
@@ -77,9 +73,10 @@ namespace LoRaWan.Tools.CLI.Helpers
             var fCntDownStartReported = ReadTwin(twin.Properties.Reported, TwinProperty.FCntDownStart);
             var fCntResetCounterReported = ReadTwin(twin.Properties.Reported, TwinProperty.FCntResetCounter);
 
-            isOtaa = !string.IsNullOrEmpty(appEui) || !string.IsNullOrEmpty(appKey);
-            isAbp = !string.IsNullOrEmpty(nwkSKey) || !string.IsNullOrEmpty(appSKey) || !string.IsNullOrEmpty(devAddr);
+            var isOtaa = !string.IsNullOrEmpty(appEui) || !string.IsNullOrEmpty(appKey);
+            var isAbp = !string.IsNullOrEmpty(nwkSKey) || !string.IsNullOrEmpty(appSKey) || !string.IsNullOrEmpty(devAddr);
 
+            bool isValid;
             // ABP device
             if (isAbp && !isOtaa)
             {

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -1310,7 +1310,8 @@ namespace LoRaWan.Tools.CLI.Helpers
 
                 try
                 {
-                    if (!await ExecuteWithIotHubErrorHandlingAsync(() => configurationHelper.RegistryManager.RemoveDeviceAsync(device)))
+                    (success, _) = await ExecuteWithIotHubErrorHandlingAsync(async () => { await configurationHelper.RegistryManager.RemoveDeviceAsync(device); return 0; });
+                    if (!success)
                         return false;
                 }
                 catch (DeviceNotFoundException)
@@ -1328,12 +1329,6 @@ namespace LoRaWan.Tools.CLI.Helpers
             StatusConsole.WriteLogLine(MessageType.Info, "Success!");
             Console.WriteLine("done.");
             return true;
-        }
-
-        private static async Task<bool> ExecuteWithIotHubErrorHandlingAsync(Func<Task> executeAsync, string errorMessageContext = null)
-        {
-            var (success, _) = await ExecuteWithIotHubErrorHandlingAsync(async () => { await executeAsync(); return true; }, errorMessageContext);
-            return success;
         }
 
         private static async Task<(bool Success, T Value)> ExecuteWithIotHubErrorHandlingAsync<T>(Func<Task<T>> executeAsync, string errorMessageContext = null)

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/NetIdHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/NetIdHelper.cs
@@ -5,7 +5,7 @@ namespace LoRaWan.Tools.CLI.Helpers
 {
     using System;
 
-    public static class NetIdHelper
+    internal static class NetIdHelper
     {
         /// <summary>
         /// Set the NetworkId Part of a devAddr with a given network Id.

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/NetIdHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/NetIdHelper.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.Tools.CLI.Helpers
 {
     using System;
+    using System.Globalization;
 
     internal static class NetIdHelper
     {
@@ -18,7 +19,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             if (ValidationHelper.ValidateHexStringTwinProperty(configurationHelper.NetId, 3, out _))
             {
                 netIdLastByte = configurationHelper.NetId.Substring(configurationHelper.NetId.Length - 2, 2);
-                netId = uint.Parse(netIdLastByte, System.Globalization.NumberStyles.HexNumber);
+                netId = uint.Parse(netIdLastByte, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
             }
 
             if (!string.IsNullOrEmpty(networkId))
@@ -26,7 +27,7 @@ namespace LoRaWan.Tools.CLI.Helpers
                 if (ValidationHelper.ValidateHexStringTwinProperty(networkId, 3, out _))
                 {
                     netIdLastByte = networkId.Substring(networkId.Length - 2, 2);
-                    netId = uint.Parse(netIdLastByte, System.Globalization.NumberStyles.HexNumber);
+                    netId = uint.Parse(netIdLastByte, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
                 }
             }
 

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/NetIdHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/NetIdHelper.cs
@@ -35,9 +35,9 @@ namespace LoRaWan.Tools.CLI.Helpers
 
         public static string SetNwkIdPart(string currentDevAddr, uint networkId)
         {
-            byte[] netId = BitConverter.GetBytes(networkId);
-            int nwkPart = netId[0] << 1;
-            byte[] deviceIdBytes = ConversionHelper.StringToByteArray(currentDevAddr);
+            var netId = BitConverter.GetBytes(networkId);
+            var nwkPart = netId[0] << 1;
+            var deviceIdBytes = ConversionHelper.StringToByteArray(currentDevAddr);
             deviceIdBytes[0] = (byte)((nwkPart & 0b11111110) | (deviceIdBytes[0] & 0b00000001));
             return ConversionHelper.ByteArrayToHexString(deviceIdBytes);
         }

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ValidationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ValidationHelper.cs
@@ -8,7 +8,7 @@ namespace LoRaWan.Tools.CLI.Helpers
     using System.Text;
     using LoRaWan.Tools.CLI.Options;
 
-    public static class ValidationHelper
+    internal static class ValidationHelper
     {
         private static List<string> euValidDataranges = new List<string>()
             {

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ValidationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ValidationHelper.cs
@@ -39,17 +39,17 @@ namespace LoRaWan.Tools.CLI.Helpers
 
         public static string GetDataRatesforLocale(string locale)
         {
-            StringBuilder result = new StringBuilder();
+            var result = new StringBuilder();
             result.Append(locale + ": ");
 
             if (string.Equals(locale, "EU", StringComparison.OrdinalIgnoreCase))
             {
-                foreach (string dr in euValidDataranges)
+                foreach (var dr in euValidDataranges)
                     result.Append(dr + ", ");
             }
             else
             {
-                foreach (string dr in usValidDataranges)
+                foreach (var dr in usValidDataranges)
                     result.Append(dr + ", ");
             }
 
@@ -125,7 +125,7 @@ namespace LoRaWan.Tools.CLI.Helpers
             }
 
             // Verify each individual byte for validity.
-            for (int i = 0; i + 1 < hexString.Length; i += 2)
+            for (var i = 0; i + 1 < hexString.Length; i += 2)
             {
                 if (!int.TryParse(hexString.Substring(i, 2), System.Globalization.NumberStyles.HexNumber, null, out _))
                 {
@@ -317,7 +317,7 @@ namespace LoRaWan.Tools.CLI.Helpers
 
             if (sensorDecoder.StartsWith("http", StringComparison.OrdinalIgnoreCase) || sensorDecoder.Contains('/'))
             {
-                if (!Uri.TryCreate(sensorDecoder, UriKind.Absolute, out Uri validatedUri))
+                if (!Uri.TryCreate(sensorDecoder, UriKind.Absolute, out var validatedUri))
                 {
                     StatusConsole.WriteLogLine(MessageType.Error, "SensorDecoder has an invalid URL.");
                     isValid = false;

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ValidationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ValidationHelper.cs
@@ -11,7 +11,7 @@ namespace LoRaWan.Tools.CLI.Helpers
 
     internal static class ValidationHelper
     {
-        private static List<string> euValidDataranges = new List<string>()
+        private static readonly List<string> EuValidDataranges = new List<string>()
             {
                 "SF12BW125", // 0
                 "SF11BW125", // 1
@@ -23,7 +23,7 @@ namespace LoRaWan.Tools.CLI.Helpers
                 "50" // 7 FSK 50
             };
 
-        private static List<string> usValidDataranges = new List<string>()
+        private static readonly List<string> UsValidDataranges = new List<string>()
             {
                 "SF10BW125", // 0
                 "SF9BW125", // 1
@@ -45,12 +45,12 @@ namespace LoRaWan.Tools.CLI.Helpers
 
             if (string.Equals(locale, "EU", StringComparison.OrdinalIgnoreCase))
             {
-                foreach (var dr in euValidDataranges)
+                foreach (var dr in EuValidDataranges)
                     _ = result.Append(dr + ", ");
             }
             else
             {
-                foreach (var dr in usValidDataranges)
+                foreach (var dr in UsValidDataranges)
                     _ = result.Append(dr + ", ");
             }
 
@@ -78,10 +78,10 @@ namespace LoRaWan.Tools.CLI.Helpers
             {
                 outNetId = inNetId.Trim().Replace("\'", string.Empty, StringComparison.Ordinal);
                 if (outNetId.Length < 6)
-                    outNetId = string.Concat(new string('0', 6).Substring(outNetId.Length), outNetId);
+                    outNetId = string.Concat(new string('0', 6)[outNetId.Length..], outNetId);
 
                 if (outNetId.Length > 6)
-                    outNetId = outNetId.Substring(outNetId.Length - 6);
+                    outNetId = outNetId[^6..];
             }
 
             return outNetId;
@@ -290,7 +290,7 @@ namespace LoRaWan.Tools.CLI.Helpers
         {
             error = null;
 
-            if (!euValidDataranges.Contains(property) && !usValidDataranges.Contains(property))
+            if (!EuValidDataranges.Contains(property) && !UsValidDataranges.Contains(property))
             {
                 error = "Property is not a valid data rate";
                 return false;

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ValidationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ValidationHelper.cs
@@ -40,21 +40,21 @@ namespace LoRaWan.Tools.CLI.Helpers
         public static string GetDataRatesforLocale(string locale)
         {
             var result = new StringBuilder();
-            result.Append(locale + ": ");
+            _ = result.Append(locale + ": ");
 
             if (string.Equals(locale, "EU", StringComparison.OrdinalIgnoreCase))
             {
                 foreach (var dr in euValidDataranges)
-                    result.Append(dr + ", ");
+                    _ = result.Append(dr + ", ");
             }
             else
             {
                 foreach (var dr in usValidDataranges)
-                    result.Append(dr + ", ");
+                    _ = result.Append(dr + ", ");
             }
 
-            result.Remove(result.Length - 2, 2);
-            result.Append(".");
+            _ = result.Remove(result.Length - 2, 2)
+                      .Append(".");
 
             return result.ToString();
         }

--- a/Tools/Cli-LoRa-Device-Provisioning/Keygen.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Keygen.cs
@@ -17,7 +17,7 @@ namespace LoRaWan.Tools.CLI
             for (var i = 0; i < keyLength; i++)
             {
                 var newKey = rnd.Next(0, 256);
-                randomKey.Append(newKey.ToString("X2"));
+                _ = randomKey.Append(newKey.ToString("X2"));
             }
 
             return randomKey.ToString();

--- a/Tools/Cli-LoRa-Device-Provisioning/Keygen.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Keygen.cs
@@ -14,7 +14,7 @@ namespace LoRaWan.Tools.CLI
         {
             var randomKey = new StringBuilder(keyLength * 2);
 
-            for (int i = 0; i < keyLength; i++)
+            for (var i = 0; i < keyLength; i++)
             {
                 var newKey = rnd.Next(0, 256);
                 randomKey.Append(newKey.ToString("X2"));

--- a/Tools/Cli-LoRa-Device-Provisioning/Keygen.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Keygen.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.Tools.CLI
 {
     using System;
+    using System.Globalization;
     using System.Text;
 
     public static class Keygen
@@ -17,7 +18,7 @@ namespace LoRaWan.Tools.CLI
             for (var i = 0; i < keyLength; i++)
             {
                 var newKey = rnd.Next(0, 256);
-                _ = randomKey.Append(newKey.ToString("X2"));
+                _ = randomKey.Append(newKey.ToString("X2", CultureInfo.InvariantCulture));
             }
 
             return randomKey.ToString();

--- a/Tools/Cli-LoRa-Device-Provisioning/Keygen.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Keygen.cs
@@ -3,21 +3,19 @@
 
 namespace LoRaWan.Tools.CLI
 {
-    using System;
     using System.Globalization;
+    using System.Security.Cryptography;
     using System.Text;
 
     public static class Keygen
     {
-        private static Random rnd = new Random();
-
         public static string Generate(int keyLength)
         {
             var randomKey = new StringBuilder(keyLength * 2);
 
             for (var i = 0; i < keyLength; i++)
             {
-                var newKey = rnd.Next(0, 256);
+                var newKey = RandomNumberGenerator.GetInt32(0, 256);
                 _ = randomKey.Append(newKey.ToString("X2", CultureInfo.InvariantCulture));
             }
 

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -20,11 +20,11 @@ namespace LoRaWan.Tools.CLI
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
-    public class Program
+    public static class Program
     {
-        static ConfigurationHelper configurationHelper = new ConfigurationHelper();
+        private static readonly ConfigurationHelper configurationHelper = new ConfigurationHelper();
 
-        static async Task<int> Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
             try
             {
@@ -80,16 +80,13 @@ namespace LoRaWan.Tools.CLI
 
         private static async Task<bool> RunListAndReturnExitCode(ListOptions opts)
         {
-            int page;
-            int total;
-
             if (!configurationHelper.ReadConfig())
                 return false;
 
-            if (!int.TryParse(opts.Page, out page))
+            if (!int.TryParse(opts.Page, out var page))
                 page = 10;
 
-            if (!int.TryParse(opts.Total, out total))
+            if (!int.TryParse(opts.Total, out var total))
                 total = -1;
 
             var isSuccess = await IoTDeviceHelper.QueryDevices(configurationHelper, page, total);
@@ -137,12 +134,10 @@ namespace LoRaWan.Tools.CLI
 
         private static async Task<bool> RunBulkVerifyAndReturnExitCode(BulkVerifyOptions opts)
         {
-            int page;
-
             if (!configurationHelper.ReadConfig())
                 return false;
 
-            if (!int.TryParse(opts.Page, out page))
+            if (!int.TryParse(opts.Page, out var page))
                 page = 0;
 
             var isSuccess = await IoTDeviceHelper.QueryDevicesAndVerify(configurationHelper, page);
@@ -167,7 +162,7 @@ namespace LoRaWan.Tools.CLI
 
             var isSuccess = false;
 
-            opts = IoTDeviceHelper.CleanOptions(opts as object, true) as AddOptions;
+            opts = IoTDeviceHelper.CleanOptions(opts, true) as AddOptions;
 
             if (opts.Type.Equals("concentrator", StringComparison.OrdinalIgnoreCase))
             {
@@ -306,7 +301,7 @@ namespace LoRaWan.Tools.CLI
 
             var isSuccess = false;
 
-            opts = IoTDeviceHelper.CleanOptions(opts as object, false) as UpdateOptions;
+            opts = IoTDeviceHelper.CleanOptions(opts, false) as UpdateOptions;
             opts = IoTDeviceHelper.CompleteMissingUpdateOptions(opts, configurationHelper);
 
             var twin = await IoTDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -154,7 +154,7 @@ namespace LoRaWan.Tools.CLI
             if (!configurationHelper.ReadConfig())
                 return false;
 
-            bool isSuccess = false;
+            var isSuccess = false;
 
             opts = iotDeviceHelper.CleanOptions(opts as object, true) as AddOptions;
 
@@ -193,7 +193,7 @@ namespace LoRaWan.Tools.CLI
 
             if (iotDeviceHelper.VerifyDevice(opts, null, null, null, configurationHelper, true))
             {
-                Twin twin = iotDeviceHelper.CreateDeviceTwin(opts);
+                var twin = iotDeviceHelper.CreateDeviceTwin(opts);
                 isSuccess = await iotDeviceHelper.WriteDeviceTwin(twin, opts.DevEui, configurationHelper, true);
             }
             else
@@ -293,7 +293,7 @@ namespace LoRaWan.Tools.CLI
             if (!configurationHelper.ReadConfig())
                 return false;
 
-            bool isSuccess = false;
+            var isSuccess = false;
 
             opts = iotDeviceHelper.CleanOptions(opts as object, false) as UpdateOptions;
             opts = iotDeviceHelper.CompleteMissingUpdateOptions(opts, configurationHelper);

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -22,7 +22,6 @@ namespace LoRaWan.Tools.CLI
     public class Program
     {
         static ConfigurationHelper configurationHelper = new ConfigurationHelper();
-        static IoTDeviceHelper iotDeviceHelper = new IoTDeviceHelper();
 
         static async Task<int> Main(string[] args)
         {
@@ -92,7 +91,7 @@ namespace LoRaWan.Tools.CLI
             if (!int.TryParse(opts.Total, out total))
                 total = -1;
 
-            var isSuccess = await iotDeviceHelper.QueryDevices(configurationHelper, page, total);
+            var isSuccess = await IoTDeviceHelper.QueryDevices(configurationHelper, page, total);
 
             return isSuccess;
         }
@@ -102,7 +101,7 @@ namespace LoRaWan.Tools.CLI
             if (!configurationHelper.ReadConfig())
                 return false;
 
-            var twin = await iotDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);
+            var twin = await IoTDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);
 
             if (twin != null)
             {
@@ -121,12 +120,12 @@ namespace LoRaWan.Tools.CLI
             if (!configurationHelper.ReadConfig())
                 return false;
 
-            var twin = await iotDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);
+            var twin = await IoTDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);
 
             if (twin != null)
             {
                 StatusConsole.WriteTwin(opts.DevEui, twin);
-                return iotDeviceHelper.VerifyDeviceTwin(opts.DevEui, opts.NetId, twin, configurationHelper, true);
+                return IoTDeviceHelper.VerifyDeviceTwin(opts.DevEui, opts.NetId, twin, configurationHelper, true);
             }
             else
             {
@@ -145,7 +144,7 @@ namespace LoRaWan.Tools.CLI
             if (!int.TryParse(opts.Page, out page))
                 page = 0;
 
-            var isSuccess = await iotDeviceHelper.QueryDevicesAndVerify(configurationHelper, page);
+            var isSuccess = await IoTDeviceHelper.QueryDevicesAndVerify(configurationHelper, page);
 
             Console.WriteLine();
             if (isSuccess)
@@ -167,11 +166,11 @@ namespace LoRaWan.Tools.CLI
 
             var isSuccess = false;
 
-            opts = iotDeviceHelper.CleanOptions(opts as object, true) as AddOptions;
+            opts = IoTDeviceHelper.CleanOptions(opts as object, true) as AddOptions;
 
             if (opts.Type.ToUpperInvariant().Equals("CONCENTRATOR"))
             {
-                var isVerified = iotDeviceHelper.VerifyConcentrator(opts);
+                var isVerified = IoTDeviceHelper.VerifyConcentrator(opts);
                 if (!isVerified) return false;
                 if (configurationHelper.CertificateStorageContainerClient is null)
                 {
@@ -179,7 +178,7 @@ namespace LoRaWan.Tools.CLI
                     return false;
                 }
 
-                if (await iotDeviceHelper.QueryDeviceTwin(opts.StationEui, configurationHelper) is not null)
+                if (await IoTDeviceHelper.QueryDeviceTwin(opts.StationEui, configurationHelper) is not null)
                 {
                     StatusConsole.WriteLogLine(MessageType.Error, "Station was already created, please use the 'update' verb to update an existing station.");
                     return false;
@@ -187,25 +186,25 @@ namespace LoRaWan.Tools.CLI
 
                 if (opts.NoCups)
                 {
-                    var twin = iotDeviceHelper.CreateConcentratorTwin(opts, 0, null);
-                    return await iotDeviceHelper.WriteDeviceTwin(twin, opts.StationEui, configurationHelper, true);
+                    var twin = IoTDeviceHelper.CreateConcentratorTwin(opts, 0, null);
+                    return await IoTDeviceHelper.WriteDeviceTwin(twin, opts.StationEui, configurationHelper, true);
                 }
                 else
                 {
                     return await UploadCertificateBundleAsync(opts.CertificateBundleLocation, opts.StationEui, async (crcHash, bundleStorageUri) =>
                     {
-                        var twin = iotDeviceHelper.CreateConcentratorTwin(opts, crcHash, bundleStorageUri);
-                        return await iotDeviceHelper.WriteDeviceTwin(twin, opts.StationEui, configurationHelper, true);
+                        var twin = IoTDeviceHelper.CreateConcentratorTwin(opts, crcHash, bundleStorageUri);
+                        return await IoTDeviceHelper.WriteDeviceTwin(twin, opts.StationEui, configurationHelper, true);
                     });
                 }
             }
 
-            opts = iotDeviceHelper.CompleteMissingAddOptions(opts, configurationHelper);
+            opts = IoTDeviceHelper.CompleteMissingAddOptions(opts, configurationHelper);
 
-            if (iotDeviceHelper.VerifyDevice(opts, null, null, null, configurationHelper, true))
+            if (IoTDeviceHelper.VerifyDevice(opts, null, null, null, configurationHelper, true))
             {
-                var twin = iotDeviceHelper.CreateDeviceTwin(opts);
-                isSuccess = await iotDeviceHelper.WriteDeviceTwin(twin, opts.DevEui, configurationHelper, true);
+                var twin = IoTDeviceHelper.CreateDeviceTwin(opts);
+                isSuccess = await IoTDeviceHelper.WriteDeviceTwin(twin, opts.DevEui, configurationHelper, true);
             }
             else
             {
@@ -214,7 +213,7 @@ namespace LoRaWan.Tools.CLI
 
             if (isSuccess)
             {
-                var twin = await iotDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);
+                var twin = await IoTDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);
                 StatusConsole.WriteTwin(opts.DevEui, twin);
             }
 
@@ -232,7 +231,7 @@ namespace LoRaWan.Tools.CLI
                 return false;
             }
 
-            var twin = await iotDeviceHelper.QueryDeviceTwin(opts.StationEui, configurationHelper);
+            var twin = await IoTDeviceHelper.QueryDeviceTwin(opts.StationEui, configurationHelper);
 
             if (twin is null)
             {
@@ -258,7 +257,7 @@ namespace LoRaWan.Tools.CLI
                 twin.Properties.Desired[TwinProperty.Cups][TwinProperty.CupsCredentialUrl] = bundleStorageUri;
                 twin.Properties.Desired[TwinProperty.Cups][TwinProperty.TcCredentialUrl] = bundleStorageUri;
 
-                return await iotDeviceHelper.WriteDeviceTwin(twin, opts.StationEui, configurationHelper, isNewDevice: false);
+                return await IoTDeviceHelper.WriteDeviceTwin(twin, opts.StationEui, configurationHelper, isNewDevice: false);
             });
 
             // Clean up old certificate bundles
@@ -279,7 +278,7 @@ namespace LoRaWan.Tools.CLI
             if (!configurationHelper.ReadConfig())
                 return false;
 
-            var twin = await iotDeviceHelper.QueryDeviceTwin(opts.StationEui, configurationHelper);
+            var twin = await IoTDeviceHelper.QueryDeviceTwin(opts.StationEui, configurationHelper);
 
             if (twin is null)
             {
@@ -296,7 +295,7 @@ namespace LoRaWan.Tools.CLI
 
             t?.Remove();
             twin.Properties.Desired[TwinProperty.ClientThumbprint] = clientThumprints;
-            return await iotDeviceHelper.WriteDeviceTwin(twin, opts.StationEui, configurationHelper, isNewDevice: false);
+            return await IoTDeviceHelper.WriteDeviceTwin(twin, opts.StationEui, configurationHelper, isNewDevice: false);
         }
 
         private static async Task<bool> RunUpdateAndReturnExitCode(UpdateOptions opts)
@@ -306,18 +305,18 @@ namespace LoRaWan.Tools.CLI
 
             var isSuccess = false;
 
-            opts = iotDeviceHelper.CleanOptions(opts as object, false) as UpdateOptions;
-            opts = iotDeviceHelper.CompleteMissingUpdateOptions(opts, configurationHelper);
+            opts = IoTDeviceHelper.CleanOptions(opts as object, false) as UpdateOptions;
+            opts = IoTDeviceHelper.CompleteMissingUpdateOptions(opts, configurationHelper);
 
-            var twin = await iotDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);
+            var twin = await IoTDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);
 
             if (twin != null)
             {
-                twin = iotDeviceHelper.UpdateDeviceTwin(twin, opts);
+                twin = IoTDeviceHelper.UpdateDeviceTwin(twin, opts);
 
-                if (iotDeviceHelper.VerifyDeviceTwin(opts.DevEui, opts.NetId, twin, configurationHelper, true))
+                if (IoTDeviceHelper.VerifyDeviceTwin(opts.DevEui, opts.NetId, twin, configurationHelper, true))
                 {
-                    isSuccess = await iotDeviceHelper.WriteDeviceTwin(twin, opts.DevEui, configurationHelper, false);
+                    isSuccess = await IoTDeviceHelper.WriteDeviceTwin(twin, opts.DevEui, configurationHelper, false);
 
                     if (isSuccess)
                     {
@@ -383,7 +382,7 @@ namespace LoRaWan.Tools.CLI
             if (!configurationHelper.ReadConfig())
                 return false;
 
-            return await iotDeviceHelper.RemoveDevice(opts.DevEui, configurationHelper);
+            return await IoTDeviceHelper.RemoveDevice(opts.DevEui, configurationHelper);
         }
 
         private static void WriteAzureLogo()

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -26,44 +26,55 @@ namespace LoRaWan.Tools.CLI
 
         static async Task<int> Main(string[] args)
         {
-            WriteAzureLogo();
-            Console.WriteLine("Azure IoT Edge LoRaWAN Starter Kit LoRa Leaf Device Provisioning Tool.");
-            Console.Write("This tool complements ");
-            Console.ForegroundColor = ConsoleColor.Blue;
-            Console.WriteLine("http://aka.ms/lora");
-            Console.ResetColor();
-            Console.WriteLine();
-
-            var success = await Parser.Default.ParseArguments<ListOptions, QueryOptions, VerifyOptions, BulkVerifyOptions, AddOptions, UpdateOptions, RemoveOptions, RotateCertificateOptions, RevokeOptions>(args)
-                .MapResult(
-                    (ListOptions opts) => RunListAndReturnExitCode(opts),
-                    (QueryOptions opts) => RunQueryAndReturnExitCode(opts),
-                    (VerifyOptions opts) => RunVerifyAndReturnExitCode(opts),
-                    (BulkVerifyOptions opts) => RunBulkVerifyAndReturnExitCode(opts),
-                    (AddOptions opts) => RunAddAndReturnExitCode(opts),
-                    (UpdateOptions opts) => RunUpdateAndReturnExitCode(opts),
-                    (RemoveOptions opts) => RunRemoveAndReturnExitCode(opts),
-                    (RotateCertificateOptions opts) => RunRotateCertificateAndReturnExitCodeAsync(opts),
-                    (RevokeOptions opts) => RunRevokeAndReturnExitCodeAsync(opts),
-                    errs => Task.FromResult(false));
-
-            if (success)
+            try
             {
-                Console.ForegroundColor = ConsoleColor.Green;
-                Console.WriteLine();
-                Console.WriteLine("Successfully terminated.");
+                WriteAzureLogo();
+                Console.WriteLine("Azure IoT Edge LoRaWAN Starter Kit LoRa Leaf Device Provisioning Tool.");
+                Console.Write("This tool complements ");
+                Console.ForegroundColor = ConsoleColor.Blue;
+                Console.WriteLine("http://aka.ms/lora");
                 Console.ResetColor();
+                Console.WriteLine();
 
-                return (int)ExitCode.Success;
+                var success = await Parser.Default.ParseArguments<ListOptions, QueryOptions, VerifyOptions, BulkVerifyOptions, AddOptions, UpdateOptions, RemoveOptions, RotateCertificateOptions, RevokeOptions>(args)
+                    .MapResult(
+                        (ListOptions opts) => RunListAndReturnExitCode(opts),
+                        (QueryOptions opts) => RunQueryAndReturnExitCode(opts),
+                        (VerifyOptions opts) => RunVerifyAndReturnExitCode(opts),
+                        (BulkVerifyOptions opts) => RunBulkVerifyAndReturnExitCode(opts),
+                        (AddOptions opts) => RunAddAndReturnExitCode(opts),
+                        (UpdateOptions opts) => RunUpdateAndReturnExitCode(opts),
+                        (RemoveOptions opts) => RunRemoveAndReturnExitCode(opts),
+                        (RotateCertificateOptions opts) => RunRotateCertificateAndReturnExitCodeAsync(opts),
+                        (RevokeOptions opts) => RunRevokeAndReturnExitCodeAsync(opts),
+                        errs => Task.FromResult(false));
+
+                if (success)
+                {
+                    WriteToConsole("Successfully terminated.", ConsoleColor.Green);
+                    return (int)ExitCode.Success;
+                }
+                else
+                {
+                    WriteToConsole("Terminated with errors.", ConsoleColor.Red);
+                    return (int)ExitCode.Error;
+                }
             }
-            else
+#pragma warning disable CA1031 // Do not catch general exception types
+            // Fallback error handling for whole CLI.
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
-                Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine();
-                Console.WriteLine("Terminated with errors.");
-                Console.ResetColor();
-
+                WriteToConsole($"Terminated with error: {ex}.", ConsoleColor.Red);
                 return (int)ExitCode.Error;
+            }
+
+            static void WriteToConsole(string message, ConsoleColor color)
+            {
+                Console.ForegroundColor = color;
+                Console.WriteLine();
+                Console.WriteLine(message);
+                Console.ResetColor();
             }
         }
 
@@ -310,7 +321,6 @@ namespace LoRaWan.Tools.CLI
 
                     if (isSuccess)
                     {
-                        var newTwin = await iotDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);
                         StatusConsole.WriteTwin(opts.DevEui, twin);
                     }
                     else

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -8,15 +8,12 @@ namespace LoRaWan.Tools.CLI
     using System.Globalization;
     using System.IO;
     using System.Linq;
-    using System.Text;
-    using System.Text.RegularExpressions;
     using System.Threading.Tasks;
     using Azure;
     using CommandLine;
     using LoRaWan.Tools.CLI.CommandLineOptions;
     using LoRaWan.Tools.CLI.Helpers;
     using LoRaWan.Tools.CLI.Options;
-    using Microsoft.Azure.Devices.Shared;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -5,6 +5,7 @@ namespace LoRaWan.Tools.CLI
 {
     using System;
     using System.Buffers.Binary;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -168,7 +169,7 @@ namespace LoRaWan.Tools.CLI
 
             opts = IoTDeviceHelper.CleanOptions(opts as object, true) as AddOptions;
 
-            if (opts.Type.ToUpperInvariant().Equals("CONCENTRATOR"))
+            if (opts.Type.Equals("concentrator", StringComparison.OrdinalIgnoreCase))
             {
                 var isVerified = IoTDeviceHelper.VerifyConcentrator(opts);
                 if (!isVerified) return false;
@@ -208,7 +209,7 @@ namespace LoRaWan.Tools.CLI
             }
             else
             {
-                StatusConsole.WriteLogLine(MessageType.Error, $"Can not add {opts.Type.ToUpper()} device.");
+                StatusConsole.WriteLogLine(MessageType.Error, $"Can not add {opts.Type.ToUpper(CultureInfo.InvariantCulture)} device.");
             }
 
             if (isSuccess)
@@ -362,7 +363,7 @@ namespace LoRaWan.Tools.CLI
 
             try
             {
-                var crc = new Force.Crc32.Crc32Algorithm();
+                using var crc = new Force.Crc32.Crc32Algorithm();
                 var crcHash = BinaryPrimitives.ReadUInt32BigEndian(crc.ComputeHash(fileContent));
                 if (!await uploadSuccessActionAsync(crcHash, blobClient.Uri))
                     await CleanupAsync();

--- a/Tools/Cli-LoRa-Device-Provisioning/StatusConsole.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/StatusConsole.cs
@@ -79,8 +79,8 @@ namespace LoRaWan.Tools.CLI
         private static string TwinToString(Twin twin)
         {
             var twinData = JObject.Parse(twin.Properties.Desired.ToJson());
-            twinData.Remove("$metadata");
-            twinData.Remove("$version");
+            _ = twinData.Remove("$metadata");
+            _ = twinData.Remove("$version");
             return twinData.ToString();
         }
     }

--- a/Tools/Cli-LoRa-Device-Provisioning/StatusConsole.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/StatusConsole.cs
@@ -7,7 +7,7 @@ namespace LoRaWan.Tools.CLI
     using Microsoft.Azure.Devices.Shared;
     using Newtonsoft.Json.Linq;
 
-    public static class StatusConsole
+    internal static class StatusConsole
     {
         public static void WriteIfVerbose(string message, bool isVerbose)
         {


### PR DESCRIPTION
# PR for issue #898

## What is being addressed

With this PR we fix existing CA/IDE warnings for the CLI project and treat CA/IDE warnings as errors.

## How is this addressed

Warnings that have many occurrences are addressed on a warning-per-commit basis, while warnings that only have one or two occurrences per CA/IDE warning are addressed in bulk.