### PR TITLE
Make `PerformEncryption` private to `LoRaPayloadJoinAccept`

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayload.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayload.cs
@@ -95,13 +95,6 @@ namespace LoRaTools.LoRaMessage
         /// <returns>the encrypted bytes.</returns>
         public abstract byte[] Serialize(NetworkSessionKey key);
 
-        /// <summary>
-        /// Method to calculate the encrypted version of the payload.
-        /// </summary>
-        /// <param name="key">The App Key.</param>
-        /// <returns>the encrypted bytes.</returns>
-        public abstract byte[] PerformEncryption(AppKey key);
-
         public void Reset32BitFcnt() => Server32BitFcnt = null;
         public void Ensure32BitFcntValue(uint? server32bitFcnt) => Server32BitFcnt ??= server32bitFcnt;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -478,7 +478,5 @@ namespace LoRaTools.LoRaMessage
         public override bool RequiresConfirmation => IsConfirmed || IsMacAnswerRequired;
 
         public override bool CheckMic(AppKey key) => throw new NotImplementedException();
-
-        public override byte[] PerformEncryption(AppKey key) => throw new NotImplementedException();
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
@@ -134,7 +134,15 @@ namespace LoRaTools.LoRaMessage
             Mic = LoRaWan.Mic.Read(inputMessage.AsSpan(inputMessage.Length - 4, 4));
         }
 
-        public override byte[] PerformEncryption(AppKey key)
+        public byte[] Serialize(AppKey appKey)
+        {
+            Mic = LoRaWan.Mic.ComputeForJoinAccept(appKey, MHdr, AppNonce, NetId, DevAddr, DlSettings, RxDelay, CfList);
+            _ = PerformEncryption(appKey);
+
+            return GetByteMessage();
+        }
+
+        private byte[] PerformEncryption(AppKey key)
         {
             var mic = Mic ?? throw new InvalidOperationException("MIC must not be null.");
 
@@ -184,14 +192,6 @@ namespace LoRaTools.LoRaMessage
         public override bool CheckMic(NetworkSessionKey key, uint? server32BitFcnt = null)
         {
             throw new NotImplementedException();
-        }
-
-        public byte[] Serialize(AppKey appKey)
-        {
-            Mic = LoRaWan.Mic.ComputeForJoinAccept(appKey, MHdr, AppNonce, NetId, DevAddr, DlSettings, RxDelay, CfList);
-            _ = PerformEncryption(appKey);
-
-            return GetByteMessage();
         }
 
         public override byte[] Serialize(NetworkSessionKey key) => throw new NotImplementedException();

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinRequest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinRequest.cs
@@ -59,7 +59,5 @@ namespace LoRaTools.LoRaMessage
         }
 
         public override byte[] Serialize(NetworkSessionKey key) => throw new NotImplementedException();
-
-        public override byte[] PerformEncryption(AppKey key) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
`PerformEncryption` was only ever implemented and privately used within `LoRaPayloadJoinAccept`. This PR removes `PerformEncryption` from the superclass `LoRaPayload` so that its subclasses are not forced to provide implementations that just throw `NotImplementedException`.

`PerformEncryption` is now a private member of `LoRaPayloadJoinAccept` and `Serialize` that uses it has been moved next to it (it can also be, technically speaking in-lined).
