### PR TITLE
Remove unused `RegionManager.CurrentRegion`

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionManager.cs
@@ -8,11 +8,6 @@ namespace LoRaTools.Regions
 
     public static class RegionManager
     {
-        public static Region CurrentRegion
-        {
-            get; set;
-        }
-
         /// <summary>
         /// Tries to get the <see cref="LoRaRegionType"/> based on <paramref name="value"/>.
         /// </summary>


### PR DESCRIPTION
## What is being addressed

The property `RegionManager.CurrentRegion` is never used.

## How is this addressed

The property is being removed. As a benefit, it should help bump up code coverage.
