### PR TITLE
Reporting package version when first connection happens to LNS Data Endpoint

### DIFF
--- a/.github/workflows/e2e-ci.yaml
+++ b/.github/workflows/e2e-ci.yaml
@@ -245,10 +245,13 @@ jobs:
         echo "::set-output name=clientthumbprint::$(sha1sum $CERT_REMOTE_PATH/cups.crt | awk '{print $1;}')"
         # -- Firmware upgrade generation section --
         chmod +x ./Tools/Cups-Firmware-Upgrade/firmwarePrep.sh
+        NEW_FW_VERSION=$(date -u +%s)
+        sed -i "s/1.0.1-e2e/$NEW_FW_VERSION/g" ./Tools/Cups-Firmware-Upgrade/fwUpdateSample.sh
         ./Tools/Cups-Firmware-Upgrade/firmwarePrep.sh $CUPS_STATION_EUI "$(realpath ./Tools/Cups-Firmware-Upgrade/fwUpdateSample.sh)"
         cp ./Tools/Cups-Firmware-Upgrade/$CUPS_STATION_EUI/sig-0.key $CERT_REMOTE_PATH/sig-0.key
         echo "::set-output name=clientsigkeycrc::$(cat ./Tools/Cups-Firmware-Upgrade/$CUPS_STATION_EUI/sig-0.crc)"
         echo "::set-output name=clientfwdigest::$(cat ./Tools/Cups-Firmware-Upgrade/$CUPS_STATION_EUI/fwUpdate.digest)"
+        echo "::set-output name=clientfwversion::$NEW_FW_VERSION"
         curl -X PUT -T ./Tools/Cups-Firmware-Upgrade/fwUpdateSample.sh -H "x-ms-date: $(date -u)" -H "x-ms-blob-type: BlockBlob" "$CUPS_FIRMWARE_BLOB_URL"
         # following commands are copying to remote "aio" device the required server and trust certificates
         ssh -i $SSH_PRIVATE_KEY_PATH $RPI_USERNAME@$RPI_HOST "sudo rm -rf $CERT_REMOTE_PATH && sudo mkdir -p $CERT_REMOTE_PATH && sudo chown -R "'$(whoami)'" $CERT_REMOTE_PATH"
@@ -269,6 +272,7 @@ jobs:
       clientbundlecrc: ${{ steps.generate_step.outputs.clientbundlecrc }}
       clientsigkeycrc: ${{ steps.generate_step.outputs.clientsigkeycrc }}
       clientfwdigest: ${{ steps.generate_step.outputs.clientfwdigest }}
+      clientfwversion: ${{ steps.generate_step.outputs.clientfwversion }}
 
   # Deploy IoT Edge solution to ARM gateway
   deploy_arm_gw_iot_edge:
@@ -493,7 +497,7 @@ jobs:
       E2ETESTS_CupsSigKeyChecksum: ${{ needs.certificates_job.outputs.clientsigkeycrc }}
       E2ETESTS_CupsFwDigest: ${{ needs.certificates_job.outputs.clientfwdigest }}
       E2ETESTS_CupsBasicStationVersion: "2.0.5(rak833x64/std)"
-      E2ETESTS_CupsBasicStationPackage: "1.0.1-e2e" # this is the version file in Tools\Cups-Firmware-Upgrade\fwUpdateSample.sh
+      E2ETESTS_CupsBasicStationPackage: ${{ needs.certificates_job.outputs.clientfwversion }}
       E2ETESTS_CupsFwUrl: ${{ secrets.CUPSFIRMWAREBLOBURL }}
       TestsToRun: ${{ needs.env_var.outputs.E2ETestsToRun }}
       E2ETESTS_TxPower: ${{ needs.env_var.outputs.TxPower }}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/IBasicsStationConfigurationService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/IBasicsStationConfigurationService.cs
@@ -9,6 +9,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
 
     internal interface IBasicsStationConfigurationService
     {
+        Task SetReportedPackageVersionAsync(StationEui stationEui, string package, CancellationToken cancellationToken);
         Task<string> GetRouterConfigMessageAsync(StationEui stationEui, CancellationToken cancellationToken);
         Task<Region> GetRegionAsync(StationEui stationEui, CancellationToken cancellationToken);
         Task<string[]> GetAllowedClientThumbprintsAsync(StationEui stationEui, CancellationToken cancellationToken);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
@@ -192,6 +192,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
                 case LnsMessageType.Version:
                     var (version, package) = LnsData.VersionMessageReader.Read(json);
                     this.logger.LogInformation("Received 'version' message for station '{StationVersion}' with package '{StationPackage}'.", version, package);
+                    await this.basicsStationConfigurationService.SetReportedPackageVersionAsync(stationEui, package, cancellationToken);
                     var routerConfigResponse = await this.basicsStationConfigurationService.GetRouterConfigMessageAsync(stationEui, cancellationToken);
                     await socket.SendAsync(routerConfigResponse, cancellationToken);
                     break;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/TwinProperty.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/TwinProperty.cs
@@ -52,5 +52,8 @@ namespace LoRaWan.NetworkServer
         /// Defines the join channel index; applicable to CN470 region.
         /// </summary>
         public const string CN470JoinChannel = "CN470JoinChannel";
+
+        // Concentrator-only properties
+        public const string Package = "Package";
     }
 }

--- a/Tests/E2E/CupsTests.cs
+++ b/Tests/E2E/CupsTests.cs
@@ -9,6 +9,8 @@ namespace LoRaWan.Tests.E2E
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
+    using LoRaTools.Utils;
+    using LoRaWan.NetworkServer;
     using LoRaWan.Tests.Common;
     using Xunit;
 
@@ -116,6 +118,11 @@ namespace LoRaWan.Tests.E2E
                 var updfLog = await TestFixtureCi.SearchNetworkServerModuleAsync(
                     (log) => log.IndexOf(expectedLog4, StringComparison.Ordinal) != -1, new SearchLogOptions(expectedLog4) { MaxAttempts = 2 });
                 Assert.True(updfLog.Found);
+
+                var twin = await TestFixture.GetTwinAsync(stationEui.ToString());
+                var twinReader = new TwinCollectionReader(twin.Properties.Reported, null);
+                Assert.True(twinReader.TryRead<string>(TwinProperty.Package, out var reportedPackage)
+                            && string.Equals(fwPackage, reportedPackage, StringComparison.OrdinalIgnoreCase));
             }
             finally
             {


### PR DESCRIPTION
# PR for issue #1345 

## What changed:

- [x] Adding Package to TwinProperty constants
- [x] Adding SetReportedPackageVersionAsync to BasicsStationConfigurationService
- [x] Making use of SetReportedPackageVersionAsync in LnsProtocolMessageProcessor
- [x] Adding UTs for SetReportedPackageVersionAsync
- [x] Modifying CUPS E2E tests to verify addition of reported property after upgrade
- [x] Generating new firmware version on the fly in e2e ci


[E2E Run here](https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/1728911660)