### PR TITLE
Move `BasicsStationNetworkServerStartupTests` into right namespace/location

### DIFF
--- a/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
+++ b/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace LoRaWan.Tests.Unit.NetworkServerTests.BasicsStation
+namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
 {
     using LoRaWan.NetworkServer.BasicsStation;
     using Microsoft.Extensions.Configuration;


### PR DESCRIPTION
## What is being addressed

`BasicsStationNetworkServerStartupTests` was in the wrong namespace and location than rest of tests from the same namespace.

## How is this addressed

Moved together with other tests from the same namespace.
