### PR TITLE
Encapsulate session key type into key calculation methods of `OTAAKeysGenerator`

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -13,6 +13,7 @@ namespace LoRaWan.NetworkServer
     using LoRaTools.LoRaMessage;
     using LoRaTools.LoRaPhysical;
     using LoRaTools.Regions;
+    using LoRaTools.Utils;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
@@ -135,8 +136,8 @@ namespace LoRaWan.NetworkServer
 
                 var netId = this.configuration.NetId;
                 var appNonce = new AppNonce(RandomNumberGenerator.GetInt32(toExclusive: AppNonce.MaxValue + 1));
-                var appSKey = OTAAKeysGenerator.CalculateAppSessionKey(appNonce, netId, joinReq.DevNonce, appKey);
-                var nwkSKey = OTAAKeysGenerator.CalculateNetworkSessionKey(appNonce, netId, joinReq.DevNonce, appKey);
+                var appSKey = OTAAKeysGenerator.CalculateAppSessionKey(new byte[1] { 0x02 }, appNonce, netId, joinReq.DevNonce, appKey);
+                var nwkSKey = OTAAKeysGenerator.CalculateNetworkSessionKey(new byte[1] { 0x01 }, appNonce, netId, joinReq.DevNonce, appKey);
                 var address = RandomNumberGenerator.GetInt32(toExclusive: DevAddr.MaxNetworkAddress + 1);
                 // The 7 LBS of the NetID become the NwkID of a DevAddr:
                 var devAddr = new DevAddr(unchecked((byte)netId.NetworkId), address);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -13,7 +13,6 @@ namespace LoRaWan.NetworkServer
     using LoRaTools.LoRaMessage;
     using LoRaTools.LoRaPhysical;
     using LoRaTools.Regions;
-    using LoRaTools.Utils;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
@@ -136,8 +135,8 @@ namespace LoRaWan.NetworkServer
 
                 var netId = this.configuration.NetId;
                 var appNonce = new AppNonce(RandomNumberGenerator.GetInt32(toExclusive: AppNonce.MaxValue + 1));
-                var appSKey = OTAAKeysGenerator.CalculateAppSessionKey(new byte[1] { 0x02 }, appNonce, netId, joinReq.DevNonce, appKey);
-                var nwkSKey = OTAAKeysGenerator.CalculateNetworkSessionKey(new byte[1] { 0x01 }, appNonce, netId, joinReq.DevNonce, appKey);
+                var appSKey = OTAAKeysGenerator.CalculateAppSessionKey(appNonce, netId, joinReq.DevNonce, appKey);
+                var nwkSKey = OTAAKeysGenerator.CalculateNetworkSessionKey(appNonce, netId, joinReq.DevNonce, appKey);
                 var address = RandomNumberGenerator.GetInt32(toExclusive: DevAddr.MaxNetworkAddress + 1);
                 // The 7 LBS of the NetID become the NwkID of a DevAddr:
                 var devAddr = new DevAddr(unchecked((byte)netId.NetworkId), address);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -144,8 +144,8 @@ namespace LoRaWan.NetworkServer
 
                 var appNonce = OTAAKeysGenerator.GetAppNonce();
                 var appNonceBytes = ConversionHelper.StringToByteArray(appNonce);
-                var appSKey = OTAAKeysGenerator.CalculateAppSessionKey(new byte[1] { 0x02 }, appNonceBytes, netId, joinReq.DevNonce, appKey);
-                var nwkSKey = OTAAKeysGenerator.CalculateNetworkSessionKey(new byte[1] { 0x01 }, appNonceBytes, netId, joinReq.DevNonce, appKey);
+                var appSKey = OTAAKeysGenerator.CalculateAppSessionKey(appNonceBytes, netId, joinReq.DevNonce, appKey);
+                var nwkSKey = OTAAKeysGenerator.CalculateNetworkSessionKey(appNonceBytes, netId, joinReq.DevNonce, appKey);
                 var devAddr = OTAAKeysGenerator.GetNwkId(this.configuration.NetId);
 
                 var oldDevAddr = loRaDevice.DevAddr;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
@@ -6,28 +6,21 @@ namespace LoRaTools
     using System;
     using System.Diagnostics;
     using System.Security.Cryptography;
-    using LoRaTools.Utils;
     using LoRaWan;
 
     public static class OTAAKeysGenerator
     {
-        public static NetworkSessionKey CalculateNetworkSessionKey(byte[] type, AppNonce appNonce, NetId netid, DevNonce devNonce, AppKey appKey)
-        {
-            var keyString = CalculateKey(type, appNonce, netid, devNonce, appKey);
-            return NetworkSessionKey.Parse(keyString);
-        }
+        private enum SessionKeyType { Network = 1, Application = 2 }
 
-        public static AppSessionKey CalculateAppSessionKey(byte[] type, AppNonce appNonce, NetId netid, DevNonce devNonce, AppKey appKey)
-        {
-            var keyString = CalculateKey(type, appNonce, netid, devNonce, appKey);
-            return AppSessionKey.Parse(keyString);
-        }
+        public static NetworkSessionKey CalculateNetworkSessionKey(AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey) =>
+            NetworkSessionKey.Read(CalculateKey(SessionKeyType.Network, appNonce, netId, devNonce, appKey));
+
+        public static AppSessionKey CalculateAppSessionKey(AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey) =>
+            AppSessionKey.Read(CalculateKey(SessionKeyType.Application, appNonce, netId, devNonce, appKey));
 
         // don't work with CFLIST atm
-        private static string CalculateKey(byte[] type, AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
+        private static byte[] CalculateKey(SessionKeyType type, AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
         {
-            if (type is null) throw new ArgumentNullException(nameof(type));
-
             using var aes = Aes.Create("AesManaged");
             var rawAppKey = new byte[AppKey.Size];
             _ = appKey.Write(rawAppKey);
@@ -38,11 +31,11 @@ namespace LoRaTools
 #pragma warning restore CA5358 // Review cipher mode usage with cryptography experts
             aes.Padding = PaddingMode.None;
 
-            var buffer = new byte[type.Length + AppNonce.Size + NetId.Size + DevNonce.Size + 7];
+            var buffer = new byte[1 + AppNonce.Size + NetId.Size + DevNonce.Size + 7];
             var pt = buffer.AsSpan();
             Debug.Assert(pt.Length == 16);
-            type.CopyTo(pt);
-            pt = pt[type.Length..];
+            pt[0] = unchecked((byte)type);
+            pt = pt[1..];
             pt = appNonce.Write(pt);
             pt = netId.Write(pt);
             pt = devNonce.Write(pt);
@@ -55,8 +48,7 @@ namespace LoRaTools
             cipher = aes.CreateEncryptor();
 #pragma warning restore CA5401 // Do not use CreateEncryptor with non-default IV
 
-            var key = cipher.TransformFinalBlock(buffer, 0, buffer.Length);
-            return ConversionHelper.ByteArrayToString(key);
+            return cipher.TransformFinalBlock(buffer, 0, buffer.Length);
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
@@ -13,15 +13,15 @@ namespace LoRaTools
     {
         private enum SessionKeyType { Network = 1, Application = 2 }
 
-        public static NetworkSessionKey CalculateNetworkSessionKey(AppNonce appNonce, NetId netid, DevNonce devNonce, AppKey appKey)
+        public static NetworkSessionKey CalculateNetworkSessionKey(AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
         {
-            var keyString = CalculateKey(SessionKeyType.Network, appNonce, netid, devNonce, appKey);
+            var keyString = CalculateKey(SessionKeyType.Network, appNonce, netId, devNonce, appKey);
             return NetworkSessionKey.Parse(keyString);
         }
 
-        public static AppSessionKey CalculateAppSessionKey(AppNonce appNonce, NetId netid, DevNonce devNonce, AppKey appKey)
+        public static AppSessionKey CalculateAppSessionKey(AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
         {
-            var keyString = CalculateKey(SessionKeyType.Application, appNonce, netid, devNonce, appKey);
+            var keyString = CalculateKey(SessionKeyType.Application, appNonce, netId, devNonce, appKey);
             return AppSessionKey.Parse(keyString);
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
@@ -6,7 +6,6 @@ namespace LoRaTools
     using System;
     using System.Diagnostics;
     using System.Security.Cryptography;
-    using LoRaTools.Utils;
     using LoRaWan;
 
     public static class OTAAKeysGenerator

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
@@ -13,20 +13,14 @@ namespace LoRaTools
     {
         private enum SessionKeyType { Network = 1, Application = 2 }
 
-        public static NetworkSessionKey CalculateNetworkSessionKey(AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
-        {
-            var keyString = CalculateKey(SessionKeyType.Network, appNonce, netId, devNonce, appKey);
-            return NetworkSessionKey.Parse(keyString);
-        }
+        public static NetworkSessionKey CalculateNetworkSessionKey(AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey) =>
+            NetworkSessionKey.Read(CalculateKey(SessionKeyType.Network, appNonce, netId, devNonce, appKey));
 
-        public static AppSessionKey CalculateAppSessionKey(AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
-        {
-            var keyString = CalculateKey(SessionKeyType.Application, appNonce, netId, devNonce, appKey);
-            return AppSessionKey.Parse(keyString);
-        }
+        public static AppSessionKey CalculateAppSessionKey(AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey) =>
+            AppSessionKey.Read(CalculateKey(SessionKeyType.Application, appNonce, netId, devNonce, appKey));
 
         // don't work with CFLIST atm
-        private static string CalculateKey(SessionKeyType type, AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
+        private static byte[] CalculateKey(SessionKeyType type, AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
         {
             using var aes = Aes.Create("AesManaged");
             var rawAppKey = new byte[AppKey.Size];
@@ -55,8 +49,7 @@ namespace LoRaTools
             cipher = aes.CreateEncryptor();
 #pragma warning restore CA5401 // Do not use CreateEncryptor with non-default IV
 
-            var key = cipher.TransformFinalBlock(buffer, 0, buffer.Length);
-            return ConversionHelper.ByteArrayToString(key);
+            return cipher.TransformFinalBlock(buffer, 0, buffer.Length);
         }
     }
 }

--- a/Tests/Common/TheoryDataFactory.cs
+++ b/Tests/Common/TheoryDataFactory.cs
@@ -54,5 +54,15 @@ namespace LoRaWan.Tests.Common
                 result.Add(a, b, c, d);
             return result;
         }
+
+        public static TheoryData<T1, T2, T3, T4, T5> From<T1, T2, T3, T4, T5>(IEnumerable<(T1, T2, T3, T4, T5)> data)
+        {
+            if (data is null) throw new ArgumentNullException(nameof(data));
+
+            var result = new TheoryData<T1, T2, T3, T4, T5>();
+            foreach (var (a, b, c, d, e) in data)
+                result.Add(a, b, c, d, e);
+            return result;
+        }
     }
 }

--- a/Tests/Unit/LoRaTools/OTAAKeysGeneratorTests.cs
+++ b/Tests/Unit/LoRaTools/OTAAKeysGeneratorTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.LoRaTools
+{
+    using System.Linq;
+    using Common;
+    using global::LoRaTools;
+    using Xunit;
+
+    public class OTAAKeysGeneratorTests
+    {
+        public static readonly (AppNonce AppNonce, NetId NetId, DevNonce DevNonce, AppKey AppKey,
+                                NetworkSessionKey NetworkSessionKey,
+                                AppSessionKey AppSessionKey)[] TestData =
+        {
+            (new AppNonce(123), new NetId(0x41), new DevNonce(456), AppKey.Parse("0102030405060708090A0B0C0D0E0F10"),
+                NetworkSessionKey.Parse("D60FD79D3EEF32C277854450918E1595"),
+                AppSessionKey.Parse("EFA581038515D4CE712ACE5FEAAECEF6"))
+        };
+
+        public static readonly TheoryData<AppSessionKey, AppNonce, NetId, DevNonce, AppKey> CalculateAppSessionKeyData =
+            TheoryDataFactory.From(from e in TestData
+                                   select (e.AppSessionKey, e.AppNonce, e.NetId, e.DevNonce, e.AppKey));
+
+        [Theory]
+        [MemberData(nameof(CalculateAppSessionKeyData))]
+        public void CalculateAppSessionKey(AppSessionKey expected, AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
+        {
+            Assert.Equal(expected, OTAAKeysGenerator.CalculateAppSessionKey(appNonce, netId, devNonce, appKey));
+        }
+
+        public static readonly TheoryData<NetworkSessionKey, AppNonce, NetId, DevNonce, AppKey> CalculateNetworkSessionKeyData =
+            TheoryDataFactory.From(from e in TestData
+                                   select (e.NetworkSessionKey, e.AppNonce, e.NetId, e.DevNonce, e.AppKey));
+
+        [Theory]
+        [MemberData(nameof(CalculateNetworkSessionKeyData))]
+        public void CalculateNetworkSessionKey(NetworkSessionKey expected, AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
+        {
+            Assert.Equal(expected, OTAAKeysGenerator.CalculateNetworkSessionKey(appNonce, netId, devNonce, appKey));
+        }
+    }
+}

--- a/Tests/Unit/LoRaTools/OTAAKeysGeneratorTests.cs
+++ b/Tests/Unit/LoRaTools/OTAAKeysGeneratorTests.cs
@@ -27,7 +27,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools
         [MemberData(nameof(CalculateAppSessionKeyData))]
         public void CalculateAppSessionKey(AppSessionKey expected, AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
         {
-            Assert.Equal(expected, OTAAKeysGenerator.CalculateAppSessionKey(new byte[] { 2 }, appNonce, netId, devNonce, appKey));
+            Assert.Equal(expected, OTAAKeysGenerator.CalculateAppSessionKey(appNonce, netId, devNonce, appKey));
         }
 
         public static readonly TheoryData<NetworkSessionKey, AppNonce, NetId, DevNonce, AppKey> CalculateNetworkSessionKeyData =
@@ -38,7 +38,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools
         [MemberData(nameof(CalculateNetworkSessionKeyData))]
         public void CalculateNetworkSessionKey(NetworkSessionKey expected, AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
         {
-            Assert.Equal(expected, OTAAKeysGenerator.CalculateNetworkSessionKey(new byte[] { 1 }, appNonce, netId, devNonce, appKey));
+            Assert.Equal(expected, OTAAKeysGenerator.CalculateNetworkSessionKey(appNonce, netId, devNonce, appKey));
         }
     }
 }

--- a/Tests/Unit/LoRaTools/OTAAKeysGeneratorTests.cs
+++ b/Tests/Unit/LoRaTools/OTAAKeysGeneratorTests.cs
@@ -27,7 +27,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools
         [MemberData(nameof(CalculateAppSessionKeyData))]
         public void CalculateAppSessionKey(AppSessionKey expected, AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
         {
-            Assert.Equal(expected, OTAAKeysGenerator.CalculateAppSessionKey(appNonce, netId, devNonce, appKey));
+            Assert.Equal(expected, OTAAKeysGenerator.CalculateAppSessionKey(new byte[] { 2 }, appNonce, netId, devNonce, appKey));
         }
 
         public static readonly TheoryData<NetworkSessionKey, AppNonce, NetId, DevNonce, AppKey> CalculateNetworkSessionKeyData =
@@ -38,7 +38,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools
         [MemberData(nameof(CalculateNetworkSessionKeyData))]
         public void CalculateNetworkSessionKey(NetworkSessionKey expected, AppNonce appNonce, NetId netId, DevNonce devNonce, AppKey appKey)
         {
-            Assert.Equal(expected, OTAAKeysGenerator.CalculateNetworkSessionKey(appNonce, netId, devNonce, appKey));
+            Assert.Equal(expected, OTAAKeysGenerator.CalculateNetworkSessionKey(new byte[] { 1 }, appNonce, netId, devNonce, appKey));
         }
     }
 }


### PR DESCRIPTION
This PR encapsulates the session key type into the distinct key calculation methods `CalculateNetworkSessionKey` and `CalculateAppSessionKey` as opposed to it being an argument of those methods.

---
PS It also adds unit tests missing for `OTAAKeysGenerator` to ensure no regression.