### PR TITLE
Ensure that `IotHubDeviceInfo` is serialized correctly

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/IoTHubDeviceInfo.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/IoTHubDeviceInfo.cs
@@ -8,20 +8,15 @@ namespace LoraKeysManagerFacade
 
     public class IoTHubDeviceInfo
     {
-        public int NetworkId { get; set; }
-
-        public int NetworkAddress { get; set; }
+        [JsonProperty("DevAddr")]
+        public string DevAddrString
+        {
+            get => DevAddr.ToString();
+            set => DevAddr = LoRaWan.DevAddr.Parse(value);
+        }
 
         [JsonIgnore]
-        public DevAddr DevAddr
-        {
-            get => new DevAddr(NetworkId, NetworkAddress);
-            set
-            {
-                NetworkId = value.NetworkId;
-                NetworkAddress = value.NetworkAddress;
-            }
-        }
+        public DevAddr DevAddr { get; set; }
 
         [JsonIgnore]
         public DevEui? DevEUI { get; set; }

--- a/Tests/Unit/NetworkServer/IotHubDeviceInfoConversionTests.cs
+++ b/Tests/Unit/NetworkServer/IotHubDeviceInfoConversionTests.cs
@@ -12,7 +12,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
     public sealed class IotHubDeviceInfoConversionTests
     {
         [Fact]
-        public void Serialization_And_Deserialization_Preserves_Information_Using_JsonNet()
+        public void Can_Be_Json_Deserialized_As_IoTHubDeviceInfo_From_NetworkServer()
         {
             // arrange
             var original = new IoTHubDeviceInfo { DevAddr = new DevAddr(123), DevEUI = new DevEui(234), PrimaryKey = "someprimarykey" };

--- a/Tests/Unit/NetworkServer/IotHubDeviceInfoConversionTests.cs
+++ b/Tests/Unit/NetworkServer/IotHubDeviceInfoConversionTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaWan.Tests.Unit.NetworkServer
+{
+    using global::LoraKeysManagerFacade;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    public sealed class IotHubDeviceInfoConversionTests
+    {
+        [Fact]
+        public void Serialization_And_Deserialization_Preserves_Information_Using_JsonNet()
+        {
+            // arrange
+            var original = new IoTHubDeviceInfo { DevAddr = new DevAddr(123), DevEUI = new DevEui(234), PrimaryKey = "someprimarykey" };
+
+            // act
+            var result = JsonConvert.DeserializeObject<LoRaWan.NetworkServer.IoTHubDeviceInfo>(JsonConvert.SerializeObject(original));
+
+            // assert
+            Assert.NotNull(result);
+            Assert.Equal(original.DevEUI, result!.DevEUI);
+            Assert.Equal(original.PrimaryKey, result.PrimaryKey);
+            Assert.Equal(original.DevAddr, result.DevAddr);
+        }
+    }
+}

--- a/Tests/Unit/NetworkServer/IotHubDeviceInfoConversionTests.cs
+++ b/Tests/Unit/NetworkServer/IotHubDeviceInfoConversionTests.cs
@@ -12,6 +12,23 @@ namespace LoRaWan.Tests.Unit.NetworkServer
     public sealed class IotHubDeviceInfoConversionTests
     {
         [Fact]
+        public void Serializes_To_Expected_Json_Object()
+        {
+            // arrange
+            var original = new IoTHubDeviceInfo { DevAddr = new DevAddr(123), DevEUI = new DevEui(234), PrimaryKey = "someprimarykey" };
+
+            // act
+            var obj = JsonConvert.DeserializeObject<JObject>(JsonConvert.SerializeObject(original));
+
+            // assert
+            Assert.NotNull(obj);
+            Assert.Equal(3, obj!.Count);
+            Assert.Equal(original.DevEuiString, obj["DevEUI"]);
+            Assert.Equal(original.PrimaryKey, obj["PrimaryKey"]);
+            Assert.Equal(original.DevAddrString, obj["DevAddr"]);
+        }
+
+        [Fact]
         public void Can_Be_Json_Deserialized_As_IoTHubDeviceInfo_From_NetworkServer()
         {
             // arrange

--- a/Tests/Unit/NetworkServer/IotHubDeviceInfoConversionTests.cs
+++ b/Tests/Unit/NetworkServer/IotHubDeviceInfoConversionTests.cs
@@ -7,6 +7,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 {
     using global::LoraKeysManagerFacade;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
     using Xunit;
 
     public sealed class IotHubDeviceInfoConversionTests


### PR DESCRIPTION
# PR for issue #1149

## What is being addressed

With this PR we ensure that the `IotHubDeviceInfo` is (de-)serialized correctly.
