### PR TITLE
Defaulting US902 frequencies to sub band 1

### DIFF
--- a/Tools/Cli-LoRa-Device-Provisioning/DefaultRouterConfig/US902.json
+++ b/Tools/Cli-LoRa-Device-Provisioning/DefaultRouterConfig/US902.json
@@ -90,11 +90,11 @@
     {
       "radio_0": {
         "enable": true,
-        "freq": 904300000
+        "freq": 902700000
       },
       "radio_1": {
         "enable": true,
-        "freq": 905000000
+        "freq": 903400000
       },
       "chan_FSK": {
         "enable": true,


### PR DESCRIPTION
# PR for issue #1421 

## What is being addressed

This PR closes #1421 by defaulting US902 frequencies to sub band 1. This change is matching what we had as a default in previous v1.0.7 packet forwarder based version