### PR TITLE
Allow missing payload case: FPort = -1, FRMPayload = ""

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/JsonHandlers/LnsData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/JsonHandlers/LnsData.cs
@@ -98,14 +98,17 @@ namespace LoRaWan.NetworkServer.BasicsStation.JsonHandlers
                               JsonReader.Property("FCtrl", from b in JsonReader.Byte() select FrameControl.Decode(b).Flags),
                               JsonReader.Property("FCnt", JsonReader.UInt16()),
                               JsonReader.Property("FOpts", JsonReader.String()),
-                              JsonReader.Property("FPort", JsonReader.Byte()),
+                              JsonReader.Property("FPort", JsonReader.Either(from n in JsonReader.Byte()
+                                                                             select (FramePort?)n,
+                                                                             from _ in JsonReader.Int32().Validate(n => n == -1)
+                                                                             select (FramePort?)null)),
                               JsonReader.Property("FRMPayload", JsonReader.String()),
                               MicProperty,
                               RadioMetadataProperties.DataRate,
                               RadioMetadataProperties.Freq,
                               RadioMetadataProperties.UpInfo,
                               (_, mhdr, devAddr, fctrlFlags, cnt, opts, port, payload, mic, dr, freq, upInfo) =>
-                                new UpstreamDataFrame(new MacHeader(mhdr), new DevAddr(devAddr), fctrlFlags, cnt, opts, (FramePort)port, payload, mic,
+                                new UpstreamDataFrame(new MacHeader(mhdr), new DevAddr(devAddr), fctrlFlags, cnt, opts, port, payload, mic,
                                                       new RadioMetadata(dr, freq, upInfo)));
         /*
          * {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/JsonHandlers/LnsData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/JsonHandlers/LnsData.cs
@@ -108,8 +108,10 @@ namespace LoRaWan.NetworkServer.BasicsStation.JsonHandlers
                               RadioMetadataProperties.Freq,
                               RadioMetadataProperties.UpInfo,
                               (_, mhdr, devAddr, fctrlFlags, cnt, opts, port, payload, mic, dr, freq, upInfo) =>
-                                new UpstreamDataFrame(new MacHeader(mhdr), new DevAddr(devAddr), fctrlFlags, cnt, opts, port, payload, mic,
-                                                      new RadioMetadata(dr, freq, upInfo)));
+                                port is null && payload.Length > 0
+                                    ? throw new JsonException(@"""FRMPayload"" without an ""FPort"" is forbidden.")
+                                    : new UpstreamDataFrame(new MacHeader(mhdr), new DevAddr(devAddr), fctrlFlags, cnt, opts, port, payload, mic,
+                                                            new RadioMetadata(dr, freq, upInfo)));
         /*
          * {
               "msgtype" : "jreq",

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/UpstreamDataFrame.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/UpstreamDataFrame.cs
@@ -3,7 +3,7 @@
 
 namespace LoRaWan.NetworkServer.BasicsStation
 {
-    public sealed class UpstreamDataFrame
+    public class UpstreamDataFrame
     {
         public UpstreamDataFrame(MacHeader macHeader,
                                  DevAddr devAddress,

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/UpstreamDataFrame.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/UpstreamDataFrame.cs
@@ -3,14 +3,14 @@
 
 namespace LoRaWan.NetworkServer.BasicsStation
 {
-    public class UpstreamDataFrame
+    public sealed class UpstreamDataFrame
     {
         public UpstreamDataFrame(MacHeader macHeader,
                                  DevAddr devAddress,
                                  FrameControlFlags fctrlFlags,
                                  ushort counter,
                                  string options,
-                                 FramePort port,
+                                 FramePort? port,
                                  string payload,
                                  Mic mic,
                                  RadioMetadata radioMetadata)
@@ -31,7 +31,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
         public FrameControlFlags FrameControlFlags { get; }
         public ushort Counter { get; }
         public string Options { get; }
-        public FramePort Port { get; }
+        public FramePort? Port { get; }
         public string Payload { get; }
         public Mic Mic { get; }
         public RadioMetadata RadioMetadata { get; }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceTelemetry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceTelemetry.cs
@@ -42,10 +42,10 @@ namespace LoRaWan.NetworkServer
         public object Data { get; set; }
 
         [JsonProperty("port")]
-        public byte PortByte { get => (byte)Port; set => Port = (FramePort)value; }
+        public byte? PortByte { get => (byte?)Port; set => Port = (FramePort?)value; }
 
         [JsonIgnore]
-        public FramePort Port { get; set; }
+        public FramePort? Port { get; private set; }
 
         [JsonProperty("fcnt")]
         public ushort Fcnt { get; set; }
@@ -85,7 +85,7 @@ namespace LoRaWan.NetworkServer
             Data = payloadData;
             Rawdata = decryptedPayloadData?.Length > 0 ? Convert.ToBase64String(decryptedPayloadData) : string.Empty;
             Fcnt = upstreamPayload.Fcnt;
-            Port = upstreamPayload.Fport.Value;
+            Port = upstreamPayload.Fport;
             Freq = radioMetadata.Frequency.InMega;
             Datr = datr.ToString();
             Rssi = radioMetadata.UpInfo.ReceivedSignalStrengthIndication;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/LoRaMessage/LoRaPayloadData.cs
@@ -90,12 +90,12 @@ namespace LoRaTools.LoRaMessage
                                ushort counter,
                                string options,
                                string payload,
-                               FramePort port,
+                               FramePort? port,
                                Mic? mic,
                                ILogger logger)
         {
             if (options is null) throw new ArgumentNullException(nameof(options));
-            if (string.IsNullOrEmpty(payload)) throw new ArgumentNullException(nameof(payload));
+            if (payload is null) throw new ArgumentNullException(nameof(payload));
 
             // Writing the DevAddr
             DevAddr = devAddress;

--- a/Tests/Common/SimulatedDevice.cs
+++ b/Tests/Common/SimulatedDevice.cs
@@ -120,15 +120,18 @@ namespace LoRaWan.Tests.Common
         /// <summary>
         /// Creates request to send unconfirmed data message.
         /// </summary>
-        public LoRaPayloadData CreateUnconfirmedDataUpMessage(string data, uint? fcnt = null, FramePort fport = FramePorts.App1, FrameControlFlags fctrlFlags = FrameControlFlags.None, bool isHexPayload = false, IList<MacCommand> macCommands = null, AppSessionKey? appSKey = null, NetworkSessionKey? nwkSKey = null)
+        public LoRaPayloadData CreateUnconfirmedDataUpMessage(string data, uint? fcnt = null, FramePort? fport = FramePorts.App1, FrameControlFlags fctrlFlags = FrameControlFlags.None, bool isHexPayload = false, IList<MacCommand> macCommands = null, AppSessionKey? appSKey = null, NetworkSessionKey? nwkSKey = null)
         {
             fcnt ??= FrmCntUp + 1;
             FrmCntUp = fcnt.GetValueOrDefault();
 
             // TestLogger.Log($"{LoRaDevice.DeviceID}: Simulated data: {data}");
             byte[] payload = null;
-            if (data != null)
+            if (!string.IsNullOrEmpty(data))
             {
+                if (fport is null)
+                    throw new ArgumentNullException(nameof(fport), "Value cannot be null when data is supplied.");
+
                 if (!isHexPayload)
                 {
                     payload = Encoding.UTF8.GetBytes(data);

--- a/Tests/Common/TheoryDataFactory.cs
+++ b/Tests/Common/TheoryDataFactory.cs
@@ -35,6 +35,9 @@ namespace LoRaWan.Tests.Common
             return result;
         }
 
+        public static TheoryData<T1, T2, T3> From<T1, T2, T3>(params (T1, T2, T3)[] data) =>
+            From(data.AsEnumerable());
+
         public static TheoryData<T1, T2, T3> From<T1, T2, T3>(IEnumerable<(T1, T2, T3)> data)
         {
             if (data is null) throw new ArgumentNullException(nameof(data));

--- a/Tests/Unit/NetworkServer/JsonHandlers/LnsDataTests.cs
+++ b/Tests/Unit/NetworkServer/JsonHandlers/LnsDataTests.cs
@@ -87,30 +87,46 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation.JsonHandlers
             Assert.Equal(9, updf.RadioMetadata.UpInfo.SignalNoiseRatio);
         }
 
+        private const string GeneralJsonErrorMessage = "Exception of type 'System.Text.Json.JsonException' was thrown.";
+
         [Theory]
-        [InlineData(@"{ 'msgtype': 'updf', 'MHdr': 300, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': 8, 'FRMPayload': '5ABBBA', 'MIC': -1943282916,
+        [InlineData(GeneralJsonErrorMessage,
+                    @"{ 'msgtype': 'updf', 'MHdr': 300, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': 8, 'FRMPayload': '5ABBBA', 'MIC': -1943282916,
                         'DR': 4, 'Freq': 868100000, 'upinfo': {'rctx': 0,'xtime': 40250921680313459,'gpstime': 0,'fts': -1,'rssi': -60,'snr': 9,'rxtime': 1635347491.917289} }")]
-        [InlineData(@"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': -58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': 8, 'FRMPayload': '5ABBBA', 'MIC': -1943282916,
+        [InlineData(GeneralJsonErrorMessage,
+                    @"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': -58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': 8, 'FRMPayload': '5ABBBA', 'MIC': -1943282916,
                         'DR': 4, 'Freq': 868100000, 'upinfo': {'rctx': 0,'xtime': 40250921680313459,'gpstime': 0,'fts': -1,'rssi': -60,'snr': 9,'rxtime': 1635347491.917289} }")]
-        [InlineData(@"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 300, 'FCnt': 164, 'FOpts': '', 'FPort': 8, 'FRMPayload': '5ABBBA', 'MIC': -1943282916,
+        [InlineData(GeneralJsonErrorMessage,
+                    @"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 300, 'FCnt': 164, 'FOpts': '', 'FPort': 8, 'FRMPayload': '5ABBBA', 'MIC': -1943282916,
                         'DR': 4, 'Freq': 868100000, 'upinfo': {'rctx': 0,'xtime': 40250921680313459,'gpstime': 0,'fts': -1,'rssi': -60,'snr': 9,'rxtime': 1635347491.917289} }")]
-        [InlineData(@"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': -164, 'FOpts': '', 'FPort': 8, 'FRMPayload': '5ABBBA', 'MIC': -1943282916,
+        [InlineData(GeneralJsonErrorMessage,
+                    @"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': -164, 'FOpts': '', 'FPort': 8, 'FRMPayload': '5ABBBA', 'MIC': -1943282916,
                         'DR': 4, 'Freq': 868100000, 'upinfo': {'rctx': 0,'xtime': 40250921680313459,'gpstime': 0,'fts': -1,'rssi': -60,'snr': 9,'rxtime': 1635347491.917289} }")]
-        [InlineData(@"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': 5, 'FPort': 8, 'FRMPayload': '5ABBBA', 'MIC': -1943282916,
+        [InlineData(GeneralJsonErrorMessage,
+                    @"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': 5, 'FPort': 8, 'FRMPayload': '5ABBBA', 'MIC': -1943282916,
                         'DR': 4, 'Freq': 868100000, 'upinfo': {'rctx': 0,'xtime': 40250921680313459,'gpstime': 0,'fts': -1,'rssi': -60,'snr': 9,'rxtime': 1635347491.917289} }")]
-        [InlineData(@"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': 300, 'FRMPayload': '5ABBBA', 'MIC': -1943282916,
+        [InlineData("Invalid value in JSON: 300",
+                    @"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': 300, 'FRMPayload': '5ABBBA', 'MIC': -1943282916,
                         'DR': 4, 'Freq': 868100000, 'upinfo': {'rctx': 0,'xtime': 40250921680313459,'gpstime': 0,'fts': -1,'rssi': -60,'snr': 9,'rxtime': 1635347491.917289} }")]
-        [InlineData(@"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': 8, 'FRMPayload': 5, 'MIC': -1943282916,
+        [InlineData(GeneralJsonErrorMessage,
+                    @"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': 8, 'FRMPayload': 5, 'MIC': -1943282916,
                         'DR': 4, 'Freq': 868100000, 'upinfo': {'rctx': 0,'xtime': 40250921680313459,'gpstime': 0,'fts': -1,'rssi': -60,'snr': 9,'rxtime': 1635347491.917289} }")]
-        [InlineData(@"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': 8, 'FRMPayload': '5ABBBA', 'MIC': 5.0,
+        [InlineData(GeneralJsonErrorMessage,
+                    @"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': 8, 'FRMPayload': '5ABBBA', 'MIC': 5.0,
                         'DR': 4, 'Freq': 868100000, 'upinfo': {'rctx': 0,'xtime': 40250921680313459,'gpstime': 0,'fts': -1,'rssi': -60,'snr': 9,'rxtime': 1635347491.917289} }")]
-        [InlineData(@"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': -2, 'FRMPayload': '5ABBBA', 'MIC': 5,
+        [InlineData("Invalid value in JSON: -2",
+                    @"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': -2, 'FRMPayload': '5ABBBA', 'MIC': 5,
                         'DR': 4, 'Freq': 868100000, 'upinfo': {'rctx': 0,'xtime': 40250921680313459,'gpstime': 0,'fts': -1,'rssi': -60,'snr': 9,'rxtime': 1635347491.917289} }")]
-        [InlineData(@"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': -1, 'FRMPayload': null, 'MIC': 5,
+        [InlineData(GeneralJsonErrorMessage,
+                    @"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': -1, 'FRMPayload': null, 'MIC': 5,
                         'DR': 4, 'Freq': 868100000, 'upinfo': {'rctx': 0,'xtime': 40250921680313459,'gpstime': 0,'fts': -1,'rssi': -60,'snr': 9,'rxtime': 1635347491.917289} }")]
-        internal void UpstreamDataframeReader_Fails(string json)
+        [InlineData(@"""FRMPayload"" without an ""FPort"" is forbidden.",
+                    @"{ 'msgtype': 'updf', 'MHdr': 128, 'DevAddr': 58772467, 'FCtrl': 0, 'FCnt': 164, 'FOpts': '', 'FPort': -1, 'FRMPayload': '5ABBBA', 'MIC': 5,
+                        'DR': 4, 'Freq': 868100000, 'upinfo': {'rctx': 0,'xtime': 40250921680313459,'gpstime': 0,'fts': -1,'rssi': -60,'snr': 9,'rxtime': 1635347491.917289} }")]
+        internal void UpstreamDataframeReader_Fails(string expectedError, string json)
         {
-            _ = Assert.Throws<JsonException>(() => _ = LnsData.UpstreamDataFrameReader.Read(JsonUtil.Strictify(json)));
+            var ex = Assert.Throws<JsonException>(() => _ = LnsData.UpstreamDataFrameReader.Read(JsonUtil.Strictify(json)));
+            Assert.Equal(expectedError, ex.Message);
         }
 
         [Fact]

--- a/Tests/Unit/NetworkServer/LoRaDeviceTelemetryTest.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceTelemetryTest.cs
@@ -24,7 +24,9 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             using var loRaRequest = WaitableLoRaRequest.CreateWaitableRequest(payload);
             var target = new LoRaDeviceTelemetry(loRaRequest, payload, decodedValue, payload.GetDecryptedPayload(simulatedDevice.AppSKey.Value));
             Assert.Equal(checked((uint)loRaRequest.RadioMetadata.DataRate), target.Chan);
-            Assert.Equal(Convert.ToBase64String(payload.GetDecryptedPayload(simulatedDevice.AppSKey.Value)), target.Rawdata);
+            Assert.Equal(payload.GetDecryptedPayload(simulatedDevice.AppSKey.Value) is { } decryptedPayload
+                         ? Convert.ToBase64String(decryptedPayload)
+                         : string.Empty, target.Rawdata);
             Assert.Equal(decodedValue, target.Data);
             Assert.Equal(TestUtils.TestRegion.GetDatarateFromIndex(loRaRequest.RadioMetadata.DataRate).ToString(), target.Datr);
             Assert.Equal(loRaRequest.RadioMetadata.Frequency.InMega, target.Freq);

--- a/Tests/Unit/NetworkServer/LoRaDeviceTelemetryTest.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceTelemetryTest.cs
@@ -11,11 +11,11 @@ namespace LoRaWan.Tests.Unit.NetworkServer
     public class LoRaDeviceTelemetryTest
     {
         [Theory]
-        [InlineData(1, FramePorts.App1, "1")]
-        [InlineData(2, FramePorts.App10, "1")]
-        [InlineData(100, FramePorts.App2, "1")]
-        [InlineData(100, null, "")]
-        public void When_Creating_Should_Copy_Values_From_Rxpk_And_Payload(uint fcnt, FramePort? fport, string data)
+        [InlineData(1, FramePorts.App1, "1", "MQ==")]
+        [InlineData(2, FramePorts.App10, "1", "MQ==")]
+        [InlineData(100, FramePorts.App2, "1", "MQ==")]
+        [InlineData(100, null, "", "")]
+        public void When_Creating_Should_Copy_Values_From_Rxpk_And_Payload(uint fcnt, FramePort? fport, string data, string expectedRawData)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage(data, fcnt: fcnt, fport: fport);
@@ -24,9 +24,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             using var loRaRequest = WaitableLoRaRequest.CreateWaitableRequest(payload);
             var target = new LoRaDeviceTelemetry(loRaRequest, payload, decodedValue, payload.GetDecryptedPayload(simulatedDevice.AppSKey.Value));
             Assert.Equal(checked((uint)loRaRequest.RadioMetadata.DataRate), target.Chan);
-            Assert.Equal(payload.GetDecryptedPayload(simulatedDevice.AppSKey.Value) is { } decryptedPayload
-                         ? Convert.ToBase64String(decryptedPayload)
-                         : string.Empty, target.Rawdata);
+            Assert.Equal(expectedRawData, target.Rawdata);
             Assert.Equal(decodedValue, target.Data);
             Assert.Equal(TestUtils.TestRegion.GetDatarateFromIndex(loRaRequest.RadioMetadata.DataRate).ToString(), target.Datr);
             Assert.Equal(loRaRequest.RadioMetadata.Frequency.InMega, target.Freq);

--- a/Tests/Unit/NetworkServer/LoRaDeviceTelemetryTest.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceTelemetryTest.cs
@@ -11,13 +11,14 @@ namespace LoRaWan.Tests.Unit.NetworkServer
     public class LoRaDeviceTelemetryTest
     {
         [Theory]
-        [InlineData(1, FramePorts.App1)]
-        [InlineData(2, FramePorts.App10)]
-        [InlineData(100, FramePorts.App2)]
-        public void When_Creating_Should_Copy_Values_From_Rxpk_And_Payload(uint fcnt, FramePort fport)
+        [InlineData(1, FramePorts.App1, "1")]
+        [InlineData(2, FramePorts.App10, "1")]
+        [InlineData(100, FramePorts.App2, "1")]
+        [InlineData(100, null, "")]
+        public void When_Creating_Should_Copy_Values_From_Rxpk_And_Payload(uint fcnt, FramePort? fport, string data)
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
-            var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1", fcnt: fcnt, fport: fport);
+            var payload = simulatedDevice.CreateUnconfirmedDataUpMessage(data, fcnt: fcnt, fport: fport);
             var decodedValue = new { value = 1 };
 
             using var loRaRequest = WaitableLoRaRequest.CreateWaitableRequest(payload);


### PR DESCRIPTION
# PR for issue #1282 and #1283

## What is being addressed

When the LBS sends an uplink data frame that has no frame payload, the members `FPort` and `FRMPayload` of the JSON message object are set to -1 and an empty string, respectively. The LNS would reject such requests as invalid message when the specification allows it. This can happen, for example, when the data frame has only MAC commands sent in `FOpts`.

## How is this addressed

`FPort` is allowed to be -1 in addition to a byte from 0 to 255 and `FRMPayload` is allowed to be an empty string. The combination of the two marks denotes “no frame payload”.

