### PR TITLE
Making AMQP MaxPoolSize configurable

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
@@ -135,8 +135,11 @@ namespace LoRaWan.NetworkServer
                         AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings()
                         {
                             Pooling = true,
-                            // pool size 1 => 995 devices.
-                            MaxPoolSize = 1
+                            // pool size for this project defaults to 1, allowing aroung 1000 amqp links
+                            // in case you need more, and the communications are proxied through edgeHub,
+                            // please consider changing this parameter in edgeHub configuration too
+                            // https://github.com/Azure/iotedge/blob/e6d52d6f6b0eb76e7ef250f3fcdeaf38e467ab4f/doc/EnvironmentVariables.md
+                            MaxPoolSize = this.configuration.IotHubConnectionPoolSize
                         },
                         OperationTimeout = TimeSpan.FromSeconds(10)
                     }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -129,7 +129,7 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Specifies the pool size for upstream AMQP connection
         /// </summary>
-        public uint IotHubConnectionPoolSize { get; internal set; }
+        public uint IotHubConnectionPoolSize { get; internal set; } = 1;
 
         // Creates a new instance of NetworkServerConfiguration by reading values from environment variables
         public static NetworkServerConfiguration CreateFromEnvironmentVariables()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -7,6 +7,7 @@ namespace LoRaWan.NetworkServer
     using System.Collections.Generic;
     using System.Linq;
     using Microsoft.AspNetCore.Server.Kestrel.Https;
+    using Microsoft.Azure.Devices.Client;
 
     // Network server configuration
     public class NetworkServerConfiguration
@@ -125,6 +126,11 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         public ClientCertificateMode ClientCertificateMode { get; internal set; }
 
+        /// <summary>
+        /// Specifies the pool size for upstream AMQP connection
+        /// </summary>
+        public uint IotHubConnectionPoolSize { get; internal set; }
+
         // Creates a new instance of NetworkServerConfiguration by reading values from environment variables
         public static NetworkServerConfiguration CreateFromEnvironmentVariables()
         {
@@ -164,6 +170,12 @@ namespace LoRaWan.NetworkServer
             config.LnsServerPfxPassword = envVars.GetEnvVar("LNS_SERVER_PFX_PASSWORD", string.Empty);
             var clientCertificateModeString = envVars.GetEnvVar("CLIENT_CERTIFICATE_MODE", "NoCertificate"); // Defaulting to NoCertificate if missing mode
             config.ClientCertificateMode = Enum.Parse<ClientCertificateMode>(clientCertificateModeString, true);
+
+            config.IotHubConnectionPoolSize = envVars.GetEnvVar("IOTHUB_CONNECTION_POOL_SIZE", 1U) is uint size
+                                              && size > 0U
+                                              && size < AmqpConnectionPoolSettings.AbsoluteMaxPoolSize
+                                              ? size
+                                              : throw new NotSupportedException($"'IOTHUB_CONNECTION_POOL_SIZE' needs to be between 1 and {AmqpConnectionPoolSettings.AbsoluteMaxPoolSize}.");
 
             return config;
         }


### PR DESCRIPTION
# PR for issue #1337

## What is being addressed

This PR is introducing IOTHUB_CONNECTION_POOL_SIZE environment variable for allowing a configurable AMQP Connection Pooling MaxPoolSize value.