### PR TITLE
E2E CI should only be run on labelling

### DIFF
--- a/.github/workflows/e2e-ci.yaml
+++ b/.github/workflows/e2e-ci.yaml
@@ -4,7 +4,7 @@ on: # rebuild any PRs and main branch changes
   schedule:
     - cron: '59 23 * * 1,2,3,4,5'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
   workflow_dispatch:
     inputs:
       RunE2ETestsOnly:


### PR DESCRIPTION
# PR for issue #1240 

This PR is adjusting E2E CI template to only be run on labelling