### PR TITLE
Add factory method to create identical DeviceClient

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
@@ -37,11 +37,7 @@ namespace LoRaWan.NetworkServer
             this.connectionString = connectionString;
             this.primaryKey = primaryKey;
             this.logger = logger;
-            var deviceClient = this.deviceClient = DeviceClient.CreateFromConnectionString(this.connectionString, this.transportSettings);
-            deviceClient.SetRetryPolicy(new ExponentialBackoff(int.MaxValue,
-                                                               minBackoff: TimeSpan.FromMilliseconds(100),
-                                                               maxBackoff: TimeSpan.FromSeconds(10),
-                                                               deltaBackoff: TimeSpan.FromMilliseconds(100)));
+            this.deviceClient = CreateDeviceClient();
         }
 
         public bool IsMatchingKey(string primaryKey) => this.primaryKey == primaryKey;
@@ -249,7 +245,7 @@ namespace LoRaWan.NetworkServer
             {
                 try
                 {
-                    this.deviceClient = DeviceClient.CreateFromConnectionString(this.connectionString, this.transportSettings);
+                    this.deviceClient = CreateDeviceClient();
                     this.logger.LogDebug("device client reconnected");
                 }
                 catch (ArgumentException ex) when (ExceptionFilterUtility.True(() => this.logger.LogError($"could not connect device client with error: {ex.Message}")))
@@ -259,6 +255,16 @@ namespace LoRaWan.NetworkServer
             }
 
             return true;
+        }
+
+        private DeviceClient CreateDeviceClient()
+        {
+            var deviceClient = DeviceClient.CreateFromConnectionString(this.connectionString, this.transportSettings);
+            deviceClient.SetRetryPolicy(new ExponentialBackoff(int.MaxValue,
+                                                               minBackoff: TimeSpan.FromMilliseconds(100),
+                                                               maxBackoff: TimeSpan.FromSeconds(10),
+                                                               deltaBackoff: TimeSpan.FromMilliseconds(100)));
+            return deviceClient;
         }
 
         public void Dispose()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
@@ -259,12 +259,12 @@ namespace LoRaWan.NetworkServer
 
         private DeviceClient CreateDeviceClient()
         {
-            var deviceClient = DeviceClient.CreateFromConnectionString(this.connectionString, this.transportSettings);
-            deviceClient.SetRetryPolicy(new ExponentialBackoff(int.MaxValue,
-                                                               minBackoff: TimeSpan.FromMilliseconds(100),
-                                                               maxBackoff: TimeSpan.FromSeconds(10),
-                                                               deltaBackoff: TimeSpan.FromMilliseconds(100)));
-            return deviceClient;
+            var dc = DeviceClient.CreateFromConnectionString(this.connectionString, this.transportSettings);
+            dc.SetRetryPolicy(new ExponentialBackoff(int.MaxValue,
+                                                     minBackoff: TimeSpan.FromMilliseconds(100),
+                                                     maxBackoff: TimeSpan.FromSeconds(10),
+                                                     deltaBackoff: TimeSpan.FromMilliseconds(100)));
+            return dc;
         }
 
         public void Dispose()


### PR DESCRIPTION
# PR for issue #1411

## What is being addressed

Device clients are created with different retry policies.

## How is this addressed

Added a factory method to ensure the same code is executed for re-creating the DeviceClient.