### PR TITLE
Fix wrong log statement when persisting data in Redis

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
@@ -154,7 +154,7 @@ namespace LoraKeysManagerFacade
                                         // Add a lock loadPrimaryKey get lock get
                                         devAddressesInfo[i].PrimaryKey = await LoadPrimaryKeyAsync(someDevEuiPrime);
                                         results.Add(devAddressesInfo[i]);
-                                        _ = devAddrCache.StoreInfo(devAddressesInfo[i]);
+                                        devAddrCache.StoreInfo(devAddressesInfo[i]);
                                     }
 
                                     // even if we fail to acquire the lock we wont enter in the next condition as devaddressinfo is not null
@@ -187,7 +187,7 @@ namespace LoraKeysManagerFacade
                                             LastUpdatedTwins = twin.Properties.Desired.GetLastUpdated()
                                         };
                                         results.Add(iotHubDeviceInfo);
-                                        _ = devAddrCache.StoreInfo(iotHubDeviceInfo);
+                                        devAddrCache.StoreInfo(iotHubDeviceInfo);
                                     }
 
                                     resultCount++;
@@ -197,7 +197,7 @@ namespace LoraKeysManagerFacade
                             // todo save when not our devaddr
                             if (resultCount == 0)
                             {
-                                _ = devAddrCache.StoreInfo(new DevAddrCacheInfo()
+                                devAddrCache.StoreInfo(new DevAddrCacheInfo()
                                 {
                                     DevAddr = someDevAddr
                                 });

--- a/LoRaEngine/LoraKeysManagerFacade/ILoRaDeviceCacheStore.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ILoRaDeviceCacheStore.cs
@@ -42,7 +42,7 @@ namespace LoraKeysManagerFacade
 
         IReadOnlyList<string> ListGet(string key);
 
-        bool TrySetHashObject(string key, string subkey, string value, TimeSpan? timeToExpire = null);
+        void SetHashObject(string key, string subkey, string value, TimeSpan? timeToExpire = null);
 
         HashEntry[] GetHashObject(string key);
 

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDevAddrCache.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDevAddrCache.cs
@@ -97,7 +97,7 @@ namespace LoraKeysManagerFacade
             return info?.Count > 0;
         }
 
-        public bool StoreInfo(DevAddrCacheInfo info)
+        public void StoreInfo(DevAddrCacheInfo info)
         {
             if (info is null) throw new ArgumentNullException(nameof(info));
 
@@ -106,15 +106,8 @@ namespace LoraKeysManagerFacade
             var cacheKeyToUse = GenerateKey(info.DevAddr);
             var subKey = info.DevEUI is { } someDevEui ? someDevEui.ToString() : string.Empty;
 
-            if (this.cacheStore.TrySetHashObject(cacheKeyToUse, subKey, serializedObjectValue))
-            {
-                this.logger.LogInformation($"Successfully saved dev address info on dictionary key: {cacheKeyToUse}, hashkey: {info.DevEUI}, object: {serializedObjectValue}");
-
-                return true;
-            }
-
-            this.logger.LogError($"Failure to save dev address info on dictionary key: {cacheKeyToUse}, hashkey: {info.DevEUI}, object: {serializedObjectValue}");
-            return false;
+            this.cacheStore.SetHashObject(cacheKeyToUse, subKey, serializedObjectValue);
+            this.logger.LogInformation($"Successfully saved dev address info on dictionary key: {cacheKeyToUse}, hashkey: {info.DevEUI}, object: {serializedObjectValue}");
         }
 
         internal async Task PerformNeededSyncs(RegistryManager registryManager)

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCacheRedisStore.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDeviceCacheRedisStore.cs
@@ -105,15 +105,13 @@ namespace LoraKeysManagerFacade
             return list.Select(x => (string)x).ToList();
         }
 
-        public bool TrySetHashObject(string key, string subkey, string value, TimeSpan? timeToExpire = null)
+        public void SetHashObject(string key, string subkey, string value, TimeSpan? timeToExpire = null)
         {
-            var returnValue = this.redisCache.HashSet(key, subkey, value);
+            _ = this.redisCache.HashSet(key, subkey, value);
             if (timeToExpire.HasValue)
             {
                 _ = this.redisCache.KeyExpire(key, DateTime.UtcNow.Add(timeToExpire.Value));
             }
-
-            return returnValue;
         }
 
         public HashEntry[] GetHashObject(string key)

--- a/Tests/Unit/LoRaInMemoryDeviceStore.cs
+++ b/Tests/Unit/LoRaInMemoryDeviceStore.cs
@@ -142,7 +142,7 @@ namespace LoRaWan.Tests.Unit
             return LockTakeAsync(key, null, timeToExpire, false).GetAwaiter().GetResult();
         }
 
-        public bool TrySetHashObject(string key, string subkey, string value, TimeSpan? timeToExpire = null)
+        public void SetHashObject(string key, string subkey, string value, TimeSpan? timeToExpire = null)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
# PR for issue #1405

## What is being addressed

`StackExchange.Redis.IDatabase.HashSet` returns `true` to indicate that the field is new, and `false` to indicate that the field already existed. We interpret the return value as success or failure and log accordingly, which is wrong. This PR fixes the broken log statement.