### PR TITLE
Concentrator functions shouldn't return 422

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/ConcentratorCredentialsFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ConcentratorCredentialsFunction.cs
@@ -5,6 +5,7 @@ namespace LoraKeysManagerFacade
 {
     using System;
     using System.IO;
+    using System.Net;
     using System.Security.Cryptography;
     using System.Threading;
     using System.Threading.Tasks;
@@ -102,7 +103,10 @@ namespace LoraKeysManagerFacade
                                               or InvalidOperationException)
                 {
                     this.logger.LogError(ex, "'{PropertyName}' desired property was not found or misconfigured.", CupsPropertyName);
-                    return new UnprocessableEntityResult();
+                    return new ObjectResult($"Failed to fetch '{CupsPropertyName}' property from device twin")
+                    {
+                        StatusCode = (int)HttpStatusCode.InternalServerError,
+                    };
                 }
             }
             else

--- a/LoRaEngine/LoraKeysManagerFacade/ConcentratorFirmwareFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ConcentratorFirmwareFunction.cs
@@ -85,7 +85,10 @@ namespace LoraKeysManagerFacade
                 catch (Exception ex) when (ex is ArgumentOutOfRangeException or JsonReaderException or NullReferenceException)
                 {
                     this.logger.LogError(ex, "Failed to parse firmware upgrade url from the '{PropertyName}' desired property.", CupsPropertyName);
-                    return new UnprocessableEntityResult();
+                    return new ObjectResult("Failed to fetch firmware upgrade url from device twin")
+                    {
+                        StatusCode = (int)HttpStatusCode.InternalServerError,
+                    };
                 }
                 catch (RequestFailedException ex)
                 {

--- a/Tests/Unit/LoraKeysManagerFacade/ConcentratorFirmwareFunctionTests.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/ConcentratorFirmwareFunctionTests.cs
@@ -137,7 +137,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
         }
 
         [Fact]
-        public async Task RunFetchConcentratorFirmware_Returns_UnprocessableEntityResult_ForTwinMissingCups()
+        public async Task RunFetchConcentratorFirmware_Returns_InternalServerErros_ForTwinMissingCups()
         {
             var httpRequest = new Mock<HttpRequest>();
             var queryCollection = new QueryCollection(new Dictionary<string, StringValues>()
@@ -151,13 +151,15 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             this.registryManager.Setup(m => m.GetTwinAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                                 .Returns(Task.FromResult(twin));
 
-            var result = await this.concentratorFirmware.RunFetchConcentratorFirmware(httpRequest.Object, CancellationToken.None);
+            var actual = await this.concentratorFirmware.RunFetchConcentratorFirmware(httpRequest.Object, CancellationToken.None);
 
-            Assert.IsType<UnprocessableEntityResult>(result);
+            var result = Assert.IsType<ObjectResult>(actual);
+            Assert.Equal(500, result.StatusCode);
+            Assert.Equal("Failed to fetch firmware upgrade url from device twin", result.Value);
         }
 
         [Fact]
-        public async Task RunFetchConcentratorFirmware_Returns_UnprocessableEntityResult_ForTwinMissingFwUrl()
+        public async Task RunFetchConcentratorFirmware_Returns_InternalServerError_ForTwinMissingFwUrl()
         {
             var httpRequest = new Mock<HttpRequest>();
             var queryCollection = new QueryCollection(new Dictionary<string, StringValues>()
@@ -175,9 +177,11 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             this.registryManager.Setup(m => m.GetTwinAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                                 .Returns(Task.FromResult(twin));
 
-            var result = await this.concentratorFirmware.RunFetchConcentratorFirmware(httpRequest.Object, CancellationToken.None);
+            var actual = await this.concentratorFirmware.RunFetchConcentratorFirmware(httpRequest.Object, CancellationToken.None);
 
-            Assert.IsType<UnprocessableEntityResult>(result);
+            var result = Assert.IsType<ObjectResult>(actual);
+            Assert.Equal(500, result.StatusCode);
+            Assert.Equal("Failed to fetch firmware upgrade url from device twin", result.Value);
         }
 
         [Fact]


### PR DESCRIPTION
# PR for issue #1329 

## What is being addressed

Concentrator functions shouldn't return `UnprocessableEntityResult` in case device twin property is missing or misconfigured.

## How is this addressed

- Both affected functions (`ConcentratorCredentialsFunction`, `ConcentratorFirmwareFunction`) return `500` in the described cases.
- Unit tests for both functions are updated.
