### PR TITLE
Simplify the deduplication cache key by using the unique DevEui

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ConcentratorDeduplication.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ConcentratorDeduplication.cs
@@ -113,9 +113,11 @@ namespace LoRaWan.NetworkServer
 
         private static string CreateCacheKeyCore(string prefix, ReadOnlySpan<byte> buffer)
         {
-            Span<char> key = stackalloc char[(buffer.Length * 3) - 1];
-            Hexadecimal.Write(buffer, key, separator: '-');
-            return string.Concat(prefix, key.ToString());
+            var bufferToHexLength = (buffer.Length * 3) - 1;
+            Span<char> hexBuffer = bufferToHexLength <= 128 ? stackalloc char[bufferToHexLength] : new char[bufferToHexLength]; // uses the stack for small allocations, otherwise the heap
+            Hexadecimal.Write(buffer, hexBuffer, separator: '-');
+
+            return string.Concat(prefix, hexBuffer.ToString());
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ConcentratorDeduplication.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ConcentratorDeduplication.cs
@@ -100,18 +100,13 @@ namespace LoRaWan.NetworkServer
 
         internal static string CreateCacheKey(LoRaPayloadJoinRequest payload)
         {
-            var joinEui = JoinEui.Read(payload.AppEUI.Span);
-            var devEui = DevEui.Read(payload.DevEUI.Span);
-
             var totalBufferLength = JoinEui.Size + DevEui.Size + DevNonce.Size;
             Span<byte> buffer = stackalloc byte[totalBufferLength];
             var head = buffer; // keeps a view pointing at the start of the buffer
 
-            buffer = joinEui.Write(buffer);
-            buffer = devEui.Write(buffer);
-
-            var devNonce = payload.DevNonce;
-            _ = devNonce.Write(buffer);
+            buffer = JoinEui.Read(payload.AppEUI.Span).Write(buffer);
+            buffer = DevEui.Read(payload.DevEUI.Span).Write(buffer);
+            _ = payload.DevNonce.Write(buffer);
 
             return CreateCacheKeyCore(JoinMessageCacheKeyPrefix, head);
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ConcentratorDeduplication.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ConcentratorDeduplication.cs
@@ -91,7 +91,7 @@ namespace LoRaWan.NetworkServer
             Span<byte> buffer = stackalloc byte[totalBufferLength];
             var head = buffer; // keeps a view pointing at the start of the buffer
 
-            buffer = DevEui.Parse(loRaDevice.DevEUI.AsSpan()).Write(buffer);
+            buffer = DevEui.Parse(loRaDevice.DevEUI).Write(buffer);
             buffer = payload.Mic is { } someMic ? someMic.Write(buffer) : throw new InvalidOperationException("Mic must not be null.");
             BinaryPrimitives.WriteUInt16LittleEndian(buffer, BinaryPrimitives.ReadUInt16LittleEndian(payload.Fcnt.Span));
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ConcentratorDeduplication.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ConcentratorDeduplication.cs
@@ -87,12 +87,14 @@ namespace LoRaWan.NetworkServer
 
         internal static string CreateCacheKey(LoRaPayloadData payload, LoRaDevice loRaDevice)
         {
+            var someMic = payload.Mic ?? throw new ArgumentException(nameof(payload.Mic));
+
             var totalBufferLength = DevEui.Size + Mic.Size + payload.Fcnt.Length;
             Span<byte> buffer = stackalloc byte[totalBufferLength];
             var head = buffer; // keeps a view pointing at the start of the buffer
 
             buffer = DevEui.Parse(loRaDevice.DevEUI).Write(buffer);
-            buffer = payload.Mic is { } someMic ? someMic.Write(buffer) : throw new InvalidOperationException("Mic must not be null.");
+            buffer = someMic.Write(buffer);
             BinaryPrimitives.WriteUInt16LittleEndian(buffer, BinaryPrimitives.ReadUInt16LittleEndian(payload.Fcnt.Span));
 
             return CreateCacheKeyCore(DataMessageCacheKeyPrefix, head);

--- a/Tests/Common/TheoryDataFactory.cs
+++ b/Tests/Common/TheoryDataFactory.cs
@@ -54,5 +54,15 @@ namespace LoRaWan.Tests.Common
                 result.Add(a, b, c, d);
             return result;
         }
+
+        public static TheoryData<T1, T2, T3, T4, T5> From<T1, T2, T3, T4, T5>(IEnumerable<(T1, T2, T3, T4, T5)> data)
+        {
+            if (data is null) throw new ArgumentNullException(nameof(data));
+
+            var result = new TheoryData<T1, T2, T3, T4, T5>();
+            foreach (var (a, b, c, d, e) in data)
+                result.Add(a, b, c, d, e);
+            return result;
+        }
     }
 }

--- a/Tests/Unit/NetworkServer/ConcentratorDeduplicationTest.cs
+++ b/Tests/Unit/NetworkServer/ConcentratorDeduplicationTest.cs
@@ -56,9 +56,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // arrange
             if (!isCacheEmpty)
             {
-                var anotherPayload = this.simulatedABPDevice.CreateConfirmedDataUpMessage("another_payload");
-                using var anotherRequest = WaitableLoRaRequest.Create(anotherPayload);
-                _ = this.concentratorDeduplication.CheckDuplicateData(anotherRequest, this.loRaDevice);
+                using var testDevice = new LoRaDevice(this.simulatedABPDevice.DevAddr, "1111:1111:1111:1111", this.connectionManager);
+                _ = this.concentratorDeduplication.CheckDuplicateData(this.dataRequest, testDevice);
             }
 
             // act
@@ -66,7 +65,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             // assert
             Assert.Equal(ConcentratorDeduplicationResult.NotDuplicate, result);
-            var key = ConcentratorDeduplication.CreateCacheKey(this.dataPayload);
+            var key = ConcentratorDeduplication.CreateCacheKey(this.dataPayload, this.loRaDevice);
             Assert.True(this.cache.TryGetValue(key, out var addedStation));
             Assert.Equal(this.dataRequest.StationEui, addedStation);
         }
@@ -78,7 +77,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [InlineData("11-11-11-11-11-11-11-11", "22-22-22-22-22-22-22-22", DeduplicationMode.Drop, ConcentratorDeduplicationResult.Duplicate)]
         [InlineData("11-11-11-11-11-11-11-11", "22-22-22-22-22-22-22-22", DeduplicationMode.Mark, ConcentratorDeduplicationResult.SoftDuplicateDueToDeduplicationStrategy)]
         [InlineData("11-11-11-11-11-11-11-11", "22-22-22-22-22-22-22-22", DeduplicationMode.None, ConcentratorDeduplicationResult.SoftDuplicateDueToDeduplicationStrategy)]
-        public void When_Data_Message_Encountered_Should_Find_Duplicates_For_Different_Deduplication(string station1, string station2, DeduplicationMode deduplicationMode, ConcentratorDeduplicationResult expectedResult)
+        public void When_Data_Message_Encountered_Should_Find_Duplicates_For_Different_Deduplication_Strategies(string station1, string station2, DeduplicationMode deduplicationMode, ConcentratorDeduplicationResult expectedResult)
         {
             // arrange
             var station1Eui = StationEui.Parse(station1);
@@ -91,29 +90,26 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // act/assert
             Assert.Equal(expectedResult, this.concentratorDeduplication.CheckDuplicateData(this.dataRequest, this.loRaDevice));
             Assert.Equal(1, this.cache.Count);
-            var key = ConcentratorDeduplication.CreateCacheKey(this.dataPayload);
+            var key = ConcentratorDeduplication.CreateCacheKey(this.dataPayload, this.loRaDevice);
             Assert.True(this.cache.TryGetValue(key, out var foundStation));
             Assert.Equal(station1Eui, foundStation);
         }
 
         [Theory]
-        [InlineData("E7-EC-EB-BC-59-0B-C8-8B-37-61-FA-6C-D0-3D-74-9F-87-46-3D-AB-B6-70-21-A5-C6-76-8C-25-EC-68-B3-F2", 0, 0, "00000000", 0)]
-        [InlineData("E7-EC-EB-BC-59-0B-C8-8B-37-61-FA-6C-D0-3D-74-9F-87-46-3D-AB-B6-70-21-A5-C6-76-8C-25-EC-68-B3-F2", 0, 0, "00000000", 0, "1")]
-        // TODO re-enable the following case when issue #1152 is fixed:
-        // https://github.com/Azure/iotedge-lorawan-starterkit/issues/1152
-        // [InlineData("93-96-BC-C2-EA-96-2D-48-0B-69-48-C0-8C-27-B5-99-69-65-94-EA-5A-EB-9C-DC-C5-83-87-32-DD-9A-08-CF", 1, 0, "00000000", 0)]
-        [InlineData("E8-F5-83-11-F7-68-CE-49-9B-33-19-A0-49-8E-07-C9-AA-78-69-54-54-21-A5-34-85-E9-64-A2-DF-5A-26-05", 0, 1, "00000000", 0)]
-        [InlineData("28-F0-52-23-07-4B-85-DF-A4-3F-20-67-AA-1F-E2-EB-CD-5E-5A-B2-A9-61-7B-A3-6F-88-62-2E-E8-84-26-AD", 0, 0, "11111111", 0)]
-        [InlineData("7A-57-DD-8A-C3-B8-01-94-19-AF-B6-21-A8-A7-7D-5D-8F-3B-18-FB-20-D2-89-FF-B5-4E-13-C8-A3-03-C8-1D", 0, 0, "00000000", 1)]
-        public void CreateKeyMethod_Should_Return_Expected_Keys_For_Different_Payloads(string expectedKey, ushort devAddr, ushort frameCounter, string rawPayload, ushort mic, string? fieldNotUsedInKey = null)
+        [InlineData("E7-EC-EB-BC-59-0B-C8-8B-37-61-FA-6C-D0-3D-74-9F-87-46-3D-AB-B6-70-21-A5-C6-76-8C-25-EC-68-B3-F2", "0000:0000:0000:0000", 0, 0)]
+        [InlineData("E7-EC-EB-BC-59-0B-C8-8B-37-61-FA-6C-D0-3D-74-9F-87-46-3D-AB-B6-70-21-A5-C6-76-8C-25-EC-68-B3-F2", "0000:0000:0000:0000", 0, 0, "1")]
+        [InlineData("D2-B5-F8-AB-CA-DC-0B-63-F3-6D-83-2E-9E-54-FA-BA-38-11-68-66-14-52-B2-8B-B9-7D-91-80-C4-1E-3E-A0", "1111:1111:1111:1111", 0, 0)]
+        [InlineData("E8-F5-83-11-F7-68-CE-49-9B-33-19-A0-49-8E-07-C9-AA-78-69-54-54-21-A5-34-85-E9-64-A2-DF-5A-26-05", "0000:0000:0000:0000", 1, 0)]
+        [InlineData("9B-94-6D-15-EC-01-8C-3F-C5-B2-A6-02-94-4C-6C-6A-92-91-97-0B-74-CC-6F-A0-70-04-73-62-9E-EE-7B-37", "0000:0000:0000:0000", 0, 1)]
+        public void CreateKeyMethod_Should_Return_Expected_Keys_For_Different_Data_Messages(string expectedKey, string devEui, ushort frameCounter, ushort mic, string? fieldNotUsedInKey = null)
         {
             var options = fieldNotUsedInKey ?? string.Empty;
-            var payload = new LoRaPayloadDataLns(new DevAddr(devAddr), new MacHeader(MacMessageType.ConfirmedDataUp),
-                                                 frameCounter, options, rawPayload, new Mic(mic));
-            _ = Hexadecimal.TryParse(rawPayload, out uint raw);
-            payload.RawMessage = BitConverter.GetBytes(raw);
+            using var testDevice = new LoRaDevice(this.simulatedABPDevice.DevAddr, devEui, this.connectionManager);
 
-            Assert.Equal(expectedKey, ConcentratorDeduplication.CreateCacheKey(payload));
+            var payload = new LoRaPayloadDataLns(this.dataPayload.DevAddr, new MacHeader(MacMessageType.ConfirmedDataUp),
+                                                 frameCounter, options, "payload", new Mic(mic));
+
+            Assert.Equal(expectedKey, ConcentratorDeduplication.CreateCacheKey(payload, testDevice));
         }
         #endregion
 

--- a/Tests/Unit/NetworkServer/ConcentratorDeduplicationTest.cs
+++ b/Tests/Unit/NetworkServer/ConcentratorDeduplicationTest.cs
@@ -6,7 +6,6 @@
 namespace LoRaWan.Tests.Unit.NetworkServer
 {
     using System;
-    using System.Collections.Generic;
     using global::LoRaTools.LoRaMessage;
     using LoRaWan.NetworkServer;
     using LoRaWan.Tests.Common;
@@ -96,15 +95,17 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.Equal(station1Eui, foundStation);
         }
 
-        public static IEnumerable<object[]> CreateKeyDataMessagesTheoryData =>
-            new List<object[]>
-            {
-                new object[] { new ConcentratorDeduplication.DataMessageKey(new DevEui(0), new Mic(0), 0), 0, 0, 0 },
-                new object[] { new ConcentratorDeduplication.DataMessageKey(new DevEui(0), new Mic(0), 0), 0, 0, 0, "1" }, // a non-relevant field should not influence the key
-                new object[] { new ConcentratorDeduplication.DataMessageKey(new DevEui(0x1010101010101010UL), new Mic(0), 0), 0x1010101010101010UL, 0, 0 },
-                new object[] { new ConcentratorDeduplication.DataMessageKey(new DevEui(0), new Mic(1), 0), 0, 1, 0 },
-                new object[] { new ConcentratorDeduplication.DataMessageKey(new DevEui(0), new Mic(0), 1), 0, 0, 1 },
-            };
+        public static TheoryData CreateKeyDataMessagesTheoryData
+            => TheoryDataFactory.From<object, ulong, ushort, ushort, string?>(
+                new (object, ulong, ushort, ushort, string?)[]
+                {
+                    (new ConcentratorDeduplication.DataMessageKey(new DevEui(0), new Mic(0), 0), 0, 0, 0, null),
+                    (new ConcentratorDeduplication.DataMessageKey(new DevEui(0), new Mic(0), 0), 0, 0, 0, "1"), // a non-relevant field should not influence the key
+                    (new ConcentratorDeduplication.DataMessageKey(new DevEui(0x1010101010101010UL), new Mic(0), 0), 0x1010101010101010UL, 0, 0, null),
+                    (new ConcentratorDeduplication.DataMessageKey(new DevEui(0), new Mic(1), 0), 0, 1, 0, null),
+                    (new ConcentratorDeduplication.DataMessageKey(new DevEui(0), new Mic(0), 1), 0, 0, 1, null)
+                }
+            );
 
         [Theory]
         [MemberData(nameof(CreateKeyDataMessagesTheoryData))]
@@ -168,15 +169,17 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.Equal(station1Eui, addedStation);
         }
 
-        public static IEnumerable<object[]> CreateKeyJoinMessagesTheoryData =>
-            new List<object[]>
-            {
-                new object[] { new ConcentratorDeduplication.JoinMessageKey(new JoinEui(0), new DevEui(0), new DevNonce(0)), 0, 0, 0 },
-                new object[] { new ConcentratorDeduplication.JoinMessageKey(new JoinEui(0), new DevEui(0), new DevNonce(0)), 0, 0, 0, (uint)1 }, // a non-relevant field should not influence the key
-                new object[] { new ConcentratorDeduplication.JoinMessageKey(new JoinEui(0x1010101010101010UL), new DevEui(0), new DevNonce(0)), 0x1010101010101010UL, 0, 0 },
-                new object[] { new ConcentratorDeduplication.JoinMessageKey(new JoinEui(0), new DevEui(0x1010101010101010UL), new DevNonce(0)), 0, 0x1010101010101010UL, 0 },
-                new object[] { new ConcentratorDeduplication.JoinMessageKey(new JoinEui(0), new DevEui(0), new DevNonce(1)), 0, 0, 1 },
-           };
+        public static TheoryData CreateKeyJoinMessagesTheoryData
+            => TheoryDataFactory.From<object, ulong, ulong, ushort, uint?>(
+                new (object, ulong, ulong, ushort, uint?)[]
+                {
+                    (new ConcentratorDeduplication.JoinMessageKey(new JoinEui(0), new DevEui(0), new DevNonce(0)), 0, 0, 0, null),
+                    (new ConcentratorDeduplication.JoinMessageKey(new JoinEui(0), new DevEui(0), new DevNonce(0)), 0, 0, 0, 1 ), // a non-relevant field should not influence the key
+                    (new ConcentratorDeduplication.JoinMessageKey(new JoinEui(0x1010101010101010UL), new DevEui(0), new DevNonce(0)), 0x1010101010101010UL, 0, 0, null),
+                    (new ConcentratorDeduplication.JoinMessageKey(new JoinEui(0), new DevEui(0x1010101010101010UL), new DevNonce(0)), 0, 0x1010101010101010UL, 0, null),
+                    (new ConcentratorDeduplication.JoinMessageKey(new JoinEui(0), new DevEui(0), new DevNonce(1)), 0, 0, 1, null),
+                }
+            );
 
         [Theory]
         [MemberData(nameof(CreateKeyJoinMessagesTheoryData))]

--- a/Tests/Unit/NetworkServer/ConcentratorDeduplicationTest.cs
+++ b/Tests/Unit/NetworkServer/ConcentratorDeduplicationTest.cs
@@ -96,12 +96,12 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         }
 
         [Theory]
-        [InlineData("E7-EC-EB-BC-59-0B-C8-8B-37-61-FA-6C-D0-3D-74-9F-87-46-3D-AB-B6-70-21-A5-C6-76-8C-25-EC-68-B3-F2", 0, 0, 0)]
-        [InlineData("E7-EC-EB-BC-59-0B-C8-8B-37-61-FA-6C-D0-3D-74-9F-87-46-3D-AB-B6-70-21-A5-C6-76-8C-25-EC-68-B3-F2", 0, 0, 0, "1")]
-        [InlineData("D2-B5-F8-AB-CA-DC-0B-63-F3-6D-83-2E-9E-54-FA-BA-38-11-68-66-14-52-B2-8B-B9-7D-91-80-C4-1E-3E-A0", 0x1111111111111111UL, 0, 0)]
-        [InlineData("E8-F5-83-11-F7-68-CE-49-9B-33-19-A0-49-8E-07-C9-AA-78-69-54-54-21-A5-34-85-E9-64-A2-DF-5A-26-05", 0, 1, 0)]
-        [InlineData("9B-94-6D-15-EC-01-8C-3F-C5-B2-A6-02-94-4C-6C-6A-92-91-97-0B-74-CC-6F-A0-70-04-73-62-9E-EE-7B-37", 0, 0, 1)]
-        public void CreateKeyMethod_Should_Return_Expected_Keys_For_Different_Data_Messages(string expectedKey, ulong devEui, ushort frameCounter, ushort mic, string? fieldNotUsedInKey = null)
+        [InlineData("00-00-00-00-00-00-00-00-00-00-00-00-00-00", 0, 0, 0)]
+        [InlineData("00-00-00-00-00-00-00-00-00-00-00-00-00-00", 0, 0, 0, "1")] // a non-relevant field should not influence the key
+        [InlineData("10-10-10-10-10-10-10-10-00-00-00-00-00-00", 0x1010101010101010UL, 0, 0)]
+        [InlineData("00-00-00-00-00-00-00-00-01-00-00-00-00-00", 0, 1, 0)]
+        [InlineData("00-00-00-00-00-00-00-00-00-00-00-00-01-00", 0, 0, 1)]
+        public void CreateKeyMethod_Should_Return_Expected_Keys_For_Different_Data_Messages(string expectedKey, ulong devEui, ushort mic, ushort frameCounter, string? fieldNotUsedInKey = null)
         {
             var options = fieldNotUsedInKey ?? string.Empty;
             using var testDevice = new LoRaDevice(this.simulatedABPDevice.DevAddr, new DevEui(devEui).ToString(), this.connectionManager);
@@ -162,11 +162,11 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         }
 
         [Theory]
-        [InlineData("60-DA-A3-A5-F7-DB-FA-20-0F-8C-82-84-0E-CF-5B-42-64-0B-70-F3-B7-21-8A-4C-6B-BD-67-DB-54-2E-75-A4", 0, 0, 0)]
-        [InlineData("60-DA-A3-A5-F7-DB-FA-20-0F-8C-82-84-0E-CF-5B-42-64-0B-70-F3-B7-21-8A-4C-6B-BD-67-DB-54-2E-75-A4", 0, 0, 0, (uint)1)] // a non-relevant field should not influence the key
-        [InlineData("BF-67-81-DB-77-1A-EF-1C-14-55-9E-2C-22-E7-D1-CF-4F-57-77-77-65-6E-2C-D6-E3-D4-1A-6E-A1-6A-17-86", 0x101010101010101UL, 0, 0)]
-        [InlineData("40-25-81-8B-EA-C7-AC-CD-32-4E-2A-02-CE-15-C8-9B-72-A4-81-32-9D-91-9F-FE-7A-62-D8-BA-3A-C4-E4-00", 0, 0x101010101010101UL, 0)]
-        [InlineData("B0-EF-53-E1-22-B3-C4-0B-57-93-55-21-96-95-43-03-29-F4-6C-3B-24-93-6C-BD-73-49-67-78-0A-60-9B-E2", 0, 0, 1)]
+        [InlineData("00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 0, 0, 0)]
+        [InlineData("00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 0, 0, 0, (uint)1)] // a non-relevant field should not influence the key
+        [InlineData("10-10-10-10-10-10-10-10-00-00-00-00-00-00-00-00-00-00", 0x1010101010101010UL, 0, 0)]
+        [InlineData("00-00-00-00-00-00-00-00-10-10-10-10-10-10-10-10-00-00", 0, 0x1010101010101010UL, 0)]
+        [InlineData("00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-01-00", 0, 0, 1)]
         public void CreateCacheKey_Should_Return_Expected_Keys_For_Different_JoinRequests(string expectedKey, ulong joinEui, ulong devEui, ushort devNonce, uint? fieldNotUsedInKey = null)
         {
             var micValue = fieldNotUsedInKey ?? 0;

--- a/Tests/Unit/NetworkServer/ConcentratorDeduplicationTest.cs
+++ b/Tests/Unit/NetworkServer/ConcentratorDeduplicationTest.cs
@@ -56,7 +56,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // arrange
             if (!isCacheEmpty)
             {
-                using var testDevice = new LoRaDevice(this.simulatedABPDevice.DevAddr, "1111:1111:1111:1111", this.connectionManager);
+                using var testDevice = new LoRaDevice(this.simulatedABPDevice.DevAddr, new DevEui(0x1111111111111111UL).ToString(), this.connectionManager);
                 _ = this.concentratorDeduplication.CheckDuplicateData(this.dataRequest, testDevice);
             }
 
@@ -96,15 +96,15 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         }
 
         [Theory]
-        [InlineData("E7-EC-EB-BC-59-0B-C8-8B-37-61-FA-6C-D0-3D-74-9F-87-46-3D-AB-B6-70-21-A5-C6-76-8C-25-EC-68-B3-F2", "0000:0000:0000:0000", 0, 0)]
-        [InlineData("E7-EC-EB-BC-59-0B-C8-8B-37-61-FA-6C-D0-3D-74-9F-87-46-3D-AB-B6-70-21-A5-C6-76-8C-25-EC-68-B3-F2", "0000:0000:0000:0000", 0, 0, "1")]
-        [InlineData("D2-B5-F8-AB-CA-DC-0B-63-F3-6D-83-2E-9E-54-FA-BA-38-11-68-66-14-52-B2-8B-B9-7D-91-80-C4-1E-3E-A0", "1111:1111:1111:1111", 0, 0)]
-        [InlineData("E8-F5-83-11-F7-68-CE-49-9B-33-19-A0-49-8E-07-C9-AA-78-69-54-54-21-A5-34-85-E9-64-A2-DF-5A-26-05", "0000:0000:0000:0000", 1, 0)]
-        [InlineData("9B-94-6D-15-EC-01-8C-3F-C5-B2-A6-02-94-4C-6C-6A-92-91-97-0B-74-CC-6F-A0-70-04-73-62-9E-EE-7B-37", "0000:0000:0000:0000", 0, 1)]
-        public void CreateKeyMethod_Should_Return_Expected_Keys_For_Different_Data_Messages(string expectedKey, string devEui, ushort frameCounter, ushort mic, string? fieldNotUsedInKey = null)
+        [InlineData("E7-EC-EB-BC-59-0B-C8-8B-37-61-FA-6C-D0-3D-74-9F-87-46-3D-AB-B6-70-21-A5-C6-76-8C-25-EC-68-B3-F2", 0, 0, 0)]
+        [InlineData("E7-EC-EB-BC-59-0B-C8-8B-37-61-FA-6C-D0-3D-74-9F-87-46-3D-AB-B6-70-21-A5-C6-76-8C-25-EC-68-B3-F2", 0, 0, 0, "1")]
+        [InlineData("D2-B5-F8-AB-CA-DC-0B-63-F3-6D-83-2E-9E-54-FA-BA-38-11-68-66-14-52-B2-8B-B9-7D-91-80-C4-1E-3E-A0", 0x1111111111111111UL, 0, 0)]
+        [InlineData("E8-F5-83-11-F7-68-CE-49-9B-33-19-A0-49-8E-07-C9-AA-78-69-54-54-21-A5-34-85-E9-64-A2-DF-5A-26-05", 0, 1, 0)]
+        [InlineData("9B-94-6D-15-EC-01-8C-3F-C5-B2-A6-02-94-4C-6C-6A-92-91-97-0B-74-CC-6F-A0-70-04-73-62-9E-EE-7B-37", 0, 0, 1)]
+        public void CreateKeyMethod_Should_Return_Expected_Keys_For_Different_Data_Messages(string expectedKey, ulong devEui, ushort frameCounter, ushort mic, string? fieldNotUsedInKey = null)
         {
             var options = fieldNotUsedInKey ?? string.Empty;
-            using var testDevice = new LoRaDevice(this.simulatedABPDevice.DevAddr, devEui, this.connectionManager);
+            using var testDevice = new LoRaDevice(this.simulatedABPDevice.DevAddr, new DevEui(devEui).ToString(), this.connectionManager);
 
             var payload = new LoRaPayloadDataLns(this.dataPayload.DevAddr, new MacHeader(MacMessageType.ConfirmedDataUp),
                                                  frameCounter, options, "payload", new Mic(mic));


### PR DESCRIPTION
# PR for issue #1152

## What is being addressed

Previously, for the cache key we were relying among others on the `RawMessage` field that was empty for all messages. This meant potentially more cache hits (if the non-unique `DevAddr`, frame counter and `Mic` were also the same) and potentially more dropped messages.

## How is this addressed

By using the unique `DevEui`, we don't need to rely on the raw message anymore. Tests were adjusted to vary the `DevEui` instead of the payload.

Since the keys now have a constant length (no variable component), we are also removing the SHA256 hashing to not have extra computational overhead.

In order to ensure that there are no key collisions in the MemoryCache we are adding also a unique prefix for the different message types with an explicit test for it.

## TODO
If #1151 gets merged before this one, update accordingly.