### PR TITLE
Reverting antenna preference changes

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/DownlinkMessage.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/DownlinkMessage.cs
@@ -43,7 +43,7 @@ namespace LoRaTools.LoRaPhysical
         /// This method is used in case of a response to a upstream message.
         /// </summary>
         /// <returns><see cref="DownlinkMessage"/> object ready to be sent.</returns>
-        public DownlinkMessage(byte[] payload, ulong xtime, DataRateIndex datrRx1, DataRateIndex datrRx2, Hertz freqRx1, Hertz freqRx2, DevEui devEui, ushort lnsRxDelay = 0, StationEui stationEui = default, uint antennaPreference = 0)
+        public DownlinkMessage(byte[] payload, ulong xtime, DataRateIndex datrRx1, DataRateIndex datrRx2, Hertz freqRx1, Hertz freqRx2, DevEui devEui, ushort lnsRxDelay = 0, StationEui stationEui = default, uint? antennaPreference = null)
         {
             if (payload is null) throw new ArgumentNullException(nameof(payload));
             Data = payload;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/RadioMetadata.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/RadioMetadata.cs
@@ -29,6 +29,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
             SignalNoiseRatio = signalNoiseRatio;
         }
 
+        // Following field is corresponding to the rctx field in LNS protocol
         public uint AntennaPreference { get; init; }
         public ulong Xtime { get; init; }
         public uint GpsTime { get; init; }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
@@ -215,7 +215,7 @@ namespace LoRaWan.NetworkServer
             return new DownlinkMessageBuilderResponse(downlinkMessage, isMessageTooLong, receiveWindow);
         }
 
-        private static DownlinkMessage BuildDownstreamMessage(LoRaDevice loRaDevice, StationEui stationEUI, ILogger logger, ulong xTime, DataRateIndex rx1Datr, DataRateIndex rx2Datr, Hertz freqRx1, Hertz freqRx2, ushort lnsRxDelay, LoRaPayloadData loRaMessage, uint antennaPreference = 0)
+        private static DownlinkMessage BuildDownstreamMessage(LoRaDevice loRaDevice, StationEui stationEUI, ILogger logger, ulong xTime, DataRateIndex rx1Datr, DataRateIndex rx2Datr, Hertz freqRx1, Hertz freqRx2, ushort lnsRxDelay, LoRaPayloadData loRaMessage, uint? antennaPreference = null)
         {
             var messageBytes = loRaMessage.Serialize(loRaDevice.AppSKey, loRaDevice.NwkSKey);
             var downlinkMessage = new DownlinkMessage(

--- a/Tests/Unit/NetworkServer/BasicsStation/DownstreamSenderTests.cs
+++ b/Tests/Unit/NetworkServer/BasicsStation/DownstreamSenderTests.cs
@@ -45,24 +45,19 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-#pragma warning disable IDE0060 // Remove unused parameter. Will be reworked when we rework the param.
-#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
         public async Task SendDownstreamAsync_Succeeds_WithValidDownlinkMessage_ClassADevice(bool rfchHasValue)
-#pragma warning restore xUnit1026 // Theory methods should use all of their parameters
-#pragma warning restore IDE0060 // Remove unused parameter
         {
-            // THIS TEST IS WRONG, rcfh
-
             // arrange
             var downlinkMessage = new DownlinkMessage(this.loraDataByteArray,
-                                                                  123456,
-                                                                  DataRateIndex.DR5,
-                                                                  DataRateIndex.DR0,
-                                                                  Hertz.Mega(868.5),
-                                                                  Hertz.Mega(869.5),
-                                                                  this.devEui,
-                                                                  lnsRxDelay: 1,
-                                                                  this.stationEui);
+                                                      123456,
+                                                      DataRateIndex.DR5,
+                                                      DataRateIndex.DR0,
+                                                      Hertz.Mega(868.5),
+                                                      Hertz.Mega(869.5),
+                                                      this.devEui,
+                                                      lnsRxDelay: 1,
+                                                      this.stationEui,
+                                                      rfchHasValue ? 1 : null);
 
             var actualMessage = string.Empty;
             this.webSocketWriter.Setup(s => s.SendAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -88,37 +83,32 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
            
             Assert.Contains(@"""priority"":0", actualMessage, StringComparison.InvariantCulture);
 
-            // THIS NEED TO BE REWORKED
-            // rctx need to be reworked
-            //if (rfchHasValue)
-            //{
-            //    Assert.Contains(@"""rctx"":1", actualMessage, StringComparison.InvariantCulture);
-            //}
-            //else
-            //{
-            //    Assert.DoesNotContain("rctx", actualMessage, StringComparison.InvariantCulture);
-            //}
+            if (rfchHasValue)
+            {
+                Assert.Contains(@"""rctx"":1", actualMessage, StringComparison.InvariantCulture);
+            }
+            else
+            {
+                Assert.DoesNotContain("rctx", actualMessage, StringComparison.InvariantCulture);
+            }
         }
 
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-#pragma warning disable IDE0060 // Remove unused parameter. Will be reworked when we rework the param.
-#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
         public async Task SendDownstreamAsync_Succeeds_WithValidDownlinkMessage_ClassCDevice(bool rfchHasValue)
-#pragma warning restore xUnit1026 // Theory methods should use all of their parameters
-#pragma warning restore IDE0060 // Remove unused parameter
         {
             // arrange
             var downlinkMessage = new DownlinkMessage(this.loraDataByteArray,
-                                                                  0,
-                                                                  DataRateIndex.DR5,
-                                                                  DataRateIndex.DR0,
-                                                                  Hertz.Mega(868.5),
-                                                                  Hertz.Mega(869.5),
-                                                                  this.devEui,
-                                                                  lnsRxDelay: 0,
-                                                                  this.stationEui);
+                                                      0,
+                                                      DataRateIndex.DR5,
+                                                      DataRateIndex.DR0,
+                                                      Hertz.Mega(868.5),
+                                                      Hertz.Mega(869.5),
+                                                      this.devEui,
+                                                      lnsRxDelay: 0,
+                                                      this.stationEui,
+                                                      rfchHasValue ? 1 : null);
 
             var actualMessage = string.Empty;
             this.webSocketWriter.Setup(s => s.SendAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -145,16 +135,14 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
             Assert.DoesNotContain("RX1Freq", actualMessage, StringComparison.InvariantCulture);
             Assert.DoesNotContain(@"""xtime"":123456", actualMessage, StringComparison.InvariantCulture);
 
-            // THIS NEED TO BE REWORKED
-            // rctx need to be reworked
-            //if (rfchHasValue)
-            //{
-            //    Assert.Contains(@"""rctx"":1,", actualMessage, StringComparison.InvariantCulture);
-            //}
-            //else
-            //{
-            //    Assert.DoesNotContain("rctx", actualMessage, StringComparison.InvariantCulture);
-            //}
+            if (rfchHasValue)
+            {
+                Assert.Contains(@"""rctx"":1,", actualMessage, StringComparison.InvariantCulture);
+            }
+            else
+            {
+                Assert.DoesNotContain("rctx", actualMessage, StringComparison.InvariantCulture);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
# PR for issue #1125 

## What is being addressed

This PR is reverting some changes related to the rctx/antenna preference field.

As per LNS documentation, class A downlink messages should have the rctx field (indicating an optional antenna preference) set to the same value as last uplink message.
At the same time, class C downlink messages can either not include the optional preference field, or reuse a previous preference. For simplicity, we decide to not include any preference field in this case.

