### PR TITLE
Remove alert from ADR

### DIFF
--- a/docs/adr/005_observability.md
+++ b/docs/adr/005_observability.md
@@ -95,7 +95,6 @@ We support the following alerts when the user opts in to use Application Insight
 | ------------------------------- | --------------------------------------------------------- | ---------------------------------------- | --------- |
 | HighUpstreamMessageLatency      | High device message processing time (throughput)          | D2CMessageDeliveryLatency                | Dynamic   |
 | HighErrorCount                  | High error count (correctness)                            | Unhandled Exceptions                     | Dynamic   |
-| HighUpstreamMessagesLostRatio   | High device messages lost ratio (correctness, throughput) | D2CMessagesReceived/D2CMessagesDelivered | Dynamic   |
 | HighReceiveWindowMisses         | High device message processing time (throughput)          | ReceiveWindowMisses                      | Dynamic   |
 | HighDownstreamMessagesLostRatio | High device messages lost ratio (correctness, throughput) | Abandoned messages (IoT Hub metric)      | Dynamic   |
 


### PR DESCRIPTION
## What is being addressed

We will not raise the alert `HighUpstreamMessagesLostRatio` as we can either define a static threshold for the metric, or create a separate metric (which is hard to do in our code base) to track when a message is lost. Since all lost messages generate exceptions, we can also observe the exception metric to detect when we lose messages.