### PR TITLE
Do not double-count cache hits

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceCache.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceCache.cs
@@ -226,7 +226,6 @@ namespace LoRaWan.NetworkServer
             {
                 if (this.devAddrCache.TryGetValue(devAddr, out var devices))
                 {
-                    this.deviceCacheHits?.Add(1);
                     device = devices.Values.FirstOrDefault(x => !string.IsNullOrEmpty(x.NwkSKey) && ValidateMic(x, payload));
                 }
             }


### PR DESCRIPTION
## What is being addressed

`DeviceCacheHits` were double-counted when device was retrieved from cache by its dev address.

## How is this addressed

The counter for this metric is only incremented in `TrackCacheStats()` method.
