### PR TITLE
Add manifest file to LNS

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/cgmanifest.json
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/cgmanifest.json
@@ -1,0 +1,13 @@
+{
+    "Registrations": [
+        {
+        "Component": {
+            "Type": "git",
+            "git": {
+            "RepositoryUrl": "https://github.com/jieter/python-lora",
+            "CommitHash": "00bc45c6d6ba366a0bc09ba287b58f7bc9bc27e0"
+            }
+        }
+        }
+    ]
+}


### PR DESCRIPTION
A manifest file is needed to correctly reference the usage/inspiration from the repository (https://github.com/jieter/python-lora/) since we are referencing that e.g. here: 

https://github.com/Azure/iotedge-lorawan-starterkit/blob/cdfecb609bcc096f656c6ee27a301a0333d4f8ab/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs#L355-L361