### PR TITLE
Firmware endpoint returns content length

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/ConcentratorFirmwareFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ConcentratorFirmwareFunction.cs
@@ -79,8 +79,8 @@ namespace LoraKeysManagerFacade
                         throw new ArgumentOutOfRangeException(CupsPropertyName, "Failed to read CUPS config");
 
                     var fwUrl = JObject.Parse(cupsProperty)[CupsFwUrlPropertyName].ToString();
-                    var stream = await GetBlobStreamAsync(fwUrl, cancellationToken);
-                    return new FileStreamResult(stream, MediaTypeNames.Application.Octet);
+                    var (fwLength, stream) = await GetBlobStreamAsync(fwUrl, cancellationToken);
+                    return new FileStreamWithContentLengthResult(stream, "application/octet-stream", fwLength);
                 }
                 catch (Exception ex) when (ex is ArgumentOutOfRangeException or JsonReaderException or NullReferenceException)
                 {
@@ -103,14 +103,15 @@ namespace LoraKeysManagerFacade
             }
         }
 
-        private async Task<Stream> GetBlobStreamAsync(string blobUrl, CancellationToken cancellationToken)
+        private async Task<(long, Stream)> GetBlobStreamAsync(string blobUrl, CancellationToken cancellationToken)
         {
             var blobServiceClient = this.azureClientFactory.CreateClient(FacadeStartup.WebJobsStorageClientName);
             var blobUri = new BlobUriBuilder(new Uri(blobUrl));
-            var streamingResult = await blobServiceClient.GetBlobContainerClient(blobUri.BlobContainerName)
-                                                         .GetBlobClient(blobUri.BlobName)
-                                                         .DownloadStreamingAsync(cancellationToken: cancellationToken);
-            return streamingResult.Value.Content;
+            var blobClient = blobServiceClient.GetBlobContainerClient(blobUri.BlobContainerName)
+                                              .GetBlobClient(blobUri.BlobName);
+            var blobProperties = await blobClient.GetPropertiesAsync(null, cancellationToken);
+            var streamingResult = await blobClient.DownloadStreamingAsync(cancellationToken: cancellationToken);
+            return (blobProperties.Value.ContentLength, streamingResult.Value.Content);
         }
     }
 }

--- a/LoRaEngine/LoraKeysManagerFacade/FileStreamWithContentLengthResult.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FileStreamWithContentLengthResult.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoraKeysManagerFacade
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Infrastructure;
+    using Microsoft.Extensions.DependencyInjection;
+
+    internal class FileStreamWithContentLengthResult : FileStreamResult, IActionResult
+    {
+        private readonly long contentLength;
+
+        public FileStreamWithContentLengthResult(Stream fileStream, string contentType, long contentLength) : base(fileStream, contentType)
+        {
+            this.contentLength = contentLength;
+        }
+
+        public override Task ExecuteResultAsync(ActionContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<FileStreamResult>>();
+            context.HttpContext.Response.ContentLength = this.contentLength;
+            return executor.ExecuteAsync(context, this);
+        }
+    }
+}

--- a/Tests/Unit/LoraKeysManagerFacade/ConcentratorFirmwareFunctionTests.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/ConcentratorFirmwareFunctionTests.cs
@@ -82,10 +82,13 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             this.blobClient.Setup(m => m.DownloadStreamingAsync(default, null, false, It.IsAny<CancellationToken>()))
                            .Returns(Task.FromResult(Response.FromValue(streamingResult, new Mock<Response>().Object)));
 
+            this.blobClient.Setup(m => m.GetPropertiesAsync(null, It.IsAny<CancellationToken>()))
+                           .Returns(Task.FromResult(Response.FromValue(new BlobProperties(), new Mock<Response>().Object)));
+
             var actual = await this.concentratorFirmware.RunFetchConcentratorFirmware(httpRequest.Object, CancellationToken.None);
 
             Assert.NotNull(actual);
-            var result = Assert.IsType<FileStreamResult>(actual);
+            var result = Assert.IsType<FileStreamWithContentLengthResult>(actual);
 
             result.FileStream.Position = 0;
             using var reader = new StreamReader(result.FileStream);


### PR DESCRIPTION
# PR for issue #1299 

## What is being addressed

Firmware endpoint in the Azure Function now also returns the length of the stream content.

## How is this addressed

- New class added that extends `FileStreamResult`
- Endpoint updated to also return the content length
- Unit tests updated
