### PR TITLE
Removing "sensor decoder module" from IoT Edge non-ci template

### DIFF
--- a/LoRaEngine/deployment.template.json
+++ b/LoRaEngine/deployment.template.json
@@ -143,16 +143,6 @@
             "version": "1.0",
             "status": "running",
             "restartPolicy": "always"
-          },
-          "sensordecodermodule": {
-            "type": "docker",
-            "settings": {
-              "image": "$CONTAINER_REGISTRY_ADDRESS/decodersample:2.0",
-              "createOptions": {}
-            },
-            "status": "running",
-            "restartPolicy": "always",
-            "version": "1.0"
           }
         }
       }


### PR DESCRIPTION
# PR for closing #1310 

## What is being addressed

This PR is removing the sensor decoder module from the IoT Edge deployment template not used for CI.