### PR TITLE
Remove dynamic bindings

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/ConcentratorCredentialsFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ConcentratorCredentialsFunction.cs
@@ -11,6 +11,7 @@ namespace LoraKeysManagerFacade
     using Azure.Storage.Blobs;
     using Azure.Storage.Blobs.Models;
     using LoRaTools.CommonAPI;
+    using LoRaTools.Utils;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Azure.Devices;
@@ -29,17 +30,19 @@ namespace LoraKeysManagerFacade
         internal const string LnsCredentialsUrlPropertyName = "tcCredentialUrl";
         private readonly RegistryManager registryManager;
         private readonly IAzureClientFactory<BlobServiceClient> azureClientFactory;
+        private readonly ILogger<ConcentratorCredentialsFunction> logger;
 
         public ConcentratorCredentialsFunction(RegistryManager registryManager,
-                                               IAzureClientFactory<BlobServiceClient> azureClientFactory)
+                                               IAzureClientFactory<BlobServiceClient> azureClientFactory,
+                                               ILogger<ConcentratorCredentialsFunction> logger)
         {
             this.registryManager = registryManager;
             this.azureClientFactory = azureClientFactory;
+            this.logger = logger;
         }
 
         [FunctionName(nameof(FetchConcentratorCredentials))]
         public async Task<IActionResult> FetchConcentratorCredentials([HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequest req,
-                                                                      ILogger log,
                                                                       CancellationToken cancellationToken)
         {
             if (req is null) throw new ArgumentNullException(nameof(req));
@@ -50,57 +53,52 @@ namespace LoraKeysManagerFacade
             }
             catch (IncompatibleVersionException ex)
             {
-                log.LogError(ex, "Invalid version");
+                this.logger.LogError(ex, "Invalid version");
                 return new BadRequestObjectResult(ex.Message);
             }
 
-            return await RunFetchConcentratorCredentials(req, log, cancellationToken);
+            return await RunFetchConcentratorCredentials(req, cancellationToken);
         }
 
-        internal async Task<IActionResult> RunFetchConcentratorCredentials(HttpRequest req, ILogger log, CancellationToken cancellationToken)
+        internal async Task<IActionResult> RunFetchConcentratorCredentials(HttpRequest req, CancellationToken cancellationToken)
         {
             var stationEui = req.Query["StationEui"];
             if (StringValues.IsNullOrEmpty(stationEui))
             {
-                log.LogError("StationEui missing in request");
+                this.logger.LogError("StationEui missing in request");
                 return new BadRequestObjectResult("StationEui missing in request");
             }
 
             var credentialTypeQueryString = req.Query["CredentialType"];
             if (StringValues.IsNullOrEmpty(credentialTypeQueryString))
             {
-                log.LogError("CredentialType missing in request");
+                this.logger.LogError("CredentialType missing in request");
                 return new BadRequestObjectResult("CredentialType missing in request");
             }
             if (!Enum.TryParse<ConcentratorCredentialType>(credentialTypeQueryString.ToString(), out var credentialType))
             {
-                log.LogError("Could not parse '{QueryString}' to a ConcentratorCredentialType.", credentialTypeQueryString.ToString());
+                this.logger.LogError("Could not parse '{QueryString}' to a ConcentratorCredentialType.", credentialTypeQueryString.ToString());
                 return new BadRequestObjectResult($"Could not parse desired concentrator credential type '{credentialTypeQueryString}'.");
             }
 
             var twin = await this.registryManager.GetTwinAsync(stationEui, cancellationToken);
-            if (twin != null)
+            var twinReader = new TwinCollectionReader(twin.Properties.Desired, this.logger);
+            this.logger.LogInformation("Retrieving '{CredentialType}' for '{StationEui}'.", credentialType.ToString(), stationEui.ToString());
+            try
             {
-                log.LogInformation("Retrieving '{CredentialType}' for '{StationEui}'.", credentialType.ToString(), stationEui.ToString());
-                try
-                {
-                    var cupsProperty = (string)twin.Properties.Desired[CupsPropertyName].ToString();
-                    var parsedJson = JObject.Parse(cupsProperty);
-                    var url = credentialType is ConcentratorCredentialType.Lns ? parsedJson[LnsCredentialsUrlPropertyName].ToString()
-                                                                               : parsedJson[CupsCredentialsUrlPropertyName].ToString();
-                    var result = await GetBase64EncodedBlobAsync(url, cancellationToken);
-                    return new OkObjectResult(result);
-                }
-                catch (Exception ex) when (ex is ArgumentOutOfRangeException or JsonReaderException)
-                {
-                    log.LogError("'{PropertyName}' desired property was not found or misconfigured.", CupsPropertyName);
-                    return new UnprocessableEntityResult();
-                }
+                var cupsProperty = twinReader.ReadRequiredString(CupsPropertyName);
+                var parsedJson = JObject.Parse(cupsProperty);
+                var url = credentialType is ConcentratorCredentialType.Lns ? parsedJson[LnsCredentialsUrlPropertyName].ToString()
+                                                                            : parsedJson[CupsCredentialsUrlPropertyName].ToString();
+                var result = await GetBase64EncodedBlobAsync(url, cancellationToken);
+                return new OkObjectResult(result);
             }
-            else
+            catch (Exception ex) when (ex is ArgumentOutOfRangeException
+                                          or JsonReaderException
+                                          or InvalidOperationException)
             {
-                log.LogInformation($"Searching for {stationEui} returned 0 devices");
-                return new NotFoundResult();
+                this.logger.LogError(ex, "'{PropertyName}' desired property was not found or misconfigured.", CupsPropertyName);
+                return new UnprocessableEntityResult();
             }
         }
 

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDevAddrCache.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDevAddrCache.cs
@@ -8,6 +8,7 @@ namespace LoraKeysManagerFacade
     using System.Globalization;
     using System.Linq;
     using System.Threading.Tasks;
+    using LoRaTools.Utils;
     using LoRaWan;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Common.Exceptions;
@@ -230,15 +231,8 @@ namespace LoraKeysManagerFacade
                     if (twin.DeviceId != null)
                     {
                         var rawDevAddr = string.Empty;
-                        if (twin.Properties.Desired.Contains(LoraKeysManagerFacadeConstants.TwinProperty_DevAddr))
-                        {
-                            rawDevAddr = twin.Properties.Desired[LoraKeysManagerFacadeConstants.TwinProperty_DevAddr].Value as string;
-                        }
-                        else if (twin.Properties.Reported.Contains(LoraKeysManagerFacadeConstants.TwinProperty_DevAddr))
-                        {
-                            rawDevAddr = twin.Properties.Reported[LoraKeysManagerFacadeConstants.TwinProperty_DevAddr].Value as string;
-                        }
-                        else
+                        if (!twin.Properties.Desired.TryReadString(LoraKeysManagerFacadeConstants.TwinProperty_DevAddr, out rawDevAddr) &&
+                            !twin.Properties.Reported.TryReadString(LoraKeysManagerFacadeConstants.TwinProperty_DevAddr, out rawDevAddr))
                         {
                             continue;
                         }

--- a/LoRaEngine/LoraKeysManagerFacade/TwinExtensions.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/TwinExtensions.cs
@@ -25,7 +25,7 @@ namespace LoraKeysManagerFacade
         public static string GetTwinPropertyStringSafe(this TwinCollection twin, string propertyName)
             => TryReadString(twin, propertyName, out var someValue) ? someValue : string.Empty;
 
-        private static bool TryReadString(this TwinCollection twin, string propertyName, out string someValue)
+        public static bool TryReadString(this TwinCollection twin, string propertyName, out string someValue)
         {
             someValue = default;
 

--- a/LoRaEngine/LoraKeysManagerFacade/TwinExtensions.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/TwinExtensions.cs
@@ -3,7 +3,9 @@
 
 namespace LoraKeysManagerFacade
 {
+    using System.Globalization;
     using Microsoft.Azure.Devices.Shared;
+    using Newtonsoft.Json.Linq;
 
     internal static class TwinExtensions
     {
@@ -32,7 +34,7 @@ namespace LoraKeysManagerFacade
             if (twin == null || !twin.Contains(propertyName))
                 return false;
 
-            someValue = (string)(object)twin[propertyName];
+            someValue = ((object)twin[propertyName]).ToString();
             return true;
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
@@ -184,12 +184,11 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
                 if (Uri.TryCreate(faceServerUrl, UriKind.Absolute, out var url) && (url.Scheme == Uri.UriSchemeHttp || url.Scheme == Uri.UriSchemeHttps))
                 {
                     this.loRaDeviceAPIService.URL = url;
-                    if (desiredProperties.Contains(Constants.FacadeServerAuthCodeKey))
+                    if (reader.TryRead<string>(Constants.FacadeServerAuthCodeKey, out var authCode))
                     {
-                        this.loRaDeviceAPIService.SetAuthCode((string)desiredProperties[Constants.FacadeServerAuthCodeKey]);
+                        this.loRaDeviceAPIService.SetAuthCode(authCode);
                     }
 
-                    this.logger.LogDebug("Desired property changed");
                     return true;
                 }
                 else

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
@@ -3,6 +3,7 @@
 
 namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
 {
+    using LoRaTools.Utils;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Azure.Devices.Shared;
@@ -177,10 +178,10 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
                 return false;
             }
 
-            if (desiredProperties.Contains(Constants.FacadeServerUrlKey)
-                && (string)desiredProperties[Constants.FacadeServerUrlKey] is { Length: > 0 } urlString)
+            var reader = new TwinCollectionReader(desiredProperties, this.logger);
+            if (reader.TryRead<string>(Constants.FacadeServerUrlKey, out var faceServerUrl))
             {
-                if (Uri.TryCreate(urlString, UriKind.Absolute, out var url) && (url.Scheme == Uri.UriSchemeHttp || url.Scheme == Uri.UriSchemeHttps))
+                if (Uri.TryCreate(faceServerUrl, UriKind.Absolute, out var url) && (url.Scheme == Uri.UriSchemeHttp || url.Scheme == Uri.UriSchemeHttps))
                 {
                     this.loRaDeviceAPIService.URL = url;
                     if (desiredProperties.Contains(Constants.FacadeServerAuthCodeKey))

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -6,11 +6,11 @@ namespace LoRaWan.NetworkServer
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.Metrics;
-    using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
     using LoRaTools.LoRaMessage;
     using LoRaTools.Regions;
+    using LoRaTools.Utils;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Azure.Devices.Shared;
@@ -262,193 +262,84 @@ namespace LoRaWan.NetworkServer
                 throw new LoRaProcessingException("Failed to load twins due to timeout.", ex, LoRaProcessingErrorCode.DeviceInitializationFailed);
             }
 
+            var desiredTwin = new TwinCollectionReader(twin.Properties.Desired, this.logger);
+            var reportedTwin = new TwinCollectionReader(twin.Properties.Reported, this.logger);
+
             // ABP requires the property AppSKey, AppNwkSKey, DevAddr to be present
-            if (twin.Properties.Desired.Contains(TwinProperty.AppSKey))
+            if (desiredTwin.Contains(TwinProperty.AppSKey))
             {
                 // ABP Case
-                AppSKey = twin.Properties.Desired[TwinProperty.AppSKey].Value as string;
-
-                if (!twin.Properties.Desired.Contains(TwinProperty.NwkSKey))
-                    throw new InvalidLoRaDeviceException("Missing NwkSKey for ABP device");
-
-                if (!twin.Properties.Desired.Contains(TwinProperty.DevAddr))
-                    throw new InvalidLoRaDeviceException("Missing DevAddr for ABP device");
-
-                NwkSKey = twin.Properties.Desired[TwinProperty.NwkSKey].Value as string;
-                DevAddr = twin.Properties.Desired[TwinProperty.DevAddr].Value as string;
-
-                if (string.IsNullOrEmpty(NwkSKey))
-                    throw new InvalidLoRaDeviceException("NwkSKey is empty");
-
-                if (string.IsNullOrEmpty(AppSKey))
-                    throw new InvalidLoRaDeviceException("AppSKey is empty");
-
-                if (string.IsNullOrEmpty(DevAddr))
-                    throw new InvalidLoRaDeviceException("DevAddr is empty");
-
-                if (twin.Properties.Desired.Contains(TwinProperty.ABPRelaxMode))
+                try
                 {
-                    IsABPRelaxedFrameCounter = GetTwinPropertyBoolValue(twin.Properties.Desired[TwinProperty.ABPRelaxMode].Value);
+                    AppSKey = desiredTwin.ReadRequiredString(TwinProperty.AppSKey);
+                    NwkSKey = desiredTwin.ReadRequiredString(TwinProperty.NwkSKey);
+                    DevAddr = desiredTwin.ReadRequiredString(TwinProperty.DevAddr);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    throw new InvalidLoRaDeviceException("Failed to read required properties for ABP.", ex);
                 }
 
+                IsABPRelaxedFrameCounter = desiredTwin.SafeRead(TwinProperty.ABPRelaxMode, IsABPRelaxedFrameCounter);
             }
             else
             {
                 // OTAA
-                if (!twin.Properties.Desired.Contains(TwinProperty.AppKey))
+                try
                 {
-                    throw new InvalidLoRaDeviceException("Missing AppKey for OTAA device");
+                    AppKey = desiredTwin.ReadRequiredString(TwinProperty.AppKey);
+                    AppEUI = desiredTwin.ReadRequiredString(TwinProperty.AppEUI);
                 }
-
-                AppKey = twin.Properties.Desired[TwinProperty.AppKey].Value as string;
-
-                if (!twin.Properties.Desired.Contains(TwinProperty.AppEUI))
+                catch (InvalidOperationException ex)
                 {
-                    throw new InvalidLoRaDeviceException("Missing AppEUI for OTAA device");
+                    throw new InvalidLoRaDeviceException("Failed to read required properties for OTAA.", ex);
                 }
-
-                AppEUI = twin.Properties.Desired[TwinProperty.AppEUI].Value as string;
 
                 // Check for already joined OTAA device properties
-                if (twin.Properties.Reported.Contains(TwinProperty.DevAddr))
-                    DevAddr = twin.Properties.Reported[TwinProperty.DevAddr].Value as string;
+                DevAddr = reportedTwin.SafeRead(TwinProperty.DevAddr, DevAddr);
+                AppSKey = reportedTwin.SafeRead(TwinProperty.AppSKey, AppSKey);
+                NwkSKey = reportedTwin.SafeRead(TwinProperty.NwkSKey, NwkSKey);
+                NetID = reportedTwin.SafeRead(TwinProperty.NetID, NetID);
 
-                if (twin.Properties.Reported.Contains(TwinProperty.AppSKey))
-                    AppSKey = twin.Properties.Reported[TwinProperty.AppSKey].Value as string;
-
-                if (twin.Properties.Reported.Contains(TwinProperty.NwkSKey))
-                    NwkSKey = twin.Properties.Reported[TwinProperty.NwkSKey].Value as string;
-
-                if (twin.Properties.Reported.Contains(TwinProperty.NetID))
-                    NetID = twin.Properties.Reported[TwinProperty.NetID].Value as string;
-
-                if (twin.Properties.Reported.Contains(TwinProperty.DevNonce))
-                {
-                    var devNonceString = twin.Properties.Reported[TwinProperty.DevNonce].Value as string;
-                    DevNonce = ushort.TryParse(devNonceString, NumberStyles.None, CultureInfo.InvariantCulture, out var d) ? new DevNonce(d) : null;
-                }
+                DevNonce = reportedTwin.TryRead<ushort>(TwinProperty.DevNonce, out var someDevNonce) ? new DevNonce(someDevNonce) : null;
 
                 // Currently the RX2DR, RX1DROffset and RXDelay are only implemented as part of OTAA
-                if (twin.Properties.Desired.Contains(TwinProperty.RX2DataRate))
-                {
-                    DesiredRX2DataRate = (DataRateIndex?)GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.RX2DataRate].Value);
-                }
+                DesiredRX2DataRate = desiredTwin.SafeRead<DataRateIndex?>(TwinProperty.RX2DataRate);
+                DesiredRX1DROffset = desiredTwin.SafeRead<ushort>(TwinProperty.RX1DROffset);
+                DesiredRXDelay = desiredTwin.SafeRead<ushort>(TwinProperty.RXDelay);
 
-                if (twin.Properties.Desired.Contains(TwinProperty.RX1DROffset))
-                {
-                    DesiredRX1DROffset = (ushort)GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.RX1DROffset].Value);
-                }
-
-                if (twin.Properties.Desired.Contains(TwinProperty.RXDelay))
-                {
-                    DesiredRXDelay = (ushort)GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.RXDelay].Value);
-                }
-
-                if (twin.Properties.Reported.Contains(TwinProperty.RX2DataRate))
-                {
-                    ReportedRX2DataRate = (DataRateIndex?)GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.RX2DataRate].Value);
-                }
-
-                if (twin.Properties.Reported.Contains(TwinProperty.RX1DROffset))
-                {
-                    ReportedRX1DROffset = (ushort)GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.RX1DROffset].Value);
-                }
-
-                if (twin.Properties.Reported.Contains(TwinProperty.RXDelay))
-                {
-                    ReportedRXDelay = (ushort)GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.RXDelay].Value);
-                }
+                ReportedRX2DataRate = reportedTwin.SafeRead<DataRateIndex?>(TwinProperty.RX2DataRate);
+                ReportedRX1DROffset = reportedTwin.SafeRead<ushort>(TwinProperty.RX1DROffset);
+                ReportedRXDelay = reportedTwin.SafeRead<ushort>(TwinProperty.RXDelay);
             }
 
-            if (twin.Properties.Desired.Contains(TwinProperty.GatewayID))
-                GatewayID = twin.Properties.Desired[TwinProperty.GatewayID].Value as string;
+            GatewayID = desiredTwin.SafeRead<string>(TwinProperty.GatewayID);
 
             _ = UpdateIsOurDevice(configuration.GatewayID);
 
-            if (twin.Properties.Desired.Contains(TwinProperty.SensorDecoder))
-                SensorDecoder = twin.Properties.Desired[TwinProperty.SensorDecoder].Value as string;
+            SensorDecoder = desiredTwin.SafeRead(TwinProperty.SensorDecoder, SensorDecoder);
 
-            InitializeFrameCounters(twin);
+            DownlinkEnabled = desiredTwin.SafeRead(TwinProperty.DownlinkEnabled, DownlinkEnabled);
+            PreferredWindow = Math.Max(desiredTwin.SafeRead(TwinProperty.PreferredWindow, Constants.ReceiveWindow1), Constants.ReceiveWindow1);
+            Deduplication = desiredTwin.SafeRead(TwinProperty.Deduplication, DeduplicationMode.None);
+            ClassType = desiredTwin.SafeRead(TwinProperty.ClassType, LoRaDeviceClassType.A);
 
-            if (twin.Properties.Desired.Contains(TwinProperty.DownlinkEnabled))
-            {
-                DownlinkEnabled = GetTwinPropertyBoolValue(twin.Properties.Desired[TwinProperty.DownlinkEnabled].Value);
-            }
+            this.preferredGatewayID = reportedTwin.ReadChangeTrackingProperty(TwinProperty.PreferredGatewayID, this.preferredGatewayID);
+            this.region = reportedTwin.ReadChangeTrackingProperty(TwinProperty.Region, this.region);
 
-            if (twin.Properties.Desired.Contains(TwinProperty.PreferredWindow))
-            {
-                var preferredWindowTwinValue = GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.PreferredWindow].Value);
-                if (preferredWindowTwinValue == Constants.ReceiveWindow2)
-                    PreferredWindow = preferredWindowTwinValue;
-            }
+            ReportedCN470JoinChannel = reportedTwin.SafeRead<int?>(TwinProperty.CN470JoinChannel);
+            DesiredCN470JoinChannel = desiredTwin.SafeRead<int?>(TwinProperty.CN470JoinChannel);
+            Supports32BitFCnt = desiredTwin.SafeRead(TwinProperty.Supports32BitFCnt, Supports32BitFCnt);
+            KeepAliveTimeout = desiredTwin.SafeRead<int>(TwinProperty.KeepAliveTimeout);
 
-            if (twin.Properties.Desired.Contains(TwinProperty.Deduplication))
-            {
-                var val = twin.Properties.Desired[TwinProperty.Deduplication].Value as string;
-                _ = Enum.TryParse<DeduplicationMode>(val, true, out var mode);
-                Deduplication = mode;
-            }
+            if (KeepAliveTimeout != 0)
+                KeepAliveTimeout = Math.Max(KeepAliveTimeout, Constants.MinKeepAliveTimeout);
 
-            if (twin.Properties.Desired.Contains(TwinProperty.ClassType) && string.Equals("c", (string)twin.Properties.Desired[TwinProperty.ClassType], StringComparison.OrdinalIgnoreCase))
-            {
-                ClassType = LoRaDeviceClassType.C;
-            }
+            this.lastProcessingStationEui = reportedTwin.ReadChangeTrackingProperty(TwinProperty.LastProcessingStationEui, this.lastProcessingStationEui);
 
-            if (twin.Properties.Reported.Contains(TwinProperty.PreferredGatewayID))
-            {
-                this.preferredGatewayID = new ChangeTrackingProperty<string>(TwinProperty.PreferredGatewayID, twin.Properties.Reported[TwinProperty.PreferredGatewayID].Value as string);
-            }
-
-            if (twin.Properties.Reported.Contains(TwinProperty.Region))
-            {
-                var regionValue = twin.Properties.Reported[TwinProperty.Region].Value as string;
-                if (Enum.TryParse<LoRaRegionType>(regionValue, true, out var loRaRegion))
-                {
-                    if (Enum.IsDefined(typeof(LoRaRegionType), loRaRegion))
-                    {
-                        this.region = new ChangeTrackingProperty<LoRaRegionType>(TwinProperty.Region, loRaRegion);
-                    }
-                }
-
-                if (LoRaRegion == LoRaRegionType.NotSet)
-                {
-                    this.logger.LogError($"invalid region value: {regionValue}");
-                }
-            }
-
-            //  We are prioritizing the choice of the join channel from reported properties (set for OTAA devices)
-            //  over the manually provisioned channel (set in desired properties for ABP devices).
-            if (twin.Properties.Reported.Contains(TwinProperty.CN470JoinChannel))
-            {
-                ReportedCN470JoinChannel = GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.CN470JoinChannel].Value);
-            }
-            else if (twin.Properties.Desired.Contains(TwinProperty.CN470JoinChannel))
-            {
-                DesiredCN470JoinChannel = GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.CN470JoinChannel].Value);
-            }
-
-            if (twin.Properties.Desired.Contains(TwinProperty.Supports32BitFCnt))
-            {
-                Supports32BitFCnt = GetTwinPropertyBoolValue(twin.Properties.Desired[TwinProperty.Supports32BitFCnt].Value);
-            }
-
-            if (twin.Properties.Desired.Contains(TwinProperty.KeepAliveTimeout))
-            {
-                var value = GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.KeepAliveTimeout].Value);
-                if (value > 0)
-                {
-                    KeepAliveTimeout = Math.Max(value, Constants.MinKeepAliveTimeout);
-                }
-            }
-
-            if (twin.Properties.Reported.Contains(TwinProperty.LastProcessingStationEui))
-            {
-                var stationEui = StationEui.Parse(twin.Properties.Reported[TwinProperty.LastProcessingStationEui].Value as string);
-                lastProcessingStationEui = new ChangeTrackingProperty<StationEui>(TwinProperty.LastProcessingStationEui, stationEui);
-            }
+            InitializeFrameCounters(desiredTwin, reportedTwin);
 
             LastUpdate = DateTimeOffset.UtcNow;
-
             return true;
         }
 
@@ -460,30 +351,24 @@ namespace LoRaWan.NetworkServer
 
         public void SetLastProcessingStationEui(StationEui s) => this.lastProcessingStationEui.Set(s);
 
-        private void InitializeFrameCounters(Twin twin)
+        protected void InitializeFrameCounters(TwinCollectionReader desiredTwin, TwinCollectionReader reportedTwin)
         {
+            _ = desiredTwin ?? throw new ArgumentNullException(nameof(desiredTwin));
+            _ = reportedTwin ?? throw new ArgumentNullException(nameof(reportedTwin));
+
             var toReport = new TwinCollection();
 
             var reset = false;
             // check if there is a reset we need to process
-            if (twin.Properties.Desired.Contains(TwinProperty.FCntResetCounter))
+            if (desiredTwin.TryRead<int>(TwinProperty.FCntResetCounter, out var resetDesired) &&
+               (!reportedTwin.TryRead<int>(TwinProperty.FCntResetCounter, out var resetReported) || resetReported < resetDesired))
             {
-                var resetDesired = GetTwinPropertyIntValue(twin.Properties.Desired[TwinProperty.FCntResetCounter].Value);
-                int? resetReported = null;
-                if (twin.Properties.Reported.Contains(TwinProperty.FCntResetCounter))
-                {
-                    resetReported = GetTwinPropertyIntValue(twin.Properties.Reported[TwinProperty.FCntResetCounter].Value);
-                }
-
-                reset = !resetReported.HasValue || resetReported.Value < resetDesired;
-                if (reset)
-                {
-                    toReport[TwinProperty.FCntResetCounter] = resetDesired;
-                }
+                toReport[TwinProperty.FCntResetCounter] = resetDesired;
+                reset = true;
             }
 
             // up
-            var fcnt = InitializeFcnt(twin, reset, TwinProperty.FCntUpStart, TwinProperty.FCntUp, toReport);
+            var fcnt = InitializeFcnt(reportedTwin, desiredTwin, reset, TwinProperty.FCntUpStart, TwinProperty.FCntUp, toReport);
             if (fcnt.HasValue)
             {
                 this.fcntUp = fcnt.Value;
@@ -491,7 +376,7 @@ namespace LoRaWan.NetworkServer
             }
 
             // down
-            fcnt = InitializeFcnt(twin, reset, TwinProperty.FCntDownStart, TwinProperty.FCntDown, toReport);
+            fcnt = InitializeFcnt(reportedTwin, desiredTwin, reset, TwinProperty.FCntDownStart, TwinProperty.FCntDown, toReport);
             if (fcnt.HasValue)
             {
                 this.fcntDown = fcnt.Value;
@@ -504,124 +389,32 @@ namespace LoRaWan.NetworkServer
             }
         }
 
-        private uint? InitializeFcnt(Twin twin, bool reset, string propertyNameStart, string fcntPropertyName, TwinCollection toReport)
+        private uint? InitializeFcnt(TwinCollectionReader reported, TwinCollectionReader desired, bool reset, string propertyNameStart, string fcntPropertyName, TwinCollection toReport)
         {
-            var desired = twin.Properties.Desired;
-            var reported = twin.Properties.Reported;
-            uint? newfCnt;
+            uint? newfCnt = null;
 
-            var frameCounterStartDesired = GetUintFromTwin(desired, propertyNameStart);
-            var frameCounterStartReported = GetUintFromTwin(reported, propertyNameStart);
-            if (frameCounterStartDesired.HasValue && (reset || frameCounterStartReported != frameCounterStartDesired))
+            if (desired.TryRead<uint>(propertyNameStart, out var frameCounterStartDesired) &&
+               (reset
+               || !reported.TryRead<uint>(propertyNameStart, out var frameCounterStartReported)
+               || frameCounterStartReported != frameCounterStartDesired))
             {
                 // force this counter in the start desired
                 newfCnt = frameCounterStartDesired;
                 toReport ??= new TwinCollection();
                 toReport[propertyNameStart] = newfCnt.Value;
                 this.hasFrameCountChanges = true;
-                this.logger.LogDebug($"set {fcntPropertyName} from {propertyNameStart} with {newfCnt.Value}, reset: {reset}");
+                this.logger.LogDebug("set {FcntPropertyName} from {PropertyNameStart} with {NewfCnt}, reset: {Reset}", fcntPropertyName, propertyNameStart, newfCnt, reset);
             }
             else
             {
-                newfCnt = GetUintFromTwin(reported, fcntPropertyName);
+                if (reported.TryRead<uint>(fcntPropertyName, out var someFcnt))
+                {
+                    newfCnt = someFcnt;
+                }
             }
 
             return newfCnt;
-        }
-
-        private uint? GetUintFromTwin(TwinCollection collection, string propertyName)
-        {
-            if (!collection.Contains(propertyName))
-            {
-                return null;
-            }
-
-            return GetTwinPropertyUIntValue(collection[propertyName].Value);
-        }
-
-        private static int GetTwinPropertyIntValue(dynamic value)
-        {
-            if (value is string valueString)
-            {
-                if (int.TryParse(valueString, out var fromString))
-                    return fromString;
-
-                return 0;
-            }
-
-            if (value is int valueInt)
-            {
-                return valueInt;
-            }
-
-            try
-            {
-                return Convert.ToInt32(value);
-            }
-            catch (FormatException)
-            {
-            }
-            catch (OverflowException)
-            {
-            }
-
-            return 0;
-        }
-
-        private uint GetTwinPropertyUIntValue(dynamic value)
-        {
-            if (value is string valueString)
-            {
-                if (uint.TryParse(valueString, out var fromString))
-                    return fromString;
-
-                return 0;
-            }
-
-            if (value is uint)
-            {
-                return value;
-            }
-
-            try
-            {
-                return Convert.ToUInt32(value);
-            }
-            catch (OverflowException) when (ExceptionFilterUtility.True(() => this.logger.LogError("value represents a number that is less than MinValue or greater than MaxValue.")))
-            {
-                // continue
-            }
-            catch (FormatException) when (ExceptionFilterUtility.True(() => this.logger.LogError("value does not consist of an optional sign followed by a sequence of digits (0 through 9).")))
-            {
-                // continue
-            }
-
-            return 0;
-        }
-
-        private static bool GetTwinPropertyBoolValue(dynamic value)
-        {
-            if (value is string valueString)
-            {
-                valueString = valueString.Trim();
-
-                return
-                    string.Equals("true", valueString, StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals("1", valueString, StringComparison.OrdinalIgnoreCase);
-            }
-
-            if (value is bool valueBool)
-            {
-                return valueBool;
-            }
-
-            if (value is int)
-            {
-                return value == 1;
-            }
-
-            return true;
-        }
+        }//*/
 
         /// <summary>
         /// Saves device changes in reported twin properties
@@ -900,7 +693,7 @@ namespace LoRaWan.NetworkServer
             reportedProperties[TwinProperty.FCntUp] = 0;
             reportedProperties[TwinProperty.DevEUI] = DevEUI;
             reportedProperties[TwinProperty.NetID] = updateProperties.NetID;
-            reportedProperties[TwinProperty.DevNonce] = updateProperties.DevNonce;
+            reportedProperties[TwinProperty.DevNonce] = updateProperties.DevNonce.AsUInt16;
 
             if (updateProperties.SaveRegion)
             {
@@ -1289,6 +1082,19 @@ namespace LoRaWan.NetworkServer
             {
                 this.loRaDevice.EndDeviceClientConnectionActivity();
             }
+        }
+    }
+
+    internal static class TwinReaderExtensions
+    {
+        internal static ChangeTrackingProperty<T> ReadChangeTrackingProperty<T>(this TwinCollectionReader reader, string property, ChangeTrackingProperty<T> defaultValue = default)
+        {
+            if (!reader.TryRead<T>(property, out var someValue))
+            {
+                return defaultValue;
+            }
+
+            return new ChangeTrackingProperty<T>(property, someValue);
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinCollectionReader.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinCollectionReader.cs
@@ -61,6 +61,7 @@ namespace LoRaTools.Utils
                 var someConvertedValue = (T)Convert.ChangeType(some, t, CultureInfo.InvariantCulture);
                 if (t.IsEnum && !t.IsEnumDefined(someConvertedValue))
                 {
+                    LogParsingError(property, some);
                     return false;
                 }
                 value = someConvertedValue;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinCollectionReader.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinCollectionReader.cs
@@ -57,7 +57,13 @@ namespace LoRaTools.Utils
 
             try
             {
-                value = (T)Convert.ChangeType(some, typeof(T), CultureInfo.InvariantCulture);
+                var t = typeof(T);
+                var someConvertedValue = (T)Convert.ChangeType(some, t, CultureInfo.InvariantCulture);
+                if (t.IsEnum && !t.IsEnumDefined(someConvertedValue))
+                {
+                    return false;
+                }
+                value = someConvertedValue;
             }
             catch (Exception ex) when (ex is ArgumentException
                                           or InvalidCastException

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinCollectionReader.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinCollectionReader.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaTools.Utils
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
+    using LoRaWan;
+    using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    public sealed class TwinCollectionReader
+    {
+        private readonly TwinCollection twinCollection;
+        private readonly ILogger logger;
+
+        public TwinCollectionReader(TwinCollection twinCollection, ILogger logger)
+        {
+            this.twinCollection = twinCollection;
+            this.logger = logger;
+        }
+        public T? SafeRead<T>(string property, T? defaultValue = default)
+        {
+            return TryRead<T>(property, out var someT) ? someT : defaultValue;
+        }
+
+        public string ReadRequiredString(string property) =>
+                TryRead<string>(property, out var someString) && !string.IsNullOrEmpty(someString)
+                    ? someString
+                    : throw new InvalidOperationException($"Property '{property}' does not exist or is empty.");
+
+        public bool Contains(string propertyName) =>
+            this.twinCollection.Contains(propertyName);
+
+        public bool TryRead<T>(string property, [NotNullWhen(true)] out T? value)
+        {
+            value = default;
+
+            if (!twinCollection.Contains(property))
+                return false;
+
+            // cast to object to avoid dynamic code to be generated
+            var some = (object)twinCollection[property];
+
+            // quick path for values that can be directly converted
+            if (some is JValue someJValue && someJValue.Value is T someT)
+            {
+                value = someT;
+                return true;
+            }
+
+            try
+            {
+                value = (T)Convert.ChangeType(some, typeof(T), CultureInfo.InvariantCulture);
+            }
+            catch (Exception ex) when (ex is ArgumentException
+                                          or InvalidCastException
+                                          or FormatException
+                                          or OverflowException
+                                          or JsonSerializationException)
+            {
+                LogParsingError(property, some, ex);
+                return false;
+            }
+            return true;
+        }
+
+        public bool TryReadDevNonce(string property, [NotNullWhen(true)] out DevNonce? result)
+        {
+            result = default;
+            if (!TryRead<ushort>(property, out var someDevNonce))
+                return false;
+
+            result = new DevNonce(someDevNonce);
+            return true;
+        }
+
+        public bool TryReadStationEui(string property, out StationEui result)
+        {
+            result = default;
+
+            if (TryRead<string>(property, out var someStationEui))
+            {
+                if (StationEui.TryParse(someStationEui, out var stationEui))
+                {
+                    result = stationEui;
+                    return true;
+                }
+                LogParsingError(property, someStationEui);
+            }
+            return false;
+        }
+
+        private void LogParsingError(string property, object value, Exception? ex = default)
+        {
+            this.logger.LogError(ex, "Failed to parse twin '{TwinProperty}'. The value stored is '{TwinValue}'", property, value);
+        }
+    }
+}

--- a/Tests/Unit/LoRaTools/TwinCollectionReaderTests.cs
+++ b/Tests/Unit/LoRaTools/TwinCollectionReaderTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.LoRaTools.Regions
+{
+    using Microsoft.Azure.Devices.Shared;
+    using Xunit;
+    using System;
+    using System.Globalization;
+    using global::LoRaTools.Utils;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Microsoft.Extensions.Logging;
+
+    public class TwinCollectionReaderTests
+    {
+        private readonly ILogger<TwinCollectionReader> logger;
+
+        public TwinCollectionReaderTests()
+        {
+            this.logger = NullLogger<TwinCollectionReader>.Instance;
+        }
+
+        [Fact]
+        public void SafeRead_Returns_Default_If_Value_Does_Not_Exist()
+        {
+            var tc = new TwinCollection();
+            var reader = new TwinCollectionReader(tc, this.logger);
+
+            Assert.False(reader.TryRead<string>("test", out var someString));
+            Assert.Null(someString);
+
+            Assert.False(reader.TryRead<ushort>("test", out var someUShort));
+            Assert.Equal(0, someUShort);
+
+            Assert.False(reader.TryRead<ushort?>("test", out var someUShortNullable));
+            Assert.Null(someUShortNullable);
+        }
+
+        [Theory]
+        [InlineData(true, null)]
+        [InlineData(false, null)]
+        [InlineData(true, "")]
+        public void ReadRequiredString_Throws_If_String_Is_Not_Configured(bool add, string val)
+        {
+            const string key = "test";
+            var tc = new TwinCollection();
+            var reader = new TwinCollectionReader(tc, this.logger);
+            if (add)
+                tc[key] = val;
+
+            Assert.Throws<InvalidOperationException>(() => reader.ReadRequiredString(key));
+        }
+
+        [Fact]
+        public void ReadRequiredString_Reads_Valid_String()
+        {
+            const string key = "test";
+            const string expectedValue = "expected";
+
+            var tc = CreateTwinCollectionReader(key, QuoteJsonString(expectedValue));
+            Assert.Equal(expectedValue, tc.ReadRequiredString(key));
+        }
+
+        [Fact]
+        public void TryRead_Returns_False_When_Key_Does_Not_Exist()
+        {
+            var tc = new TwinCollectionReader(new TwinCollection(), this.logger);
+            Assert.False(tc.TryRead<string>("invalid", out _));
+        }
+
+        [Theory]
+        [InlineData(typeof(string), "test", "'test'")]
+        [InlineData(typeof(int),   int.MinValue)]
+        [InlineData(typeof(int),   int.MaxValue)]
+        [InlineData(typeof(bool),  true, "true")]
+        [InlineData(typeof(ulong), ulong.MaxValue)]
+        [InlineData(typeof(ushort),ushort.MaxValue)]
+        public void TryRead_Returns_True_When_Key_Exists_And_Correct_Value_Is_Returned(Type targetType, object someValue, string jsonValue = null)
+        {
+            const string key = "test";
+
+            var tr = CreateTwinCollectionReader(key, jsonValue ?? someValue);
+            var openMethod = typeof(TwinCollectionReader).GetMethod("TryRead");
+            var typedMethod = openMethod.MakeGenericMethod(targetType);
+            var parameters = new object[] { key, null };
+            Assert.True((bool)typedMethod.Invoke(tr, parameters));
+            Assert.Equal(someValue, parameters[^1]);
+        }
+
+        [Fact]
+        public void TryRead_Overflows_Are_Handled()
+        {
+            const string key = "test";
+            var tc = CreateTwinCollectionReader(key, ulong.MaxValue);
+            Assert.False(tc.TryRead<int>(key, out _));
+        }
+
+        [Fact]
+        public void TryRead_InvalidTypeConversions_Are_Handled()
+        {
+            const string key = "test";
+            var tc = CreateTwinCollectionReader(key, "true");
+            Assert.False(tc.TryRead<DateTime>(key, out _));
+        }
+
+        [Fact]
+        public void TryRead_String_As_Numeric_Should_Succeed()
+        {
+            const string key = "test";
+            const int val = 10;
+            var tc = CreateTwinCollectionReader(key, val.ToString(CultureInfo.InvariantCulture));
+            Assert.True(tc.TryRead<int>(key, out var n));
+            Assert.Equal(val, n);
+        }
+
+        [Fact]
+        public void TryRead_Can_Convert_Numbers_To_Enum()
+        {
+            const string key = "test";
+            var tc = CreateTwinCollectionReader(key, (int)DataRateIndex.DR8);
+            Assert.True(tc.TryRead<DataRateIndex>(key, out var dr));
+            Assert.Equal(DataRateIndex.DR8, dr);
+        }
+
+        [Theory]
+        [InlineData(nameof(DataRateIndex.DR8), DataRateIndex.DR8)]
+        [InlineData("dr8", DataRateIndex.DR8)]
+        public void TryRead_Can_Convert_Strings_To_Enum(string jsonValue, DataRateIndex expectedValue)
+        {
+            const string key = "test";
+            var tc = CreateTwinCollectionReader(key, QuoteJsonString(jsonValue));
+            Assert.True(tc.TryRead<DataRateIndex>(key, out var dr));
+            Assert.Equal(expectedValue, dr);
+        }
+
+        private static string QuoteJsonString(string someString)
+            => someString != null ? $"'{someString}'" : null;
+
+        private TwinCollectionReader CreateTwinCollectionReader<T>(string key, T jsonValue)
+            => new TwinCollectionReader(new TwinCollection($"{{'{key}':{jsonValue}}}"), this.logger);
+    }
+}

--- a/Tests/Unit/LoRaTools/TwinCollectionReaderTests.cs
+++ b/Tests/Unit/LoRaTools/TwinCollectionReaderTests.cs
@@ -122,6 +122,14 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
             Assert.Equal(DataRateIndex.DR8, dr);
         }
 
+        [Fact]
+        public void Undefined_Enum_Values_Are_Not_Parsed()
+        {
+            const string key = "test";
+            var tc = CreateTwinCollectionReader(key, 100);
+            Assert.False(tc.TryRead<DataRateIndex>(key, out _));
+        }
+
         [Theory]
         [InlineData(nameof(DataRateIndex.DR8), DataRateIndex.DR8)]
         [InlineData("dr8", DataRateIndex.DR8)]

--- a/Tests/Unit/LoRaTools/TwinCollectionReaderTests.cs
+++ b/Tests/Unit/LoRaTools/TwinCollectionReaderTests.cs
@@ -68,6 +68,17 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
             Assert.False(tc.TryRead<string>("invalid", out _));
         }
 
+        [Fact]
+        public void Null_Values_Are_Returned_As_Null()
+        {
+            var tc = new TwinCollection();
+            const string key = "test";
+            tc[key] = null;
+            var reader = new TwinCollectionReader(tc, this.logger);
+            Assert.Null(reader.SafeRead<string>(key));
+            Assert.False(reader.TryRead<string>(key, out _));
+        }
+
         [Theory]
         [InlineData(typeof(string), "test", "'test'")]
         [InlineData(typeof(int),   int.MinValue)]

--- a/Tests/Unit/LoraKeysManagerFacade/ConcentratorCredentialTests.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/ConcentratorCredentialTests.cs
@@ -19,7 +19,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Azure;
-    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
     using Microsoft.Extensions.Primitives;
     using Moq;
     using Xunit;
@@ -29,7 +29,6 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
         private readonly Mock<RegistryManager> registryManager;
         private readonly Mock<IAzureClientFactory<BlobServiceClient>> azureClientFactory;
         private readonly ConcentratorCredentialsFunction concentratorCredential;
-        private readonly Mock<ILogger> loggerMock;
         private const string RawStringContent = "hello";
         private const string Base64EncodedString = "aGVsbG8=";
 
@@ -37,8 +36,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
         {
             this.registryManager = new Mock<RegistryManager>();
             this.azureClientFactory = new Mock<IAzureClientFactory<BlobServiceClient>>();
-            this.concentratorCredential = new ConcentratorCredentialsFunction(registryManager.Object, azureClientFactory.Object);
-            this.loggerMock = new Mock<ILogger>();
+            this.concentratorCredential = new ConcentratorCredentialsFunction(registryManager.Object, azureClientFactory.Object, NullLogger<ConcentratorCredentialsFunction>.Instance);
         }
 
         [Fact]
@@ -85,7 +83,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             this.registryManager.Setup(m => m.GetTwinAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                                 .Returns(Task.FromResult(twin));
 
-            var result = await this.concentratorCredential.RunFetchConcentratorCredentials(httpRequest.Object, this.loggerMock.Object, CancellationToken.None);
+            var result = await this.concentratorCredential.RunFetchConcentratorCredentials(httpRequest.Object, CancellationToken.None);
 
             Assert.NotNull(result);
             Assert.IsType<OkObjectResult>(result);
@@ -116,7 +114,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             this.registryManager.Setup(m => m.GetTwinAsync("AnotherTwin", It.IsAny<CancellationToken>()))
                                 .Returns(Task.FromResult(twin));
 
-            var result = await this.concentratorCredential.RunFetchConcentratorCredentials(httpRequest.Object, this.loggerMock.Object, CancellationToken.None);
+            var result = await this.concentratorCredential.RunFetchConcentratorCredentials(httpRequest.Object, CancellationToken.None);
 
             Assert.NotNull(result);
             Assert.IsType<NotFoundResult>(result);
@@ -142,7 +140,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var queryCollection = new QueryCollection(queryDictionary);
             httpRequest.SetupGet(x => x.Query).Returns(queryCollection);
 
-            var result = await this.concentratorCredential.RunFetchConcentratorCredentials(httpRequest.Object, this.loggerMock.Object, CancellationToken.None);
+            var result = await this.concentratorCredential.RunFetchConcentratorCredentials(httpRequest.Object, CancellationToken.None);
 
             Assert.NotNull(result);
             Assert.IsType<BadRequestObjectResult>(result);

--- a/Tests/Unit/NetworkServer/BasicsStation/BasicsStationConfigurationServiceTests.cs
+++ b/Tests/Unit/NetworkServer/BasicsStation/BasicsStationConfigurationServiceTests.cs
@@ -3,6 +3,7 @@
 
 namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
 {
+    using Castle.Core.Logging;
     using global::LoRaTools.Regions;
     using LoRaWan.NetworkServer;
     using LoRaWan.NetworkServer.BasicsStation;
@@ -10,6 +11,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
     using LoRaWan.Tests.Unit.NetworkServer.BasicsStation.JsonHandlers;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Caching.Memory;
+    using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
     using System;
     using System.Linq;
@@ -34,7 +36,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
             this.memoryCache = new MemoryCache(new MemoryCacheOptions());
             this.sut = new BasicsStationConfigurationService(this.loRaDeviceApiServiceMock.Object,
                                                              this.loRaDeviceFactoryMock.Object,
-                                                             this.memoryCache);
+                                                             this.memoryCache,
+                                                             NullLogger<BasicsStationConfigurationService>.Instance);
         }
 
 

--- a/Tests/Unit/NetworkServer/LoRaDeviceTest.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceTest.cs
@@ -229,7 +229,6 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [Theory]
         [InlineData("false")]
         [InlineData("FALSE")]
-        [InlineData("0")]
         [InlineData(0)]
         [InlineData(false)]
         public async Task When_Downlink_Is_Disabled_In_Twin_Should_Have_DownlinkEnabled_Equals_False(object downlinkEnabledTwinValue)


### PR DESCRIPTION
# PR for issue #774 

## What is being addressed

The use of dynamics has a negative performance impact when working with dynamics. There are a lot of places, where this was not necessary and the runtime evaluations could be removed from the IL. 

## How is this addressed
All dynamic use is removed except for the use in `CreateEdgeDevice` (which is used to setup edge devices from the starter kit template and is not perf critical). 

The wrapping in a reader was done to have easy access to a logger. This way we can now log all parsing failures in a single place.