### PR TITLE
Remove unused `lockKeyDevNonce` in `DeviceGetter`

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
@@ -89,7 +89,6 @@ namespace LoraKeysManagerFacade
                 // OTAA join
                 using var deviceCache = new LoRaDeviceCache(this.cacheStore, devEUI, gatewayId);
                 var cacheKeyDevNonce = string.Concat(devEUI, ":", devNonce);
-                var lockKeyDevNonce = string.Concat(cacheKeyDevNonce, ":joinlockdevnonce");
 
                 if (this.cacheStore.StringSet(cacheKeyDevNonce, devNonce, TimeSpan.FromMinutes(5), onlyIfNotExists: true))
                 {


### PR DESCRIPTION
## What is being addressed

`lockKeyDevNonce` was nowhere used in `DeviceGetter`.

## How is this addressed

`lockKeyDevNonce` is removed.
