### PR TITLE
Removes custom CUPS retry config so that the default of 1 minute will be used

### DIFF
--- a/LoRaEngine/modules/LoRaBasicsStationModule/station.conf
+++ b/LoRaEngine/modules/LoRaBasicsStationModule/station.conf
@@ -24,7 +24,6 @@
         "log_file":  "stderr",
         "log_level": "XDEBUG",  /* XDEBUG,DEBUG,VERBOSE,INFO,NOTICE,WARNING,ERROR,CRITICAL */
         "log_size":  10000000,
-        "log_rotate":  3,
-        "CUPS_RESYNC_INTV": "1s"
+        "log_rotate":  3
     }
 }


### PR DESCRIPTION
# PR for issue #1389

## What is being addressed

In our station.conf we previously set CUPS retries to happen on every second.

## How is this addressed

By removing the custom setting - the LBS will use the default value of 60 seconds.

This was manually verified with Atif: by removing the setting in station.conf and re-starting the basics module, the default value of 60 seconds was picked up.