### PR TITLE
Make `LoRaPayload.GetByteMessage` private to each subclass

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayload.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayload.cs
@@ -63,12 +63,6 @@ namespace LoRaTools.LoRaMessage
         }
 
         /// <summary>
-        /// Method to take the different fields and assemble them in the message bytes.
-        /// </summary>
-        /// <returns>the message bytes.</returns>
-        public abstract byte[] GetByteMessage();
-
-        /// <summary>
         /// Method to check a Mic.
         /// </summary>
         /// <param name="key">The Network Secret Key.</param>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -435,7 +435,7 @@ namespace LoRaTools.LoRaMessage
             }
         }
 
-        public override byte[] GetByteMessage()
+        private byte[] GetByteMessage()
         {
             var messageArray = new List<byte>
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
@@ -179,7 +179,7 @@ namespace LoRaTools.LoRaMessage
             return encryptedPayload;
         }
 
-        public override byte[] GetByteMessage() => RawMessage.Prepend((byte)MHdr).ToArray();
+        private byte[] GetByteMessage() => RawMessage.Prepend((byte)MHdr).ToArray();
 
         public override bool CheckMic(NetworkSessionKey key, uint? server32BitFcnt = null)
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinRequest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinRequest.cs
@@ -37,27 +37,6 @@ namespace LoRaTools.LoRaMessage
 
         public override byte[] Serialize(AppSessionKey key) => throw new NotImplementedException("The payload is not encrypted in case of a join message");
 
-        public override byte[] GetByteMessage()
-        {
-            var messageArray = new byte[MacHeader.Size + JoinEui.Size + DevEui.Size + DevNonce.Size + LoRaWan.Mic.Size];
-            var start = 0;
-            _ = MHdr.Write(messageArray.AsSpan(start));
-            start += MacHeader.Size;
-            _ = AppEui.Write(messageArray.AsSpan(start));
-            start += JoinEui.Size;
-            _ = DevEUI.Write(messageArray.AsSpan(start));
-            start += DevEui.Size;
-            _ = DevNonce.Write(messageArray.AsSpan(start));
-            start += DevNonce.Size;
-
-            if (Mic is { } someMic)
-            {
-                _ = someMic.Write(messageArray.AsSpan(start));
-            }
-
-            return messageArray;
-        }
-
         public override byte[] Serialize(NetworkSessionKey key) => throw new NotImplementedException();
 
         public override byte[] PerformEncryption(AppKey key) => throw new NotImplementedException();


### PR DESCRIPTION
Method `GetByteMessage` of `LoRaPayload` was never publicly access. This PR removes the method from `LoRaPayload` and makes the implementations in the subclass private since they were only accessed from within the same class. In the case of `LoRaPayloadJoinRequest`, it was completely unused so it's been entirely unremoved there. In addition to reducing the public surface of `LoRaPayload` and impositions on subclasses, removing the unused code (as in the case of `LoRaPayloadJoinRequest`) should improve the code coverage.
