### PR TITLE
Expose read-only memory on payloads

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Mic.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan/Mic.cs
@@ -84,7 +84,7 @@ namespace LoRaWan
             return new Mic(BinaryPrimitives.ReadInt32LittleEndian(cmac));
         }
 
-        public static Mic ComputeForJoinAccept(AppKey appKey, MacHeader macHeader, AppNonce joinNonce, NetId netId, DevAddr devAddr, Memory<byte> dlSettings, RxDelay rxDelay, Memory<byte> cfList)
+        public static Mic ComputeForJoinAccept(AppKey appKey, MacHeader macHeader, AppNonce joinNonce, NetId netId, DevAddr devAddr, ReadOnlyMemory<byte> dlSettings, RxDelay rxDelay, ReadOnlyMemory<byte> cfList)
         {
             var algoInput = new byte[MacHeader.Size + AppNonce.Size + NetId.Size + DevAddr.Size + dlSettings.Length + sizeof(RxDelay) + cfList.Length];
             var index = 0;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -67,7 +67,7 @@ namespace LoRaTools.LoRaMessage
         /// <summary>
         /// Gets or sets optional frame.
         /// </summary>
-        public Memory<byte> Fopts { get; }
+        public ReadOnlyMemory<byte> Fopts { get; }
 
         /// <summary>
         /// Gets or sets port field.
@@ -77,7 +77,7 @@ namespace LoRaTools.LoRaMessage
         /// <summary>
         /// Gets or sets mAC Frame Payload Encryption.
         /// </summary>
-        public Memory<byte> Frmpayload { get; }
+        public ReadOnlyMemory<byte> Frmpayload { get; }
 
         /// <summary>
         /// Gets or sets get message direction.
@@ -127,8 +127,9 @@ namespace LoRaTools.LoRaMessage
             Fcnt = counter;
 
             // Setting FOpts
-            Fopts = new byte[options.Length / 2];
-            _ = Hexadecimal.TryParse(options, Fopts.Span);
+            var foptsBytes = new byte[options.Length / 2];
+            Fopts = foptsBytes;
+            _ = Hexadecimal.TryParse(options, foptsBytes);
 
             // Populate the MacCommands present in the payload.
             if (options.Length > 0)
@@ -137,8 +138,9 @@ namespace LoRaTools.LoRaMessage
             }
 
             // Setting FRMPayload
-            Frmpayload = new byte[payload.Length / 2];
-            _ = Hexadecimal.TryParse(payload, Frmpayload.Span);
+            var payloadBytes = new byte[payload.Length / 2];
+            Frmpayload = payloadBytes;
+            _ = Hexadecimal.TryParse(payload, payloadBytes);
 
             // Fport can be empty if no commands
             Fport = port;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadJoinAccept.cs
@@ -28,7 +28,7 @@ namespace LoRaTools.LoRaMessage
         /// <summary>
         /// Gets or sets dLSettings.
         /// </summary>
-        public Memory<byte> DlSettings { get; set; }
+        public ReadOnlyMemory<byte> DlSettings { get; set; }
 
         /// <summary>
         /// Gets or sets rxDelay.
@@ -38,7 +38,7 @@ namespace LoRaTools.LoRaMessage
         /// <summary>
         /// Gets or sets cFList / Optional.
         /// </summary>
-        public Memory<byte> CfList { get; set; }
+        public ReadOnlyMemory<byte> CfList { get; set; }
 
         public int Rx1DrOffset => (DlSettings.Span[0] >> 4) & 0b00000111;
 


### PR DESCRIPTION
This PR changes all properties on payloads that are `Memory<byte>` to be `ReadOnlyMemory<byte>`. It should not be possible to modify the memory directly from outside the objects.
