### PR TITLE
Cli-LoRa-Device-Provisioning should be able to provision no-cups devices with client certificate thumbprints

### DIFF
--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/IoTDeviceHelper.cs
@@ -958,7 +958,10 @@ namespace LoRaWan.Tools.CLI.Helpers
                     [TwinProperty.CupsUri] = opts.CupsUri,
                     [TwinProperty.TcUri] = opts.TcUri,
                 };
+            }
 
+            if (opts.ClientCertificateThumbprints is not null && opts.ClientCertificateThumbprints.Any())
+            {
                 // Add client certificate thumbprints
                 twinProperties.Desired[TwinProperty.ClientThumbprint] = new JArray(opts.ClientCertificateThumbprints);
             }


### PR DESCRIPTION
# PR for issue #1043 

## What is being addressed

Cli-LoRa-Device-Provisioning should be able to provision no-cups devices with client certificate thumbprints as we might want to provision no-cups devices with mutual authentication against the LNS endpoints only