### PR TITLE
Add more debug info to failing test case

### DIFF
--- a/Tests/Integration/JoinTests.cs
+++ b/Tests/Integration/JoinTests.cs
@@ -120,7 +120,7 @@ namespace LoRaWan.Tests.Integration
                 CreateWaitableRequest(joinRequestPayload, constantElapsedTime: TimeSpan.FromMilliseconds(300));
             messageProcessor.DispatchRequest(joinRequest);
             Assert.True(await joinRequest.WaitCompleteAsync());
-            Assert.True(joinRequest.ProcessingSucceeded);
+            Assert.True(joinRequest.ProcessingSucceeded, $"Failed due to '{joinRequest.ProcessingFailedReason}'.");
             Assert.NotNull(joinRequest.ResponseDownlink);
             Assert.Single(PacketForwarder.DownlinkMessages);
             var downlinkJoinAcceptMessage = PacketForwarder.DownlinkMessages[0];


### PR DESCRIPTION
# PR for issue #1235

## What is being addressed

With this PR we add more debug output to a test case which was failing intermittently. This does not explain the failure we saw, but it will help debug such failures in the future.