### PR TITLE
Change `LoRaPayloadJoinAccept.RxDelay` to `RxDelay` type

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Mic.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Mic.cs
@@ -84,9 +84,9 @@ namespace LoRaWan
             return new Mic(BinaryPrimitives.ReadInt32LittleEndian(cmac));
         }
 
-        public static Mic ComputeForJoinAccept(AppKey appKey, MacHeader macHeader, AppNonce joinNonce, NetId netId, DevAddr devAddr, Memory<byte> dlSettings, Memory<byte> rxDelay, Memory<byte> cfList)
+        public static Mic ComputeForJoinAccept(AppKey appKey, MacHeader macHeader, AppNonce joinNonce, NetId netId, DevAddr devAddr, Memory<byte> dlSettings, RxDelay rxDelay, Memory<byte> cfList)
         {
-            var algoInput = new byte[MacHeader.Size + AppNonce.Size + NetId.Size + DevAddr.Size + dlSettings.Length + rxDelay.Length + cfList.Length];
+            var algoInput = new byte[MacHeader.Size + AppNonce.Size + NetId.Size + DevAddr.Size + dlSettings.Length + sizeof(RxDelay) + cfList.Length];
             var index = 0;
             _ = macHeader.Write(algoInput.AsSpan(index));
             index += MacHeader.Size;
@@ -98,8 +98,8 @@ namespace LoRaWan
             index += DevAddr.Size;
             dlSettings.CopyTo(algoInput.AsMemory(index));
             index += dlSettings.Length;
-            rxDelay.CopyTo(algoInput.AsMemory(index));
-            index += rxDelay.Length;
+            _ = rxDelay.Write(algoInput.AsSpan(index));
+            index += sizeof(RxDelay);
             if (!cfList.IsEmpty)
                 cfList.CopyTo(algoInput.AsMemory(index));
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/RxDelay.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/RxDelay.cs
@@ -52,5 +52,14 @@ namespace LoRaWan
         /// Converts to <see cref="TimeSpan"/>, if valid.
         /// </summary>
         public static TimeSpan ToTimeSpan(this RxDelay delay) => TimeSpan.FromSeconds(ToSeconds(delay));
+
+        /// <summary>
+        /// Write the value to a bytes buffer.
+        /// </summary>
+        public static Span<byte> Write(this RxDelay delay, Span<byte> buffer)
+        {
+            buffer[0] = (byte)delay;
+            return buffer[sizeof(RxDelay)..];
+        }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
@@ -33,7 +33,7 @@ namespace LoRaTools.LoRaMessage
         /// <summary>
         /// Gets or sets rxDelay.
         /// </summary>
-        public Memory<byte> RxDelay { get; set; }
+        public RxDelay RxDelay { get; set; }
 
         /// <summary>
         /// Gets or sets cFList / Optional.
@@ -67,7 +67,7 @@ namespace LoRaTools.LoRaMessage
             _ = devAddr.Write(RawMessage.AsSpan(7));
             DlSettings = new Memory<byte>(RawMessage, 11, 1);
             Array.Copy(dlSettings, 0, RawMessage, 11, 1);
-            RxDelay = new Memory<byte>(RawMessage, 12, 1);
+            RxDelay = rxDelay;
             RawMessage[12] = (byte)(Enum.IsDefined(rxDelay) ? rxDelay : default);
             // set payload Wrapper fields
             if (cfListLength > 0)
@@ -79,10 +79,7 @@ namespace LoRaTools.LoRaMessage
             // cfList = StringToByteArray("184F84E85684B85E84886684586E8400");
             Fcnt = BitConverter.GetBytes(0x01);
             if (BitConverter.IsLittleEndian)
-            {
                 DlSettings.Span.Reverse();
-                RxDelay.Span.Reverse();
-            }
         }
 
         public LoRaPayloadJoinAccept(ReadOnlyMemory<byte> inputMessage, AppKey appKey) : this(inputMessage.ToArray(), appKey)
@@ -132,9 +129,7 @@ namespace LoRaTools.LoRaMessage
             var dlSettings = new byte[1];
             Array.Copy(inputMessage, 11, dlSettings, 0, 1);
             DlSettings = new Memory<byte>(dlSettings);
-            var rxDelay = new byte[1];
-            Array.Copy(inputMessage, 12, rxDelay, 0, 1);
-            RxDelay = new Memory<byte>(rxDelay);
+            RxDelay = (RxDelay)(inputMessage[12] & 0b111); // upper bits are reserved for future use
             // It's the configuration list, it can be empty or up to 15 bytes
             // - 17 = - 1 - 3 - 3 - 4 - 1 - 1 - 4
             // This is the size of all mandatory elements of the message
@@ -152,7 +147,7 @@ namespace LoRaTools.LoRaMessage
             var channelFrequencies = !CfList.Span.IsEmpty ? CfList.ToArray() : Array.Empty<byte>();
 
             var buffer = new byte[AppNonce.Size + NetId.Size + DevAddr.Size + DlSettings.Length +
-                                  RxDelay.Length + channelFrequencies.Length + LoRaWan.Mic.Size];
+                                  sizeof(RxDelay) + channelFrequencies.Length + LoRaWan.Mic.Size];
 
             static Span<byte> Copy(ReadOnlyMemory<byte> source, Span<byte> target)
             {
@@ -166,7 +161,7 @@ namespace LoRaTools.LoRaMessage
             pt = NetId.Write(pt);
             pt = DevAddr.Write(pt);
             pt = Copy(DlSettings, pt);
-            pt = Copy(RxDelay, pt);
+            pt = RxDelay.Write(pt);
             pt = Copy(channelFrequencies, pt);
             _ = mic.Write(pt);
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
@@ -129,7 +129,7 @@ namespace LoRaTools.LoRaMessage
             var dlSettings = new byte[1];
             Array.Copy(inputMessage, 11, dlSettings, 0, 1);
             DlSettings = new Memory<byte>(dlSettings);
-            RxDelay = (RxDelay)(inputMessage[12] & 0b111); // upper bits are reserved for future use
+            RxDelay = (RxDelay)(inputMessage[12] & 0b1111); // upper bits are reserved for future use
             // It's the configuration list, it can be empty or up to 15 bytes
             // - 17 = - 1 - 3 - 3 - 4 - 1 - 1 - 4
             // This is the size of all mandatory elements of the message

--- a/Tests/Unit/LoRaWan/MicTests.cs
+++ b/Tests/Unit/LoRaWan/MicTests.cs
@@ -79,10 +79,10 @@ namespace LoRaWan.Tests.Unit
             var netId = new NetId(0xbcbbba);
             var devAddr = new DevAddr(0x14131211);
             var dlSettings = new byte[] { 0xca };
-            var rxDelay = new byte[] { 0xda };
+            var rxDelay = RxDelay.RxDelay10;
             var cfList = new byte[16] { 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xea, 0xeb, 0xec, 0xed, 0xef, 0xf1, 0xf2, 0xf3 };
             var mic = Mic.ComputeForJoinAccept(key, mhdr, joinNonce, netId, devAddr, dlSettings, rxDelay, cfList);
-            Assert.Equal(new Mic(0x19cf5627), mic);
+            Assert.Equal(new Mic(-1539170837), mic);
         }
 
         [Fact]

--- a/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
+++ b/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
@@ -754,7 +754,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         }
 
         [Theory]
-        [InlineData(0, RxDelay1)]
+        [InlineData(0, RxDelay0)]
         [InlineData(1, RxDelay1)]
         [InlineData(2, RxDelay2)]
         [InlineData(3, RxDelay3)]


### PR DESCRIPTION
This PR adds to #1144, which missed an opportunity to use the `RxDelay` type.

## What is being addressed

`LoRaPayloadJoinAccept.RxDelay` was typed as `Memory<byte>`.

## How is this addressed

The type of the property is changed to the type `RxDelay`.
