### PR TITLE
Added StationEui to LoRaDeviceTelemetry (#1357)

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceTelemetry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceTelemetry.cs
@@ -62,6 +62,8 @@ namespace LoRaWan.NetworkServer
         [JsonProperty("gatewayid")]
         public string GatewayID { get; set; }
 
+        [JsonProperty("stationeui")]
+        public string StationEui { get; set; }
 
         [JsonProperty("dupmsg", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool? DupMsg { get; set; }
@@ -89,10 +91,11 @@ namespace LoRaWan.NetworkServer
             Rssi = radioMetadata.UpInfo.ReceivedSignalStrengthIndication;
             Rfch = radioMetadata.UpInfo.AntennaPreference;
             Lsnr = radioMetadata.UpInfo.SignalNoiseRatio;
-            Time = unchecked(radioMetadata.UpInfo.Xtime); // This is used by former computation only. 
+            Time = unchecked(radioMetadata.UpInfo.Xtime); // This is used by former computation only.
             Chan = (uint)radioMetadata.DataRate; // This is not used in any computation. It is only reported in the device telemetry.
             GpsTime = radioMetadata.UpInfo.GpsTime; // This is not used in any computation. It is only reported in the device telemetry.
             Modu = datr.ModulationKind.ToString(); // This is only used in test path by legacy PacketForwarder code. Safe to eventually remove. Could be also "FSK"
+            StationEui = request.StationEui.ToString();
         }
     }
 }

--- a/Tests/Integration/DecoderTests.cs
+++ b/Tests/Integration/DecoderTests.cs
@@ -51,7 +51,8 @@ namespace LoRaWan.Tests.Integration
         ///     "rawdata": "QAEAAAKAAQABD31lQaU5Vus=",
         ///     "eui": "0000000000000001",
         ///     "gatewayid": "test-gateway",
-        ///     "edgets": 1550217512748
+        ///     "edgets": 1550217512748,
+        ///     "stationeui": "0000000000000000",
         /// }.
         /// </summary>
         [Theory]
@@ -108,7 +109,7 @@ namespace LoRaWan.Tests.Integration
 
             // Validate json
             var actualJsonTelemetry = JsonConvert.SerializeObject(loRaDeviceTelemetry, Formatting.None);
-            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":{{\"value\":\"{rawPayload}\"}},\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\"}}";
+            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":{{\"value\":\"{rawPayload}\"}},\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\",\"stationeui\":\"0000000000000000\"}}";
             Assert.Equal(expectedTelemetryJson, actualJsonTelemetry);
 
             LoRaDeviceClient.VerifyAll();
@@ -143,6 +144,7 @@ namespace LoRaWan.Tests.Integration
         ///     "eui": "0000000000000001",
         ///     "gatewayid": "test-gateway",
         ///     "edgets": 1550223375041
+        ///     "stationeui": "0000000000000000"
         /// }.
         /// </summary>
         [Theory]
@@ -196,7 +198,7 @@ namespace LoRaWan.Tests.Integration
             // Validate json
             var actualJsonTelemetry = JsonConvert.SerializeObject(loRaDeviceTelemetry, Formatting.None);
             var expectedValueQuotes = expectedValue.GetType() == typeof(string) ? "\"" : string.Empty;
-            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":{{\"value\":{expectedValueQuotes}{msgPayload}{expectedValueQuotes}}},\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\"}}";
+            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":{{\"value\":{expectedValueQuotes}{msgPayload}{expectedValueQuotes}}},\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\",\"stationeui\":\"0000000000000000\"}}";
             Assert.Equal(expectedTelemetryJson, actualJsonTelemetry);
 
             LoRaDeviceApi.VerifyAll();
@@ -227,7 +229,8 @@ namespace LoRaWan.Tests.Integration
         ///     "rawdata": "JDE=",
         ///     "eui": "0000000000000001",
         ///     "gatewayid": "test-gateway",
-        ///     "edgets": 1550223375041
+        ///     "edgets": 1550223375041,
+        ///     "stationeui": "0000000000000000"
         /// }.
         /// </summary>
         [Fact]
@@ -282,7 +285,7 @@ namespace LoRaWan.Tests.Integration
 
             // Validate json
             var actualJsonTelemetry = JsonConvert.SerializeObject(loRaDeviceTelemetry, Formatting.None);
-            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":\"decoded\",\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\"}}";
+            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":\"decoded\",\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\",\"stationeui\":\"0000000000000000\"}}";
             Assert.Equal(expectedTelemetryJson, actualJsonTelemetry);
 
             LoRaDeviceApi.VerifyAll();
@@ -313,7 +316,8 @@ namespace LoRaWan.Tests.Integration
         ///     "rawdata": "JDE=",
         ///     "eui": "0000000000000001",
         ///     "gatewayid": "test-gateway",
-        ///     "edgets": 1550223375041
+        ///     "edgets": 1550223375041,
+        ///     "stationeui": "0000000000000000"
         /// }.
         /// </summary>
         [Fact]
@@ -368,7 +372,7 @@ namespace LoRaWan.Tests.Integration
 
             // Validate json
             var actualJsonTelemetry = JsonConvert.SerializeObject(loRaDeviceTelemetry, Formatting.None);
-            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":\"\",\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\"}}";
+            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":\"\",\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\",\"stationeui\":\"0000000000000000\"}}";
             Assert.Equal(expectedTelemetryJson, actualJsonTelemetry);
 
             LoRaDeviceApi.VerifyAll();
@@ -401,7 +405,8 @@ namespace LoRaWan.Tests.Integration
         ///     "rawdata": "JDE=",
         ///     "eui": "0000000000000001",
         ///     "gatewayid": "test-gateway",
-        ///     "edgets": 1550223375041
+        ///     "edgets": 1550223375041,
+        ///     "stationeui": "0000000000000000"
         /// }.
         /// </summary>
         [Fact]
@@ -456,7 +461,7 @@ namespace LoRaWan.Tests.Integration
 
             // Validate json
             var actualJsonTelemetry = JsonConvert.SerializeObject(loRaDeviceTelemetry, Formatting.None);
-            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":{{\"value\":\"decoded\"}},\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\"}}";
+            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":{{\"value\":\"decoded\"}},\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\",\"stationeui\":\"0000000000000000\"}}";
             Assert.Equal(expectedTelemetryJson, actualJsonTelemetry);
 
             LoRaDeviceApi.VerifyAll();
@@ -489,7 +494,8 @@ namespace LoRaWan.Tests.Integration
         ///     "rawdata": "JDE=",
         ///     "eui": "0000000000000001",
         ///     "gatewayid": "test-gateway",
-        ///     "edgets": 1550223375041
+        ///     "edgets": 1550223375041,
+        ///     "stationeui": "0000000000000000"
         /// }.
         /// </summary>
         [Fact]
@@ -545,7 +551,7 @@ namespace LoRaWan.Tests.Integration
 
             // Validate json
             var actualJsonTelemetry = JsonConvert.SerializeObject(loRaDeviceTelemetry, Formatting.None);
-            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":{{\"temp\":10,\"humidity\":22.1,\"text\":\"abc\"}},\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\"}}";
+            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":{{\"temp\":10,\"humidity\":22.1,\"text\":\"abc\"}},\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\",\"stationeui\":\"0000000000000000\"}}";
             Assert.Equal(expectedTelemetryJson, actualJsonTelemetry);
 
             LoRaDeviceApi.VerifyAll();
@@ -577,7 +583,8 @@ namespace LoRaWan.Tests.Integration
         ///     "rawdata": "JDE=",
         ///     "eui": "0000000000000001",
         ///     "gatewayid": "test-gateway",
-        ///     "edgets": 1550223375041
+        ///     "edgets": 1550223375041,
+        ///     "stationeui": "0000000000000000"
         /// }.
         /// </summary>
         [Fact]
@@ -635,7 +642,7 @@ namespace LoRaWan.Tests.Integration
 
             // Validate json
             var actualJsonTelemetry = JsonConvert.SerializeObject(loRaDeviceTelemetry, Formatting.None);
-            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":{{\"error\":\"SensorDecoderModule 'http://customdecoder/test1?devEUI=0000000000000001&fport=1&payload=MQ%3d%3d' returned bad request.\",\"errorDetail\":\"my error\"}},\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{ rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\"}}";
+            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":{{\"error\":\"SensorDecoderModule 'http://customdecoder/test1?devEUI=0000000000000001&fport=1&payload=MQ%3d%3d' returned bad request.\",\"errorDetail\":\"my error\"}},\"port\":1,\"fcnt\":1,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{ rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\",\"stationeui\":\"0000000000000000\"}}";
             Assert.Equal(expectedTelemetryJson, actualJsonTelemetry);
 
             LoRaDeviceApi.VerifyAll();
@@ -697,7 +704,7 @@ namespace LoRaWan.Tests.Integration
             // Validate json
             var actualJsonTelemetry = JsonConvert.SerializeObject(loRaDeviceTelemetry, Formatting.None);
 
-            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":{{\"temp\":10,\"humidity\":22.1,\"text\":\"abc\"}},\"port\":1,\"fcnt\":10,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\"}}";
+            var expectedTelemetryJson = $"{{\"time\":100000,\"tmms\":100000,\"freq\":868.3,\"chan\":2,\"rfch\":1,\"modu\":\"LoRa\",\"datr\":\"SF10BW125\",\"rssi\":2.0,\"lsnr\":0.1,\"data\":{{\"temp\":10,\"humidity\":22.1,\"text\":\"abc\"}},\"port\":1,\"fcnt\":10,\"edgets\":{loRaDeviceTelemetry.Edgets},\"rawdata\":\"{rawPayload}\",\"eui\":\"0000000000000001\",\"gatewayid\":\"test-gateway\",\"stationeui\":\"0000000000000000\"}}";
             Assert.Equal(expectedTelemetryJson, actualJsonTelemetry);
 
             // send a second message with same fcnt to simulate


### PR DESCRIPTION
# PR for issue #1357

## What is being addressed
Adding StationEui to messages sent to Azure IoT Hub.
<!-- Describe the current behavior you are modifying -->
The StationEui is currently not sent to Azure IoT Hub.  This PR adds that property to the LoRaDeviceTelemetry class.
## How is this addressed
Added StationEui property which is set from the StationEui property of LoRaRequestpassed to the LoRaDeviceTelemetry constructor.
<!--
- Describe the changes made, and if appropriate, why they are addressed this way
- Note any pending work (with links to the issues that will address them)
-->
