### PR TITLE
Update how we raise Prometheus metrics

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -139,6 +139,8 @@ namespace LoRaWan.NetworkServer.BasicsStation
                    .UseWebSockets()
                    .UseEndpoints(endpoints =>
                    {
+                       _ = endpoints.MapMetrics();
+
                        Map(HttpMethod.Get, BasicsStationNetworkServer.DiscoveryEndpoint,
                            context => context.Request.Host.Port is BasicsStationNetworkServer.LnsPort or BasicsStationNetworkServer.LnsSecurePort,
                            (ILnsProtocolMessageProcessor processor) => processor.HandleDiscoveryAsync);
@@ -168,8 +170,6 @@ namespace LoRaWan.NetworkServer.BasicsStation
                            });
                        }
                    });
-
-            _ = app.UseMetricServer();
         }
     }
 }


### PR DESCRIPTION
## What is being addressed

We use the [recommended way](https://github.com/prometheus-net/prometheus-net#aspnet-core-exporter-middleware) instead of another [recommended way](https://github.com/prometheus-net/prometheus-net#aspnet-core-with-basic-authentication) to expose Prometheus metrics in ASP.NET Core. This might solve error messages, such as `No candidates found for the request path '/metrics' Request did not match any endpoints` that we see in the pipelines.