### PR TITLE
Update CLI tool documentation - using command line arguments

### DIFF
--- a/docs/tools/device-provisioning.md
+++ b/docs/tools/device-provisioning.md
@@ -40,8 +40,8 @@ The tool can be configured through command line arguments and an
 `appsettings.json` file.
 
 Required command line arguments are specific to the command the user wants to
-perform and are described later in this document. `iothub-connection-string`
-parameter is required for all commands and needs to contain a connection string
+run and are described later in this document. `iothub-connection-string`
+argument is required for all commands and needs to contain a connection string
 for the Azure IoT Hub you want to work with. The connection string needs to
 belong to a shared access policy with **registry read**, **registry write** and
 **service connect** permissions enabled. You can use the default policy named

--- a/docs/tools/device-provisioning.md
+++ b/docs/tools/device-provisioning.md
@@ -1,6 +1,9 @@
 # LoRa Device Provisioning
 
-This is a Command Line Interface Provisioning Tool to list, query, verify add, update, and remove LoRaWAN leaf devices and LoRaWAN Basic Station devices configured in Azure IoT Hub for the Azure IoT Edge LoRaWAN Gateway project located at: <http://aka.ms/lora>
+This is a Command Line Interface Provisioning Tool to list, query, verify add,
+update, and remove LoRaWAN leaf devices and LoRaWAN Basic Station devices
+configured in Azure IoT Hub for the Azure IoT Edge LoRaWAN Gateway project
+located at: <http://aka.ms/lora>
 
 ## Building
 
@@ -13,11 +16,13 @@ dotnet publish -c Release -r osx-x64
 ```
 
 See the [.NET Core RID Catalog
-](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) for a list of valid runtime identifiers.
+](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) for a list of valid
+runtime identifiers.
 
 ## Running
 
-You can run the tool from the command line using .NET Core by executing the dotnet run command from the project folder
+You can run the tool from the command line using .NET Core by executing the
+dotnet run command from the project folder
 
 ```powershell
 dotnet run -- (add verbs and parameters here)
@@ -31,30 +36,39 @@ dotnet .\bin\Release\net6.0\loradeviceprovisioning.dll -- (add verbs and paramet
 
 ## Setting up
 
-[appsettings.json](https://github.com/Azure/iotedge-lorawan-starterkit/blob/dev/Tools/Cli-LoRa-Device-Provisioning/appsettings.json) needs to be in the same directory as the cli-lora-device-provisioning binary (verifyloradevice.dll or verifyloradevice.exe).
+The tool can be configured through command line arguments and an
+`appsettings.json` file.
 
-[appsettings.json](https://github.com/Azure/iotedge-lorawan-starterkit/blob/dev/Tools/Cli-LoRa-Device-Provisioning/appsettings.json) needs to contain a connection string from the Azure IoT Hub you want to work with. This connection string needs to belong to a shared access policy with **registry read**, **registry write** and **service connect** permissions enabled. You can use the default policy named **iothubowner**. It also needs to contain the connection string to the Azure Storage account you want to work with.
+Required command line arguments are specific to the command the user wants to
+perform and are described later in this document. `iothub-connection-string`
+parameter is required for all commands and needs to contain a connection string
+for the Azure IoT Hub you want to work with. The connection string needs to
+belong to a shared access policy with **registry read**, **registry write** and
+**service connect** permissions enabled. You can use the default policy named
+**iothubowner**.
+
+[appsettings.json](https://github.com/Azure/iotedge-lorawan-starterkit/blob/dev/Tools/Cli-LoRa-Device-Provisioning/appsettings.json)
+file only contains the Network Id (`NetId`) value which can be optionally
+overridden, in case your solution does not use the default Network Id 000001. To
+set your custom Network Id, create a local `appsettings.local.json` file with
+your own `NetId` value. Since just the last byte from this 3 hex string byte
+array (6 characters) are used to create a valid DevAddr for ABP LoRa devices,
+the setting can be either the full 3 bytes (000000 to FFFFFF) or just the
+shortened, last byte (0 to FF). Both appsettings files need to be in the same
+directory as the cli-lora-device-provisioning binary
+(`loradeviceprovisioning.dll` or `loradeviceprovisioning.exe`).
 
 ```json
 {
-  "IoTHubConnectionString": "HostName=youriothub.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=AeVMLayazGTS9QRMJtFGSSNwdhUdYR5VwCjaafc3DL0=",
-  "StorageConnectionString": "DefaultEndpointsProtocol=https;AccountName=yourstorageaccountname;AccountKey=thekey;EndpointSuffix=core.windows.net."
+  "NetId": "000001"
 }
 ```
 
-[appsettings.json](https://github.com/Azure/iotedge-lorawan-starterkit/blob/dev/Tools/Cli-LoRa-Device-Provisioning/appsettings.json) may **optionally** contain a Network Id (NetId) in case your solution does not use the default Network Id 000001. Since just the last byte from this 3 hex string byte array (6 characters) are used to create a valid DevAddr for ABP LoRa devices, the setting can be either the full 3 bytes (000000 to FFFFFF) or just the shortened, last byte (0 to FF).
+The `NetId` value can also be overridden with a command line argument (using
+`--netid` option).
 
-```json
-{
-  "IoTHubConnectionString": "HostName=youriothub.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=AeVMLayazGTS9QRMJtFGSSNwdhUdYR5VwCjaafc3DL0=",
-  "NetId": "000001",
-  "CredentialStorageConnectionString": "DefaultEndpointsProtocol=https;AccountName=yourstorageaccountname;AccountKey=thekey;EndpointSuffix=core.windows.net."
-}
-```
-
-If NetId is not set, the default 000001 is used. If you have a NetId set in appsettings.json, you can always override it by calling a command of this utility with the --netid option.
-
-To learn more about what each of the settings in the LoRa device twin does, refer to the [Quick Start Guide](../quickstart.md#optional-device-properties).
+To learn more about what each of the settings in the LoRa device twin does,
+refer to the [Quick Start Guide](../quickstart.md#optional-device-properties).
 
 ## Supported commands
 
@@ -80,13 +94,14 @@ List the devices in IoT Hub and show their device twin.
 Example:
 
 ```powershell
-dotnet run -- list
+dotnet run -- list --iothub-connection-string <connection-string>
 ```
 
 The list verb supports the following parameters:
 
 |parameter|required|description|
 |-|-|-|
+|--iothub-connection-string|yes|Connection string of the IoT Hub.|
 |--page|no|Devices per page. Default is 10.|
 |--total|no|Maximum number of devices to list. Default is all.|
 |--help|no|Display this help screen.|
@@ -94,12 +109,13 @@ The list verb supports the following parameters:
 
 ### query
 
-Show the device twin for an existing device in IoT Hub by it's DevEUI / Device Id.
+Show the device twin for an existing device in IoT Hub by it's DevEUI / Device
+Id.
 
 Example:
 
 ```powershell
-dotnet run -- query --deveui 33CCC86800430010
+dotnet run -- query --deveui 33CCC86800430010 --iothub-connection-string <connection-string>
 ```
 
 The query verb supports the following parameters:
@@ -107,6 +123,7 @@ The query verb supports the following parameters:
 |parameter|required|description|
 |-|-|-|
 |--deveui|yes|DevEUI / Device Id.|
+|--iothub-connection-string|yes|Connection string of the IoT Hub.|
 |--help|no|Display this help screen.|
 |--version|no|Display version information.|
 
@@ -117,7 +134,7 @@ Verify an existing device in IoT Hub by it's DevEUI / Device Id.
 Example:
 
 ```powershell
-dotnet run -- verify --deveui 33CCC86800430010
+dotnet run -- verify --deveui 33CCC86800430010 --iothub-connection-string <connection-string>
 ```
 
 The verify verb supports the following parameters:
@@ -125,38 +142,47 @@ The verify verb supports the following parameters:
 |parameter|required|description|
 |-|-|-|
 |--deveui|yes|DevEUI / Device Id.|
+|--iothub-connection-string|yes|Connection string of the IoT Hub.|
 |--netid|no|Network ID (Only for ABP devices): A 3 bit hex string. Will default to 000001 or NetId set in settings file if left blank.|
 |--help|no|Display this help screen.|
 |--version|no|Display version information.|
 
 ### bulkverify
 
-Bulk verify all devices in IoT Hub. Only shows the devices that have configuration errors and displays a summary in the end how many devcies are properly  configured and how many contain errors.
+Bulk verify all devices in IoT Hub. Only shows the devices that have
+configuration errors and displays a summary in the end how many devcies are
+properly  configured and how many contain errors.
 
 Example:
 
 ```powershell
-dotnet run -- bulkverify --page 10
+dotnet run -- bulkverify --page 10 --iothub-connection-string <connection-string>
 ```
 
 The bulkverify verb supports the following parameters:
 
 |parameter|required|description|
 |-|-|-|
+|--iothub-connection-string|yes|Connection string of the IoT Hub.|
 |--page|no|Errors per page. Default is all.|
 |--help|no|Display this help screen.|
 |--version|no|Display version information.|
 
 ### add
 
-Add a new device to IoT Hub. The data entered will be verified and only created in IoT Hub if it's valid. All required fields that are not provided will be automatically populated with valid, randomly generated by the tool. The only mandatory field is `type` which has to be set to either `ABP` or `OTAA` or `concentrator`.
+Add a new device to IoT Hub. The data entered will be verified and only created
+in IoT Hub if it's valid. All required fields that are not provided will be
+automatically populated with valid, randomly generated by the tool. The only
+mandatory field is `type` which has to be set to either `ABP` or `OTAA` or
+`concentrator`.
 
-To learn more about what each of the settings in the LoRa device twin does, refer to the [Quick Start Guide](../quickstart.md#optional-device-properties).
+To learn more about what each of the settings in the LoRa device twin does,
+refer to the [Quick Start Guide](../quickstart.md#optional-device-properties).
 
 Example:
 
 ```powershell
-dotnet run -- add --type abp --deveui 33CCC86800430010 --decoder http://decodermodule/api/customdecoder
+dotnet run -- add --type abp --deveui 33CCC86800430010 --decoder http://decodermodule/api/customdecoder --iothub-connection-string <connection-string>
 ```
 
 The add verb supports the following parameters:
@@ -166,6 +192,7 @@ The add verb supports the following parameters:
 |--type|yes|Device type: Must be ABP, OTAA or Concentrator.|
 |--region|yes for 'Concentrator' type devices| Must be the name of one of the regions in the DefaultRouterConfig folder.|
 |--stationeui|yes for 'Concentrator' type devices| A 16 bit hex string ('AABBCCDDEEFFGGHH').|
+|--iothub-connection-string|yes|Connection string of the IoT Hub.|
 |--no-cups|no|No CUPS: Only applicable to 'Concentrator' type devices. If set to true indicates that the concentrator does not use CUPS.|
 |--certificate-bundle-location|no|Certificate bundle location: Required if --no-cups set to false. Points to the location of the (UTF-8-encoded) certificate bundle file.|
 |--client-certificate-thumbprint|no|Client certificate thumbprint: Required if --no-cups set to false. A list of client certificate thumbprints (separated by a space) that should be accepted by the CUPS/LNS endpoints.|
@@ -200,14 +227,16 @@ The add verb supports the following parameters:
 
 Update the twin information for an existing device.
 
-To remove an existing value that is currently set on the twin, pass it the value `null`.
+To remove an existing value that is currently set on the twin, pass it the value
+`null`.
 
-To learn more about what each of the settings in the LoRa device twin does, refer to the [Quick Start Guide](../quickstart.md#optional-device-properties).
+To learn more about what each of the settings in the LoRa device twin does,
+refer to the [Quick Start Guide](../quickstart.md#optional-device-properties).
 
 Example:
 
 ```powershell
-dotnet run -- update --deveui 33CCC86800430010 --decoder null
+dotnet run -- update --deveui 33CCC86800430010 --decoder null --iothub-connection-string <connection-string>
 ```
 
 The update verb supports the following parameters:
@@ -215,6 +244,7 @@ The update verb supports the following parameters:
 |parameter|required|description|
 |-|-|-|
 |--deveui|yes|DevEUI / Device Id: A 16 bit hex string.|
+|--iothub-connection-string|yes|Connection string of the IoT Hub.|
 |--appskey|no|AppSKey (Only for ABP devices): A 16 bit hex string.|
 |--nwkskey|no|NwkSKey (Only for ABP devices): A 16 bit hex string.|
 |--devaddr|no|DevAddr (Only for ABP devices): A 4 bit hex string.|
@@ -246,7 +276,7 @@ Remove an existing device from IoT Hub by it's DevEUI / Device Id.
 Example:
 
 ```powershell
-dotnet run -- remove --deveui 33CCC86800430010
+dotnet run -- remove --deveui 33CCC86800430010 --iothub-connection-string <connection-string>
 ```
 
 The query verb supports the following parameters:
@@ -254,6 +284,7 @@ The query verb supports the following parameters:
 |parameter|required|description|
 |-|-|-|
 |--deveui|yes|DevEUI / Device Id.|
+|--iothub-connection-string|yes|Connection string of the IoT Hub.|
 |--help|no|Display this help screen.|
 |--version|no|Display version information.|
 
@@ -267,7 +298,14 @@ upgrade](../user-guide/station-firmware-upgrade.md) user guide.
 Example:
 
  ```powershell
-   dotnet run -- upgrade-firmware --stationeui <station_eui> --package <package_version> --firmware-location <firmware_file_path> --digest-location <digest_file_path> --checksum-location <checksum_file_path>
+   dotnet run -- upgrade-firmware 
+    --stationeui <station_eui> 
+    --package <package_version> 
+    --firmware-location <firmware_file_path> 
+    --digest-location <digest_file_path> 
+    --checksum-location <checksum_file_path> 
+    --iothub-connection-string <iothub-connection-string> 
+    --storage-connection-string <storage-connection-string>
 ```
 
 The upgrade-firmware verb accepts the following parameters:
@@ -279,5 +317,7 @@ The upgrade-firmware verb accepts the following parameters:
 |--firmware-location|yes|Local file path of the firmware upgrade executable|
 |--digest-location|yes|Local file path of the file containing a digest of the firmware upgrade|
 |--checksum-location|yes|Local file path of the file containing a CRC32 checksum of the key used to generate the digest|
+|--iothub-connection-string|yes|Connection string of the IoT Hub.|
+|--storage-connection-string|yes|Connection string of the Storage account.|
 |--help|no|Display this help screen|
 |--version|no|Display version information|

--- a/docs/tools/device-provisioning.md
+++ b/docs/tools/device-provisioning.md
@@ -94,7 +94,7 @@ List the devices in IoT Hub and show their device twin.
 Example:
 
 ```powershell
-dotnet run -- list --iothub-connection-string <connection-string>
+dotnet run -- list --iothub-connection-string <connection_string>
 ```
 
 The list verb supports the following parameters:
@@ -115,7 +115,7 @@ Id.
 Example:
 
 ```powershell
-dotnet run -- query --deveui 33CCC86800430010 --iothub-connection-string <connection-string>
+dotnet run -- query --deveui 33CCC86800430010 --iothub-connection-string <connection_string>
 ```
 
 The query verb supports the following parameters:
@@ -134,7 +134,7 @@ Verify an existing device in IoT Hub by it's DevEUI / Device Id.
 Example:
 
 ```powershell
-dotnet run -- verify --deveui 33CCC86800430010 --iothub-connection-string <connection-string>
+dotnet run -- verify --deveui 33CCC86800430010 --iothub-connection-string <connection_string>
 ```
 
 The verify verb supports the following parameters:
@@ -156,7 +156,7 @@ properly  configured and how many contain errors.
 Example:
 
 ```powershell
-dotnet run -- bulkverify --page 10 --iothub-connection-string <connection-string>
+dotnet run -- bulkverify --page 10 --iothub-connection-string <connection_string>
 ```
 
 The bulkverify verb supports the following parameters:
@@ -182,7 +182,7 @@ refer to the [Quick Start Guide](../quickstart.md#optional-device-properties).
 Example:
 
 ```powershell
-dotnet run -- add --type abp --deveui 33CCC86800430010 --decoder http://decodermodule/api/customdecoder --iothub-connection-string <connection-string>
+dotnet run -- add --type abp --deveui 33CCC86800430010 --decoder http://decodermodule/api/customdecoder --iothub-connection-string <connection_string>
 ```
 
 The add verb supports the following parameters:
@@ -236,7 +236,7 @@ refer to the [Quick Start Guide](../quickstart.md#optional-device-properties).
 Example:
 
 ```powershell
-dotnet run -- update --deveui 33CCC86800430010 --decoder null --iothub-connection-string <connection-string>
+dotnet run -- update --deveui 33CCC86800430010 --decoder null --iothub-connection-string <connection_string>
 ```
 
 The update verb supports the following parameters:
@@ -276,7 +276,7 @@ Remove an existing device from IoT Hub by it's DevEUI / Device Id.
 Example:
 
 ```powershell
-dotnet run -- remove --deveui 33CCC86800430010 --iothub-connection-string <connection-string>
+dotnet run -- remove --deveui 33CCC86800430010 --iothub-connection-string <connection_string>
 ```
 
 The query verb supports the following parameters:
@@ -304,8 +304,8 @@ Example:
     --firmware-location <firmware_file_path> 
     --digest-location <digest_file_path> 
     --checksum-location <checksum_file_path> 
-    --iothub-connection-string <iothub-connection-string> 
-    --storage-connection-string <storage-connection-string>
+    --iothub-connection-string <iothub_connection_string> 
+    --storage-connection-string <storage_connection_string>
 ```
 
 The upgrade-firmware verb accepts the following parameters:

--- a/docs/user-guide/station-firmware-upgrade.md
+++ b/docs/user-guide/station-firmware-upgrade.md
@@ -17,7 +17,14 @@ required to execute such upgrade.
 1. Use LoRa Device Provisioning CLI tool to upload the upgrade files in the cloud.
 
    ```powershell
-   dotnet .\Tools\Cli-LoRa-Device-Provisioning\bin\Release\net6.0\loradeviceprovisioning.dll upgrade-firmware --stationeui <station_eui> --package <package_version> --firmware-location <firmware_file_path> --digest-location <digest_file_path> --checksum-location <checksum_file_path>
+   dotnet .\Tools\Cli-LoRa-Device-Provisioning\bin\Release\net6.0\loradeviceprovisioning.dll upgrade-firmware 
+    --stationeui <station_eui> 
+    --package <package_version> 
+    --firmware-location <firmware_file_path> 
+    --digest-location <digest_file_path> 
+    --checksum-location <checksum_file_path>
+    --iothub-connection-string <iothub_connection_string> 
+    --storage-connection-string <storage_connection_string>
    ```
 
    Parameters:


### PR DESCRIPTION
# PR for issue #1335 

## What is being addressed

The Device Provisioning CLI tool documentation is updated to reflect the new way of passing connection strings - using command line arguments instead of `appsettings.json` file.

This PR complements https://github.com/Azure/iotedge-lorawan-starterkit/pull/1375
