### PR TITLE
Remove incorrect payload reversal in `ADRMessageProcessorTest`

### DIFF
--- a/Tests/Unit/NetworkServer/ADRMessageProcessorTest.cs
+++ b/Tests/Unit/NetworkServer/ADRMessageProcessorTest.cs
@@ -462,7 +462,6 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // We expect a mac command in the payload
             Assert.Equal(5, payloadDataDown.Frmpayload.Span.Length);
             var decryptedPayload = payloadDataDown.Serialize(simulatedDevice.NwkSKey.Value);
-            Array.Reverse(decryptedPayload);
             Assert.Equal(FramePort.MacCommand, payloadDataDown.Fport);
             Assert.Equal((byte)Cid.LinkADRCmd, decryptedPayload[0]);
             var linkAdr = new LinkADRRequest(decryptedPayload);


### PR DESCRIPTION
This is an addendum to PR #1371.

## What is being addressed

`Perform_NbRep_Adaptation_When_Needed` in `ADRMessageProcessorTest` was incorrectly reversing the payload array. PR #1371 fixed the reversal of MAC commands so this reversal was not needed anymore. The test was still passing by sheer coincidence because the first and last byte of the payload happened to be 3, which is the **CID** of **LinkADRReq** as well as the value of **NbTrans** (`LinkADRRequest.NbRep` in code) being asserted! The reversal made no difference.

## How is this addressed

The reversal of the payload is removed.
