### PR TITLE
Move 32-bit frame counter to `LoRaPayloadData`

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -80,7 +80,7 @@ namespace LoRaWan.NetworkServer
 
             var payloadFcnt = loraPayload.Fcnt;
 
-            var payloadFcntAdjusted = LoRaPayload.InferUpper32BitsForClientFcnt(payloadFcnt, loRaDevice.FCntUp);
+            var payloadFcntAdjusted = LoRaPayloadData.InferUpper32BitsForClientFcnt(payloadFcnt, loRaDevice.FCntUp);
             this.logger.LogDebug($"converted 16bit FCnt {payloadFcnt} to 32bit FCnt {payloadFcntAdjusted}");
 
             var requiresConfirmation = request.Payload.RequiresConfirmation;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -897,7 +897,7 @@ namespace LoRaWan.NetworkServer
 
             uint? Get32BitAdjustedFcntIfSupported(LoRaPayloadData payload, bool rollHi = false) =>
                 Supports32BitFCnt && payload is { Fcnt: var fcnt }
-                ? LoRaPayload.InferUpper32BitsForClientFcnt(fcnt, rollHi ? IncrementUpper16bit(FCntUp) : FCntUp)
+                ? LoRaPayloadData.InferUpper32BitsForClientFcnt(fcnt, rollHi ? IncrementUpper16bit(FCntUp) : FCntUp)
                 : null;
 
             bool CanRolloverToNext16Bits(ushort payloadFcntUp) =>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayload.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayload.cs
@@ -36,12 +36,6 @@ namespace LoRaTools.LoRaMessage
         public DevAddr DevAddr { get; set; }
 
         /// <summary>
-        /// Gets the representation of the 32bit Frame counter to be used
-        /// in the block if we are in 32bit mode.
-        /// </summary>
-        protected uint? Server32BitFcnt { get; private set; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="LoRaPayload"/> class.
         /// Wrapper of a LoRa message, consisting of the MIC and MHDR, common to all LoRa messages
         /// This is used for uplink / decoding.
@@ -88,30 +82,6 @@ namespace LoRaTools.LoRaMessage
         /// <param name="key">The Network Session Key.</param>
         /// <returns>the encrypted bytes.</returns>
         public abstract byte[] Serialize(NetworkSessionKey key);
-
-        public void Reset32BitFcnt() => Server32BitFcnt = null;
-        public void Ensure32BitFcntValue(uint? server32bitFcnt) => Server32BitFcnt ??= server32bitFcnt;
-
-        /// <summary>
-        /// In 32bit mode, the server needs to infer the upper 16bits by observing
-        /// the traffic between the device and the server. We keep a 32bit counter
-        /// on the server and combine the upper 16bits with what the client sends us
-        /// on the wire (lower 16bits). The result is the inferred counter as we
-        /// assume it is on the client.
-        /// </summary>
-        /// <param name="payloadFcnt">16bits counter sent in the package.</param>
-        /// <param name="fcnt">Current server frame counter holding 32bits.</param>
-        /// <returns>The inferred 32bit framecounter value, with the higher 16bits holding the server
-        /// observed counter information and the lower 16bits the information we got on the wire.</returns>
-        public static uint InferUpper32BitsForClientFcnt(ushort payloadFcnt, uint fcnt)
-        {
-            const uint MaskHigher16 = 0xFFFF0000;
-
-            // server represents the counter in 32bit so does the client, but only sends the lower 16bits
-            // infering the upper 16bits from the current count
-            var fcntServerUpper = fcnt & MaskHigher16;
-            return fcntServerUpper | payloadFcnt;
-        }
 
         public virtual bool RequiresConfirmation
             => false;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -274,6 +274,36 @@ namespace LoRaTools.LoRaMessage
         }
 
         /// <summary>
+        /// The 32bit Frame counter to be used
+        /// in the block if we are in 32bit mode.
+        /// </summary>
+        private uint? server32BitFcnt;
+
+        public void Reset32BitFcnt() => this.server32BitFcnt = null;
+        private void Ensure32BitFcntValue(uint? value) => this.server32BitFcnt ??= value;
+
+        /// <summary>
+        /// In 32bit mode, the server needs to infer the upper 16bits by observing
+        /// the traffic between the device and the server. We keep a 32bit counter
+        /// on the server and combine the upper 16bits with what the client sends us
+        /// on the wire (lower 16bits). The result is the inferred counter as we
+        /// assume it is on the client.
+        /// </summary>
+        /// <param name="payloadFcnt">16bits counter sent in the package.</param>
+        /// <param name="fcnt">Current server frame counter holding 32bits.</param>
+        /// <returns>The inferred 32bit framecounter value, with the higher 16bits holding the server
+        /// observed counter information and the lower 16bits the information we got on the wire.</returns>
+        public static uint InferUpper32BitsForClientFcnt(ushort payloadFcnt, uint fcnt)
+        {
+            const uint MaskHigher16 = 0xFFFF0000;
+
+            // server represents the counter in 32bit so does the client, but only sends the lower 16bits
+            // infering the upper 16bits from the current count
+            var fcntServerUpper = fcnt & MaskHigher16;
+            return fcntServerUpper | payloadFcnt;
+        }
+
+        /// <summary>
         /// Serialize a message to be sent downlink on the wire.
         /// </summary>
         /// <param name="appSKey">the app key used for encryption.</param>
@@ -306,14 +336,14 @@ namespace LoRaTools.LoRaMessage
             Ensure32BitFcntValue(server32BitFcnt);
             // do not include MIC as it was already set
             var byteMsg = GetByteMessage()[..^4].ToArray();
-            var fcnt = Server32BitFcnt ?? Fcnt;
+            var fcnt = this.server32BitFcnt ?? Fcnt;
             return Mic == LoRaWan.Mic.ComputeForData(key, (byte)Direction, DevAddr, fcnt, byteMsg);
         }
 
         public void SetMic(NetworkSessionKey nwskey)
         {
             var byteMsg = GetByteMessage();
-            var fcnt = Server32BitFcnt ?? Fcnt;
+            var fcnt = this.server32BitFcnt ?? Fcnt;
             Mic = LoRaWan.Mic.ComputeForData(nwskey, (byte)Direction, DevAddr, fcnt, byteMsg);
             _ = Mic.Value.Write(RawMessage.AsSpan(RawMessage.Length - 4, 4));
         }


### PR DESCRIPTION
32-bit **FCnt** management is only needed for `LoRaPayloadData` therefore this PR moves all those members from `LoRaPayload` to `LoRaPayloadData`.

- `Ensure32BitFcntValue` has been made private since it's only used from within `LoRaPayloadData`.
- `Server32BitFcnt` has been converted to the field `server32BitFcnt` since it's never access publicly except via `Reset32BitFcnt`.
