### PR TITLE
Getting rid of mixed content issue in docs and pointing to v2.0.0 tag

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,10 +43,10 @@ The template will deploy in your Azure subscription the Following resources:
 
 ## Step-by-step instructions
 
-1. Press on the button here below to start your Azure Deployment.
+1. Press on the button here below to start your Azure Deployment.  
     <!-- markdownlint-disable MD033 -->
-    <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fiotedge-lorawan-starterkit%2Fmaster%2FTemplate%2Fazuredeploy.json" target="_blank">
-        <img src="http://azuredeploy.net/deploybutton.png"/>
+    <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fiotedge-lorawan-starterkit%2Fv2.0.0%2FTemplate%2Fazuredeploy.json" target="_blank">
+        <img src="https://azurecomcdn.azureedge.net/mediahandler/acomblog/media/Default/blog/deploybutton.png"/>
     </a>
     <!-- markdownlint-enable MD033 -->
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,7 +46,7 @@ The template will deploy in your Azure subscription the Following resources:
 1. Press on the button here below to start your Azure Deployment.  
     <!-- markdownlint-disable MD033 -->
     <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fiotedge-lorawan-starterkit%2Fv2.0.0%2FTemplate%2Fazuredeploy.json" target="_blank">
-        <img src="https://azurecomcdn.azureedge.net/mediahandler/acomblog/media/Default/blog/deploybutton.png"/>
+        <img src="https://aka.ms/deploytoazurebutton"/>
     </a>
     <!-- markdownlint-enable MD033 -->
 


### PR DESCRIPTION
# PR for issue #1384 

# What changed
- [x] Getting rid of mixed content issue by pointing to different https "button" image
- [x] Updating to v2.0.0 tag the link for deployment (it still does not work, will work when new release is released)