### PR TITLE
Fix doc references to old .NET Core versions

### DIFF
--- a/docs/samples/decoders/decoder.md
+++ b/docs/samples/decoders/decoder.md
@@ -61,7 +61,7 @@ You should see the result as JSON string.
 
 ![Decoder Sample - Debugging on localhost](../../images/decodersample-debugging.png)
 
-When running the solution in a container, the [Kestrel webserver](https://docs.microsoft.com/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.1) from .NET Core uses the HTTP default port 80 of the container and does not need to bind it to a port on the host machine as Docker allows for container-to-container communication. IoT Edge automatically creates the required [Docker Network Bridge](https://docs.docker.com/network/bridge/).
+When running the solution in a container, the [Kestrel webserver](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-6.0) from .NET Core uses the HTTP default port 80 of the container and does not need to bind it to a port on the host machine as Docker allows for container-to-container communication. IoT Edge automatically creates the required [Docker Network Bridge](https://docs.docker.com/network/bridge/).
 
 ## Preparing and Testing the Docker Image
 

--- a/docs/tools/device-provisioning.md
+++ b/docs/tools/device-provisioning.md
@@ -26,7 +26,7 @@ dotnet run -- (add verbs and parameters here)
 or dotnet loradeviceprovisioning.dll from the bin folder.
 
 ```powershell
-dotnet .\bin\Release\netcoreapp3.1\loradeviceprovisioning.dll -- (add verbs and parameters here)
+dotnet .\bin\Release\net6.0\loradeviceprovisioning.dll -- (add verbs and parameters here)
 ```
 
 ## Setting up

--- a/docs/user-guide/devguide.md
+++ b/docs/user-guide/devguide.md
@@ -4,7 +4,7 @@
 
 The code is organized into three sections:
 
-- **LoRaEngine** - a .NET core 3.1 solution with the following folders:
+- **LoRaEngine** - a .NET 6 solution with the following folders:
   - **modules** - Azure IoT Edge modules.
   - **LoraKeysManagerFacade** - An Azure function handling device provisioning
   (e.g. LoRa network join, OTAA) with Azure IoT Hub as persistence layer.
@@ -12,7 +12,7 @@ The code is organized into three sections:
 - **Arduino** - Examples and references for LoRa Arduino based devices.
 - **Template** - Contain code useful for the "deploy to Azure button"
 - **Tools** - Contains tools that support the LoRaWan Gateway project
-  - **Cli-LoRa-Device-Provisioning** - .NET Core 2.1 Command Line tool that
+  - **Cli-LoRa-Device-Provisioning** - .NET 6 Command Line tool that
   allows to list, query, verify, insert, edit, update and delete LoRa leaf
   device configurations into IoT Hub
 - **Samples** - Contains sample decoders
@@ -20,7 +20,7 @@ The code is organized into three sections:
 
 ## LoRaEngine
 
-A **.NET Core 3.1** solution with the following projects:
+A **.NET 6** solution with the following projects:
 
 - **modules** - Azure IoT Edge modules.
   - **LoRaBasicsStationModule** packages the Basics Station into an IoT Edge compatible docker container. See <https://github.com/lorabasics/basicstation>. If you are using a RAK833-USB you need to build your own Basics Station docker image starting from the fork [at this link](https://github.com/danigian/basicstation)
@@ -92,7 +92,7 @@ On your Visual Studio Solution, right click on the 'LoRaKeysManagerFacade' proje
 
 - Open the [Azure function folder](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/LoRaEngine/LoraKeysManagerFacade) with Visual Studio Code with the [Azure Functions Plugin](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions) installed. Now run the command `Azure Functions: Deploy to function app...` and provide the name of the Azure function to deploy to. If prompted, select  environment `C#` and  version `V3`.
 
-- If you want to just deploy the function from Visual Studio Code with the root project folder `iotedge-lorawan-starterkit` open (of which the Function is a subfolder `/LoRaEngine/LoraKeysManagerFacade`), you need to run the Visual Studio Command `Azure Functions: Deploy to function app...` and then **manually** choose the folder `LoraKeysManagerFacade/bin/Release/netcoreapp3.1/publish`. (Unfortunately at time of this writing we saw the behavior that VSCode is proposing the wrong folder). Building the function does not work in this way unfortunately.
+- If you want to just deploy the function from Visual Studio Code with the root project folder `iotedge-lorawan-starterkit` open (of which the Function is a subfolder `/LoRaEngine/LoraKeysManagerFacade`), you need to run the Visual Studio Command `Azure Functions: Deploy to function app...` and then **manually** choose the folder `LoraKeysManagerFacade/bin/Release/net6.0/publish`. (Unfortunately at time of this writing we saw the behavior that VSCode is proposing the wrong folder). Building the function does not work in this way unfortunately.
 
 #### If you choose to create an empty Azure Function pointing to our Zipped code
 

--- a/docs/user-guide/station-firmware-upgrade.md
+++ b/docs/user-guide/station-firmware-upgrade.md
@@ -15,7 +15,7 @@ an upgrade.
 1. Use LoRa Device Provisioning CLI tool to trigger the upgrade.
 
    ```powershell
-   dotnet .\Tools\Cli-LoRa-Device-Provisioning\bin\Release\netcoreapp3.1\loradeviceprovisioning.dll upgrade-firmware --stationeui <station_eui> --package <package_version> --firmware-location <firmware_file_path> --digest-location <digest_file_path> --checksum-location <checksum_file_path>
+   dotnet .\Tools\Cli-LoRa-Device-Provisioning\bin\Release\net6.0\loradeviceprovisioning.dll upgrade-firmware --stationeui <station_eui> --package <package_version> --firmware-location <firmware_file_path> --digest-location <digest_file_path> --checksum-location <checksum_file_path>
    ```
 
    Parameters:


### PR DESCRIPTION
# PR for issue #1360

## What is being addressed

References to old .NET Core versions, and as a result, obsolete paths.

## How is this addressed

Updated all references to reflect migration to .NET 6.
