### PR TITLE
Remove `LoRaPayloadData.AddMacCommand` that's not used anywhere

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -420,22 +420,7 @@ namespace LoRaTools.LoRaMessage
             return messageArray.ToArray();
         }
 
-        /// <summary>
-        /// Add Mac Command to a LoRa Payload
-        /// Warning, do not use this method if your LoRaPayload was created from bytes.
-        /// </summary>
-        public void AddMacCommand(MacCommand mac)
-        {
-            if (MacCommands == null)
-            {
-                MacCommands = new List<MacCommand>();
-            }
-
-            MacCommands.Add(mac);
-        }
-
-        public override bool RequiresConfirmation
-            => IsConfirmed || IsMacAnswerRequired;
+        public override bool RequiresConfirmation => IsConfirmed || IsMacAnswerRequired;
 
         public override bool CheckMic(AppKey key) => throw new NotImplementedException();
 


### PR DESCRIPTION
## What is being addressed

The method `LoRaPayloadData.AddMacCommand` is no longer used anywhere.

## How is this addressed

The method `LoRaPayloadData.AddMacCommand` is removed.
