### PR TITLE
Bug/1129 rssi double

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/CheckPreferredGateway/PreferredGatewayTableItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/CheckPreferredGateway/PreferredGatewayTableItem.cs
@@ -7,9 +7,9 @@ namespace LoraKeysManagerFacade
     {
         public string GatewayID { get; private set; }
 
-        public int Rssi { get; private set; }
+        public double Rssi { get; private set; }
 
-        public PreferredGatewayTableItem(string gatewayID, int rssi)
+        public PreferredGatewayTableItem(string gatewayID, double rssi)
         {
             GatewayID = gatewayID;
             Rssi = rssi;
@@ -34,7 +34,7 @@ namespace LoraKeysManagerFacade
             if (values?.Length != 2)
                 return null;
 
-            if (!int.TryParse(values[1], out var rssi))
+            if (!double.TryParse(values[1], out var rssi))
                 return null;
 
             return new PreferredGatewayTableItem(values[0], rssi);

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerRequest.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerRequest.cs
@@ -17,6 +17,6 @@ namespace LoraKeysManagerFacade.FunctionBundler
 
         public FunctionBundlerItemType FunctionItems { get; set; }
 
-        public int? Rssi { get; set; }
+        public double? Rssi { get; set; }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FunctionBundler/FunctionBundlerProvider.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FunctionBundler/FunctionBundlerProvider.cs
@@ -68,7 +68,7 @@ namespace LoRaWan.NetworkServer
                 ClientFCntDown = context.FCntDown,
                 ClientFCntUp = context.FCntUp,
                 GatewayId = gatewayId,
-                Rssi = (int)context.Request.RadioMetadata.UpInfo.ReceivedSignalStrengthIndication,
+                Rssi = context.Request.RadioMetadata.UpInfo.ReceivedSignalStrengthIndication,
             };
 
             for (var i = 0; i < qualifyingExecutionItems.Count; i++)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FunctionBundler/FunctionBundlerRequest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FunctionBundler/FunctionBundlerRequest.cs
@@ -14,7 +14,7 @@ namespace LoRaWan.NetworkServer
 
         public uint ClientFCntDown { get; set; }
 
-        public int? Rssi { get; set; }
+        public double? Rssi { get; set; }
 
         public LoRaADRRequest AdrRequest { get; set; }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Rxpk.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Rxpk.cs
@@ -47,7 +47,7 @@ namespace LoRaTools.LoRaPhysical
         public string Codr { get; set; }
 
         [JsonProperty("rssi")]
-        public double Rssi { get; set; }
+        public int Rssi { get; set; }
 
         [JsonProperty("lsnr")]
         public float Lsnr { get; set; }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Rxpk.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaPhysical/Rxpk.cs
@@ -47,7 +47,7 @@ namespace LoRaTools.LoRaPhysical
         public string Codr { get; set; }
 
         [JsonProperty("rssi")]
-        public int Rssi { get; set; }
+        public double Rssi { get; set; }
 
         [JsonProperty("lsnr")]
         public float Lsnr { get; set; }

--- a/Tests/Unit/LoraKeysManagerFacade/FunctionBundlerProviderTests.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/FunctionBundlerProviderTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
+{
+    using System.Threading.Tasks;
+    using LoRaWan.NetworkServer;
+    using LoRaWan.Tests.Common;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Moq;
+    using Xunit;
+
+    public class FunctionBundlerProviderTests
+    {
+        [Fact]
+        public async Task CreateIfRequired_Result_Has_Correct_Bundler_Request()
+        {
+            // arrange
+            const string gatewayId = "foo";
+            const double rssi = 2.3;
+            var device = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(0));
+            using var loRaDevice = TestUtils.CreateFromSimulatedDevice(device, new Mock<ILoRaDeviceClientConnectionManager>().Object);
+            var payload = device.CreateConfirmedDataUpMessage("foo");
+            using var request = WaitableLoRaRequest.Create(TestUtils.GenerateTestRadioMetadata(rssi: rssi), payload);
+            var deviceApiServiceMock = new Mock<LoRaDeviceAPIServiceBase>();
+            deviceApiServiceMock.Setup(s => s.ExecuteFunctionBundlerAsync(It.IsAny<string>(), It.IsAny<FunctionBundlerRequest>())).ReturnsAsync(new FunctionBundlerResult());
+            var subject = new FunctionBundlerProvider(deviceApiServiceMock.Object, NullLoggerFactory.Instance, NullLogger<FunctionBundlerProvider>.Instance);
+
+            // act
+            var bundler = subject.CreateIfRequired(gatewayId, payload, loRaDevice, new Mock<IDeduplicationStrategyFactory>().Object, request);
+            _ = await bundler.Execute();
+
+            // assert
+            deviceApiServiceMock.Verify(s => s.ExecuteFunctionBundlerAsync(loRaDevice.DevEUI,
+                                                                           It.Is<FunctionBundlerRequest>(actual => actual.ClientFCntDown == 0
+                                                                                                                   && actual.ClientFCntUp == 1
+                                                                                                                   && actual.GatewayId == gatewayId
+                                                                                                                   && actual.Rssi == rssi)));
+        }
+    }
+}

--- a/Tests/Unit/LoraKeysManagerFacade/PreferredGatewayTableItemTests.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/PreferredGatewayTableItemTests.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
+{
+    using global::LoraKeysManagerFacade;
+    using Xunit;
+
+    public class PreferredGatewayTableItemTests
+    {
+        [Theory]
+        [InlineData(1.2)]
+        [InlineData(-1.2)]
+        [InlineData(1)]
+        public void When_Composing_ToCachedString_CreateFromCachedString_Is_Identity(double rssi)
+        {
+            // arrange
+            const string gatewayId = "foo";
+            var initial = new PreferredGatewayTableItem(gatewayId, rssi);
+
+            // act
+            var result = PreferredGatewayTableItem.CreateFromCachedString(initial.ToCachedString());
+
+            // assert
+            Assert.Equal(initial.GatewayID, result.GatewayID);
+            Assert.Equal(initial.Rssi, result.Rssi);
+        }
+    }
+}


### PR DESCRIPTION
# PR for issue #1129 

## What is being addressed

Ensures that all occurrences of RSSI are typed as `double` instead of a mixture between `double` and `int`.
