### PR TITLE
Add type for `AppNonce`

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -54,7 +54,7 @@ namespace LoRaWan.NetworkServer
 
         public AppSessionKey? AppSKey { get; set; }
 
-        public string AppNonce { get; set; }
+        public AppNonce AppNonce { get; set; }
 
         public DevNonce? DevNonce { get; set; }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceJoinUpdateProperties.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceJoinUpdateProperties.cs
@@ -24,7 +24,7 @@ namespace LoRaWan.NetworkServer
 
         public string PreferredGatewayID { get; set; }
 
-        public string AppNonce { get; set; }
+        public AppNonce AppNonce { get; set; }
 
         /// <summary>
         /// Gets or sets value indicating if region should be saved in reported properties.

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/AppNonce.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/AppNonce.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan
+{
+    using System;
+    using System.Globalization;
+
+    /// <summary>
+    /// A random value or some form of unique ID provided by the network server and used by the
+    /// end-device to derive the two session keys <c>NwkSKey</c> and <c>AppSKey</c>.
+    /// </summary>
+    public readonly record struct AppNonce
+    {
+        public const int Size = 3;
+        public const int MaxValue = 0xff_ffff;
+
+        private readonly int value;
+
+        public AppNonce(int value) =>
+            this.value = value is >= 0 and <= MaxValue ? value : throw new ArgumentOutOfRangeException(nameof(value), value, null);
+
+        public override string ToString() => this.value.ToString(CultureInfo.InvariantCulture);
+
+        public static explicit operator int(AppNonce nonce) => nonce.value;
+
+        public Span<byte> Write(Span<byte> buffer)
+        {
+            if (buffer.Length < Size) throw new ArgumentException("Insufficient buffer length.");
+
+            unchecked
+            {
+                buffer[0] = (byte)this.value;
+                buffer[1] = (byte)(this.value >> 8);
+                buffer[2] = (byte)(this.value >> 16);
+            }
+            return buffer[Size..];
+        }
+
+        public static AppNonce Read(ReadOnlySpan<byte> buffer) =>
+            buffer.Length >= 3 ? new AppNonce(buffer[0] | (buffer[1] << 8) | (buffer[2] << 16))
+                               : throw new ArgumentException("Insufficient buffer length.");
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Mic.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Mic.cs
@@ -78,14 +78,14 @@ namespace LoRaWan
             return new Mic(BinaryPrimitives.ReadUInt32LittleEndian(cmac));
         }
 
-        public static Mic ComputeForJoinAccept(AppKey appKey, MacHeader macHeader, Memory<byte> joinNonce, Memory<byte> netId, DevAddr devAddr, Memory<byte> dlSettings, Memory<byte> rxDelay, Memory<byte> cfList)
+        public static Mic ComputeForJoinAccept(AppKey appKey, MacHeader macHeader, AppNonce joinNonce, Memory<byte> netId, DevAddr devAddr, Memory<byte> dlSettings, Memory<byte> rxDelay, Memory<byte> cfList)
         {
-            var algoInput = new byte[MacHeader.Size + joinNonce.Length + NetId.Size + DevAddr.Size + dlSettings.Length + rxDelay.Length + cfList.Length];
+            var algoInput = new byte[MacHeader.Size + AppNonce.Size + NetId.Size + DevAddr.Size + dlSettings.Length + rxDelay.Length + cfList.Length];
             var index = 0;
             _ = macHeader.Write(algoInput.AsSpan(index));
             index += MacHeader.Size;
-            joinNonce.CopyTo(algoInput.AsMemory(index));
-            index += joinNonce.Length;
+            _ = joinNonce.Write(algoInput.AsSpan(index));
+            index += AppNonce.Size;
             netId.CopyTo(algoInput.AsMemory(index));
             index += netId.Length;
             _ = devAddr.Write(algoInput.AsSpan(index));

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
@@ -223,12 +223,5 @@ namespace LoRaTools.LoRaMessage
         public override byte[] Serialize(AppSessionKey key) => throw new NotImplementedException();
 
         public override bool CheckMic(AppKey key) => throw new NotImplementedException();
-
-        private byte[] GetDevAddrBytes()
-        {
-            var bytes = new byte[DevAddr.Size];
-            _ = DevAddr.Write(bytes);
-            return bytes;
-        }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/OTAAHelper/OTAAKeysGenerator.cs
@@ -4,6 +4,7 @@
 namespace LoRaTools
 {
     using System;
+    using System.Diagnostics;
     using System.Security.Cryptography;
     using LoRaTools.Utils;
     using LoRaWan;
@@ -17,23 +18,22 @@ namespace LoRaTools
             return new DevAddr(unchecked((byte)netId) & 0b0111_1111, address);
         }
 
-        public static NetworkSessionKey CalculateNetworkSessionKey(byte[] type, byte[] appnonce, byte[] netid, DevNonce devNonce, AppKey appKey)
+        public static NetworkSessionKey CalculateNetworkSessionKey(byte[] type, AppNonce appNonce, byte[] netid, DevNonce devNonce, AppKey appKey)
         {
-            var keyString = CalculateKey(type, appnonce, netid, devNonce, appKey);
+            var keyString = CalculateKey(type, appNonce, netid, devNonce, appKey);
             return NetworkSessionKey.Parse(keyString);
         }
 
-        public static AppSessionKey CalculateAppSessionKey(byte[] type, byte[] appnonce, byte[] netid, DevNonce devNonce, AppKey appKey)
+        public static AppSessionKey CalculateAppSessionKey(byte[] type, AppNonce appNonce, byte[] netid, DevNonce devNonce, AppKey appKey)
         {
-            var keyString = CalculateKey(type, appnonce, netid, devNonce, appKey);
+            var keyString = CalculateKey(type, appNonce, netid, devNonce, appKey);
             return AppSessionKey.Parse(keyString);
         }
 
         // don't work with CFLIST atm
-        private static string CalculateKey(byte[] type, byte[] appnonce, byte[] netid, DevNonce devNonce, AppKey appKey)
+        private static string CalculateKey(byte[] type, AppNonce appNonce, byte[] netid, DevNonce devNonce, AppKey appKey)
         {
             if (type is null) throw new ArgumentNullException(nameof(type));
-            if (appnonce is null) throw new ArgumentNullException(nameof(appnonce));
             if (netid is null) throw new ArgumentNullException(nameof(netid));
 
             using var aes = Aes.Create("AesManaged");
@@ -46,53 +46,16 @@ namespace LoRaTools
 #pragma warning restore CA5358 // Review cipher mode usage with cryptography experts
             aes.Padding = PaddingMode.None;
 
-            var devNonceBytes = new byte[DevNonce.Size];
-            _ = devNonce.Write(devNonceBytes);
-
-            var pt = new byte[type.Length + appnonce.Length + netid.Length + DevNonce.Size + 7];
-            Array.Copy(type, pt, type.Length);
-            Array.Copy(appnonce, 0, pt, type.Length, appnonce.Length);
-            Array.Copy(netid, 0, pt, type.Length + appnonce.Length, netid.Length);
-            _ = devNonce.Write(pt.AsSpan(type.Length + appnonce.Length + netid.Length));
-
-            aes.IV = new byte[16];
-            ICryptoTransform cipher;
-#pragma warning disable CA5401 // Do not use CreateEncryptor with non-default IV
-            // Part of the LoRaWAN specification
-            cipher = aes.CreateEncryptor();
-#pragma warning restore CA5401 // Do not use CreateEncryptor with non-default IV
-
-            var key = cipher.TransformFinalBlock(pt, 0, pt.Length);
-            return ConversionHelper.ByteArrayToString(key);
-        }
-
-        // don't work with CFLIST atm
-        public static string CalculateKey(byte[] type, byte[] appnonce, byte[] netid, ReadOnlyMemory<byte> devnonce, byte[] appKey)
-        {
-            if (type is null) throw new ArgumentNullException(nameof(type));
-            if (appnonce is null) throw new ArgumentNullException(nameof(appnonce));
-            if (netid is null) throw new ArgumentNullException(nameof(netid));
-
-            using var aes = Aes.Create("AesManaged");
-            aes.Key = appKey;
-#pragma warning disable CA5358 // Review cipher mode usage with cryptography experts
-            // Cipher is part of the LoRaWAN specification
-            aes.Mode = CipherMode.ECB;
-#pragma warning restore CA5358 // Review cipher mode usage with cryptography experts
-            aes.Padding = PaddingMode.None;
-
-            var pt = new byte[type.Length + appnonce.Length + netid.Length + devnonce.Length + 7];
-            var destIndex = 0;
-            Array.Copy(type, 0, pt, destIndex, type.Length);
-
-            destIndex += type.Length;
-            Array.Copy(appnonce, 0, pt, destIndex, appnonce.Length);
-
-            destIndex += appnonce.Length;
-            Array.Copy(netid, 0, pt, destIndex, netid.Length);
-
-            destIndex += netid.Length;
-            devnonce.CopyTo(new Memory<byte>(pt, destIndex, devnonce.Length));
+            var buffer = new byte[type.Length + AppNonce.Size + netid.Length + DevNonce.Size + 7];
+            var pt = buffer.AsSpan();
+            Debug.Assert(pt.Length == 16);
+            type.CopyTo(pt);
+            pt = pt[type.Length..];
+            pt = appNonce.Write(pt);
+            netid.CopyTo(pt);
+            pt = pt[netid.Length..];
+            pt = devNonce.Write(pt);
+            Debug.Assert(pt.Length == 7);
 
             aes.IV = new byte[16];
             ICryptoTransform cipher;
@@ -101,17 +64,8 @@ namespace LoRaTools
             cipher = aes.CreateEncryptor();
 #pragma warning restore CA5401 // Do not use CreateEncryptor with non-default IV
 
-            var key = cipher.TransformFinalBlock(pt, 0, pt.Length);
+            var key = cipher.TransformFinalBlock(buffer, 0, buffer.Length);
             return ConversionHelper.ByteArrayToString(key);
-        }
-
-        public static string GetAppNonce()
-        {
-            Span<byte> bytes = stackalloc byte[3];
-            RandomNumberGenerator.Fill(bytes);
-            Span<char> chars = stackalloc char[bytes.Length * 2];
-            Hexadecimal.Write(bytes, chars);
-            return new string(chars);
         }
     }
 }

--- a/Tests/Unit/LoRaWan/AppNonceTests.cs
+++ b/Tests/Unit/LoRaWan/AppNonceTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit
+{
+    using System;
+    using System.Linq;
+    using Xunit;
+
+    public class AppNonceTests
+    {
+        private readonly AppNonce subject = new(0x123456);
+
+        [Fact]
+        public void Size_Is_3_Bytes()
+        {
+            Assert.Equal(3, AppNonce.Size);
+        }
+
+        [Fact]
+        public void MaxValue_Is_Largest_24_Bit_Integer()
+        {
+            Assert.Equal(16777215, AppNonce.MaxValue);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(AppNonce.MaxValue + 1)]
+        public void Init_Throws_For_Invalid_Value(int value)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new AppNonce(value));
+        }
+
+        [Fact]
+        public void ToString_Returns_Decimal_String()
+        {
+            Assert.Equal("1193046", this.subject.ToString());
+        }
+
+        [Fact]
+        public void Conversion_To_Int_Returns_Value()
+        {
+            var result = (int)this.subject;
+            Assert.Equal(1193046, result);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void Read_Throws_When_Buffer_Is_Too_Small(int size)
+        {
+            var ex = Assert.Throws<ArgumentException>(() => AppNonce.Read(new byte[size]));
+            Assert.Equal("Insufficient buffer length.", ex.Message);
+        }
+
+        [Theory]
+        [InlineData(0x123456, new byte[] { 0x56, 0x34, 0x12 })]
+        [InlineData(0x123456, new byte[] { 0x56, 0x34, 0x12, 0xff })]
+        public void Read_Decodes_In_Little_Endian(int expected, byte[] bytes)
+        {
+            var result = AppNonce.Read(bytes);
+            Assert.Equal(new AppNonce(expected), result);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void Write_Throws_When_Buffer_Is_Too_Small(int size)
+        {
+            var ex = Assert.Throws<ArgumentException>(() => this.subject.Write(new byte[size]));
+            Assert.Equal("Insufficient buffer length.", ex.Message);
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 0x56, 0x34, 0x12 }, 0x123456)]
+        public void Write_Encodes_In_Little_Endian(byte[] expected, int input)
+        {
+            const byte fill = 0xff;
+            var buffer = Enumerable.Repeat(fill, 10).ToArray();
+            var nonce = new AppNonce(input);
+
+            var result = nonce.Write(buffer);
+
+            Assert.Equal(expected, buffer[..3]);
+            Assert.Equal(Enumerable.Repeat(fill, 7).ToArray(), result.ToArray());
+        }
+    }
+}

--- a/Tests/Unit/LoRaWan/MicTests.cs
+++ b/Tests/Unit/LoRaWan/MicTests.cs
@@ -75,14 +75,14 @@ namespace LoRaWan.Tests.Unit
         {
             var key = TestKeys.CreateAppKey(0x0005100000000004);
             var mhdr = new MacHeader(1);
-            var joinNonce = new byte[] { 0xab, 0xcd };
+            var joinNonce = new AppNonce(0xabcdef);
             var netId = new byte[] { 0xba, 0xbb, 0xbc };
             var devAddr = new DevAddr(0x14131211);
             var dlSettings = new byte[] { 0xca };
             var rxDelay = new byte[] { 0xda };
             var cfList = new byte[16] { 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xea, 0xeb, 0xec, 0xed, 0xef, 0xf1, 0xf2, 0xf3 };
             var mic = Mic.ComputeForJoinAccept(key, mhdr, joinNonce, netId, devAddr, dlSettings, rxDelay, cfList);
-            Assert.Equal(new Mic(0x48148BC8), mic);
+            Assert.Equal(new Mic(0x19cf5627), mic);
         }
 
         [Fact]

--- a/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
+++ b/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
@@ -9,7 +9,6 @@ namespace LoRaWan.Tests.Unit.NetworkServer
     using System.Threading.Tasks;
     using global::LoRaTools.LoRaMessage;
     using global::LoRaTools.Regions;
-    using global::LoRaTools.Utils;
     using LoRaWan.NetworkServer;
     using LoRaWan.Tests.Common;
     using Microsoft.Azure.Devices.Client;
@@ -101,7 +100,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.Equal(joinAccept.DevAddr, loRaDevice.DevAddr);
 
             // Device properties were set with the computes values of the join operation
-            Assert.Equal(joinAccept.AppNonce.ToArray(), ReversedByteArray(loRaDevice.AppNonce).ToArray());
+            Assert.Equal(joinAccept.AppNonce, loRaDevice.AppNonce);
             Assert.NotNull(loRaDevice.NwkSKey);
             Assert.NotNull(loRaDevice.AppSKey);
             Assert.True(loRaDevice.IsOurDevice);
@@ -114,14 +113,6 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // Twin property were updated
             LoRaDeviceClient.VerifyAll();
             LoRaDeviceApi.VerifyAll();
-        }
-
-        private static Memory<byte> ReversedByteArray(string value)
-        {
-            var array = ConversionHelper.StringToByteArray(value);
-
-            Array.Reverse(array);
-            return array;
         }
 
         [Fact]


### PR DESCRIPTION
# PR for issue #1225

## What is being addressed

- Lack of encapsulation of details regarding **AppNonce** from the LoRaWAN specification
- Use of byte arrays and memory to represent the nonce

## How is this addressed

A new type `AppNonce` has been added to encapsulate the details and used for properties in composite types and method signatures.
