### PR TITLE
CLI tool - documentation for `rotate-certificate` and `revoke` commands

### DIFF
--- a/docs/tools/device-provisioning.md
+++ b/docs/tools/device-provisioning.md
@@ -62,13 +62,15 @@ The following verbs/commands are supported:
 
 |verb|description|
 |-|-|
-|list|Lits devices in IoT Hub.|
+|list|List devices in IoT Hub.|
 |query|Query a device twin.|
 |verify|Verify a single device in IoT Hub.|
 |bulkverify|Bulk verify all devices in IoT Hub.|
 |add|Add a new device to IoT Hub.|
 |update|Update an existing device in IoT Hub.|
 |remove|Remove an existing device from IoT Hub.|
+|rotate-certificate|Update a client certificate for a Basics Station.|
+|revoke|Revoke a client certificate installed on a Basics Station.|
 |upgrade-firmware|Trigger a firmware upgrade of a Basics Station.|
 |help|Display more information on a specific command.|
 |version|Display version information.|

--- a/docs/tools/device-provisioning.md
+++ b/docs/tools/device-provisioning.md
@@ -257,6 +257,29 @@ The query verb supports the following parameters:
 |--help|no|Display this help screen.|
 |--version|no|Display version information.|
 
+### rotate-certificate
+
+Triggers an update of a client certificate installed on the Basics Station.
+
+Example:
+
+```powershell
+dotnet run -- rotate-certificate 
+  --stationeui 33CCC86800430010 
+  --certificate-bundle-location <bundle_location>
+  --client-certificate-thumbprint <thumbprint>
+  --iothub-connection-string <iothub_connection_string> 
+  --storage-connection-string <storage_connection_string>
+```
+
+|parameter|required|description|
+|-|-|-|
+|--stationeui|yes|Station EUI|
+|--certificate-bundle-location|yes|Location of the (UTF-8-encoded) certificate bundle file|
+|--client-certificate-thumbprint|yes|Client certificate thumbprint that should be accepted by the CUPS/LNS endpoints|
+|--iothub-connection-string|yes|Connection string of the IoT Hub.|
+|--storage-connection-string|yes|Connection string of the Storage account.|
+
 ### upgrade-firmware
 
 Triggers a firmware upgrade of a Basics Station.

--- a/docs/tools/device-provisioning.md
+++ b/docs/tools/device-provisioning.md
@@ -277,8 +277,27 @@ dotnet run -- rotate-certificate
 |--stationeui|yes|Station EUI|
 |--certificate-bundle-location|yes|Location of the (UTF-8-encoded) certificate bundle file|
 |--client-certificate-thumbprint|yes|Client certificate thumbprint that should be accepted by the CUPS/LNS endpoints|
-|--iothub-connection-string|yes|Connection string of the IoT Hub.|
-|--storage-connection-string|yes|Connection string of the Storage account.|
+|--iothub-connection-string|yes|Connection string of the IoT Hub|
+|--storage-connection-string|yes|Connection string of the Storage account|
+
+### revoke
+
+Revokes a client certificate installed on the Basics Station.
+
+Example:
+
+```powerhsell
+dotnet run -- revoke 
+  --stationeui 33CCC86800430010 
+  --client-certificate-thumbprint <thumbprint> 
+  --iothub-connection-string <iothub_connection_string>
+```
+
+|parameter|required|description|
+|-|-|-|
+|--stationeui|yes|Station EUI|
+|--client-certificate-thumbprint|yes|Client certificate thumbprint that should be revoked|
+|--iothub-connection-string|yes|Connection string of the IoT Hub|
 
 ### upgrade-firmware
 


### PR DESCRIPTION
# PR for issue #1377 

## What is being addressed

There was no documentation in the CLI Device Provisioning tool user guide for `rotate-certificate` and `revoke` commands which are both related to client certificate management for the Basics Station.

## How is this addressed

- The two commands and their parameters are documented.
