### PR TITLE
Fix OTAA E2E tests broken by RX window changes

### DIFF
--- a/Tests/E2E/OTAAJoinTest.cs
+++ b/Tests/E2E/OTAAJoinTest.cs
@@ -234,7 +234,7 @@ namespace LoRaWan.Tests.E2E
             // Checking than the communication occurs on DR 4 and RX2 as part of preferred windows RX2 and custom RX2 DR
             await AssertUtils.ContainsWithRetriesAsync(x => x.StartsWith("+CMSG: RXWIN2", StringComparison.Ordinal), ArduinoDevice.SerialLogs);
             // this test has a custom datarate for RX 2 of 3
-            const string logMessage2 = "\"Rx2\":{\"DataRateIndex\":3";
+            const string logMessage2 = "\"Rx2\":{\"DataRate\":3";
             await TestFixtureCi.AssertNetworkServerModuleLogExistsAsync(x => x.Contains(logMessage2, StringComparison.Ordinal), new SearchLogOptions(logMessage2));
 
 

--- a/Tests/E2E/OTAAJoinTest.cs
+++ b/Tests/E2E/OTAAJoinTest.cs
@@ -234,7 +234,7 @@ namespace LoRaWan.Tests.E2E
             // Checking than the communication occurs on DR 4 and RX2 as part of preferred windows RX2 and custom RX2 DR
             await AssertUtils.ContainsWithRetriesAsync(x => x.StartsWith("+CMSG: RXWIN2", StringComparison.Ordinal), ArduinoDevice.SerialLogs);
             // this test has a custom datarate for RX 2 of 3
-            const string logMessage2 = "\"Rx2\":{\"Item1\":3";
+            const string logMessage2 = "\"Rx2\":{\"DataRateIndex\":3";
             await TestFixtureCi.AssertNetworkServerModuleLogExistsAsync(x => x.Contains(logMessage2, StringComparison.Ordinal), new SearchLogOptions(logMessage2));
 
 

--- a/Tests/E2E/OTAATest.cs
+++ b/Tests/E2E/OTAATest.cs
@@ -133,7 +133,7 @@ namespace LoRaWan.Tests.E2E
                 if (ArduinoDevice.SerialLogs.Any(x => x.StartsWith("+CMSG: RXWIN1", StringComparison.Ordinal)))
                 {
                     // Expect that the response is done on DR4 as the RX1 offset is 1 on this device.
-                    const string logMessage = "\"Rx1\":{\"DataRateIndex\":4";
+                    const string logMessage = "\"Rx1\":{\"DataRate\":4";
                     await TestFixtureCi.AssertNetworkServerModuleLogExistsAsync(log => log.Contains(logMessage, StringComparison.Ordinal), new SearchLogOptions(logMessage));
                 }
 

--- a/Tests/E2E/OTAATest.cs
+++ b/Tests/E2E/OTAATest.cs
@@ -133,7 +133,7 @@ namespace LoRaWan.Tests.E2E
                 if (ArduinoDevice.SerialLogs.Any(x => x.StartsWith("+CMSG: RXWIN1", StringComparison.Ordinal)))
                 {
                     // Expect that the response is done on DR4 as the RX1 offset is 1 on this device.
-                    const string logMessage = "\"Rx1\":{\"Item1\":4";
+                    const string logMessage = "\"Rx1\":{\"DataRateIndex\":4";
                     await TestFixtureCi.AssertNetworkServerModuleLogExistsAsync(log => log.Contains(logMessage, StringComparison.Ordinal), new SearchLogOptions(logMessage));
                 }
 


### PR DESCRIPTION
## What is being addressed

[OTAA E2E tests were broken](https://github.com/Azure/iotedge-lorawan-starterkit/runs/4875871505?check_suite_focus=true) by #1318:

**OTAA:**

     2022-01-20T01:41:15.0470005Z Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Executed endpoint 'Prometheus metrics'
     2022-01-20T01:45:56.4906383Z Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: 01F5A9FF00000004: sending message to station with EUI 'B827EBFFFEF4E332' with diid 485849269. Payload '6021625103A0010040BB94F9'.
     2022-01-20T01:52:11.0363188Z Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T01:57:53.6317384Z Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T01:57:55.4736651Z    Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Executed endpoint 'Prometheus metrics'
     2022-01-20T01:57:55.4858131Z    Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: 01F5A9FF00000004: sending message to station with EUI 'B827EBFFFEF4E332' with diid 485849269. Payload '6021625103A0010040BB94F9'.
     2022-01-20T01:57:55.4897052Z    Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T01:57:55.4953870Z    Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T02:02:02.2294442Z Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T02:06:23.1062170Z Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T02:12:14.5632969Z Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T02:17:04.5510827Z Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T02:17:04.9639752Z    Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T02:17:04.9715929Z    Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T02:17:04.9793681Z    Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T02:17:04.9833656Z    Searching for "Rx1":{"Item1":4 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'

**OTAA Join:**

     2022-01-20T00:32:40.6354086Z Searching for "Rx2":{"Item1":3 failed. Current log content: [itesteflow: getting device twin
     2022-01-20T00:35:54.3891837Z Searching for "Rx2":{"Item1":3 failed. Current log content: [itestarm1: 01F5A90000000020: UnconfirmedDataDown {"DevEui":{"IsValid":true,"AsUInt64":141204780797132832},"LnsRxDelay":0,"DeviceClassType":0,"Xtime":32369623007650987,"AntennaPreference":0,"Rx1":null,"Rx2":{"DataRate":3,"Frequency":{"AsUInt64":869525000,"InKilo":869525.0,"InMega":869.525,"InGiga":0.869525}},"Data":{"Length":12,"IsEmpty":false},"StationEui":{"IsValid":true,"AsUInt64":13269834311785941743}}
     2022-01-20T00:39:29.4808998Z Searching for "Rx2":{"Item1":3 failed. Current log content: [itestarm1: B827EBFFFE4A8AEF: Received 'dntxed' message: '{"msgtype":"dntxed","seqno":-1543726947,"diid":-1543726947,"DR":3,"Freq":869525000,"DevEui":"01-F5-A9-00-00-00-00-20","rctx":0,"xtime":32369623224723940,"txtime":461001.159723,"gpstime":0}'.
     2022-01-20T00:45:24.7190222Z Searching for "Rx2":{"Item1":3 failed. Current log content: [itestarm1: B827EBFFFE4A8AEF: Received 'dntxed' message: '{"msgtype":"dntxed","seqno":1488815140,"diid":1488815140,"DR":3,"Freq":869525000,"DevEui":"01-F5-A9-00-00-00-00-20","rctx":0,"xtime":32369623579940867,"txtime":461356.382418,"gpstime":0}'.
     2022-01-20T00:45:26.5459329Z    Searching for "Rx2":{"Item1":3 failed. Current log content: [itesteflow: getting device twin
     2022-01-20T00:45:26.5568321Z    Searching for "Rx2":{"Item1":3 failed. Current log content: [itestarm1: 01F5A90000000020: UnconfirmedDataDown {"DevEui":{"IsValid":true,"AsUInt64":141204780797132832},"LnsRxDelay":0,"DeviceClassType":0,"Xtime":32369623007650987,"AntennaPreference":0,"Rx1":null,"Rx2":{"DataRate":3,"Frequency":{"AsUInt64":869525000,"InKilo":869525.0,"InMega":869.525,"InGiga":0.869525}},"Data":{"Length":12,"IsEmpty":false},"StationEui":{"IsValid":true,"AsUInt64":13269834311785941743}}
     2022-01-20T00:45:26.5616364Z    Searching for "Rx2":{"Item1":3 failed. Current log content: [itestarm1: B827EBFFFE4A8AEF: Received 'dntxed' message: '{"msgtype":"dntxed","seqno":-1543726947,"diid":-1543726947,"DR":3,"Freq":869525000,"DevEui":"01-F5-A9-00-00-00-00-20","rctx":0,"xtime":32369623224723940,"txtime":461001.159723,"gpstime":0}'.
     2022-01-20T00:45:26.5655011Z    Searching for "Rx2":{"Item1":3 failed. Current log content: [itestarm1: B827EBFFFE4A8AEF: Received 'dntxed' message: '{"msgtype":"dntxed","seqno":1488815140,"diid":1488815140,"DR":3,"Freq":869525000,"DevEui":"01-F5-A9-00-00-00-00-20","rctx":0,"xtime":32369623579940867,"txtime":461356.382418,"gpstime":0}'.
     2022-01-20T00:52:08.9384765Z Searching for "Rx2":{"Item1":3 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T00:55:35.4176777Z Searching for "Rx2":{"Item1":3 failed. Current log content: [itesteflow: B827EBFFFEF4E332: Received 'dntxed' message: '{"msgtype":"dntxed","seqno":2049147262,"diid":2049147262,"DR":3,"Freq":869525000,"DevEui":"01-F5-A9-FF-00-00-00-20","rctx":0,"xtime":844426839277915,"txtime":461911.582923,"gpstime":0}'.
     2022-01-20T01:00:31.0902283Z Searching for "Rx2":{"Item1":3 failed. Current log content: [itestarm1: B827EBFFFE4A8AEF: Received 'dntxed' message: '{"msgtype":"dntxed","seqno":1947608386,"diid":1947608386,"DR":3,"Freq":869525000,"DevEui":"01-F5-A9-FF-00-00-00-20","rctx":0,"xtime":32369624486332587,"txtime":462262.780793,"gpstime":0}'.
     2022-01-20T01:06:46.9509632Z Searching for "Rx2":{"Item1":3 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T01:06:48.4780595Z    Searching for "Rx2":{"Item1":3 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'
     2022-01-20T01:06:48.4860187Z    Searching for "Rx2":{"Item1":3 failed. Current log content: [itesteflow: B827EBFFFEF4E332: Received 'dntxed' message: '{"msgtype":"dntxed","seqno":2049147262,"diid":2049147262,"DR":3,"Freq":869525000,"DevEui":"01-F5-A9-FF-00-00-00-20","rctx":0,"xtime":844426839277915,"txtime":461911.582923,"gpstime":0}'.
     2022-01-20T01:06:48.4917078Z    Searching for "Rx2":{"Item1":3 failed. Current log content: [itestarm1: B827EBFFFE4A8AEF: Received 'dntxed' message: '{"msgtype":"dntxed","seqno":1947608386,"diid":1947608386,"DR":3,"Freq":869525000,"DevEui":"01-F5-A9-FF-00-00-00-20","rctx":0,"xtime":32369624486332587,"txtime":462262.780793,"gpstime":0}'.
     2022-01-20T01:06:48.4958510Z    Searching for "Rx2":{"Item1":3 failed. Current log content: [itesteflow: Request matched endpoint 'Prometheus metrics'

They were looking for a specific data shape of receive windows in `DownlinkMessage` that was based on tuples, but which changed with #1318 using `ReceiveWindow`

## How is this addressed

Changed the search text to be based on the JSON serialization of `ReceiveWindow`.
