### PR TITLE
Remove unimplemented `Serialize` on payload subclasses

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayload.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayload.cs
@@ -69,21 +69,6 @@ namespace LoRaTools.LoRaMessage
         /// <param name="key">The App Key.</param>
         public abstract bool CheckMic(AppKey key);
 
-        /// <summary>
-        /// Method to calculate the encrypted version of the payload.
-        /// </summary>
-        /// <param name="key">the Application Secret Key.</param>
-        /// <returns>the encrypted bytes.</returns>
-        public abstract byte[] Serialize(AppSessionKey key);
-
-        /// <summary>
-        /// Method to calculate the encrypted version of the payload.
-        /// </summary>
-        /// <param name="key">The Network Session Key.</param>
-        /// <returns>the encrypted bytes.</returns>
-        public abstract byte[] Serialize(NetworkSessionKey key);
-
-        public virtual bool RequiresConfirmation
-            => false;
+        public virtual bool RequiresConfirmation => false;
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -443,13 +443,13 @@ namespace LoRaTools.LoRaMessage
         /// <summary>
         ///  Replaces the <see cref="Frmpayload"/>, encrypting the values.
         /// </summary>
-        public override byte[] Serialize(NetworkSessionKey key) =>
+        public byte[] Serialize(NetworkSessionKey key) =>
             Serialize(GetDecryptedPayload(key));
 
         /// <summary>
         ///  Replaces the <see cref="Frmpayload"/>, encrypting the values.
         /// </summary>
-        public override byte[] Serialize(AppSessionKey key) =>
+        public byte[] Serialize(AppSessionKey key) =>
             Serialize(GetDecryptedPayload(key));
 
         private byte[] Serialize(byte[] rawDecryptedPayload)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
@@ -190,10 +190,6 @@ namespace LoRaTools.LoRaMessage
             throw new NotImplementedException();
         }
 
-        public override byte[] Serialize(NetworkSessionKey key) => throw new NotImplementedException();
-
-        public override byte[] Serialize(AppSessionKey key) => throw new NotImplementedException();
-
         public override bool CheckMic(AppKey key)
         {
             var expectedMic = LoRaWan.Mic.ComputeForJoinAccept(key, MHdr, AppNonce, NetId, DevAddr, DlSettings, RxDelay, CfList);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinRequest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinRequest.cs
@@ -35,8 +35,5 @@ namespace LoRaTools.LoRaMessage
         public override bool CheckMic(AppKey key) =>
             Mic == LoRaWan.Mic.ComputeForJoinRequest(key, MHdr, AppEui, DevEUI, DevNonce);
 
-        public override byte[] Serialize(AppSessionKey key) => throw new NotImplementedException("The payload is not encrypted in case of a join message");
-
-        public override byte[] Serialize(NetworkSessionKey key) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
This PR removes `Serialize` overloads on `LoRaPayload` so subclasses don't have to implement it. They were only implemented on and used from `LoRaPayloadData`. All other subclasses threw `NotImplementedException`.
