### PR TITLE
Class C E2E test uses function endpoint

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
@@ -45,6 +45,15 @@ namespace LoraKeysManagerFacade
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "cloudtodevicemessage/{devEUI}")] HttpRequest req,
             string devEUI)
         {
+            try
+            {
+                VersionValidator.Validate(req);
+            }
+            catch (IncompatibleVersionException ex)
+            {
+                return new BadRequestObjectResult(ex.Message);
+            }
+
             EUIValidator.ValidateDevEUI(devEUI);
 
             var requestBody = await req.ReadAsStringAsync();

--- a/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
@@ -137,7 +137,10 @@ namespace LoraKeysManagerFacade
                         }
 
                         // class c device that did not send a single upstream message
-                        return new ObjectResult("Class C devices must sent at least one message upstream. None has been received") { StatusCode = (int)HttpStatusCode.InternalServerError };
+                        return new ObjectResult("Class C devices must sent at least one message upstream. None has been received")
+                        {
+                            StatusCode = (int)HttpStatusCode.InternalServerError
+                        };
                     }
 
                     // Not a class C device? Send message using sdk/queue

--- a/Tests/Common/IntegrationTestFixtureBase.cs
+++ b/Tests/Common/IntegrationTestFixtureBase.cs
@@ -184,21 +184,6 @@ namespace LoRaWan.Tests.Common
             return this.moduleClient;
         }
 
-        public async Task InvokeModuleDirectMethodAsync(string edgeDeviceId, string moduleId, string methodName, object body)
-        {
-            try
-            {
-                var c2d = new CloudToDeviceMethod(methodName, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
-                c2d.SetPayloadJson(JsonConvert.SerializeObject(body));
-                await GetServiceClient().InvokeDeviceMethodAsync(edgeDeviceId, moduleId, c2d);
-            }
-            catch (Exception ex)
-            {
-                TestLogger.Log($"[ERROR] Failed to call direct method, deviceId: {edgeDeviceId}, moduleId: {moduleId}, method: {methodName}: {ex.Message}");
-                throw;
-            }
-        }
-
         public async Task InvokeDeviceMethodAsync(string deviceId, string moduleId, CloudToDeviceMethod method)
         {
             using var sc = ServiceClient.CreateFromConnectionString(Configuration.IoTHubConnectionString);

--- a/Tests/E2E/ClassCTest.cs
+++ b/Tests/E2E/ClassCTest.cs
@@ -61,7 +61,7 @@ namespace LoRaWan.Tests.E2E
             {
                 try
                 {
-                    await LoRaAPIHelper.SendCloudToDeviceMessage(device.DeviceID, c2d);
+                    Assert.True(await LoRaAPIHelper.SendCloudToDeviceMessage(device.DeviceID, c2d));
                     break;
                 }
                 catch (Exception ex)

--- a/Tests/E2E/ClassCTest.cs
+++ b/Tests/E2E/ClassCTest.cs
@@ -61,7 +61,7 @@ namespace LoRaWan.Tests.E2E
             {
                 try
                 {
-                    await TestFixtureCi.InvokeModuleDirectMethodAsync(TestFixture.Configuration.LeafDeviceGatewayID, TestFixture.Configuration.NetworkServerModuleID, "cloudtodevicemessage", c2d);
+                    await LoRaAPIHelper.SendCloudToDeviceMessage(device.DeviceID, c2d);
                     break;
                 }
                 catch (Exception ex)

--- a/Tests/E2E/ClassCTest.cs
+++ b/Tests/E2E/ClassCTest.cs
@@ -21,12 +21,13 @@ namespace LoRaWan.Tests.E2E
         {
         }
 
-        // Ensures that class C devices can receive messages from a direct method call
+        // Ensures that class C devices can receive messages from a direct method call;
+        // the test uses the SendCloudToDeviceMessage endpoint in LoRaKeysManagerFacade
+        // instead of callling direct method from the test code.
         // Uses Device24_ABP
         [Fact]
-        public async Task Test_ClassC_Send_Message_From_Direct_Method_Should_Be_Received()
+        public async Task Test_ClassC_Send_Message_Using_Function_Endpoint_Should_Be_Received()
         {
-            const int MAX_MODULE_DIRECT_METHOD_CALL_TRIES = 3;
             var device = TestFixtureCi.Device24_ABP;
             LogTestStart(device);
 
@@ -54,25 +55,11 @@ namespace LoRaWan.Tests.E2E
                 RawPayload = Convert.ToBase64String(new byte[] { 0xFF, 0x00 }),
             };
 
-            TestLogger.Log($"[INFO] Using service client to call direct method to {TestFixture.Configuration.LeafDeviceGatewayID}/{TestFixture.Configuration.NetworkServerModuleID}");
+            TestLogger.Log($"[INFO] Using service API to send C2D message to device {device.DeviceID}");
             TestLogger.Log($"[INFO] {JsonConvert.SerializeObject(c2d, Formatting.None)}");
 
-            for (var i = 0; i < MAX_MODULE_DIRECT_METHOD_CALL_TRIES; ++i)
-            {
-                try
-                {
-                    Assert.True(await LoRaAPIHelper.SendCloudToDeviceMessage(device.DeviceID, c2d));
-                    break;
-                }
-                catch (Exception ex)
-                {
-#pragma warning disable CA1508 // Avoid dead conditional code (false positive)
-                    if (i == MAX_MODULE_DIRECT_METHOD_CALL_TRIES - 1) throw;
-#pragma warning restore CA1508 // Avoid dead conditional code
-                    TestLogger.Log($"[ERR] Failed to call module direct method: {ex.Message}");
-                    await Task.Delay(TimeSpan.FromSeconds(5));
-                }
-            }
+            // send message using the SendCloudToDeviceMessage API endpoint
+            Assert.True(await LoRaAPIHelper.SendCloudToDeviceMessage(device.DeviceID, c2d));
 
             await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
 

--- a/Tests/E2E/ClassCTest.cs
+++ b/Tests/E2E/ClassCTest.cs
@@ -63,6 +63,9 @@ namespace LoRaWan.Tests.E2E
 
             await Task.Delay(Constants.DELAY_BETWEEN_MESSAGES);
 
+            // 0000000000000024: received cloud to device message from direct method
+            await TestFixtureCi.AssertNetworkServerModuleLogStartsWithAsync($"{device.DeviceID}: received cloud to device message from direct method");
+
             Assert.Contains(ArduinoDevice.SerialLogs, (l) => l.StartsWith("+MSG: PORT: 23; RX: \"FF00\"", StringComparison.Ordinal));
             Assert.Contains(ArduinoDevice.SerialLogs, (l) => l.StartsWith("+MSG: RXWIN0, RSSI", StringComparison.Ordinal));
             await AssertUtils.ContainsWithRetriesAsync("+MSG: Done", ArduinoDevice.SerialLogs);

--- a/Tests/E2E/IntegrationTestFixtureCI.cs
+++ b/Tests/E2E/IntegrationTestFixtureCI.cs
@@ -507,7 +507,6 @@ namespace LoRaWan.Tests.E2E
                 AppSKey = GetKey32(24),
                 NwkSKey = GetKey32(24),
                 DevAddr = "00000024",
-                GatewayID = gatewayID,
                 IsIoTHubDevice = true,
                 ClassType = 'C',
             };

--- a/Tests/E2E/LoRaAPIHelper.cs
+++ b/Tests/E2E/LoRaAPIHelper.cs
@@ -6,13 +6,11 @@ namespace LoRaWan.Tests.E2E
     using System;
     using System.Net.Http;
     using System.Net.Http.Headers;
-    using System.Net.WebSockets;
     using System.Text;
     using System.Threading.Tasks;
     using LoRaTools.CommonAPI;
     using LoRaWan.Core;
     using Newtonsoft.Json;
-    using Xunit;
 
     public static class LoRaAPIHelper
     {

--- a/Tests/E2E/LoRaAPIHelper.cs
+++ b/Tests/E2E/LoRaAPIHelper.cs
@@ -6,10 +6,12 @@ namespace LoRaWan.Tests.E2E
     using System;
     using System.Net.Http;
     using System.Net.Http.Headers;
+    using System.Net.WebSockets;
     using System.Text;
     using System.Threading.Tasks;
     using LoRaTools.CommonAPI;
     using LoRaWan.Core;
+    using Newtonsoft.Json;
 
     public static class LoRaAPIHelper
     {
@@ -39,6 +41,15 @@ namespace LoRaWan.Tests.E2E
             var payload = "{\"AdrRequest\":{\"ClearCache\": true},\"GatewayId\":\"integrationTesting\", \"FunctionItems\": " + (int)FunctionBundlerItemType.ADR + "}";
 
             using var content = PreparePostContent(payload);
+            using var response = await httpClient.Value.PostAsync(url, content);
+            return response.IsSuccessStatusCode;
+        }
+
+        public static async Task<bool> SendCloudToDeviceMessage(string devEUI, LoRaCloudToDeviceMessage c2dMessage)
+        {
+            var url = new Uri($"{baseUrl}cloudtodevicemessage/{devEUI}?code={authCode}");
+            var json = JsonConvert.SerializeObject(c2dMessage);
+            using var content = PreparePostContent(json);
             using var response = await httpClient.Value.PostAsync(url, content);
             return response.IsSuccessStatusCode;
         }

--- a/Tests/E2E/LoRaAPIHelper.cs
+++ b/Tests/E2E/LoRaAPIHelper.cs
@@ -45,13 +45,12 @@ namespace LoRaWan.Tests.E2E
             return response.IsSuccessStatusCode;
         }
 
-        public static async Task<bool> SendCloudToDeviceMessage(string devEUI, LoRaCloudToDeviceMessage c2dMessage)
+        public static async Task SendCloudToDeviceMessage(string devEUI, LoRaCloudToDeviceMessage c2dMessage)
         {
             var url = new Uri($"{baseUrl}cloudtodevicemessage/{devEUI}?code={authCode}");
             var json = JsonConvert.SerializeObject(c2dMessage);
             using var content = PreparePostContent(json);
-            using var response = await httpClient.Value.PostAsync(url, content);
-            return response.IsSuccessStatusCode;
+            await httpClient.Value.PostAsync(url, content);
         }
 
         private static ByteArrayContent PreparePostContent(string requestBody)

--- a/Tests/E2E/LoRaAPIHelper.cs
+++ b/Tests/E2E/LoRaAPIHelper.cs
@@ -12,6 +12,7 @@ namespace LoRaWan.Tests.E2E
     using LoRaTools.CommonAPI;
     using LoRaWan.Core;
     using Newtonsoft.Json;
+    using Xunit;
 
     public static class LoRaAPIHelper
     {
@@ -45,12 +46,13 @@ namespace LoRaWan.Tests.E2E
             return response.IsSuccessStatusCode;
         }
 
-        public static async Task SendCloudToDeviceMessage(string devEUI, LoRaCloudToDeviceMessage c2dMessage)
+        public static async Task<bool> SendCloudToDeviceMessage(string devEUI, LoRaCloudToDeviceMessage c2dMessage)
         {
             var url = new Uri($"{baseUrl}cloudtodevicemessage/{devEUI}?code={authCode}");
             var json = JsonConvert.SerializeObject(c2dMessage);
             using var content = PreparePostContent(json);
-            await httpClient.Value.PostAsync(url, content);
+            using var response = await httpClient.Value.PostAsync(url, content);
+            return response.IsSuccessStatusCode;
         }
 
         private static ByteArrayContent PreparePostContent(string requestBody)

--- a/Tests/E2E/LoRaAPIHelper.cs
+++ b/Tests/E2E/LoRaAPIHelper.cs
@@ -7,6 +7,7 @@ namespace LoRaWan.Tests.E2E
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using LoRaTools.CommonAPI;
     using LoRaWan.Core;
@@ -34,22 +35,25 @@ namespace LoRaWan.Tests.E2E
 
         public static async Task<bool> ResetADRCache(string devEUI)
         {
-            var url = new Uri($"{baseUrl}FunctionBundler/{devEUI}?code={authCode}");
+            var path = $"FunctionBundler/{devEUI}";
             // the gateway id is only used to identify who is taking the lock when
             // releasing the cache. Hence we do not need a real GW id
             var payload = "{\"AdrRequest\":{\"ClearCache\": true},\"GatewayId\":\"integrationTesting\", \"FunctionItems\": " + (int)FunctionBundlerItemType.ADR + "}";
-
-            using var content = PreparePostContent(payload);
-            using var response = await httpClient.Value.PostAsync(url, content);
-            return response.IsSuccessStatusCode;
+            return await PostFunctionEndpointAsync(path, payload);
         }
 
         public static async Task<bool> SendCloudToDeviceMessage(string devEUI, LoRaCloudToDeviceMessage c2dMessage)
         {
-            var url = new Uri($"{baseUrl}cloudtodevicemessage/{devEUI}?code={authCode}");
+            var path = $"cloudtodevicemessage/{devEUI}";
             var json = JsonConvert.SerializeObject(c2dMessage);
-            using var content = PreparePostContent(json);
-            using var response = await httpClient.Value.PostAsync(url, content);
+            return await PostFunctionEndpointAsync(path, json);
+        }
+
+        private static async Task<bool> PostFunctionEndpointAsync(string path, string contentJson, CancellationToken cancellationToken = default)
+        {
+            var url = new Uri($"{baseUrl}" + path + $"?code={authCode}"); 
+            using var content = PreparePostContent(contentJson);
+            using var response = await httpClient.Value.PostAsync(url, content, cancellationToken);
             return response.IsSuccessStatusCode;
         }
 

--- a/Tests/Unit/LoRaTools/ApiVersionTest.cs
+++ b/Tests/Unit/LoRaTools/ApiVersionTest.cs
@@ -31,7 +31,8 @@ namespace LoRaWan.Tests.Unit.LoRaTools.CommonAPI
             {
                 (req) => new DeviceGetter(null, null).GetDevice(req, NullLogger.Instance),
                 (req) => Task.Run(() => new FCntCacheCheck(null).NextFCntDownInvoke(req, NullLogger.Instance)),
-                (req) => Task.Run(() => new FunctionBundlerFunction(Array.Empty<IFunctionBundlerExecutionItem>()).FunctionBundler(req, NullLogger.Instance, string.Empty))
+                (req) => Task.Run(() => new FunctionBundlerFunction(Array.Empty<IFunctionBundlerExecutionItem>()).FunctionBundler(req, NullLogger.Instance, string.Empty)),
+                (req) => new SendCloudToDeviceMessage(null, null, null, null).Run(req, string.Empty)
             };
 
             foreach (var apiCall in apiCalls)

--- a/Tests/Unit/LoraKeysManagerFacade/SendCloudToDeviceMessageTest.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/SendCloudToDeviceMessageTest.cs
@@ -4,12 +4,15 @@
 namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
 {
     using System;
+    using System.Collections.Generic;
+    using System.IO;
     using System.Net;
     using System.Text;
     using System.Threading.Tasks;
     using global::LoraKeysManagerFacade;
     using global::LoRaTools.CommonAPI;
     using LoRaWan.Tests.Common;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Client.Exceptions;
@@ -21,6 +24,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
 
     public class SendCloudToDeviceMessageTest
     {
+        private const string TestDevEUI = "B827EBFFFFF30000";
         private const FramePort TestPort = FramePorts.App1;
 
         private readonly LoRaInMemoryDeviceStore cacheStore;
@@ -41,9 +45,24 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
         [InlineData("")]
         public async Task When_DevEUI_Is_Missing_Should_Return_BadRequest(string devEUI)
         {
-            var actual = await this.sendCloudToDeviceMessage.SendCloudToDeviceMessageImplementationAsync(
-                devEUI,
-                new LoRaCloudToDeviceMessage());
+            var c2dMessage = new LoRaCloudToDeviceMessage()
+            {
+                DevEUI = devEUI,
+            };
+
+            var request = CreateC2DMessageRequest(devEUI, c2dMessage);
+
+            var result = await this.sendCloudToDeviceMessage.Run(request, devEUI);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            this.serviceClient.VerifyAll();
+            this.registryManager.VerifyAll();
+        }
+
+        [Fact]
+        public async Task When_Request_Is_Missing_Should_Return_BadRequest()
+        {
+            var actual = await this.sendCloudToDeviceMessage.Run(null, TestDevEUI);
 
             Assert.IsType<BadRequestObjectResult>(actual);
 
@@ -462,6 +481,18 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             this.serviceClient.VerifyAll();
             this.registryManager.VerifyAll();
             query.VerifyAll();
+        }
+
+        private static HttpRequest CreateC2DMessageRequest(string devEUI, LoRaCloudToDeviceMessage c2dMessage)
+        {
+            var request = new DefaultHttpContext().Request;
+            request.Query = new QueryCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+                    {
+                        { ApiVersion.QueryStringParamName, ApiVersion.LatestVersion.Name },
+                        { "DevEUI", devEUI }
+                    });
+            request.Body = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(c2dMessage)));
+            return request;
         }
     }
 }

--- a/Tests/Unit/LoraKeysManagerFacade/SendCloudToDeviceMessageTest.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/SendCloudToDeviceMessageTest.cs
@@ -388,13 +388,13 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
         [Fact]
         public async Task When_Querying_Devices_And_Finds_No_Gateway_For_Class_C_Should_Return_InternalServerError()
         {
-            const string devEUI = "0123456789";
-
+            var devEUI = new DevEui(0123456789);
+            var devAddr = new DevAddr(03010101);
             var deviceTwin = new Twin
             {
                 Properties = new TwinProperties()
                 {
-                    Desired = new TwinCollection($"{{\"DevAddr\": \"03010101\", \"ClassType\": \"C\"}}"),
+                    Desired = new TwinCollection($"{{\"DevAddr\": \"{devAddr}\", \"ClassType\": \"C\"}}"),
                     Reported = new TwinCollection(),
                 }
             };
@@ -414,12 +414,12 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             };
 
             var actual = await this.sendCloudToDeviceMessage.SendCloudToDeviceMessageImplementationAsync(
-                devEUI,
+                devEUI.ToString(),
                 actualMessage);
 
-            Assert.IsType<ObjectResult>(actual);
-            Assert.Equal(500, ((ObjectResult)actual).StatusCode);
-            Assert.Equal("Class C devices must sent at least one message upstream. None has been received", ((ObjectResult)actual).Value.ToString());
+            var result = Assert.IsType<ObjectResult>(actual);
+            Assert.Equal(500, result.StatusCode);
+            Assert.Equal("Class C devices must sent at least one message upstream. None has been received", result.Value.ToString());
 
             this.serviceClient.VerifyAll();
             this.registryManager.VerifyAll();


### PR DESCRIPTION
# PR for issue #1142 

## What is being addressed

Class C E2E test now calls the Facade endpoint `SendCloudToDeviceMessage` instead of calling direct method from the test code.

Successful E2E CI run for the ClassC E2E test: https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/1657729247

## How is this addressed

- Device 24 used in Class C E2E test no longer has gateway assigned at the provisioning time - it's now determined by the LNS.
- Functionality to call `SendCloudToDeviceMessage` endpoint has been added to `LoRaApiHelper` in the E2E test project.
- The ClassC E2E test calls the API endpoint `SendCloudToDeviceMessage` (using the `LoRaApiHelper`) instead of calling direct method from the test code.
- `InvokeModuleDirectMethodAsync` helper method in `IntegrationTestFixtureBase` is now unused and has been deleted.
- `SendCloudToDeviceMessage` has been improved by adding API version and DevEUI validation.
- `SendCloudToDeviceMessage` endpoint returns InternalServerError instead of BadRequest in case no gateway has been found for the device in either reported or desired twin properties.
- `SendCloudToDeviceMessage` unit tests have been expanded to cover API version validation, invalid/missing devEUI and unknown gateway ID for the device.
