### PR TITLE
Inject `Meter` singleton only once

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -108,8 +108,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                                 new CompositeMetricExporter(useApplicationInsights ? new ApplicationInsightsMetricExporter(sp.GetRequiredService<TelemetryClient>(),
                                                                                                                            sp.GetRequiredService<RegistryMetricTagBag>(),
                                                                                                                            sp.GetRequiredService<ILogger<ApplicationInsightsMetricExporter>>()) : null,
-                                                            new PrometheusMetricExporter(sp.GetRequiredService<RegistryMetricTagBag>(), sp.GetRequiredService<ILogger<PrometheusMetricExporter>>()))))
-                        .AddSingleton(_ => new Meter(MetricRegistry.Namespace, MetricRegistry.Version));
+                                                            new PrometheusMetricExporter(sp.GetRequiredService<RegistryMetricTagBag>(), sp.GetRequiredService<ILogger<PrometheusMetricExporter>>()))));
 
             if (useApplicationInsights)
                 _ = services.AddApplicationInsightsTelemetry(appInsightsKey);


### PR DESCRIPTION
# PR for issue #1419

Inject `Meter` singleton once instead of twice.
