### PR TITLE
Make `RequiresConfirmation` specific to `LoRaPayloadData`

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayload.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayload.cs
@@ -26,7 +26,5 @@ namespace LoRaTools.LoRaMessage
         /// Gets or sets assigned Dev Address, TODO change??.
         /// </summary>
         public DevAddr DevAddr { get; set; }
-
-        public virtual bool RequiresConfirmation => false;
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -504,7 +504,7 @@ namespace LoRaTools.LoRaMessage
             return messageArray.ToArray();
         }
 
-        public override bool RequiresConfirmation => IsConfirmed || IsMacAnswerRequired;
+        public bool RequiresConfirmation => IsConfirmed || IsMacAnswerRequired;
 
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -505,6 +505,5 @@ namespace LoRaTools.LoRaMessage
         }
 
         public bool RequiresConfirmation => IsConfirmed || IsMacAnswerRequired;
-
     }
 }

--- a/Tests/Unit/LoRaTools/LoRaPayloadTest.cs
+++ b/Tests/Unit/LoRaTools/LoRaPayloadTest.cs
@@ -17,20 +17,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools.LoRaMessage
             using var loraRequest = WaitableLoRaRequest.Create(dataPayload);
 
             // act/assert
-            Assert.True(loraRequest.Payload.RequiresConfirmation);
-        }
-
-        [Fact]
-        public void When_Not_Data_Payload_RequiresConfirmation_Should_Return_False()
-        {
-            // arrange
-            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(0));
-            var payload = simulatedDevice.CreateJoinRequest();
-            using var loraRequest = WaitableLoRaRequest.Create(payload);
-            loraRequest.SetPayload(payload);
-
-            // act/assert
-            Assert.False(loraRequest.Payload.RequiresConfirmation);
+            Assert.True(dataPayload.RequiresConfirmation);
         }
 
         [Fact]
@@ -42,7 +29,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools.LoRaMessage
             using var loraRequest = WaitableLoRaRequest.Create(dataPayload);
 
             // act/assert
-            Assert.False(loraRequest.Payload.RequiresConfirmation);
+            Assert.False(dataPayload.RequiresConfirmation);
         }
     }
 }


### PR DESCRIPTION
This PR removes `RequiresConfirmation` from `LoRaPayload` and makes it specific to `LoRaPayloadData` where it's only needed and used.

The only method using `RequiresConfirmation` via `LoRaPayload` was `ValidateRequest` of `DefaultLoRaDataRequestHandler`. However, `DefaultLoRaDataRequestHandler` is only invoked for a `LoRaPayload` that's a `LoRaPayloadData` and a cast is done very early on `ProcessRequestAsync`:

https://github.com/Azure/iotedge-lorawan-starterkit/blob/cdfecb609bcc096f656c6ee27a301a0333d4f8ab/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs#L78

This PR refactors `ValidateRequest` to take a `LoRaPayloadData` instead of a `LoRaRequest` so it can directly use its `RequiresConfirmation` property. It just returns the reason for invalidation, a `LoRaDeviceRequestFailedReason?` instead of a `bool` and outputting a `LoRaDeviceRequestProcessResult` with the reason. This completely removes the need to pass `LoRaRequest` to `ValidateRequest`.

The test `LoRaPayloadTest.When_Not_Data_Payload_RequiresConfirmation_Should_Return_False` has been removed completely because it is no longer applicable.
