### PR TITLE
[docs] fix broken links

### DIFF
--- a/docs/user-guide/testing/e2e_tests.md
+++ b/docs/user-guide/testing/e2e_tests.md
@@ -66,7 +66,7 @@ Configure LoRa Basics Station and Network Server to run on your concentrator:
     select Create Deployment for Single Device.
 
 4. Provision a device in your IoT Hub by following the [Basics Station
-   configuration](../user-guide/station-device-provisioning.md)
+   configuration](../station-device-provisioning.md)
    docs.
 
 ### End device setup


### PR DESCRIPTION
One of the previous PRs moved some files, and therefore broke the link check.
This PR fixes that

I also fixed the branch policy that was misconfigured: It was not requiring the Actions to complete successfully. From now on, both the linting and link-check need to pass.