### PR TITLE
Bug/1407 ensure connection on cache refresh

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -635,7 +635,7 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Ensures that the device is connected. Calls the connection manager that keeps track of device connection lifetime.
         /// </summary>
-        internal IDisposable BeginDeviceClientConnectionActivity()
+        internal virtual IDisposable BeginDeviceClientConnectionActivity()
         {
             // Most devices won't have a connection timeout
             // In that case check without lock and return a cached disposable

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceCache.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceCache.cs
@@ -108,8 +108,8 @@ namespace LoRaWan.NetworkServer
         protected virtual async Task RefreshDeviceAsync(LoRaDevice device, CancellationToken cancellationToken)
         {
             _ = device ?? throw new ArgumentNullException(nameof(device));
-            using var activity = device.BeginDeviceClientConnectionActivity();
-            _ = await device.InitializeAsync(this.configuration, cancellationToken);
+            using (device.BeginDeviceClientConnectionActivity())
+                _ = await device.InitializeAsync(this.configuration, cancellationToken);
         }
 
         public virtual bool Remove(LoRaDevice device, bool dispose = true)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceCache.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceCache.cs
@@ -105,10 +105,11 @@ namespace LoRaWan.NetworkServer
             }
         }
 
-        protected virtual Task RefreshDeviceAsync(LoRaDevice device, CancellationToken cancellationToken)
+        protected virtual async Task RefreshDeviceAsync(LoRaDevice device, CancellationToken cancellationToken)
         {
             _ = device ?? throw new ArgumentNullException(nameof(device));
-            return device.InitializeAsync(this.configuration, cancellationToken);
+            using var activity = device.BeginDeviceClientConnectionActivity();
+            _ = await device.InitializeAsync(this.configuration, cancellationToken);
         }
 
         public virtual bool Remove(LoRaDevice device, bool dispose = true)


### PR DESCRIPTION
# PR for issue #1407

## What is being addressed

When refreshing the device cache, we did not ensure the connection during the refresh. When we start using KeepAliveTimeout, it could interfere with the refresh.

## How is this addressed

Reserve the connection for the duration of the update.