### PR TITLE
Introducing Region as record for supporting non-destructive mutations

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/Region.cs
@@ -11,13 +11,13 @@ namespace LoRaTools.Regions
     using LoRaWan;
     using Microsoft.Extensions.Logging;
 
-    public abstract class Region
+    public abstract record Region
     {
         private const ushort MAX_RX_DELAY = 15;
 
         protected const double EPSILON = 0.00001;
 
-        public LoRaRegionType LoRaRegion { get; set; }
+        public LoRaRegionType LoRaRegion { get; init; }
 
         /// <summary>
         /// Gets or sets datarate to configuration and max payload size (M)
@@ -37,60 +37,60 @@ namespace LoRaTools.Regions
         /// X = RX1DROffset Upstream DR
         /// Y = Downstream DR in RX1 slot.
         /// </summary>
-        public IReadOnlyList<IReadOnlyList<int>> RX1DROffsetTable { get; set; }
+        public IReadOnlyList<IReadOnlyList<int>> RX1DROffsetTable { get; init; }
 
         /// <summary>
         /// Gets or sets default first receive windows. [sec].
         /// </summary>
-        public uint ReceiveDelay1 { get; set; }
+        public uint ReceiveDelay1 { get; init; }
 
         /// <summary>
         /// Gets or sets default second receive Windows. Should be receive_delay1+1 [sec].
         /// </summary>
-        public uint ReceiveDelay2 { get; set; }
+        public uint ReceiveDelay2 { get; init; }
 
         /// <summary>
         /// Gets or sets default Join Accept Delay for first Join Accept Windows.[sec].
         /// </summary>
-        public uint JoinAcceptDelay1 { get; set; }
+        public uint JoinAcceptDelay1 { get; init; }
 
         /// <summary>
         /// Gets or sets default Join Accept Delay for second Join Accept Windows. [sec].
         /// </summary>
-        public uint JoinAcceptDelay2 { get; set; }
+        public uint JoinAcceptDelay2 { get; init; }
 
         /// <summary>
         /// Gets or sets max fcnt gap between expected and received. [#frame]
         /// If this difference is greater than the value of MAX_FCNT_GAP then too many data frames have been lost then subsequent will be discarded.
         /// </summary>
-        public int MaxFcntGap { get; set; }
+        public int MaxFcntGap { get; init; }
 
         /// <summary>
         /// Gets or sets number of uplink an end device can send without asking for an ADR acknowledgement request (set ADRACKReq bit to 1). [#frame].
         /// </summary>
-        public uint AdrAckLimit { get; set; }
+        public uint AdrAckLimit { get; init; }
 
         /// <summary>
         /// Gets or sets number of frames in which the network is required to respond to a ADRACKReq request. [#frame]
         /// If no response, during time select a lower data rate.
         /// </summary>
-        public uint AdrAdrDelay { get; set; }
+        public uint AdrAdrDelay { get; init; }
 
         /// <summary>
         /// Gets or sets timeout for ack transmissiont, tuple with (min,max). Value should be a delay between min and max. [sec, sec].
         /// If  an  end-­device  does  not  receive  a  frame  with  the  ACK  bit  set  in  one  of  the  two  receive  19   windows  immediately  following  the  uplink  transmission  it  may  resend  the  same  frame  with  20   the  same  payload  and  frame  counter  again  at  least  ACK_TIMEOUT  seconds  after  the  21   second  reception  window.
         /// </summary>
-        public (uint min, uint max) RetransmitTimeout { get; set; }
+        public (uint min, uint max) RetransmitTimeout { get; init; }
 
         /// <summary>
         /// Gets or sets the limits on the region to ensure valid properties.
         /// </summary>
-        public RegionLimits RegionLimits { get; set; }
+        public RegionLimits RegionLimits { get; init; }
 
         /// <summary>
         /// Gets or sets set the Max ADR datarate acceptable, this is not necessarelly the highest in the region hence we need an additional param.
         /// </summary>
-        public int MaxADRDataRate { get; set; }
+        public int MaxADRDataRate { get; init; }
 
         protected Region(LoRaRegionType regionEnum)
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionAS923.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionAS923.cs
@@ -11,14 +11,14 @@ namespace LoRaTools.Regions
     using LoRaWan;
     using static LoRaWan.Metric;
 
-    public class RegionAS923 : Region
+    public record RegionAS923 : Region
     {
         private static readonly Hertz Channel0Frequency = Mega(923.2);
         private static readonly Hertz Channel1Frequency = Mega(923.4);
 
         private readonly bool useDwellTimeLimit;
 
-        public long FrequencyOffset { get; private set; }
+        public long FrequencyOffset { get; init; }
 
         public RegionAS923(int dwellTime = 0)
             : base(LoRaRegionType.AS923)
@@ -105,15 +105,15 @@ namespace LoRaTools.Regions
         /// <param name="frequencyChannel1">Configured frequency for radio 1.</param>
         public RegionAS923 WithFrequencyOffset(Hertz frequencyChannel0, Hertz frequencyChannel1)
         {
-            FrequencyOffset = frequencyChannel0 - Channel0Frequency;
+            var channel0Offset = frequencyChannel0 - Channel0Frequency;
 
             var channel1Offset = frequencyChannel1 - Channel1Frequency;
-            if (channel1Offset != FrequencyOffset)
+            if (channel1Offset != channel0Offset)
             {
                 throw new ConfigurationErrorsException($"Provided channel frequencies {frequencyChannel0}, {frequencyChannel1} for Region {LoRaRegion} are inconsistent.");
             }
 
-            return this;
+            return this with { FrequencyOffset = channel0Offset };
         }
 
         /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionCN470RP1.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionCN470RP1.cs
@@ -11,7 +11,7 @@ namespace LoRaTools.Regions
     using static LoRaWan.Metric;
 
     // Frequency plan for region CN470-510 using version 1 of LoRaWAN 1.0.3 Regional Parameters specification
-    public class RegionCN470RP1 : Region
+    public record RegionCN470RP1 : Region
     {
         private static readonly Hertz StartingUpstreamFrequency = Mega(470.3);
         private static readonly Hertz StartingDownstreamFrequency = Mega(500.3);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionCN470RP2.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionCN470RP2.cs
@@ -12,7 +12,7 @@ namespace LoRaTools.Regions
     using static LoRaWan.Metric;
 
     // Frequency plan for region CN470-510 using version RP002-1.0.3 of LoRaWAN Regional Parameters specification
-    public class RegionCN470RP2 : Region
+    public record RegionCN470RP2 : Region
     {
         private static readonly Mega FrequencyIncrement = new(0.2);
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionEU868.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionEU868.cs
@@ -10,7 +10,7 @@ namespace LoRaTools.Regions
     using System.Collections.Generic;
     using static LoRaWan.Metric;
 
-    public class RegionEU868 : Region
+    public record RegionEU868 : Region
     {
         public RegionEU868()
             : base(LoRaRegionType.EU868)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionUS915.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Regions/RegionUS915.cs
@@ -10,7 +10,7 @@ namespace LoRaTools.Regions
     using LoRaWan;
     using static LoRaWan.Metric;
 
-    public class RegionUS915 : Region
+    public record RegionUS915 : Region
     {
         // Frequencies calculated according to formula:
         // 923.3 + upstreamChannelNumber % 8 * 0.6,

--- a/Tests/Unit/NetworkServer/JsonHandlers/LnsStationConfigurationTests.cs
+++ b/Tests/Unit/NetworkServer/JsonHandlers/LnsStationConfigurationTests.cs
@@ -580,5 +580,110 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation.JsonHandlers
             Assert.Equal(typeof(RegionAS923), region.GetType());
             Assert.Equal(exptectedOffset, ((RegionAS923)region).FrequencyOffset);
         }
+
+        [Fact]
+        public void RegionConfigurationConverter_CorrectlyReadsAS923Region_WithOffset_WithoutMutatingExistingOnes()
+        {
+            var input = @"{{
+            'msgtype': 'router_config',
+            'NetID': [1],
+            'JoinEui': [[0, 18446744073709551615]],
+	        'region': 'AS923',
+	        'hwspec': 'sx1301/1',
+	        'freq_range': [ 920000000, 925000000 ],
+            'DRs': [ [ 11, 125, 0 ],
+                     [ 10, 125, 0 ],
+                     [ 9, 125, 0 ],
+                     [ 8, 125, 0 ],
+                     [ 7, 125, 0 ],
+                     [ 7, 250, 0 ] ],
+            'sx1301_conf': [
+                {{
+                    'radio_0': {{
+                        'enable': true,
+                        'type': 'SX1257',
+                        'freq': {0},
+                        'rssi_offset': -166.0,
+                        'tx_enable': true,
+                        'tx_freq_min': 920000000,
+                        'th_freq_max': 923400000
+                    }},
+                    'radio_1': {{
+                        'enable': true,
+                        'type': 'SX1257',
+                        'freq': {1},
+                        'rssi_offset': -166.0,
+                        'tx_enable': false,
+                    }},
+                    'chan_FSK': {{
+                        'enable': true,
+                        'radio': 1,
+                        'if': -1800000
+                    }},
+                    'chan_Lora_std': {{
+                        'enable': true,
+                        'radio': 1,
+                        'if': -1800000,
+                        'bandwidth': 250000,
+                        'spread_factor': 7
+                    }},
+                    'chan_multiSF_0': {{
+                        'enable': true,
+                        'radio': 0,
+                        'if': {2}
+                    }},
+                    'chan_multiSF_1': {{
+                        'enable': true,
+                        'radio': 0,
+                        'if': {3}
+                    }},
+                    'chan_multiSF_2': {{
+                        'enable': true,
+                        'radio': 1,
+                        'if': 0
+                    }},
+                    'chan_multiSF_3': {{
+                        'enable': true,
+                        'radio': 0,
+                        'if': -1800000
+                    }},
+                    'chan_multiSF_4': {{
+                        'enable': true,
+                        'radio': 0,
+                        'if': -1800000
+                    }},
+                    'chan_multiSF_5': {{
+                        'enable': true,
+                        'radio': 0,
+                        'if': 0
+                    }},
+                    'chan_multiSF_6': {{
+                        'enable': true,
+                        'radio': 0,
+                        'if': -1800000
+                    }},
+                    'chan_multiSF_7': {{
+                        'enable': true,
+                        'radio': 0,
+                        'if': -1800000
+                    }}
+                }}
+            ],
+            'nocca': true,
+            'nodc': true,
+            'nodwell': true}}";
+
+            var config1 = JsonUtil.Strictify(string.Format(CultureInfo.InvariantCulture, input, 923000000, 922000000, 200000, 400000));
+            var region1 = LnsStationConfiguration.GetRegion(config1);
+
+            var config2 = JsonUtil.Strictify(string.Format(CultureInfo.InvariantCulture, input, 923000000, 922000000, -1600000, -1400000));
+            var region2 = LnsStationConfiguration.GetRegion(config2);
+
+            // asserting that reading region2 is not affecting region1
+            Assert.Equal(typeof(RegionAS923), region1.GetType());
+            Assert.Equal(0, ((RegionAS923)region1).FrequencyOffset);
+            Assert.Equal(typeof(RegionAS923), region2.GetType());
+            Assert.Equal(-1800000, ((RegionAS923)region2).FrequencyOffset);
+        }
     }
 }

--- a/Tests/Unit/NetworkServer/JsonHandlers/LnsStationConfigurationTests.cs
+++ b/Tests/Unit/NetworkServer/JsonHandlers/LnsStationConfigurationTests.cs
@@ -680,10 +680,10 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation.JsonHandlers
             var region2 = LnsStationConfiguration.GetRegion(config2);
 
             // asserting that reading region2 is not affecting region1
-            Assert.Equal(typeof(RegionAS923), region1.GetType());
-            Assert.Equal(0, ((RegionAS923)region1).FrequencyOffset);
-            Assert.Equal(typeof(RegionAS923), region2.GetType());
-            Assert.Equal(-1800000, ((RegionAS923)region2).FrequencyOffset);
+            var as923_1 = Assert.IsType<RegionAS923>(region1);
+            Assert.Equal(0, as923_1.FrequencyOffset);
+            var as923_2 = Assert.IsType<RegionAS923>(region2);
+            Assert.Equal(-1800000, as923_2.FrequencyOffset);
         }
     }
 }


### PR DESCRIPTION
# PR for issue #1082 

## What is being addressed

Region is now a record and all its properties are only settable at initialization. In the case of AS923, the WithFrequencyOffset is creating a copy of the region record for a non-destructive mutation of the frequencyoffset field