### PR TITLE
Use command line args for settings with secrets in Device Provisioning tool 

### DIFF
--- a/Tools/Cli-LoRa-Device-Provisioning/Cli-LoRa-Device-Provisioning.csproj
+++ b/Tools/Cli-LoRa-Device-Provisioning/Cli-LoRa-Device-Provisioning.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.36.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/AddOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/AddOptions.cs
@@ -6,9 +6,10 @@ namespace LoRaWan.Tools.CLI.Options
     using System;
     using System.Collections.Generic;
     using CommandLine;
+    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("add", HelpText = "Add a new device to IoT Hub.")]
-    public class AddOptions
+    public class AddOptions : OptionsBase
     {
         private const string ConcentratorSetName = "Contentrator";
         private const string LoRaDeviceSetName = "LoRaDevice";

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/AddOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/AddOptions.cs
@@ -6,7 +6,6 @@ namespace LoRaWan.Tools.CLI.Options
     using System;
     using System.Collections.Generic;
     using CommandLine;
-    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("add", HelpText = "Add a new device to IoT Hub.")]
     public class AddOptions : OptionsBase

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/BulkVerifyOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/BulkVerifyOptions.cs
@@ -4,9 +4,10 @@
 namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
+    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("bulkverify", HelpText = "Verify all devices in IoT Hub.")]
-    public class BulkVerifyOptions
+    public class BulkVerifyOptions : OptionsBase
     {
         [Option(
             "page",

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/BulkVerifyOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/BulkVerifyOptions.cs
@@ -4,7 +4,6 @@
 namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
-    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("bulkverify", HelpText = "Verify all devices in IoT Hub.")]
     public class BulkVerifyOptions : OptionsBase

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/ListOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/ListOptions.cs
@@ -4,7 +4,6 @@
 namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
-    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("list", HelpText = "Lits devices in IoT Hub.")]
     public class ListOptions : OptionsBase

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/ListOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/ListOptions.cs
@@ -4,9 +4,10 @@
 namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
+    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("list", HelpText = "Lits devices in IoT Hub.")]
-    public class ListOptions
+    public class ListOptions : OptionsBase
     {
         [Option(
             "page",

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/OptionsBase.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/OptionsBase.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tools.CLI.CommandLineOptions
+{
+    using CommandLine;
+
+    public class OptionsBase
+    {
+        [Option(
+            "iothub-connection-string",
+            Required = true,
+            HelpText = "IoT Hub connection string: Connection string (iothubowner) of the IoT Hub (HostName=xxx.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=xxx).")]
+        public string IoTHubConnectionString { get; set; }
+    }
+}

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/OptionsBase.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/OptionsBase.cs
@@ -7,10 +7,9 @@ namespace LoRaWan.Tools.CLI.CommandLineOptions
 
     public class OptionsBase
     {
-        [Option(
-            "iothub-connection-string",
-            Required = true,
-            HelpText = "IoT Hub connection string: Connection string (iothubowner) of the IoT Hub (HostName=xxx.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=xxx).")]
+        [Option("iothub-connection-string",
+                Required = true,
+                HelpText = "IoT Hub connection string: Connection string (iothubowner) of the IoT Hub (HostName=xxx.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=xxx).")]
         public string IoTHubConnectionString { get; set; }
     }
 }

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/OptionsBase.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/OptionsBase.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace LoRaWan.Tools.CLI.CommandLineOptions
+namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
 

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/QueryOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/QueryOptions.cs
@@ -4,9 +4,10 @@
 namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
+    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("query", HelpText = "Query a device twin.")]
-    public class QueryOptions
+    public class QueryOptions : OptionsBase
     {
         [Option(
             "deveui",

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/QueryOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/QueryOptions.cs
@@ -4,7 +4,6 @@
 namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
-    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("query", HelpText = "Query a device twin.")]
     public class QueryOptions : OptionsBase

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RemoveOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RemoveOptions.cs
@@ -4,9 +4,10 @@
 namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
+    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("remove", HelpText = "Remove an existing device from IoT Hub.")]
-    public class RemoveOptions
+    public class RemoveOptions : OptionsBase
     {
         [Option(
             "deveui",

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RemoveOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RemoveOptions.cs
@@ -4,7 +4,6 @@
 namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
-    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("remove", HelpText = "Remove an existing device from IoT Hub.")]
     public class RemoveOptions : OptionsBase

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RevokeOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RevokeOptions.cs
@@ -6,22 +6,16 @@ namespace LoRaWan.Tools.CLI.CommandLineOptions
     using CommandLine;
 
     [Verb("revoke", HelpText = "Revokes a client certificate thumbprint for a station.")]
-    public class RevokeOptions
+    public class RevokeOptions : OptionsBase
     {
-        public RevokeOptions(string stationEui, string clientCertificateThumbprint)
-        {
-            StationEui = stationEui;
-            ClientCertificateThumbprint = clientCertificateThumbprint;
-        }
-
         [Option("stationeui",
                 Required = true,
                 HelpText = "Station EUI: Required id '--concentrator' switch is set. A 16 bit hex string ('AABBCCDDEEFFGGHH').")]
-        public string StationEui { get; }
+        public string StationEui { get; set; }
 
         [Option("client-certificate-thumbprint",
                 Required = true,
                 HelpText = "Client certificate thumbprint: A client certificate thumbprint that should be revoked and not accepted anymore by the CUPS/LNS endpoints.")]
-        public string ClientCertificateThumbprint { get; }
+        public string ClientCertificateThumbprint { get; set; }
     }
 }

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RevokeOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RevokeOptions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace LoRaWan.Tools.CLI.CommandLineOptions
+namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
 

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RotateCertificateOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RotateCertificateOptions.cs
@@ -6,28 +6,26 @@ namespace LoRaWan.Tools.CLI.CommandLineOptions
     using CommandLine;
 
     [Verb("rotate-certificate", HelpText = "Rotates the certificates for a station.")]
-    public class RotateCertificateOptions
+    public class RotateCertificateOptions : OptionsBase
     {
-        public RotateCertificateOptions(string stationEui, string certificateBundleLocation, string clientCertificateThumbprint)
-        {
-            StationEui = stationEui;
-            CertificateBundleLocation = certificateBundleLocation;
-            ClientCertificateThumbprint = clientCertificateThumbprint;
-        }
+        [Option("storage-connection-string",
+                Required = true,
+                HelpText = "Storage account connection string: Connection string of the Storage account.")]
+        public string StorageConnectionString { get; set; }
 
         [Option("stationeui",
                 Required = true,
                 HelpText = "Station EUI: Required id '--concentrator' switch is set. A 16 bit hex string ('AABBCCDDEEFFGGHH').")]
-        public string StationEui { get; }
+        public string StationEui { get; set; }
 
         [Option("certificate-bundle-location",
                 Required = true,
                 HelpText = "Certificate bundle location: Points to the location of the (UTF-8-encoded) certificate bundle file.")]
-        public string CertificateBundleLocation { get; }
+        public string CertificateBundleLocation { get; set; }
 
         [Option("client-certificate-thumbprint",
                 Required = true,
                 HelpText = "Client certificate thumbprint: A client certificate thumbprint that should be accepted by the CUPS/LNS endpoints.")]
-        public string ClientCertificateThumbprint { get; }
+        public string ClientCertificateThumbprint { get; set; }
     }
 }

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RotateCertificateOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/RotateCertificateOptions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace LoRaWan.Tools.CLI.CommandLineOptions
+namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
 

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/UpdateOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/UpdateOptions.cs
@@ -4,9 +4,10 @@
 namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
+    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("update", HelpText = "Update an existing device in IoT Hub.")]
-    public class UpdateOptions
+    public class UpdateOptions : OptionsBase
     {
         [Option(
             "deveui",

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/UpdateOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/UpdateOptions.cs
@@ -4,7 +4,6 @@
 namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
-    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("update", HelpText = "Update an existing device in IoT Hub.")]
     public class UpdateOptions : OptionsBase

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/UpgradeFirmwareOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/UpgradeFirmwareOptions.cs
@@ -8,10 +8,9 @@ namespace LoRaWan.Tools.CLI.CommandLineOptions
     [Verb("upgrade-firmware", HelpText = "Triggers a firmware upgrade for a station.")]
     public class UpgradeFirmwareOptions : OptionsBase
     {
-        [Option(
-            "storage-connection-string",
-            Required = true,
-            HelpText = "Storage account connection string: Connection string of the Storage account.")]
+        [Option("storage-connection-string",
+                Required = true,
+                HelpText = "Storage account connection string: Connection string of the Storage account.")]
         public string StorageConnectionString { get; set; }
 
         [Option("stationeui",

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/UpgradeFirmwareOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/UpgradeFirmwareOptions.cs
@@ -6,40 +6,37 @@ namespace LoRaWan.Tools.CLI.CommandLineOptions
     using CommandLine;
 
     [Verb("upgrade-firmware", HelpText = "Triggers a firmware upgrade for a station.")]
-    public class UpgradeFirmwareOptions
+    public class UpgradeFirmwareOptions : OptionsBase
     {
-        public UpgradeFirmwareOptions(string stationEui, string package, string firmwareLocation, string digestLocation, string checksumLocation)
-        {
-            StationEui = stationEui;
-            Package = package;
-            FirmwareLocation = firmwareLocation;
-            DigestLocation = digestLocation;
-            ChecksumLocation = checksumLocation;
-        }
+        [Option(
+            "storage-connection-string",
+            Required = true,
+            HelpText = "Storage account connection string: Connection string of the Storage account.")]
+        public string StorageConnectionString { get; set; }
 
         [Option("stationeui",
                 Required = true,
                 HelpText = "Station EUI: A 16 bit hex string (e.g. 'AABBCCDDEEFFGGHH').")]
-        public string StationEui { get; }
+        public string StationEui { get; set; }
 
         [Option("package",
                 Required = true,
                 HelpText = "Package: New package version to be installed on the station (e.g. '1.0.0').")]
-        public string Package { get; }
+        public string Package { get; set; }
 
         [Option("firmware-location",
                 Required = true,
                 HelpText = "Firmware location: Local path of the firmware upgrade executable.")]
-        public string FirmwareLocation { get; }
+        public string FirmwareLocation { get; set; }
 
         [Option("digest-location",
                 Required = true,
                 HelpText = "Digest location: Local path of the file containing a base 64 encoded digest of the upgrade file.")]
-        public string DigestLocation { get; }
+        public string DigestLocation { get; set; }
 
         [Option("checksum-location",
                 Required = true,
                 HelpText = "Checksum location: Local path of the file containing a CRC32 checksum of the signature key used to generate the digest.")]
-        public string ChecksumLocation { get; }
+        public string ChecksumLocation { get; set; }
     }
 }

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/UpgradeFirmwareOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/UpgradeFirmwareOptions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace LoRaWan.Tools.CLI.CommandLineOptions
+namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
 

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/VerifyOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/VerifyOptions.cs
@@ -4,9 +4,10 @@
 namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
+    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("verify", HelpText = "Verify a single device in IoT Hub.")]
-    public class VerifyOptions
+    public class VerifyOptions : OptionsBase
     {
         [Option(
             "deveui",

--- a/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/VerifyOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/CommandLineOptions/VerifyOptions.cs
@@ -4,7 +4,6 @@
 namespace LoRaWan.Tools.CLI.Options
 {
     using CommandLine;
-    using LoRaWan.Tools.CLI.CommandLineOptions;
 
     [Verb("verify", HelpText = "Verify a single device in IoT Hub.")]
     public class VerifyOptions : OptionsBase

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
@@ -42,7 +42,7 @@ namespace LoRaWan.Tools.CLI.Helpers
 
                 if (iotHubConnectionString is null || netId is null)
                 {
-                    StatusConsole.WriteLogLine(MessageType.Info, "IoT Hub connection string and NetId are required.");
+                    StatusConsole.WriteLogLine(MessageType.Error, "IoT Hub connection string and NetId are required.");
                     return false;
                 }
             }

--- a/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Helpers/ConfigurationHelper.cs
@@ -20,11 +20,11 @@ namespace LoRaWan.Tools.CLI.Helpers
         public BlobContainerClient CertificateStorageContainerClient { get; set; }
         public BlobContainerClient FirmwareStorageContainerClient { get; set; }
 
-        public bool ReadConfig()
+        public bool ReadConfig(string[] args)
         {
-            string connectionString, netId, storageConnectionString;
+            string iotHubConnectionString, netId, storageConnectionString;
 
-            Console.WriteLine("Reading configuration file \"appsettings.json\"...");
+            Console.WriteLine("Reading configuration from command line and \"appsettings.json\" file...");
 
             // Read configuration file appsettings.json
             try
@@ -33,15 +33,16 @@ namespace LoRaWan.Tools.CLI.Helpers
                     .SetBasePath(Directory.GetCurrentDirectory())
                     .AddJsonFile("appsettings.json", optional: false, reloadOnChange: false)
                     .AddJsonFile("appsettings.local.json", optional: true, reloadOnChange: false)
+                    .AddCommandLine(args)
                     .Build();
 
-                connectionString = configurationBuilder["IoTHubConnectionString"];
-                storageConnectionString = configurationBuilder["StorageConnectionString"];
+                iotHubConnectionString = configurationBuilder["iothub-connection-string"];
+                storageConnectionString = configurationBuilder["storage-connection-string"];
                 netId = configurationBuilder["NetId"];
 
-                if (connectionString is null || storageConnectionString is null || netId is null)
+                if (iotHubConnectionString is null || netId is null)
                 {
-                    StatusConsole.WriteLogLine(MessageType.Info, "The file should have the following structure: { \"IoTHubConnectionString\" : \"HostName=xxx.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=xxx\" }");
+                    StatusConsole.WriteLogLine(MessageType.Info, "IoT Hub connection string and NetId are required.");
                     return false;
                 }
             }
@@ -52,15 +53,15 @@ namespace LoRaWan.Tools.CLI.Helpers
             }
 
             // Validate connection setting
-            if (string.IsNullOrEmpty(connectionString))
+            if (string.IsNullOrEmpty(iotHubConnectionString))
             {
-                StatusConsole.WriteLogLine(MessageType.Error, "Connection string 'IoTHubConnectionString' may not be empty.");
+                StatusConsole.WriteLogLine(MessageType.Error, "IoT Hub connection string may not be empty.");
                 return false;
             }
             else
             {
                 // Just show IoT Hub Hostname
-                if (GetHostFromConnectionString(connectionString, out var hostName))
+                if (GetHostFromConnectionString(iotHubConnectionString, out var hostName))
                 {
                     StatusConsole.WriteLogLine(MessageType.Info, $"Using IoT Hub: {hostName}");
                 }
@@ -101,24 +102,27 @@ namespace LoRaWan.Tools.CLI.Helpers
             // Create Registry Manager using connection string
             try
             {
-                RegistryManager = RegistryManager.CreateFromConnectionString(connectionString);
+                RegistryManager = RegistryManager.CreateFromConnectionString(iotHubConnectionString);
             }
             catch (Exception ex) when (ex is ArgumentNullException
                                           or FormatException
                                           or ArgumentException)
             {
-                StatusConsole.WriteLogLine(MessageType.Error, $"Failed to create connection string: {ex.Message}.");
+                StatusConsole.WriteLogLine(MessageType.Error, $"Failed to create Registry Manager from connection string: {ex.Message}.");
                 return false;
             }
 
-            try
+            if (storageConnectionString != null)
             {
-                CertificateStorageContainerClient = new BlobContainerClient(storageConnectionString, CredentialsStorageContainerName);
-                FirmwareStorageContainerClient = new BlobContainerClient(storageConnectionString, FirmwareStorageContainerName);
-            }
-            catch (FormatException)
-            {
-                StatusConsole.WriteLogLine(MessageType.Info, "Storage account is incorrectly configured.");
+                try
+                {
+                    CertificateStorageContainerClient = new BlobContainerClient(storageConnectionString, CredentialsStorageContainerName);
+                    FirmwareStorageContainerClient = new BlobContainerClient(storageConnectionString, FirmwareStorageContainerName);
+                }
+                catch (FormatException)
+                {
+                    StatusConsole.WriteLogLine(MessageType.Info, "Storage account is incorrectly configured.");
+                }
             }
 
             Console.WriteLine("done.");

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -15,7 +15,6 @@ namespace LoRaWan.Tools.CLI
     using LoRaWan.Tools.CLI.CommandLineOptions;
     using LoRaWan.Tools.CLI.Helpers;
     using LoRaWan.Tools.CLI.Options;
-    using Microsoft.Azure.Devices.Common;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
@@ -25,6 +24,8 @@ namespace LoRaWan.Tools.CLI
 
         public static async Task<int> Main(string[] args)
         {
+            if (args is null) throw new ArgumentNullException(nameof(args));
+
             try
             {
                 WriteAzureLogo();
@@ -34,6 +35,12 @@ namespace LoRaWan.Tools.CLI
                 Console.WriteLine("http://aka.ms/lora");
                 Console.ResetColor();
                 Console.WriteLine();
+
+                if (!configurationHelper.ReadConfig(args))
+                {
+                    WriteToConsole("Failed to parse configuration.", ConsoleColor.Red);
+                    return (int)ExitCode.Error;
+                }
 
                 var success = await Parser.Default.ParseArguments<ListOptions, QueryOptions, VerifyOptions, BulkVerifyOptions, AddOptions, UpdateOptions, RemoveOptions, RotateCertificateOptions, RevokeOptions, UpgradeFirmwareOptions>(args)
                     .MapResult(
@@ -80,9 +87,6 @@ namespace LoRaWan.Tools.CLI
 
         private static async Task<bool> RunListAndReturnExitCode(ListOptions opts)
         {
-            if (!configurationHelper.ReadConfig())
-                return false;
-
             if (!int.TryParse(opts.Page, out var page))
                 page = 10;
 
@@ -96,9 +100,6 @@ namespace LoRaWan.Tools.CLI
 
         private static async Task<bool> RunQueryAndReturnExitCode(QueryOptions opts)
         {
-            if (!configurationHelper.ReadConfig())
-                return false;
-
             var twin = await IoTDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);
 
             if (twin != null)
@@ -115,9 +116,6 @@ namespace LoRaWan.Tools.CLI
 
         private static async Task<bool> RunVerifyAndReturnExitCode(VerifyOptions opts)
         {
-            if (!configurationHelper.ReadConfig())
-                return false;
-
             var twin = await IoTDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);
 
             if (twin != null)
@@ -134,9 +132,6 @@ namespace LoRaWan.Tools.CLI
 
         private static async Task<bool> RunBulkVerifyAndReturnExitCode(BulkVerifyOptions opts)
         {
-            if (!configurationHelper.ReadConfig())
-                return false;
-
             if (!int.TryParse(opts.Page, out var page))
                 page = 0;
 
@@ -157,9 +152,6 @@ namespace LoRaWan.Tools.CLI
 
         private static async Task<bool> RunAddAndReturnExitCode(AddOptions opts)
         {
-            if (!configurationHelper.ReadConfig())
-                return false;
-
             var isSuccess = false;
 
             opts = IoTDeviceHelper.CleanOptions(opts, true) as AddOptions;
@@ -218,9 +210,6 @@ namespace LoRaWan.Tools.CLI
 
         private static async Task<bool> RunRotateCertificateAndReturnExitCodeAsync(RotateCertificateOptions opts)
         {
-            if (!configurationHelper.ReadConfig())
-                return false;
-
             if (!File.Exists(opts.CertificateBundleLocation))
             {
                 StatusConsole.WriteLogLine(MessageType.Error, "Certificate bundle does not exist at defined location.");
@@ -271,9 +260,6 @@ namespace LoRaWan.Tools.CLI
 
         private static async Task<bool> RunRevokeAndReturnExitCodeAsync(RevokeOptions opts)
         {
-            if (!configurationHelper.ReadConfig())
-                return false;
-
             var twin = await IoTDeviceHelper.QueryDeviceTwin(opts.StationEui, configurationHelper);
 
             if (twin is null)
@@ -296,9 +282,6 @@ namespace LoRaWan.Tools.CLI
 
         private static async Task<bool> RunUpdateAndReturnExitCode(UpdateOptions opts)
         {
-            if (!configurationHelper.ReadConfig())
-                return false;
-
             var isSuccess = false;
 
             opts = IoTDeviceHelper.CleanOptions(opts, false) as UpdateOptions;
@@ -375,9 +358,6 @@ namespace LoRaWan.Tools.CLI
 
         private static async Task<bool> RunUpgradeFirmwareAndReturnExitCodeAsync(UpgradeFirmwareOptions opts)
         {
-            if (!configurationHelper.ReadConfig())
-                return false;
-
             if (!File.Exists(opts.FirmwareLocation))
             {
                 StatusConsole.WriteLogLine(MessageType.Error, "Firmware upgrade file does not exist at the specified location.");
@@ -464,9 +444,6 @@ namespace LoRaWan.Tools.CLI
 
         private static async Task<bool> RunRemoveAndReturnExitCode(RemoveOptions opts)
         {
-            if (!configurationHelper.ReadConfig())
-                return false;
-
             return await IoTDeviceHelper.RemoveDevice(opts.DevEui, configurationHelper);
         }
 

--- a/Tools/Cli-LoRa-Device-Provisioning/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Program.cs
@@ -12,7 +12,6 @@ namespace LoRaWan.Tools.CLI
     using System.Threading.Tasks;
     using Azure;
     using CommandLine;
-    using LoRaWan.Tools.CLI.CommandLineOptions;
     using LoRaWan.Tools.CLI.Helpers;
     using LoRaWan.Tools.CLI.Options;
     using Newtonsoft.Json;

--- a/Tools/Cli-LoRa-Device-Provisioning/appsettings.json
+++ b/Tools/Cli-LoRa-Device-Provisioning/appsettings.json
@@ -1,5 +1,3 @@
 {
-  "IoTHubConnectionString": "Your IoT Hub Connection String (iothubowner) here.",
-  "NetId": "1",
-  "StorageConnectionString": "Your Storage Account connection string here."
+  "NetId": "1"
 }


### PR DESCRIPTION
# PR for issue #1335 

## What is being addressed

`appsettings.json` file should not be used to configure the tool with values which may contain secrets. See #1335 for more details.

## How is this addressed

- IoT Hub and storage account connection strings are no longer parsed from `appsettings.json` file. They are instead read from command line options.
- `OptionsBase` class was added to represent the IoT Hub connection string which is a required option for all commands exposed in the CLI tool (specific options classes inherit from it to avoid code duplication).
- Storage account connection string has been added to `UpgradeFirmwareOptions` and `RotateCertificateOptions` only, since it's only required for these commands. The tool will still return an error if the storage connection string is missing but only if the specific command requires it.
- `configurationHelper.ReadConfig()` is now called before the specific command is determined instead of in each command implementation; `configurationHelper.ReadConfig()` now accepts `string[] args` as it also needs to parse command line arguments.

Documentation of the CLI tool is updated in https://github.com/Azure/iotedge-lorawan-starterkit/pull/1376 to reflect these changes.