### PR TITLE
Refresh devices in cache when loading

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
@@ -5,6 +5,7 @@ namespace LoRaWan.NetworkServer
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using LoRaTools.Utils;
@@ -127,7 +128,7 @@ namespace LoRaWan.NetworkServer
             {
                 initTasks = new List<Task<LoRaDevice>>(devices.Count);
 
-                foreach (var foundDevice in devices)
+                foreach (var foundDevice in devices.DistinctBy(x => x.DevEUI))
                 {
                     using var scope = this.logger.BeginDeviceScope(foundDevice.DevEUI);
                     // Only create devices that does not exist in the cache

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
@@ -137,15 +137,11 @@ namespace LoRaWan.NetworkServer
                     }
                     else
                     {
-                        if (string.IsNullOrEmpty(cachedDevice.DevAddr))
-                        {
-                            // device in cache from a previous join that we didn't complete
-                            // (lost race with another gw) - refresh the twins now and keep it
-                            // in the cache
-                            refreshTasks ??= new List<Task<bool>>();
-                            refreshTasks.Add(cachedDevice.InitializeAsync(this.configuration, CancellationToken.None));
-                            this.logger.LogDebug("refreshing device to fetch DevAddr");
-                        }
+                        // device in cache from a previous join that we didn't complete (lost race with another gw)
+                        // or it re-joined and has a new key - refresh the twins now and keep it in the cache
+                        refreshTasks ??= new List<Task<bool>>();
+                        refreshTasks.Add(cachedDevice.InitializeAsync(this.configuration, CancellationToken.None));
+                        this.logger.LogDebug("refreshing device");
                     }
                 }
 

--- a/Tests/Unit/NetworkServer/DeviceLoaderSynchronizerTest.cs
+++ b/Tests/Unit/NetworkServer/DeviceLoaderSynchronizerTest.cs
@@ -371,14 +371,15 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             using var deviceCache = LoRaDeviceCacheDefault.CreateDefault();
 
             const string devEUI = "123";
-            var loRaDevice = new Mock<LoRaDevice>(null, devEUI, null);
+            var devAddr = new DevAddr(100);
+            var loRaDevice = new Mock<LoRaDevice>(devAddr.ToString(), devEUI, null);
             loRaDevice.Setup(x => x.InitializeAsync(It.IsAny<NetworkServerConfiguration>(), CancellationToken.None))
                 .ReturnsAsync(true);
             deviceCache.Register(loRaDevice.Object);
 
             var deviceLoader = new TestDeviceLoaderSynchronizer(null, null, null, deviceCache);
 
-            await deviceLoader.ExecuteCreateDevicesAsync(new List<IoTHubDeviceInfo> { new IoTHubDeviceInfo { DevAddr = "456",  DevEUI = devEUI} });
+            await deviceLoader.ExecuteCreateDevicesAsync(new List<IoTHubDeviceInfo> { new IoTHubDeviceInfo { DevAddr = devAddr.ToString(),  DevEUI = devEUI} });
 
             loRaDevice.Verify(x => x.InitializeAsync(It.IsAny<NetworkServerConfiguration>(), CancellationToken.None), Times.Once);
         }


### PR DESCRIPTION
This ensures that we refresh session keys when a re-join happens

# PR for issue #1185

## What is being addressed

We did not refresh the cache on re-joins on GW that lost the race (did not process the join). Hence those session keys got outdated.

## How is this addressed
We always refresh the twins for existing cached items.