### PR TITLE
Set RoleName and RoleInstance on each LNS telemetry item

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -16,6 +16,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
     using LoRaWan.NetworkServer.BasicsStation.ModuleConnection;
     using LoRaWan.NetworkServer.BasicsStation.Processors;
     using Microsoft.ApplicationInsights;
+    using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
@@ -69,7 +70,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                             {
                                 _ = loggingBuilder.AddApplicationInsights(appInsightsKey)
                                                   .AddFilter<ApplicationInsightsLoggerProvider>(string.Empty, logLevel);
-
+                                _ = services.AddSingleton<ITelemetryInitializer>(_ => new TelemetryInitializer(NetworkServerConfiguration));
                             }
                         })
                         .AddMemoryCache()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/TelemetryInitializer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/TelemetryInitializer.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaWan.NetworkServer
+{
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    internal sealed class TelemetryInitializer : ITelemetryInitializer
+    {
+        private const string RoleName = "NetworkServer";
+        private readonly string gatewayId;
+
+        public TelemetryInitializer(NetworkServerConfiguration networkServerConfiguration) =>
+            this.gatewayId = networkServerConfiguration.GatewayID;
+
+        public void Initialize(ITelemetry telemetry)
+        {
+            telemetry.Context.Cloud.RoleName = RoleName;
+            telemetry.Context.Cloud.RoleInstance = this.gatewayId;
+        }
+    }
+}

--- a/Tests/Unit/NetworkServer/TelemetryInitializerTests.cs
+++ b/Tests/Unit/NetworkServer/TelemetryInitializerTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.NetworkServer
+{
+    using LoRaWan.NetworkServer;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Moq;
+    using Xunit;
+
+    public class TelemetryInitializerTests
+    {
+        private readonly Mock<ITelemetry> telemetry;
+
+        public TelemetryInitializerTests()
+        {
+            this.telemetry = new Mock<ITelemetry>();
+            var telemetryContext = new TelemetryContext();
+            _ = this.telemetry.SetupGet(t => t.Context).Returns(telemetryContext);
+        }
+
+        [Fact]
+        public void Initialize_RoleName()
+        {
+            // arrange
+            var subject = new TelemetryInitializer(new NetworkServerConfiguration());
+
+            // act
+            subject.Initialize(this.telemetry.Object);
+
+            // assert
+            Assert.Equal("NetworkServer", this.telemetry.Object.Context.Cloud.RoleName);
+        }
+
+        [Fact]
+        public void Initialize_RoleInstance()
+        {
+            // arrange
+            const string gatewayId = "foo";
+            var subject = new TelemetryInitializer(new NetworkServerConfiguration { GatewayID = gatewayId });
+
+            // act
+            subject.Initialize(this.telemetry.Object);
+
+            // assert
+            Assert.Equal(gatewayId, this.telemetry.Object.Context.Cloud.RoleInstance);
+        }
+    }
+}


### PR DESCRIPTION
# PR for issue #1038 

## What is being addressed

Sets the `cloud_RoleName` and `cloud_RoleInstance` on each LNS telemetry item that is sent to Application Insights