### PR TITLE
add notice files to docker images

### DIFF
--- a/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.amd64
+++ b/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.amd64
@@ -16,5 +16,6 @@ COPY LoRaEngine/modules/LoRaBasicsStationModule/start_basicsstation.sh .
 COPY LoRaEngine/modules/LoRaBasicsStationModule/station.conf .
 COPY --from=build /basicstation/deps/lgw/platform-linux/reset_lgw.sh .
 COPY LICENSE .
+COPY ./LoRaEngine/modules/LoRaBasicsStationModule/NOTICE.txt .
 RUN chmod +x ./start_basicsstation.sh
 ENTRYPOINT ["./start_basicsstation.sh"]

--- a/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.arm32v7
@@ -32,5 +32,6 @@ COPY LoRaEngine/modules/LoRaBasicsStationModule/station.conf .
 COPY LoRaEngine/modules/LoRaBasicsStationModule/helper-functions.sh .
 COPY LoRaEngine/modules/LoRaBasicsStationModule/start_basicsstation.sh .
 COPY LICENSE .
+COPY ./LoRaEngine/modules/LoRaBasicsStationModule/NOTICE.txt .
 RUN chmod +x ./start_basicsstation.sh
 ENTRYPOINT ["./start_basicsstation.sh"]

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64
@@ -5,6 +5,8 @@ COPY Directory.Build.props ./
 COPY AssemblyInfo.cs ./
 COPY .editorconfig ./
 COPY global.json ./
+COPY LICENSE ./
+COPY ./LoRaEngine/modules/LoRaWanNetworkSrvModule/NOTICE.txt ./
 
 WORKDIR /build/LoRaEngine/modules/LoRaWanNetworkSrvModule
 COPY ["LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule.csproj", "LoRaWanNetworkSrvModule/"]

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64.debug
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.amd64.debug
@@ -15,6 +15,8 @@ WORKDIR /build
 COPY Directory.Build.props ./
 COPY AssemblyInfo.cs ./
 COPY .editorconfig ./
+COPY LICENSE ./
+COPY ./LoRaEngine/modules/LoRaWanNetworkSrvModule/NOTICE.txt ./
 
 WORKDIR /build/LoRaEngine/modules/LoRaWanNetworkSrvModule
 COPY ["LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule.csproj", "LoRaWanNetworkSrvModule/"]

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.arm32v7
@@ -5,6 +5,8 @@ COPY Directory.Build.props ./
 COPY AssemblyInfo.cs ./
 COPY .editorconfig ./
 COPY global.json ./
+COPY LICENSE ./
+COPY ./LoRaEngine/modules/LoRaWanNetworkSrvModule/NOTICE.txt ./
 
 WORKDIR /build/LoRaEngine/modules/LoRaWanNetworkSrvModule
 COPY ["LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule.csproj", "LoRaWanNetworkSrvModule/"]

--- a/Samples/UniversalDecoder/Dockerfile.amd64
+++ b/Samples/UniversalDecoder/Dockerfile.amd64
@@ -3,6 +3,7 @@ FROM node:14-alpine
 WORKDIR /app/
 
 COPY package*.json ./
+COPY NOTICE.txt ./
 
 RUN npm install --production
 

--- a/Samples/UniversalDecoder/Dockerfile.arm32v7
+++ b/Samples/UniversalDecoder/Dockerfile.arm32v7
@@ -3,6 +3,7 @@ FROM arm32v7/node:14-slim
 WORKDIR /app/
 
 COPY package*.json ./
+COPY NOTICE.txt ./
 
 RUN npm install --production
 

--- a/Samples/UniversalDecoder/Dockerfile.arm64v8
+++ b/Samples/UniversalDecoder/Dockerfile.arm64v8
@@ -3,6 +3,7 @@ FROM arm64v8/node:14-slim
 WORKDIR /app/
 
 COPY package*.json ./
+COPY NOTICE.txt ./
 
 RUN npm install --production
 


### PR DESCRIPTION
## What is being addressed

Now that we have valid NOTICE files, they need to be added to the docker images which we are redistributing.

## How is this addressed

Adds a `COPY` statement for the NOTICE files in each dockerfile
