### PR TITLE
Various fixes to documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -307,3 +307,7 @@ Tools/Cli-LoRa-Device-Provisioning/settings\.local\.json
 
 #codecs
 **/codecs
+
+Tools/BasicStation-Certificates-Generation/ca
+Tools/BasicStation-Certificates-Generation/client
+Tools/BasicStation-Certificates-Generation/server

--- a/docs/license.md
+++ b/docs/license.md
@@ -20,30 +20,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE
 
---- For the LoRa Basics™ Station related binaries ---
+## Third party licenses
 
---- Revised 3-Clause BSD License ---
-Copyright Semtech Corporation 2020. All rights reserved.
+This software incorporates material from third parties:
 
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-        this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright notice,
-        this list of conditions and the following disclaimer in the documentation
-        and/or other materials provided with the distribution.
-    * Neither the name of the Semtech corporation nor the names of its
-        contributors may be used to endorse or promote products derived from this
-        software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL SEMTECH CORPORATION. BE LIABLE FOR ANY DIRECT,
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- [LoRaEngine/modules/LoRaWanNetworkSrvModule/NOTICE.txt](https://github.com/Azure/iotedge-lorawan-starterkit/blob/88909f2462ac9ceb9daad9ad9cb45b0546524aec/LoRaEngine/modules/LoRaWanNetworkSrvModule/NOTICE.txt)
+- [LoRaEngine/modules/LoRaBasicsStationModule/NOTICE.txt](https://github.com/Azure/iotedge-lorawan-starterkit/blob/88909f2462ac9ceb9daad9ad9cb45b0546524aec/LoRaEngine/modules/LoRaBasicsStationModule/NOTICE.txt)
+- [Samples/UniversalDecoder/NOTICE.txt](https://github.com/Azure/iotedge-lorawan-starterkit/blob/88909f2462ac9ceb9daad9ad9cb45b0546524aec/Samples/UniversalDecoder/NOTICE.txt)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -52,14 +52,14 @@ The template will deploy in your Azure subscription the Following resources:
 
 2. You will get to a page asking you to fill the following fields :
 
-    - **Resource Group** - A logical "folder" where all the template resource would be put into, just choose a meaningful name.
-    - **Location** - In which DataCenter the resources should be deployed. Make sure to choose a location where [IoT Hub is available](https://azure.microsoft.com/en-us/global-infrastructure/services/?products=iot-hub&regions=all)
-    - **Unique Solution Prefix** - A string that would be used as prefix for all the resources name to ensure their uniqueness. Hence, avoid any standard prefix such as "lora" as it might already be in use and might make your deployment fail. NB: the template is creating a Storage account with the value specified here, therefore the [naming restrictions of Storage](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage) apply here.
-    - **Edge gateway name** - the name of your LoRa Gateway node in the IoT Hub.
-    - **Deploy Device** - Do you want demo end devices to be already provisioned (one using OTAA and one using ABP)? If yes set this to true, the code located in the [Arduino folder](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/Arduino) would be ready to use immediately.
-    - **Reset pin** - The reset pin of your gateway (the value should be 7 for the Seed Studio LoRaWam, 25 for the IC880A)
-    - **Region** - In what region are you operating your device (currently only EU868 and US915 is supported)
-    - **useAzureMonitorOnEdge** - You can opt out of using Azure Monitor services for observability on IoT Edge.
+    - **Resource Group** - A logical "folder" where all the template resource would be put into, just choose a meaningful name.  
+    - **Location** - In which DataCenter the resources should be deployed. Make sure to choose a location where [IoT Hub is available](https://azure.microsoft.com/en-us/global-infrastructure/services/?products=iot-hub&regions=all)  
+    - **Unique Solution Prefix** - A string that would be used as prefix for all the resources name to ensure their uniqueness. Hence, avoid any standard prefix such as "lora" as it might already be in use and might make your deployment fail. NB: the template is creating a Storage account with the value specified here, therefore the [naming restrictions of Storage](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage) apply here.  
+    - **Edge gateway name** - the name of your LoRa Gateway node in the IoT Hub.  
+    - **Deploy Device** - Do you want demo end devices to be already provisioned (one using OTAA and one using ABP)? If yes set this to true, the code located in the [Arduino folder](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/Arduino) would be ready to use immediately.  
+    - **Reset pin** - The reset pin of your gateway (the value should be 7 for the Seed Studio LoRaWam, 25 for the IC880A)  
+    - **Region** - In what region are you operating your device (currently only EU868 and US915 is supported)  
+    - **useAzureMonitorOnEdge** - You can opt out of using Azure Monitor services for observability on IoT Edge.  
 
     The deployment would take c.a. 10 minutes to complete.
 
@@ -67,7 +67,7 @@ The template will deploy in your Azure subscription the Following resources:
 
 4. Once the Azure deployment is finished, connect your IoT Edge with the cloud [as described in point 3](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-install-iot-edge-linux-arm#configure-the-azure-iot-edge-security-daemon). You can get the connection string by clicking on the deployed IoT Hub -> IoT Edge Devices -> Connection string, as shown in the picture below.
 
-5. If your gateway is a Raspberry Pi, **don't forget to [enable SPI](https://www.makeuseof.com/tag/enable-spi-i2c-raspberry-pi/) , (You need to restart your pi)**.
+5. If your gateway is a Raspberry Pi, **don't forget to [enable SPI](https://www.makeuseof.com/tag/enable-spi-i2c-raspberry-pi/)** and to **restart your Pi**
 
 By using the `docker ps` command, you should see the Edge containers being deployed on your local gateway. You can now try one of the samples in the [Arduino folder](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/Arduino) to see LoRa messages being sent to the cloud. If you have checked the Deploy Device checkbox you can use this sample directly "TransmissionTestOTAALoRa.ino" without provisioning the device first.
 
@@ -76,6 +76,8 @@ By using the `docker ps` command, you should see the Edge containers being deplo
 The template provision an IoT Hub with a [LoRa Basics™ Station](https://github.com/lorabasics/basicstation) and a network server module already pre-configured to work out of the box. As soon as you connect your IoT Edge device in point 4 above, those will be pushed on your device. You can find template definition and Edge deployment specification [here](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/Template).
 
 If you are using the the RAK833-USB, you'll need to build a different LoRa Basics™ Station image. You can find a fork of the official Basic Station repository with support for RAK833-USB [here](https://github.com/danigian/basicstation).
+
+If you are using a SX1302 board via USB, you'll need to build a different LoRa Basics™ Station image. You can find a fork of the official Basic Station repository with support for SX1302 USB boards [here](https://github.com/danigian/basicstation/tree/corecell).
 
 ## Using a Proxy Server to connect your Concentrator to Azure
 
@@ -91,7 +93,7 @@ Follow [this guide](user-guide/devguide.md#use-a-proxy-server-to-connect-your-co
 ## LoRa Device provisioning
 
 A LoRa device is a normal IoT Hub device with some specific device twin tags. You manage it like you would with any other IoT Hub device.
-**To avoid caching issues you should not allow the device to join or send data before it is provisioned in IoT Hub. In case that you did plese follow the ClearCache procedure that you find below.**
+**To avoid caching issues you should not allow the device to join or send data before it is provisioned in IoT Hub. In case that you did please follow the ClearCache procedure that you find below.**
 
 ### ABP (personalization) and OTAA (over the air) provisioning
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -2,4 +2,4 @@
 
 The LoRaWAN starter kit is an open source solution, it is NOT a Microsoft
 supported solution or product. For bugs and issues with the codebase please log
-an issue in the [GitHub repository](https://github.com/Azure/iotedge-lorawan-starterkit/issues/395).
+an issue in the [GitHub repository](https://github.com/Azure/iotedge-lorawan-starterkit/issues).

--- a/docs/tools/certificate-generation.md
+++ b/docs/tools/certificate-generation.md
@@ -1,0 +1,43 @@
+# Basic Station Certificates Generation
+
+This starter kit is providing a [BasicStation Certificates Generation](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/Tools/BasicStation-Certificates-Generation) tool for helping its users to generate LoRaWAN Network Server certificates and Basics Station certificates for **testing** secure communication between a Basics Station client and the CUPS/LNS Protocol Endpoint in Network Server.
+
+The starter kit, and, therefore also this tool, are expecting the same certificate sets for both CUPS and LNS endpoints.
+
+!!! danger "Only for testing"
+    In a production environment, you should not use certificates provided by this tool, but generate and sign certificates with a trusted root authority.
+
+## Generate a server certificate
+
+As an example, if you want to generate a server certificate for a LoRaWAN Network Server hosted at `mytest.endpoint.com` and secure the output .PFX with a passphrase, you will need to issue the following script in the `Tools\BasicStation-Certificates-Generation` folder of the StarterKit:
+
+```bash
+./certificate-generate.sh server mytest.endpoint.com chosenPfxPassword
+```
+
+!!! warning "IMPORTANT"
+    when running the Basic Station client with Server Authentication enabled, the common name of the Server Certificate should exactly match the hostname specified in cups.uri/tc.uri. Even though this is decreasing security, it is possible to disable [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) by setting the '**TLS_SNI**' environment variable to false when executing the Basic Station client (or provided LoRaBasicsStationModule)
+
+The previous command will both generate a self-signed certificate authority (located in the 'ca' folder) and a mytest.endpoint.com.pfx (located in 'server' folder)
+
+You can now follow previous sections instructions on how to import this certificate in the provided LoRaWanNetworkSrvModule.
+
+## Generate a client certificate
+
+As an example, if you want to generate a client certificate for a Basic Station with DevEUI 'AABBCCFFFE001122', you will need to issue the following command
+
+```bash
+./certificate-generate.sh client AABBCCFFFE001122
+```
+
+!!! warning "IMPORTANT"
+    for client authentication to successfully work, the Common Name of the certificate should exactly match the DevEUI of the Basic Station.
+
+The previous command will generate the following files in the 'client' subfolder:
+
+- AABBCCFFFE001122.crt (the client certificate in DER format)
+- AABBCCFFFE001122.key (the client certificate key in DER format)
+- AABBCCFFFE001122.trust (the root certificate in DER format)
+- AABBCCFFFE001122.bundle (the concatenation of the three above mentioned files, useful if you want to use CUPS)
+
+As soon as certificates are generated, you can now follow previous sections instructions on how to import this certificate in the provided LoRaBasicsStationModule or you can just copy the needed files to your Basic Station compatible concentrator.

--- a/docs/tools/cups-firmware-file-preparation.md
+++ b/docs/tools/cups-firmware-file-preparation.md
@@ -1,0 +1,18 @@
+# CUPS - Firmware update file preparation
+
+The ['firmware update file preparation' bash script](https://github.com/Azure/iotedge-lorawan-starterkit/blob/ba6dfbc57aee5c72b9378516c555f104d5aa03b7/Tools/Cups-Firmware-Upgrade/firmwarePrep.sh) is helping Azure IoT Edge LoRaWAN Starter Kit users to generate the files needed for executing a firmware upgrade.
+
+More information on how to execute a firmware update can be found in ['Firmware upgrade'](../user-guide/station-firmware-upgrade.md) section of this documentation.
+
+Usage: `./firmwarePrep.sh stationEui firmwareUpgradeFilePath`
+
+Arguments:
+
+- `stationEui` (REQUIRED) EUI of the target Basics Station
+- `firmwareUpgradeFilePath` (REQUIRED) The path of the binary to be executed on Basics Station for upgrading the firmware
+
+The tool will generate three output files being:
+
+- A `sig-0.key` to be placed on the Basics Station
+- A `sig-0.crc` containing the checksum of the sig-0.key. This is required to understand which key generated the digest of the firmware upgrade file. This value has to be saved in the IoT Hub Device Twin for the Station, using the Device Provisioning tool.
+- A `fwUpdate.digest` file containing the base64 encoding of the digest computed for the firmware upgrade file. This value has to be saved in the IoT Hub Device Twin for the Station, using the Device Provisioning tool.

--- a/docs/user-guide/devguide.md
+++ b/docs/user-guide/devguide.md
@@ -302,26 +302,24 @@ Refer to the [Observability](observability.md) guide if you want to learn about 
 
 ## Debugging in Visual Studio, outside of IoT Edge and Docker
 
-<!-- markdown-link-check-disable -->
-
 It is possible to run the LoRaEngine locally from Visual Studio in order to enable a better debugging experience. Here are the steps you will need to follow in order to enable this feature:
 
-1. Either change the value *server_adress* in the file [local_conf.json](https://github.com/Azure/iotedge-lorawan-starterkit/blob/dev/LoRaEngine/modules/LoRaWanPktFwdModule/local_conf.json) (located in LoRaEngine/modules/LoRaWanPktFwdModule) to point to your computer. Rebuild and redeploy the container.
+1. You need to point the `cups.uri` and/or the `tc.uri` Basics Station files to the endpoints exposed by your machine <!-- markdown-link-check-disable --> (i.e. `https://IP_ADDRESS:5002` and `wss://IP_ADDRESS:5001` when using a server PFX certificate or `ws://IP_ADDRESS:5000`) <!-- markdown-link-check-enable -->
 
-1. **Alternatively**, configure your unmodified LoRaWanPktFwdModule Docker container / Edge module with the environment variable `NETWORK_SERVER=<ip of your computer>`
+1. If you are using a Wireless network in Windows, make sure it is configured as a private network in your Windows settings. Otherwise, the Windows Firewall could bock the incoming packets.
 
-1. If you are using a Wireless network in Windows, make sure it is configured as a private network in your Windows settings. Otherwise, the Windows Firewall will bock the incoming UDP packets.
+1. Open the properties of the project [LoRaWanNetworkServerModule](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule) and set the following Environment Variables under the Debug tab: <!-- markdown-link-check-disable -->
 
-1. Open the properties of the project [LoRaWanNetworkServerModule](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule) and set the following Environment Variables under the Debug tab:
+    ```env
+    'IOTEDGE_IOTHUBHOSTNAME': <your iot hub hostname>.azure-devices.net
+    'ENABLE_GATEWAY': false
+    'FACADE_SERVER_URL': <http://localhost:7071/api/> (when debugging locally or any other URL of the Azure function you want to use)
+    'IOTEDGE_DEVICEID': The name of your PC
+    'FACADE_AUTH_CODE': (only needed for deployed Azure Function) the code for authenticating and authorizing requests
+    'LOG_LEVEL': 1 or Debug (optional, to activate most verbose logging level)
+    ```
 
-    IOTEDGE_IOTHUBHOSTNAME : XXX.azure-devices.net (XXX = your iot hub hostname)  
-    ENABLE_GATEWAY : false  
-    LOG_LEVEL : 1 or Debug (optional, to activate most verbose logging level)  
-    FACADE_SERVER_URL : <http://localhost:7071/api/> (when debugging locally or any other URL of the Azure function you want to use)  
-    IOTEDGE_DEVICEID : The Name of your PC  
-    FACADE_AUTH_CODE : needed only if pointing to a deployed Azure Function, the code for authenticating and authorizing requests to it  
-
-1. Add a `local.settings.json` file to the project [LoRaKeysManagerFacade](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/LoRaEngine/LoraKeysManagerFacade) containing:
+1. <!-- markdown-link-check-enable --> Add a `local.settings.json` file to the project [LoRaKeysManagerFacade](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/LoRaEngine/LoraKeysManagerFacade) containing:
 
     ```json
     {
@@ -343,5 +341,3 @@ It is possible to run the LoRaEngine locally from Visual Studio in order to enab
 1. If you hit start in your VS solution, you will receive messages directly from your LoRa Basics™ Station. You will be able to debug directly from your computer.
 
 Happy Debugging!
-
-<!-- markdown-link-check-enable -->

--- a/docs/user-guide/devguide.md
+++ b/docs/user-guide/devguide.md
@@ -8,13 +8,14 @@ The code is organized into three sections:
   - **modules** - Azure IoT Edge modules.
   - **LoraKeysManagerFacade** - An Azure function handling device provisioning
   (e.g. LoRa network join, OTAA) with Azure IoT Hub as persistence layer.
-  - **LoRaDevTools** - library for dev tools (git submodule)
 - **Arduino** - Examples and references for LoRa Arduino based devices.
 - **Template** - Contain code useful for the "deploy to Azure button"
 - **Tools** - Contains tools that support the LoRaWan Gateway project
-  - **Cli-LoRa-Device-Provisioning** - .NET 6 Command Line tool that
-  allows to list, query, verify, insert, edit, update and delete LoRa leaf
-  device configurations into IoT Hub
+  - **BasicStation-Certificates-Generation** - Bash scripts for generating self-signed certificates for LoRa Basics Station to LoRaWan Network Server
+  interactions. Read more in ["Basics Station configuration - Authentication Modes"](./station-authentication-modes.md)
+  - **Cli-LoRa-Device-Provisioning** - .NET 6 Command Line tool that allows to list, query, verify, insert, edit, update and delete LoRa leaf device configurations into IoT Hub
+  - **Cups-Firmware-Upgrade** - Bash scripts helping Starter Kit users to generate the files needed for executing a Basics Station firmware upgrade. Read more in ["Basics Station configuration - Firmware upgrade"](./station-firmware-upgrade.md)
+  - **Eflow** - Includes a PowerShell script to install Edge For Linux On Windows (EFLOW) on a new Windows Server VM. The script is not intended to be run as-is, but should be seen as a collection of manual steps to be run to get eflow up and running. In case of doubts, read more in ["Create and provision an IoT Edge for Linux on Windows device using symmetric keys"](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-provision-single-device-linux-on-windows-symmetric) official documentation
 - **Samples** - Contains sample decoders
 - **Docs** - Additional modules, pictures and documentations
 
@@ -23,10 +24,9 @@ The code is organized into three sections:
 A **.NET 6** solution with the following projects:
 
 - **modules** - Azure IoT Edge modules.
-  - **LoRaBasicsStationModule** packages the Basics Station into an IoT Edge compatible docker container. See <https://github.com/lorabasics/basicstation>. If you are using a RAK833-USB you need to build your own Basics Station docker image starting from the fork [at this link](https://github.com/danigian/basicstation)
+  - **LoRaBasicsStationModule** packages the Basics Station into an IoT Edge compatible docker container (See <https://github.com/lorabasics/basicstation>). If you are using a RAK833-USB, you need to build your own Basics Station docker image starting from the fork [at this link](https://github.com/danigian/basicstation). At the time of writing, SX1302 boards are supported only through SPI. If you are using a SX1302 board via USB you need to build your own Basics Station docker image starting from the fork [at this link](https://github.com/danigian/basicstation/tree/corecell)
   - **LoRaWanNetworkSrvModule** - is the LoRaWAN network server implementation.
 - **LoraKeysManagerFacade** - An Azure function handling device provisioning (e.g. LoRa network join, OTAA) with Azure IoT Hub as persistence layer.
-- **LoRaDevTools** - library for dev tools (git submodule)
 
 ## The overall architecture
 
@@ -102,7 +102,7 @@ On your Visual Studio Solution, right click on the 'LoRaKeysManagerFacade' proje
 
 |App Settings Name|Value|
 |-|-|
-|WEBSITE_RUN_FROM_ZIP|<https://github.com/Azure/iotedge-lorawan-starterkit/releases/download/v1.0.4/function-1.0.4.zip>|
+|WEBSITE_RUN_FROM_ZIP|The url of the .zip file containing the Function code|
 
 ![Run Azure Function from Zip file](../images/FunctionRunFromZip.png)
 
@@ -145,9 +145,9 @@ FACADE_AUTH_CODE=yourfunctionpassword
 ...
 ```
 
-### Use a Proxy server to connect your Concentrator to Azure
+### Use a Proxy server to connect your edge gateway to Azure
 
-> **This step is optional and should only be executed if your concentrator needs to use a proxy server to communicate with Azure**
+> **This step is optional and should only be executed if your edge gateway needs to use a proxy server to communicate with Azure**
 
 Follow the guide on [configuring an IoT Edge device to communicate through a proxy server](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-configure-proxy-support) to:
 
@@ -314,11 +314,12 @@ It is possible to run the LoRaEngine locally from Visual Studio in order to enab
 
 1. Open the properties of the project [LoRaWanNetworkServerModule](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWanNetworkSrvModule) and set the following Environment Variables under the Debug tab:
 
-    - IOTEDGE_IOTHUBHOSTNAME : XXX.azure-devices.net (XXX = your iot hub hostname)
-    - ENABLE_GATEWAY : false
-    - LOG_LEVEL : 1 or Debug (optional, to activate most verbose logging level)
-    - FACADE_SERVER_URL : <http://localhost:7071/api/> (when debugging locally or any other URL of the Azure function you want to use)
-    - IOTEDGE_DEVICEID : The Name of your PC
+    IOTEDGE_IOTHUBHOSTNAME : XXX.azure-devices.net (XXX = your iot hub hostname)  
+    ENABLE_GATEWAY : false  
+    LOG_LEVEL : 1 or Debug (optional, to activate most verbose logging level)  
+    FACADE_SERVER_URL : <http://localhost:7071/api/> (when debugging locally or any other URL of the Azure function you want to use)  
+    IOTEDGE_DEVICEID : The Name of your PC  
+    FACADE_AUTH_CODE : needed only if pointing to a deployed Azure Function, the code for authenticating and authorizing requests to it  
 
 1. Add a `local.settings.json` file to the project [LoRaKeysManagerFacade](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/LoRaEngine/LoraKeysManagerFacade) containing:
 

--- a/docs/user-guide/partner.md
+++ b/docs/user-guide/partner.md
@@ -1,16 +1,16 @@
 # Device Manufacturer Guidance
 
-We have developed the LoRaWAN starter kit agnostic of a device manufacturer implementation and focussed on the specifics on underlying architectures (arm, x86). However, we understand that device manufacturers can have specific requirements to ensure the LoRa packets are processed and decoded correctly. In this section, we provide guidance for the following:
+We have developed the LoRaWAN starter kit agnostic of any device manufacturer implementation and focused on the specifics of underlying architectures (arm, x86). However, we understand that device manufacturers can have specific requirements to ensure the LoRa packets are processed and decoded correctly. In this section, we provide guidance for the following:
 
 - **Gateway Manufacturers**: Allow a gateway to be compatible with our kit. Gateway manufacturers will test / make our Edge Hub modules work on their gateway.
 
-- **LoRA Sensor Manufacturers**: These manufacturers will develop a custom decoder using our decoding framework for their sensors.
+- **LoRa Sensor Manufacturers**: These manufacturers will develop a custom decoder using our decoding framework for their sensors.
 
 Please choose from a section that relates to your requirements.
 
 ## Device Gateway Manufacturer Guidance
 
-The LoRaWAN starter kit currently is tested on many popular gateways, we run some of those as part of daily CI/CD pipeline to test integrity and performance of our codebase. However, we cannot test each and every gateway out there and hence we have created a process for device manufacturer to support their gateways and get them highlighted in this repo.
+The LoRaWAN starter kit currently is tested on many popular gateways, we run some of those as part of daily CI/CD pipeline to test integrity and performance of our codebase. Ideally any Basics Station compatible gateway should be compatible, however, we cannot test each and every gateway out there and hence we have created a process for device manufacturer to support their gateways and get them highlighted in this repo.
 
 ### Instructions
 
@@ -19,7 +19,7 @@ If you would like to test gateway compatibility with out starter kit and also ge
 - Go through the [Developer Guidance](devguide.md) to clone the repo and make sure everything works in your local dev environment.
 - Make sure everything works with an Azure subscription with Standard Pricing SKU's, for example we do not support the Free Azure IoT Hub SKU.
 - Ensure that the gateway specification meet the minimal hardware configuration required for Azure IoT Edge and a container framework like Docker, Moby to run. We recommend at the minimum of 1 GB RAM, rPi based boards and similar configuration devices will be a good candidate for our starter kit.
-- If the gateway requires a specific LoRa Basics™ Station not provided by our kit (we leverage an implementation of the LoRa Basics™ Station). Create the appropriate code for the LoRa Basics™ Station and link to our repo.
+- If the gateway requires a specific LoRa Basics™ Station not provided by our kit (we leverage an implementation of the LoRa Basics™ Station), create the appropriate code for building the LoRa Basics™ Station binary.
 - Run the tests on the Gateway (must be a real device) to connect to a LoRa end node and receive and send packets.
 - Once you have tested the framework and have all things running, open an issue on the repo and we will invite you to add a page for your gateway on our repo. The page can include details about your gateway and any specific instructions to make your gateway running with LoRaWAN starter kit.
 
@@ -37,4 +37,4 @@ Follow these steps to onboard your device with a custom decoder:
 - Make sure everything works with an Azure subscription with Standard Pricing SKU's, for example we do not support the Free Azure IoT Hub SKU.
 - We have provided a [sample reference implementation](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/Samples/DecoderSample) of a decoder, please refer to this as a template and leverage the [instructions](../samples/decoders/decoder.md) to create implementation of your customer decoder.
 - The Sample code can also contain device model specific tests that when run allows for testing of the gateway.
-- Since we are .NET Core and C# based, the sample is based on the .NET technology stack, however you can create your decoders in your preferred languages by implementing similar interfaces. If you have a specific language or platform to be supported, submit an issue to let us know.
+- Since we are .NET and C# based, the sample is based on the .NET technology stack, however you can create your decoders in your preferred languages by implementing similar interfaces. If you have a specific language or platform to be supported, submit an issue to let us know.

--- a/docs/user-guide/station-authentication-modes.md
+++ b/docs/user-guide/station-authentication-modes.md
@@ -101,44 +101,4 @@ If you can't use the tool, when creating the Concentrator device in IoT Hub, all
 
 This starter kit is providing a [BasicStation Certificates Generation](https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/Tools/BasicStation-Certificates-Generation) tool for helping its users to generate LoRaWAN Network Server certificates and Basics Station certificates for **testing** secure communication between a Basics Station client and the CUPS/LNS Protocol Endpoint in Network Server.
 
-The starter kit, and, therefore also this tool, are expecting the same certificate sets for both CUPS and LNS endpoints.
-
-!!! danger "Only for testing"
-    In a production environment, you should not use certificates provided by this tool, but generate and sign certificates with a trusted root authority.
-
-### Generate a server certificate
-
-As an example, if you want to generate a server certificate for a LoRaWAN Network Server hosted at `mytest.endpoint.com` and secure the output .PFX with a passphrase, you will need to issue the following script in the `Tools\BasicStation-Certificates-Generation` folder of the StarterKit:
-
-```bash
-./certificate-generate.sh server mytest.endpoint.com chosenPfxPassword
-```
-
-!!! warning "IMPORTANT"
-    when running the Basic Station client with Server Authentication enabled, the common name of the Server Certificate should exactly match the hostname specified in cups.uri/tc.uri. Even though this is decreasing security, it is possible to disable [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) by setting the '**TLS_SNI**' environment variable to false when executing the Basic Station client (or provided LoRaBasicsStationModule)
-
-The previous command will both generate a self-signed certificate authority (located in the 'ca' folder) and a mytest.endpoint.com.pfx (located in 'server' folder)
-
-You can now follow previous sections instructions on how to import this certificate in the provided LoRaWanNetworkSrvModule.
-
-### Generate a client certificate
-
-As an example, if you want to generate a client certificate for a Basic Station with DevEUI 'AABBCCFFFE001122', you will need to issue the following command
-
-```bash
-./certificate-generate.sh client AABBCCFFFE001122
-```
-
-!!! warning "IMPORTANT"
-    for client authentication to successfully work, the Common Name of the certificate should exactly match the DevEUI of the Basic Station.
-
-The previous command will generate the following files in the 'client' subfolder:
-
-- AABBCCFFFE001122.crt (the client certificate in DER format)
-- AABBCCFFFE001122.key (the client certificate key in DER format)
-- AABBCCFFFE001122.trust (the root certificate in DER format)
-- AABBCCFFFE001122.bundle (the concatenation of the three above mentioned files, useful if you want to use CUPS)
-
-As soon as certificates are generated, you can now follow previous sections instructions on how to import this certificate in the provided LoRaBasicsStationModule or you can just copy the needed files to your Basic Station compatible concentrator.
-
---8<-- "includes/abbreviations.md"
+Please refer to [tool documentation](../tools/certificate-generation.md) for instructions on how to use it.

--- a/docs/user-guide/station-firmware-upgrade.md
+++ b/docs/user-guide/station-firmware-upgrade.md
@@ -1,18 +1,20 @@
-# Firmware upgrade
+# Firmware upgrade with CUPS
 
-The Starterkit offers the functionality of performing a firmware upgrade of the
-Basics Station. This document explains which steps are required to execute such
-an upgrade.
+The Azure IoT Edge LoRaWAN Starter Kit offers the functionality of performing a
+firmware upgrade of the Basics Station. This document explains which steps are
+required to execute such upgrade.
 
 1. When provisioning a concentrator device that will require future firmware
-   upgrades, you will need to generate a signature key and store it on the
-   device and in a centralized repository of your choice. You will also need to
-   generate a CRC32 checksum of the key and a digest of your firmware upgrade
-   executable. You can use the [CUPS Protocol - Firmware Upgrade
-   Preparation][cups-firmware-upgrade] tool which generates all these values,
-   given a Station EUI and a firmware upgrade file.
+   upgrades, you will need to generate a *signature key* and store it on the
+   device and in a centralized repository of your choice.  
+   During the update process, CUPS Protocol is using the CRC32 checksum of
+   the signature key on the device to compare the digest of the firmware
+   upgrade executable generated with such key.  
+   You can use the
+   [CUPS Protocol - Firmware Upgrade Preparation](../tools/cups-firmware-file-preparation.md)
+   tool to generate all needed files.
 
-1. Use LoRa Device Provisioning CLI tool to trigger the upgrade.
+1. Use LoRa Device Provisioning CLI tool to upload the upgrade files in the cloud.
 
    ```powershell
    dotnet .\Tools\Cli-LoRa-Device-Provisioning\bin\Release\net6.0\loradeviceprovisioning.dll upgrade-firmware --stationeui <station_eui> --package <package_version> --firmware-location <firmware_file_path> --digest-location <digest_file_path> --checksum-location <checksum_file_path>
@@ -28,7 +30,7 @@ an upgrade.
    - `checksum-location` - local path of the file containing the CRC32 checksum
      of the key used to generate the digest
 
-   The LoRa Device Provisioning CLI tool will trigger the upgrade by uploading
+   The LoRa Device Provisioning CLI tool will save the upgrade data by uploading
    the firmware to a storage account and updating the device twin of the
    concentrator with required data.
 
@@ -36,11 +38,10 @@ an upgrade.
    refer to the [LoRa Device Provisioning](../tools/device-provisioning.md#upgrade-firmware) tool
    documentation.
 
-1. During the next startup of the system, the Station will execute the upgrade
-   after receiving the updated information from the Network Server. A system
-   downtime is to be expected in order for the upgrade to complete. After the
-   upgrade is finished, the current version of the Basics Station can be found
-   in the desired reported properties of the concentrator twin in IoT Hub.
-
-[cups-firmware-upgrade]:
-    https://github.com/Azure/iotedge-lorawan-starterkit/tree/dev/Tools/Cups-Firmware-Upgrade
+1. During the next reconnection of the Basics Station to the CUPS endpoint,
+   it will execute the upgrade after receiving the updated information from the
+   Network Server.  
+   A system downtime is to be expected in order for the upgrade to complete.  
+   After the upgrade is finished, and the Basics Station is reconnecting to the
+   LNS Data endpoint, the updated version of the Basics Station will be reported
+   in the properties of the concentrator twin in IoT Hub.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
   - Tools:
     - tools/device-provisioning.md
     - tools/arduino-samples.md
+    - tools/certificate-generation.md
   - 'Decision Log':
     - adr/001_region_cn470_implementation.md
     - adr/002_lbs_configuration.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
     - tools/device-provisioning.md
     - tools/arduino-samples.md
     - tools/certificate-generation.md
+    - tools/cups-firmware-file-preparation.md
   - 'Decision Log':
     - adr/001_region_cn470_implementation.md
     - adr/002_lbs_configuration.md


### PR DESCRIPTION
# PR for issue #1367

- [x] Align gitignore with dev
- [x] Fix wrong link in support page
- [x] Modify LICENSE page to only include links to notice files
- [x] Fix old references to PktFwd in devguide
- [x] Update quick start removing typos and give proper formatting
- [x] Create tool pages for 'Basic Station Certificates Generation' and 'Cups Firmware' tools