### PR TITLE
Renaming IPacketForwarder to IDownstreamMessageSender

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -95,7 +95,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         .AddSingleton<ILoRaModuleClientFactory>(loraModuleFactory)
                         .AddSingleton<LoRaDeviceAPIServiceBase, LoRaDeviceAPIService>()
                         .AddSingleton<WebSocketWriterRegistry<StationEui, string>>()
-                        .AddSingleton<IPacketForwarder, DownstreamSender>()
+                        .AddSingleton<IDownstreamMessageSender, DownstreamMessageSender>()
                         .AddSingleton<LoRaDeviceCache>()
                         .AddSingleton(new LoRaDeviceCacheOptions { MaxUnobservedLifetime = TimeSpan.FromDays(10), RefreshInterval = TimeSpan.FromDays(2), ValidationInterval = TimeSpan.FromMinutes(10) })
                         .AddTransient<ILnsProtocolMessageProcessor, LnsProtocolMessageProcessor>()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/DownstreamMessageSender.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/DownstreamMessageSender.cs
@@ -13,7 +13,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
     using LoRaTools.LoRaPhysical;
     using Microsoft.Extensions.Logging;
 
-    internal class DownstreamSender : IPacketForwarder
+    internal class DownstreamMessageSender : IDownstreamMessageSender
     {
         private static readonly Action<ILogger, StationEui, int, string, Exception> LogSendingMessage =
             LoggerMessage.Define<StationEui, int, string>(LogLevel.Debug, default,
@@ -21,12 +21,12 @@ namespace LoRaWan.NetworkServer.BasicsStation
 
         private readonly WebSocketWriterRegistry<StationEui, string> socketWriterRegistry;
         private readonly IBasicsStationConfigurationService basicsStationConfigurationService;
-        private readonly ILogger<DownstreamSender> logger;
+        private readonly ILogger<DownstreamMessageSender> logger;
         private readonly Random random = new Random();
 
-        public DownstreamSender(WebSocketWriterRegistry<StationEui, string> socketWriterRegistry,
-                                IBasicsStationConfigurationService basicsStationConfigurationService,
-                                ILogger<DownstreamSender> logger)
+        public DownstreamMessageSender(WebSocketWriterRegistry<StationEui, string> socketWriterRegistry,
+                                       IBasicsStationConfigurationService basicsStationConfigurationService,
+                                       ILogger<DownstreamMessageSender> logger)
         {
             this.socketWriterRegistry = socketWriterRegistry;
             this.basicsStationConfigurationService = basicsStationConfigurationService;
@@ -93,7 +93,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                     writer.WriteNumber("xtime", message.Xtime);
                     break;
                 case LoRaDeviceClassType.B:
-                    throw new NotSupportedException($"{nameof(DownstreamSender)} does not support class B devices yet.");
+                    throw new NotSupportedException($"{nameof(DownstreamMessageSender)} does not support class B devices yet.");
                 case LoRaDeviceClassType.C:
                     // if Xtime is not zero, it means that we are answering to a previous message
                     if (message.Xtime != 0)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
@@ -28,7 +28,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
 
         private readonly IBasicsStationConfigurationService basicsStationConfigurationService;
         private readonly WebSocketWriterRegistry<StationEui, string> socketWriterRegistry;
-        private readonly IPacketForwarder downstreamSender;
+        private readonly IDownstreamMessageSender downstreamMessageSender;
         private readonly IMessageDispatcher messageDispatcher;
         private readonly ILogger<LnsProtocolMessageProcessor> logger;
         private readonly RegistryMetricTagBag registryMetricTagBag;
@@ -38,7 +38,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
 
         public LnsProtocolMessageProcessor(IBasicsStationConfigurationService basicsStationConfigurationService,
                                            WebSocketWriterRegistry<StationEui, string> socketWriterRegistry,
-                                           IPacketForwarder packetForwarder,
+                                           IDownstreamMessageSender downstreamMessageSender,
                                            IMessageDispatcher messageDispatcher,
                                            ILogger<LnsProtocolMessageProcessor> logger,
                                            RegistryMetricTagBag registryMetricTagBag,
@@ -46,7 +46,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
         {
             this.basicsStationConfigurationService = basicsStationConfigurationService;
             this.socketWriterRegistry = socketWriterRegistry;
-            this.downstreamSender = packetForwarder;
+            this.downstreamMessageSender = downstreamMessageSender;
             this.messageDispatcher = messageDispatcher;
             this.logger = logger;
             this.registryMetricTagBag = registryMetricTagBag;
@@ -204,7 +204,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
 
                         var routerRegion = await this.basicsStationConfigurationService.GetRegionAsync(stationEui, cancellationToken);
 
-                        var loraRequest = new LoRaRequest(jreq.RadioMetadata, this.downstreamSender, DateTime.UtcNow);
+                        var loraRequest = new LoRaRequest(jreq.RadioMetadata, this.downstreamMessageSender, DateTime.UtcNow);
                         loraRequest.SetPayload(new LoRaPayloadJoinRequest(jreq.JoinEui,
                                                                           jreq.DevEui,
                                                                           jreq.DevNonce,
@@ -230,7 +230,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
 
                         var routerRegion = await this.basicsStationConfigurationService.GetRegionAsync(stationEui, cancellationToken);
 
-                        var loraRequest = new LoRaRequest(updf.RadioMetadata, this.downstreamSender, DateTime.UtcNow);
+                        var loraRequest = new LoRaRequest(updf.RadioMetadata, this.downstreamMessageSender, DateTime.UtcNow);
                         loraRequest.SetPayload(new LoRaPayloadData(updf.DevAddr,
                                                                    updf.MacHeader,
                                                                    updf.FrameControlFlags,

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Constants.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Constants.cs
@@ -41,11 +41,6 @@ namespace LoRaWan.NetworkServer
         public const string CloudToDeviceClearCache = "clearcache";
 
         /// <summary>
-        /// Convert the time to the packet forward time (millionth of seconds).
-        /// </summary>
-        public const uint ConvertToPktFwdTime = 1000000;
-
-        /// <summary>
         /// Minimum value for device connection keep alive timeout (1 minute).
         /// </summary>
         public const int MinKeepAliveTimeout = 60;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultClassCDevicesMessageSender.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultClassCDevicesMessageSender.cs
@@ -14,7 +14,7 @@ namespace LoRaWan.NetworkServer
     {
         private readonly NetworkServerConfiguration configuration;
         private readonly ILoRaDeviceRegistry loRaDeviceRegistry;
-        private readonly IPacketForwarder packetForwarder;
+        private readonly IDownstreamMessageSender downstreamMessageSender;
         private readonly ILoRaDeviceFrameCounterUpdateStrategyProvider frameCounterUpdateStrategyProvider;
         private readonly ILogger<DefaultClassCDevicesMessageSender> logger;
         private readonly Counter<int> c2dMessageTooLong;
@@ -22,14 +22,14 @@ namespace LoRaWan.NetworkServer
         public DefaultClassCDevicesMessageSender(
             NetworkServerConfiguration configuration,
             ILoRaDeviceRegistry loRaDeviceRegistry,
-            IPacketForwarder packetForwarder,
+            IDownstreamMessageSender downstreamMessageSender,
             ILoRaDeviceFrameCounterUpdateStrategyProvider frameCounterUpdateStrategyProvider,
             ILogger<DefaultClassCDevicesMessageSender> logger,
             Meter meter)
         {
             this.configuration = configuration;
             this.loRaDeviceRegistry = loRaDeviceRegistry;
-            this.packetForwarder = packetForwarder;
+            this.downstreamMessageSender = downstreamMessageSender;
             this.frameCounterUpdateStrategyProvider = frameCounterUpdateStrategyProvider;
             this.logger = logger;
             this.c2dMessageTooLong = meter?.CreateCounter<int>(MetricRegistry.C2DMessageTooLong);
@@ -129,7 +129,7 @@ namespace LoRaWan.NetworkServer
             {
                 try
                 {
-                    await this.packetForwarder.SendDownstreamAsync(downlinkMessageBuilderResp.DownlinkMessage);
+                    await this.downstreamMessageSender.SendDownstreamAsync(downlinkMessageBuilderResp.DownlinkMessage);
                 }
                 catch (Exception ex)
                 {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -384,7 +384,7 @@ namespace LoRaWan.NetworkServer
                     if (downlinkMessageBuilderResp.DownlinkMessage != null)
                     {
                         this.receiveWindowHits?.Add(1, KeyValuePair.Create(MetricRegistry.ReceiveWindowTagName, (object)downlinkMessageBuilderResp.ReceiveWindow));
-                        _ = request.PacketForwarder.SendDownstreamAsync(downlinkMessageBuilderResp.DownlinkMessage);
+                        _ = request.DownstreamMessageSender.SendDownstreamAsync(downlinkMessageBuilderResp.DownlinkMessage);
 
                         if (cloudToDeviceMessage != null)
                         {
@@ -549,7 +549,7 @@ namespace LoRaWan.NetworkServer
             _ = request ?? throw new ArgumentNullException(nameof(request));
             _ = confirmDownlinkMessageBuilderResp ?? throw new ArgumentNullException(nameof(confirmDownlinkMessageBuilderResp));
 
-            return request.PacketForwarder.SendDownstreamAsync(confirmDownlinkMessageBuilderResp.DownlinkMessage);
+            return request.DownstreamMessageSender.SendDownstreamAsync(confirmDownlinkMessageBuilderResp.DownlinkMessage);
         }
 
         protected virtual async Task SaveChangesToDeviceAsync(LoRaDevice loRaDevice, bool stationEuiChanged)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DownlinkMessageBuilder.cs
@@ -90,7 +90,7 @@ namespace LoRaWan.NetworkServer
                 // The logic for passing CN470 join channel will change as part of #561
                 if (!loRaRegion.TryGetDownstreamChannelFrequency(radioMetadata.Frequency, upstreamDataRate: radioMetadata.DataRate, deviceJoinInfo: deviceJoinInfo, downstreamFrequency: out freq))
                 {
-                    logger.LogError("there was a problem in setting the frequency in the downstream message packet forwarder settings");
+                    logger.LogError("there was a problem in setting the frequency in the downstream message settings");
                     return new DownlinkMessageBuilderResponse(null, false, receiveWindow);
                 }
             }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/IDownstreamMessageSender.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/IDownstreamMessageSender.cs
@@ -6,8 +6,8 @@ namespace LoRaWan.NetworkServer
     using System.Threading.Tasks;
     using LoRaTools.LoRaPhysical;
 
-    // Packet forwarder
-    public interface IPacketForwarder
+    // Interface for sending downstream messages
+    public interface IDownstreamMessageSender
     {
         /// <summary>
         /// Send downstream message to LoRa device.

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -282,7 +282,7 @@ namespace LoRaWan.NetworkServer
                                                           request.RadioMetadata.UpInfo.AntennaPreference);
 
                 this.receiveWindowHits?.Add(1, KeyValuePair.Create(MetricRegistry.ReceiveWindowTagName, (object)windowToUse));
-                _ = request.PacketForwarder.SendDownstreamAsync(downlinkMessage);
+                _ = request.DownstreamMessageSender.SendDownstreamAsync(downlinkMessage);
                 request.NotifySucceeded(loRaDevice, downlinkMessage);
 
                 if (this.logger.IsEnabled(LogLevel.Debug))

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaOperationTimeWatcher.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaOperationTimeWatcher.cs
@@ -18,7 +18,7 @@ namespace LoRaWan.NetworkServer
     public class LoRaOperationTimeWatcher
     {
         /// <summary>
-        /// Gets the expected time required to package and send message back to package forwarder
+        /// Gets the expected time required to package and send message back to message sender
         /// 400ms.
         /// </summary>
         public static TimeSpan ExpectedTimeToPackageAndSendMessage { get; } = TimeSpan.FromMilliseconds(400);
@@ -37,7 +37,7 @@ namespace LoRaWan.NetworkServer
         public static TimeSpan CheckForCloudMessageCallEstimatedOverhead { get; } = TimeSpan.FromMilliseconds(100);
 
         /// <summary>
-        /// Gets the expected time required to package and send message back to package forwarder plus the checking for cloud to device message overhead
+        /// Gets the expected time required to package and send message back to message sender plus the checking for cloud to device message overhead
         /// 400ms.
         /// </summary>
         public static TimeSpan ExpectedTimeToPackageAndSendMessageAndCheckForCloudMessageOverhead { get; } = ExpectedTimeToPackageAndSendMessage + CheckForCloudMessageCallEstimatedOverhead;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaRequest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaRequest.cs
@@ -17,7 +17,7 @@ namespace LoRaWan.NetworkServer
 
         public virtual LoRaPayload Payload { get; private set; }
 
-        public virtual IPacketForwarder PacketForwarder { get; }
+        public virtual IDownstreamMessageSender DownstreamMessageSender { get; }
 
         public virtual DateTime StartTime { get; }
 
@@ -34,11 +34,11 @@ namespace LoRaWan.NetworkServer
 
         public LoRaRequest(
             RadioMetadata radioMetadata,
-            IPacketForwarder packetForwarder,
+            IDownstreamMessageSender downstreamMessageSender,
             DateTime startTime)
         {
             RadioMetadata = radioMetadata;
-            PacketForwarder = packetForwarder;
+            DownstreamMessageSender = downstreamMessageSender;
             StartTime = startTime;
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoggingLoRaRequest.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoggingLoRaRequest.cs
@@ -21,7 +21,7 @@ namespace LoRaWan.NetworkServer
         private readonly ILogger<LoggingLoRaRequest> logger;
         private readonly Histogram<double> d2cMessageDeliveryLatencyHistogram;
 
-        public override IPacketForwarder PacketForwarder => this.wrappedRequest.PacketForwarder;
+        public override IDownstreamMessageSender DownstreamMessageSender => this.wrappedRequest.DownstreamMessageSender;
 
         public override Region Region => this.wrappedRequest.Region;
 

--- a/Tests/Common/MessageProcessorMultipleGatewayBase.cs
+++ b/Tests/Common/MessageProcessorMultipleGatewayBase.cs
@@ -22,7 +22,7 @@ namespace LoRaWan.Tests.Common
 
         public NetworkServerConfiguration SecondServerConfiguration { get; }
 
-        public TestPacketForwarder SecondPacketForwarder { get; }
+        public TestDownstreamMessageSender SecondDownstreamMessageSender { get; }
 
         public Mock<LoRaDeviceAPIServiceBase> SecondLoRaDeviceApi { get; }
 
@@ -47,7 +47,7 @@ namespace LoRaWan.Tests.Common
                 LogLevel = ((int)LogLevel.Debug).ToString(CultureInfo.InvariantCulture),
             };
 
-            SecondPacketForwarder = new TestPacketForwarder();
+            SecondDownstreamMessageSender = new TestDownstreamMessageSender();
             SecondLoRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
             SecondFrameCounterUpdateStrategyProvider = new LoRaDeviceFrameCounterUpdateStrategyProvider(SecondServerConfiguration, SecondLoRaDeviceApi.Object);
             this.cache = new MemoryCache(new MemoryCacheOptions() { ExpirationScanFrequency = TimeSpan.FromSeconds(5) });

--- a/Tests/Common/MessageProcessorTestBase.cs
+++ b/Tests/Common/MessageProcessorTestBase.cs
@@ -29,7 +29,7 @@ namespace LoRaWan.Tests.Common
         private readonly long startTime;
         private bool disposedValue;
 
-        public TestPacketForwarder PacketForwarder { get; }
+        public TestDownstreamMessageSender DownstreamMessageSender { get; }
 
         protected Region DefaultRegion { get; }
 
@@ -69,7 +69,7 @@ namespace LoRaWan.Tests.Common
 
             this.testOutputLoggerFactory = new TestOutputLoggerFactory(testOutputHelper);
             PayloadDecoder = new TestLoRaPayloadDecoder(new LoRaPayloadDecoder(this.testOutputLoggerFactory.CreateLogger<LoRaPayloadDecoder>()));
-            PacketForwarder = new TestPacketForwarder();
+            DownstreamMessageSender = new TestDownstreamMessageSender();
             LoRaDeviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
             FrameCounterUpdateStrategyProvider = new LoRaDeviceFrameCounterUpdateStrategyProvider(ServerConfiguration, LoRaDeviceApi.Object);
             this.cache = new MemoryCache(new MemoryCacheOptions() { ExpirationScanFrequency = TimeSpan.FromSeconds(5) });
@@ -156,7 +156,7 @@ namespace LoRaWan.Tests.Common
         }
 
         protected WaitableLoRaRequest CreateWaitableRequest(LoRaPayload loRaPayload,
-                                                            IPacketForwarder packetForwarder = null,
+                                                            IDownstreamMessageSender downstreamMessageSender = null,
                                                             TimeSpan? startTimeOffset = null,
                                                             TimeSpan? constantElapsedTime = null,
                                                             bool useRealTimer = false,
@@ -171,7 +171,7 @@ namespace LoRaWan.Tests.Common
             };
             return CreateWaitableRequest(radioMetadata,
                                          loRaPayload,
-                                         packetForwarder,
+                                         downstreamMessageSender,
                                          startTimeOffset,
                                          constantElapsedTime,
                                          useRealTimer,
@@ -181,7 +181,7 @@ namespace LoRaWan.Tests.Common
 
         protected WaitableLoRaRequest CreateWaitableRequest(RadioMetadata metadata,
                                                             LoRaPayload loRaPayload,
-                                                            IPacketForwarder packetForwarder = null,
+                                                            IDownstreamMessageSender downstreamMessageSender = null,
                                                             TimeSpan? startTimeOffset = null,
                                                             TimeSpan? constantElapsedTime = null,
                                                             bool useRealTimer = false,
@@ -190,7 +190,7 @@ namespace LoRaWan.Tests.Common
             var effectiveRegion = region ?? DefaultRegion;
             var request = WaitableLoRaRequest.Create(metadata,
                                                      loRaPayload,
-                                                     packetForwarder ?? PacketForwarder,
+                                                     downstreamMessageSender ?? DownstreamMessageSender,
                                                      startTimeOffset,
                                                      constantElapsedTime,
                                                      useRealTimer,

--- a/Tests/Common/TestDownstreamMessageSender.cs
+++ b/Tests/Common/TestDownstreamMessageSender.cs
@@ -8,11 +8,11 @@ namespace LoRaWan.Tests.Common
     using LoRaTools.LoRaPhysical;
     using LoRaWan.NetworkServer;
 
-    public class TestPacketForwarder : IPacketForwarder
+    public class TestDownstreamMessageSender : IDownstreamMessageSender
     {
         public IList<DownlinkMessage> DownlinkMessages { get; }
 
-        public TestPacketForwarder()
+        public TestDownstreamMessageSender()
         {
             DownlinkMessages = new List<DownlinkMessage>();
         }

--- a/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
+++ b/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
@@ -28,7 +28,7 @@ namespace LoRaWan.Tests.Integration
     {
         private const string ServerGatewayID = "test-gateway";
 
-        private TestPacketForwarder PacketForwarder { get; }
+        private TestDownstreamMessageSender DownstreamMessageSender { get; }
 
         private readonly NetworkServerConfiguration serverConfiguration;
         private readonly Region loRaRegion;
@@ -50,7 +50,7 @@ namespace LoRaWan.Tests.Integration
             };
 
             this.loRaRegion = RegionManager.EU868;
-            PacketForwarder = new TestPacketForwarder();
+            DownstreamMessageSender = new TestDownstreamMessageSender();
             this.deviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
             this.deviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Loose);
             this.testOutputLoggerFactory = new TestOutputLoggerFactory(testOutputHelper);
@@ -123,7 +123,7 @@ namespace LoRaWan.Tests.Integration
             var target = new DefaultClassCDevicesMessageSender(
                 this.serverConfiguration,
                 this.loRaDeviceRegistry,
-                PacketForwarder,
+                DownstreamMessageSender,
                 this.frameCounterStrategyProvider,
                 this.testOutputLoggerFactory.CreateLogger<DefaultClassCDevicesMessageSender>(),
                 TestMeter.Instance);
@@ -133,14 +133,14 @@ namespace LoRaWan.Tests.Integration
             Assert.True(await target.SendAsync(c2d));
 
             // Verify that exactly one C2D message was received
-            Assert.Single(PacketForwarder.DownlinkMessages);
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
 
             // Verify donwlink message is correct
             EnsureDownlinkIsCorrect(
-                PacketForwarder.DownlinkMessages.First(), simulatedDevice, c2d);
+                DownstreamMessageSender.DownlinkMessages.First(), simulatedDevice, c2d);
 
             // Get C2D message payload
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
             payloadDataDown.Serialize(simulatedDevice.AppSKey.Value);
 
@@ -208,7 +208,7 @@ namespace LoRaWan.Tests.Integration
             var target = new DefaultClassCDevicesMessageSender(
                 this.serverConfiguration,
                 this.loRaDeviceRegistry,
-                PacketForwarder,
+                DownstreamMessageSender,
                 this.frameCounterStrategyProvider,
                 this.testOutputLoggerFactory.CreateLogger<DefaultClassCDevicesMessageSender>(),
                 TestMeter.Instance);
@@ -218,7 +218,7 @@ namespace LoRaWan.Tests.Integration
             Assert.False(await target.SendAsync(c2d));
 
             // Verify that exactly one C2D message was received
-            Assert.Empty(PacketForwarder.DownlinkMessages);
+            Assert.Empty(DownstreamMessageSender.DownlinkMessages);
 
             this.deviceApi.VerifyAll();
             this.deviceClient.VerifyAll();

--- a/Tests/Integration/ClassCIntegrationTests.cs
+++ b/Tests/Integration/ClassCIntegrationTests.cs
@@ -113,7 +113,7 @@ namespace LoRaWan.Tests.Integration
             var classCSender = new DefaultClassCDevicesMessageSender(
                 ServerConfiguration,
                 deviceRegistry,
-                PacketForwarder,
+                DownstreamMessageSender,
                 FrameCounterUpdateStrategyProvider,
                 new TestOutputLogger<DefaultClassCDevicesMessageSender>(this.testOutputHelper),
                 TestMeter.Instance);
@@ -135,8 +135,8 @@ namespace LoRaWan.Tests.Integration
             }
 
             Assert.True(await classCSender.SendAsync(c2d));
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downstreamMsg = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downstreamMsg = DownstreamMessageSender.DownlinkMessages[0];
 
             var downstreamPayloadBytes = downstreamMsg.Data;
             var downstreamPayload = new LoRaPayloadData(downstreamPayloadBytes);
@@ -218,7 +218,7 @@ namespace LoRaWan.Tests.Integration
             var classCSender = new DefaultClassCDevicesMessageSender(
                 ServerConfiguration,
                 deviceRegistry,
-                PacketForwarder,
+                DownstreamMessageSender,
                 FrameCounterUpdateStrategyProvider,
                 new TestOutputLogger<DefaultClassCDevicesMessageSender>(this.testOutputHelper),
                 TestMeter.Instance);
@@ -238,8 +238,8 @@ namespace LoRaWan.Tests.Integration
             }
 
             Assert.True(await classCSender.SendAsync(c2d));
-            Assert.Equal(2, PacketForwarder.DownlinkMessages.Count);
-            var downstreamMsg = PacketForwarder.DownlinkMessages[1];
+            Assert.Equal(2, DownstreamMessageSender.DownlinkMessages.Count);
+            var downstreamMsg = DownstreamMessageSender.DownlinkMessages[1];
 
             TestLogger.Log($"appSKey: {simDevice.AppSKey}, nwkSKey: {simDevice.NwkSKey}");
 

--- a/Tests/Integration/CloudToDeviceMessageSizeLimitShouldAbandonTests.cs
+++ b/Tests/Integration/CloudToDeviceMessageSizeLimitShouldAbandonTests.cs
@@ -110,7 +110,7 @@ namespace LoRaWan.Tests.Integration
 
             Assert.Equal(expectedDownlinkDatr, request.ResponseDownlink.Rx2.DataRate);
 
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
             if (hasMacInUpstream)
             {

--- a/Tests/Integration/CloudToDeviceMessageSizeLimitShouldAcceptTests.cs
+++ b/Tests/Integration/CloudToDeviceMessageSizeLimitShouldAcceptTests.cs
@@ -121,7 +121,7 @@ namespace LoRaWan.Tests.Integration
             TestUtils.CheckDRAndFrequencies(request, request.ResponseDownlink);
 
             // Get downlink message
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
             payloadDataDown.Serialize(loraDevice.AppSKey.Value);
 

--- a/Tests/Integration/CloudToDeviceMessageSizeLimitShouldRejectTests.cs
+++ b/Tests/Integration/CloudToDeviceMessageSizeLimitShouldRejectTests.cs
@@ -104,7 +104,7 @@ namespace LoRaWan.Tests.Integration
                 // TODO CHANGE THIS WHEN MOVING RXPK in #1086
                 // Assert.Equal(expectedDownlinkDatr, request.ResponseDownlink.Txpk.Datr);
 
-                var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+                var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
                 var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
                 payloadDataDown.Serialize(loraDevice.AppSKey.Value);
 

--- a/Tests/Integration/CloudToDeviceMessageTests.cs
+++ b/Tests/Integration/CloudToDeviceMessageTests.cs
@@ -135,7 +135,7 @@ namespace LoRaWan.Tests.Integration
             Assert.True(await request.WaitCompleteAsync());
             Assert.NotNull(request.ResponseDownlink);
             Assert.True(request.ProcessingSucceeded);
-            Assert.Single(PacketForwarder.DownlinkMessages);
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
 
             LoRaDeviceClient.Verify(x => x.ReceiveAsync(It.IsAny<TimeSpan>()), Times.Never());
 
@@ -207,8 +207,8 @@ namespace LoRaWan.Tests.Integration
             // 2. Return is downstream message
             Assert.NotNull(request.ResponseDownlink);
             Assert.True(request.ProcessingSucceeded);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
             payloadDataDown.Serialize(loraDevice.AppSKey.Value);
             Assert.Equal(payloadDataDown.DevAddr, loraDevice.DevAddr);
@@ -286,8 +286,8 @@ namespace LoRaWan.Tests.Integration
             // 2. Return is downstream message
             Assert.NotNull(request.ResponseDownlink);
             Assert.True(request.ProcessingSucceeded);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
             payloadDataDown.Serialize(loraDevice.AppSKey.Value);
             Assert.Equal(payloadDataDown.DevAddr, loraDevice.DevAddr);
@@ -368,8 +368,8 @@ namespace LoRaWan.Tests.Integration
             // 2. Return is downstream message
             Assert.NotNull(request.ResponseDownlink);
             Assert.True(request.ProcessingSucceeded);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             TestUtils.CheckDRAndFrequencies(request, downlinkMessage);
 
 
@@ -454,8 +454,8 @@ namespace LoRaWan.Tests.Integration
             // 2. Return is downstream message
             Assert.NotNull(request.ResponseDownlink);
             Assert.True(request.ProcessingSucceeded);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkMessage = PacketForwarder.DownlinkMessages.First();
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages.First();
 
             TestUtils.CheckDRAndFrequencies(request, downlinkMessage, true);
 
@@ -545,8 +545,8 @@ namespace LoRaWan.Tests.Integration
             // 3. Return is downstream message
             Assert.True(request.ProcessingSucceeded);
             Assert.NotNull(request.ResponseDownlink);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkMessage = PacketForwarder.DownlinkMessages.First();
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages.First();
 
             TestUtils.CheckDRAndFrequencies(request, downlinkMessage, true);
 
@@ -639,7 +639,7 @@ namespace LoRaWan.Tests.Integration
             messageProcessor.DispatchRequest(request);
             Assert.True(await request.WaitCompleteAsync());
             Assert.NotNull(request.ResponseDownlink);
-            var downlinkMessage = Assert.Single(PacketForwarder.DownlinkMessages);
+            var downlinkMessage = Assert.Single(DownstreamMessageSender.DownlinkMessages);
 
             Assert.Equal(LoRaDeviceClassType.A, downlinkMessage.DeviceClassType);
             Assert.Equal(loRaDevice.ReportedRXDelay, downlinkMessage.LnsRxDelay);
@@ -721,8 +721,8 @@ namespace LoRaWan.Tests.Integration
             // 2. Return is downstream message
             Assert.NotNull(request.ResponseDownlink);
             Assert.True(request.ProcessingSucceeded);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
 
             // in case no payload the mac is in the FRMPayload and is decrypted with NwkSKey
@@ -884,8 +884,8 @@ namespace LoRaWan.Tests.Integration
             // 2. Return is downstream message
             Assert.NotNull(request.ResponseDownlink);
             Assert.True(request.ProcessingSucceeded);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
             payloadDataDown.Serialize(loraDevice.AppSKey.Value);
             Assert.Equal(payloadDataDown.DevAddr, loraDevice.DevAddr);
@@ -953,7 +953,7 @@ namespace LoRaWan.Tests.Integration
                 FrameCounterUpdateStrategyProvider);
 
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: PayloadFcnt);
-            using var request = WaitableLoRaRequest.Create(TestUtils.GenerateTestRadioMetadata(), PacketForwarder,
+            using var request = WaitableLoRaRequest.Create(TestUtils.GenerateTestRadioMetadata(), DownstreamMessageSender,
                                                            inTimeForC2DMessageCheck: true,
                                                            inTimeForAdditionalMessageCheck: false,
                                                            inTimeForDownlinkDelivery: false,
@@ -971,7 +971,7 @@ namespace LoRaWan.Tests.Integration
             // 2. No downstream message
             Assert.Null(request.ResponseDownlink);
             Assert.True(request.ProcessingSucceeded);
-            Assert.Empty(PacketForwarder.DownlinkMessages);
+            Assert.Empty(DownstreamMessageSender.DownlinkMessages);
 
             // 3. Device FcntDown did change
             Assert.True(DeviceCache.TryGetForPayload(request.Payload, out var loRaDevice));

--- a/Tests/Integration/DeduplicationStrategyIntegrationTests.cs
+++ b/Tests/Integration/DeduplicationStrategyIntegrationTests.cs
@@ -111,7 +111,7 @@ namespace LoRaWan.Tests.Integration
             Assert.Equal(expectedCounts, actualCounts);
 
             // downstream
-            var sentDownstream = PacketForwarder.DownlinkMessages.Concat(SecondPacketForwarder.DownlinkMessages).ToArray();
+            var sentDownstream = DownstreamMessageSender.DownlinkMessages.Concat(SecondDownstreamMessageSender.DownlinkMessages).ToArray();
 
             if (confirmedMessages)
                 Assert.Single(sentDownstream);

--- a/Tests/Integration/JoinSlowGetTwinTests.cs
+++ b/Tests/Integration/JoinSlowGetTwinTests.cs
@@ -87,8 +87,8 @@ namespace LoRaWan.Tests.Integration
             Assert.True(await joinRequest2.WaitCompleteAsync());
             Assert.True(joinRequest2.ProcessingSucceeded);
             Assert.NotNull(joinRequest2.ResponseDownlink);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var joinRequestDownlinkMessage = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var joinRequestDownlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var joinAccept = new LoRaPayloadJoinAccept(joinRequestDownlinkMessage.Data, simulatedDevice.LoRaDevice.AppKey.Value);
             Assert.Equal(joinAccept.DevAddr.ToString(), afterJoinDevAddr);
 

--- a/Tests/Integration/JoinSlowTwinUpdateTests.cs
+++ b/Tests/Integration/JoinSlowTwinUpdateTests.cs
@@ -100,7 +100,7 @@ namespace LoRaWan.Tests.Integration
             Assert.Equal(LoRaDeviceRequestFailedReason.IoTHubProblem, joinRequest1.ProcessingFailedReason);
             Assert.True(joinRequest2.ProcessingSucceeded);
             Assert.NotNull(joinRequest2.ResponseDownlink);
-            Assert.Single(PacketForwarder.DownlinkMessages);
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
 
             Assert.True(DeviceCache.TryGetByDevEui(devEui, out var loRaDevice));
             Assert.True(loRaDevice.IsOurDevice);

--- a/Tests/Integration/JoinTests.cs
+++ b/Tests/Integration/JoinTests.cs
@@ -145,8 +145,8 @@ namespace LoRaWan.Tests.Integration
             Assert.True(await joinRequest.WaitCompleteAsync());
             Assert.True(joinRequest.ProcessingSucceeded, $"Failed due to '{joinRequest.ProcessingFailedReason}'.");
             Assert.NotNull(joinRequest.ResponseDownlink);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkJoinAcceptMessage = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkJoinAcceptMessage = DownstreamMessageSender.DownlinkMessages[0];
             var joinAccept = new LoRaPayloadJoinAccept(downlinkJoinAcceptMessage.Data, simulatedDevice.LoRaDevice.AppKey.Value);
             Assert.Equal(joinAccept.DevAddr.ToString(), afterJoinDevAddr);
 
@@ -206,9 +206,9 @@ namespace LoRaWan.Tests.Integration
             Assert.True(await confirmedRequest.WaitCompleteAsync());
             Assert.True(confirmedRequest.ProcessingSucceeded);
             Assert.NotNull(confirmedRequest.ResponseDownlink);
-            Assert.Equal(2, PacketForwarder.DownlinkMessages.Count);
+            Assert.Equal(2, DownstreamMessageSender.DownlinkMessages.Count);
             Assert.Equal(2, sentTelemetry.Count);
-            var downstreamMessage = PacketForwarder.DownlinkMessages[1];
+            var downstreamMessage = DownstreamMessageSender.DownlinkMessages[1];
 
             // validates txpk according to region
             DeviceJoinInfo deviceJoinInfo = null;
@@ -315,8 +315,8 @@ namespace LoRaWan.Tests.Integration
             Assert.True(await joinRequest2.WaitCompleteAsync());
             Assert.NotNull(joinRequest2.ResponseDownlink);
             Assert.True(joinRequest2.ProcessingSucceeded);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var joinRequestDownlinkMessage2 = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var joinRequestDownlinkMessage2 = DownstreamMessageSender.DownlinkMessages[0];
             var joinAccept = new LoRaPayloadJoinAccept(joinRequestDownlinkMessage2.Data, simulatedDevice.LoRaDevice.AppKey.Value);
             Assert.Equal(joinAccept.DevAddr.ToString(), afterJoinDevAddr);
 
@@ -487,8 +487,8 @@ namespace LoRaWan.Tests.Integration
             Assert.True(await joinRequest.WaitCompleteAsync());
             Assert.True(joinRequest.ProcessingSucceeded);
             Assert.NotNull(joinRequest.ResponseDownlink);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkJoinAcceptMessage = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkJoinAcceptMessage = DownstreamMessageSender.DownlinkMessages[0];
             // validates txpk according to eu region
             Assert.True(RegionManager.EU868.TryGetDownstreamChannelFrequency(radio.Frequency, joinRequest.RadioMetadata.DataRate, deviceJoinInfo: null, downstreamFrequency: out var receivedFrequency));
             Assert.Equal(receivedFrequency, downlinkJoinAcceptMessage.Rx1?.Frequency);
@@ -548,7 +548,7 @@ namespace LoRaWan.Tests.Integration
 
             await Task.WhenAll(joinRequest1.WaitCompleteAsync(), joinRequest2.WaitCompleteAsync());
 
-            Assert.Equal(2, PacketForwarder.DownlinkMessages.Count);
+            Assert.Equal(2, DownstreamMessageSender.DownlinkMessages.Count);
             Assert.NotNull(joinRequest1.ResponseDownlink);
             Assert.NotNull(joinRequest2.ResponseDownlink);
 

--- a/Tests/Integration/KeepAliveConnectionTests.cs
+++ b/Tests/Integration/KeepAliveConnectionTests.cs
@@ -351,13 +351,13 @@ namespace LoRaWan.Tests.Integration
             var target = new DefaultClassCDevicesMessageSender(
                 ServerConfiguration,
                 deviceRegistry,
-                PacketForwarder,
+                DownstreamMessageSender,
                 FrameCounterUpdateStrategyProvider,
                 new TestOutputLogger<DefaultClassCDevicesMessageSender>(testOutputHelper),
                 TestMeter.Instance);
 
             Assert.True(await target.SendAsync(c2dToDeviceMessage));
-            Assert.Single(PacketForwarder.DownlinkMessages);
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
 
             await EnsureDisconnectedAsync(disconnectedEvent);
 

--- a/Tests/Integration/ParallelProcessingTests.cs
+++ b/Tests/Integration/ParallelProcessingTests.cs
@@ -22,11 +22,11 @@ namespace LoRaWan.Tests.Integration
     // Parallel message processing
     public class ParallelProcessingTests : MessageProcessorTestBase
     {
-        private readonly TestPacketForwarder packetForwarder;
+        private readonly TestDownstreamMessageSender downstreamMessageSender;
 
         public ParallelProcessingTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
         {
-            this.packetForwarder = new TestPacketForwarder();
+            this.downstreamMessageSender = new TestDownstreamMessageSender();
         }
 
         public static IEnumerable<object[]> Multiple_ABP_Messages()
@@ -209,15 +209,15 @@ namespace LoRaWan.Tests.Integration
             var unconfirmedMessage2 = simulatedDevice.CreateUnconfirmedDataUpMessage("2", fcnt: 2);
             var unconfirmedMessage3 = simulatedDevice.CreateUnconfirmedDataUpMessage("3", fcnt: 3);
 
-            var req1 = CreateWaitableRequest(unconfirmedMessage1, this.packetForwarder);
+            var req1 = CreateWaitableRequest(unconfirmedMessage1, this.downstreamMessageSender);
             messageDispatcher.DispatchRequest(req1);
             await Task.Delay(parallelTestConfiguration.BetweenMessageDuration.Next());
 
-            var req2 = CreateWaitableRequest(unconfirmedMessage2, this.packetForwarder);
+            var req2 = CreateWaitableRequest(unconfirmedMessage2, this.downstreamMessageSender);
             messageDispatcher.DispatchRequest(req2);
             await Task.Delay(parallelTestConfiguration.BetweenMessageDuration.Next());
 
-            var req3 = CreateWaitableRequest(unconfirmedMessage3, this.packetForwarder);
+            var req3 = CreateWaitableRequest(unconfirmedMessage3, this.downstreamMessageSender);
             messageDispatcher.DispatchRequest(req3);
             await Task.Delay(parallelTestConfiguration.BetweenMessageDuration.Next());
 

--- a/Tests/Integration/ProcessingTests.cs
+++ b/Tests/Integration/ProcessingTests.cs
@@ -626,9 +626,9 @@ namespace LoRaWan.Tests.Integration
             // ack should be received
             Assert.True(await confirmedRequest.WaitCompleteAsync());
             Assert.NotNull(confirmedRequest.ResponseDownlink);
-            Assert.Single(PacketForwarder.DownlinkMessages);
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
 
-            var confirmedMessageResult = PacketForwarder.DownlinkMessages[0];
+            var confirmedMessageResult = DownstreamMessageSender.DownlinkMessages[0];
 
             // validates transmission for EU868
             Assert.Equal(radio.Frequency, confirmedMessageResult.Rx1?.Frequency);
@@ -803,8 +803,8 @@ namespace LoRaWan.Tests.Integration
             messageDispatcher.DispatchRequest(request);
             Assert.True(await request.WaitCompleteAsync());
             Assert.NotNull(request.ResponseDownlink);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var confirmedMessageResult = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var confirmedMessageResult = DownstreamMessageSender.DownlinkMessages[0];
             Assert.Equal(radio.Frequency, confirmedMessageResult.Rx1?.Frequency);
             Assert.Equal(radio.DataRate, confirmedMessageResult.Rx1?.DataRate);
             Assert.Equal(radio.UpInfo.Xtime, confirmedMessageResult.Xtime);
@@ -918,7 +918,7 @@ namespace LoRaWan.Tests.Integration
             messageDispatcher.DispatchRequest(request1);
             Assert.True(await request1.WaitCompleteAsync());
             Assert.Null(request1.ResponseDownlink);
-            Assert.Empty(PacketForwarder.DownlinkMessages);
+            Assert.Empty(DownstreamMessageSender.DownlinkMessages);
 
             Assert.False(DeviceCache.TryGetForPayload(request1.Payload, out _));
 
@@ -932,7 +932,7 @@ namespace LoRaWan.Tests.Integration
             Assert.True(await request2.WaitCompleteAsync());
             Assert.True(request2.ProcessingSucceeded);
             Assert.Null(request2.ResponseDownlink);
-            Assert.Empty(PacketForwarder.DownlinkMessages);
+            Assert.Empty(DownstreamMessageSender.DownlinkMessages);
 
             Assert.True(DeviceCache.TryGetForPayload(request2.Payload, out var loRaDevice));
             Assert.Equal(simulatedDevice.NwkSKey, loRaDevice.NwkSKey);
@@ -1157,7 +1157,7 @@ namespace LoRaWan.Tests.Integration
 
                 // ack should be received
                 Assert.NotNull(firstMessageRequest.ResponseDownlink);
-                Assert.Equal(i + 1, PacketForwarder.DownlinkMessages.Count);
+                Assert.Equal(i + 1, DownstreamMessageSender.DownlinkMessages.Count);
             }
 
             // resubmitting should fail
@@ -1165,7 +1165,7 @@ namespace LoRaWan.Tests.Integration
             messageDispatcher.DispatchRequest(fourthRequest);
             Assert.True(await fourthRequest.WaitCompleteAsync());
             Assert.Null(fourthRequest.ResponseDownlink);
-            Assert.Equal(4, PacketForwarder.DownlinkMessages.Count);
+            Assert.Equal(4, DownstreamMessageSender.DownlinkMessages.Count);
             Assert.Equal(LoRaDeviceRequestFailedReason.ConfirmationResubmitThresholdExceeded, fourthRequest.ProcessingFailedReason);
 
             // Sending the next fcnt with failed messages should work, including resubmit
@@ -1180,7 +1180,7 @@ namespace LoRaWan.Tests.Integration
 
                 // ack should be received
                 Assert.NotNull(request.ResponseDownlink);
-                Assert.Equal(i + 5, PacketForwarder.DownlinkMessages.Count);
+                Assert.Equal(i + 5, DownstreamMessageSender.DownlinkMessages.Count);
             }
 
             // resubmitting should fail
@@ -1188,7 +1188,7 @@ namespace LoRaWan.Tests.Integration
             messageDispatcher.DispatchRequest(resubmitSecondRequest);
             Assert.True(await resubmitSecondRequest.WaitCompleteAsync());
             Assert.Null(resubmitSecondRequest.ResponseDownlink);
-            Assert.Equal(8, PacketForwarder.DownlinkMessages.Count);
+            Assert.Equal(8, DownstreamMessageSender.DownlinkMessages.Count);
             Assert.Equal(LoRaDeviceRequestFailedReason.ConfirmationResubmitThresholdExceeded, resubmitSecondRequest.ProcessingFailedReason);
 
             Assert.Equal(2 + deviceInitialFcntUp, loRaDevice.FCntUp);

--- a/Tests/Unit/NetworkServer/ADRMessageProcessorTest.cs
+++ b/Tests/Unit/NetworkServer/ADRMessageProcessorTest.cs
@@ -95,8 +95,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             Assert.NotNull(request.ResponseDownlink);
             Assert.True(request.ProcessingSucceeded);
-            Assert.Equal(2, PacketForwarder.DownlinkMessages.Count);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[1];
+            Assert.Equal(2, DownstreamMessageSender.DownlinkMessages.Count);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[1];
             var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
 
             // in this case we expect a null payload
@@ -211,7 +211,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.True(request.ProcessingSucceeded);
 
             Assert.NotNull(request.ResponseDownlink);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[1];
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[1];
             var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
             // We expect a mac command in the payload
             if (deviceId == 221)
@@ -311,8 +311,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.True(await request.WaitCompleteAsync());
 
             Assert.NotNull(request.ResponseDownlink);
-            Assert.Equal(2, PacketForwarder.DownlinkMessages.Count);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[1];
+            Assert.Equal(2, DownstreamMessageSender.DownlinkMessages.Count);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[1];
             var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
             // We expect a mac command in the payload
             Assert.Equal(5, payloadDataDown.Frmpayload.Span.Length);
@@ -357,8 +357,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.True(await secondRequest.WaitCompleteAsync());
 
             Assert.NotNull(secondRequest.ResponseDownlink);
-            Assert.Equal(3, PacketForwarder.DownlinkMessages.Count);
-            downlinkMessage = PacketForwarder.DownlinkMessages[2];
+            Assert.Equal(3, DownstreamMessageSender.DownlinkMessages.Count);
+            downlinkMessage = DownstreamMessageSender.DownlinkMessages[2];
             payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
             // We expect a mac command in the payload
             Assert.Equal(5, payloadDataDown.Frmpayload.Span.Length);
@@ -456,8 +456,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.True(request.ProcessingSucceeded);
 
             Assert.NotNull(request.ResponseDownlink);
-            Assert.Equal(2, PacketForwarder.DownlinkMessages.Count);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[1];
+            Assert.Equal(2, DownstreamMessageSender.DownlinkMessages.Count);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[1];
             var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
             // We expect a mac command in the payload
             Assert.Equal(5, payloadDataDown.Frmpayload.Span.Length);
@@ -489,8 +489,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.True(secondRequest.ProcessingSucceeded);
 
             Assert.NotNull(secondRequest.ResponseDownlink);
-            Assert.Equal(3, PacketForwarder.DownlinkMessages.Count);
-            downlinkMessage = PacketForwarder.DownlinkMessages[2];
+            Assert.Equal(3, DownstreamMessageSender.DownlinkMessages.Count);
+            downlinkMessage = DownstreamMessageSender.DownlinkMessages[2];
             payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
             // We expect a mac command in the payload
             Assert.Equal(5, payloadDataDown.Frmpayload.Span.Length);
@@ -530,8 +530,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.True(thirdRequest.ProcessingSucceeded);
 
             Assert.NotNull(thirdRequest.ResponseDownlink);
-            Assert.Equal(4, PacketForwarder.DownlinkMessages.Count);
-            downlinkMessage = PacketForwarder.DownlinkMessages[3];
+            Assert.Equal(4, DownstreamMessageSender.DownlinkMessages.Count);
+            downlinkMessage = DownstreamMessageSender.DownlinkMessages[3];
             payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
             // We expect a mac command in the payload
             Assert.Equal(5, payloadDataDown.Frmpayload.Span.Length);

--- a/Tests/Unit/NetworkServer/BasicsStation/DownstreamSenderTests.cs
+++ b/Tests/Unit/NetworkServer/BasicsStation/DownstreamSenderTests.cs
@@ -24,7 +24,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
         private readonly DevEui devEui = new DevEui(ulong.MaxValue);
         private readonly Mock<IWebSocketWriter<string>> webSocketWriter;
         private readonly byte[] loraDataByteArray;
-        private readonly DownstreamSender downlinkSender;
+        private readonly DownstreamMessageSender downlinkSender;
 
         public DownstreamSenderTests()
         {
@@ -39,9 +39,9 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
 
             loraDataByteArray = Encoding.UTF8.GetBytes(loraDataBase64);
 
-            downlinkSender = new DownstreamSender(socketWriterRegistry,
+            downlinkSender = new DownstreamMessageSender(socketWriterRegistry,
                                                   basicStationConfigurationService.Object,
-                                                  Mock.Of<ILogger<DownstreamSender>>());
+                                                  Mock.Of<ILogger<DownstreamMessageSender>>());
         }
 
         [Theory]

--- a/Tests/Unit/NetworkServer/DefaultClassCDevicesMessageSenderTest.cs
+++ b/Tests/Unit/NetworkServer/DefaultClassCDevicesMessageSenderTest.cs
@@ -26,7 +26,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         private readonly NetworkServerConfiguration serverConfiguration;
         private readonly Region loRaRegion;
         private readonly LoRaDeviceRegistry loRaDeviceRegistry;
-        private readonly Mock<IPacketForwarder> packetForwarder;
+        private readonly Mock<IDownstreamMessageSender> downstreamMessageSender;
         private readonly Mock<LoRaDeviceAPIServiceBase> deviceApi;
         private readonly Mock<ILoRaDeviceClient> deviceClient;
         private readonly TestLoRaDeviceFactory loRaDeviceFactory;
@@ -43,7 +43,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             this.loRaRegion = RegionManager.EU868;
 
-            this.packetForwarder = new Mock<IPacketForwarder>(MockBehavior.Strict);
+            this.downstreamMessageSender = new Mock<IDownstreamMessageSender>(MockBehavior.Strict);
             this.deviceApi = new Mock<LoRaDeviceAPIServiceBase>(MockBehavior.Strict);
             this.deviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Loose);
 
@@ -71,7 +71,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [Theory]
         [InlineData(null)]
         [InlineData(ServerGatewayID)]
-        public async Task When_Sending_Message_Should_Send_Downlink_To_PacketForwarder(string deviceGatewayID)
+        public async Task When_Sending_Message_Should_Send_Downlink_To_DownstreamMessageSender(string deviceGatewayID)
         {
             var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, deviceClassType: 'c', gatewayID: deviceGatewayID));
             var devEUI = simDevice.DevEUI;
@@ -104,24 +104,24 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             };
 
             DownlinkMessage receivedDownlinkMessage = null;
-            this.packetForwarder.Setup(x => x.SendDownstreamAsync(It.IsNotNull<DownlinkMessage>()))
+            this.downstreamMessageSender.Setup(x => x.SendDownstreamAsync(It.IsNotNull<DownlinkMessage>()))
                 .Returns(Task.CompletedTask)
                 .Callback<DownlinkMessage>(d => receivedDownlinkMessage = d);
 
             var target = new DefaultClassCDevicesMessageSender(
                 this.serverConfiguration,
                 this.loRaDeviceRegistry,
-                this.packetForwarder.Object,
+                this.downstreamMessageSender.Object,
                 this.frameCounterStrategyProvider,
                 NullLogger<DefaultClassCDevicesMessageSender>.Instance,
                 TestMeter.Instance);
 
             Assert.True(await target.SendAsync(c2dToDeviceMessage));
 
-            this.packetForwarder.Verify(x => x.SendDownstreamAsync(It.IsNotNull<DownlinkMessage>()), Times.Once());
+            this.downstreamMessageSender.Verify(x => x.SendDownstreamAsync(It.IsNotNull<DownlinkMessage>()), Times.Once());
             EnsureDownlinkIsCorrect(receivedDownlinkMessage, simDevice, c2dToDeviceMessage);
 
-            this.packetForwarder.VerifyAll();
+            this.downstreamMessageSender.VerifyAll();
             this.deviceApi.VerifyAll();
             this.deviceClient.VerifyAll();
         }
@@ -149,14 +149,14 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var target = new DefaultClassCDevicesMessageSender(
                 this.serverConfiguration,
                 this.loRaDeviceRegistry,
-                this.packetForwarder.Object,
+                this.downstreamMessageSender.Object,
                 this.frameCounterStrategyProvider,
                 NullLogger<DefaultClassCDevicesMessageSender>.Instance,
                 TestMeter.Instance);
 
             Assert.False(await target.SendAsync(c2dToDeviceMessage));
 
-            this.packetForwarder.VerifyAll();
+            this.downstreamMessageSender.VerifyAll();
             this.deviceApi.VerifyAll();
             this.deviceClient.VerifyAll();
         }
@@ -174,14 +174,14 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var target = new DefaultClassCDevicesMessageSender(
                 this.serverConfiguration,
                 this.loRaDeviceRegistry,
-                this.packetForwarder.Object,
+                this.downstreamMessageSender.Object,
                 this.frameCounterStrategyProvider,
                 NullLogger<DefaultClassCDevicesMessageSender>.Instance,
                 TestMeter.Instance);
 
             Assert.False(await target.SendAsync(c2dToDeviceMessage));
 
-            this.packetForwarder.VerifyAll();
+            this.downstreamMessageSender.VerifyAll();
             this.deviceApi.VerifyAll();
             this.deviceClient.VerifyAll();
         }
@@ -209,14 +209,14 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var target = new DefaultClassCDevicesMessageSender(
                 this.serverConfiguration,
                 this.loRaDeviceRegistry,
-                this.packetForwarder.Object,
+                this.downstreamMessageSender.Object,
                 this.frameCounterStrategyProvider,
                 NullLogger<DefaultClassCDevicesMessageSender>.Instance,
                 TestMeter.Instance);
 
             Assert.False(await target.SendAsync(c2dToDeviceMessage));
 
-            this.packetForwarder.VerifyAll();
+            this.downstreamMessageSender.VerifyAll();
             this.deviceApi.VerifyAll();
             this.deviceClient.VerifyAll();
         }
@@ -254,14 +254,14 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var target = new DefaultClassCDevicesMessageSender(
                 this.serverConfiguration,
                 this.loRaDeviceRegistry,
-                this.packetForwarder.Object,
+                this.downstreamMessageSender.Object,
                 this.frameCounterStrategyProvider,
                 NullLogger<DefaultClassCDevicesMessageSender>.Instance,
                 TestMeter.Instance);
 
             _ = await Assert.ThrowsAsync<TimeoutException>(() => target.SendAsync(c2dToDeviceMessage));
 
-            this.packetForwarder.VerifyAll();
+            this.downstreamMessageSender.VerifyAll();
             this.deviceApi.VerifyAll();
             this.deviceClient.VerifyAll();
         }
@@ -283,14 +283,14 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var target = new DefaultClassCDevicesMessageSender(
                 this.serverConfiguration,
                 this.loRaDeviceRegistry,
-                this.packetForwarder.Object,
+                this.downstreamMessageSender.Object,
                 this.frameCounterStrategyProvider,
                 NullLogger<DefaultClassCDevicesMessageSender>.Instance,
                 TestMeter.Instance);
 
             Assert.False(await target.SendAsync(c2dToDeviceMessage));
 
-            this.packetForwarder.VerifyAll();
+            this.downstreamMessageSender.VerifyAll();
             this.deviceApi.VerifyAll();
             this.deviceClient.VerifyAll();
         }
@@ -312,14 +312,14 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var target = new DefaultClassCDevicesMessageSender(
                 this.serverConfiguration,
                 this.loRaDeviceRegistry,
-                this.packetForwarder.Object,
+                this.downstreamMessageSender.Object,
                 this.frameCounterStrategyProvider,
                 NullLogger<DefaultClassCDevicesMessageSender>.Instance,
                 TestMeter.Instance);
 
             Assert.False(await target.SendAsync(c2dToDeviceMessage));
 
-            this.packetForwarder.VerifyAll();
+            this.downstreamMessageSender.VerifyAll();
             this.deviceApi.VerifyAll();
             this.deviceClient.VerifyAll();
         }
@@ -365,27 +365,27 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             };
 
             DownlinkMessage receivedDownlinkMessage = null;
-            this.packetForwarder.Setup(x => x.SendDownstreamAsync(It.IsNotNull<DownlinkMessage>()))
+            this.downstreamMessageSender.Setup(x => x.SendDownstreamAsync(It.IsNotNull<DownlinkMessage>()))
                 .Returns(Task.CompletedTask)
                 .Callback<DownlinkMessage>(d => receivedDownlinkMessage = d);
 
             var target = new DefaultClassCDevicesMessageSender(
                 this.serverConfiguration,
                 this.loRaDeviceRegistry,
-                this.packetForwarder.Object,
+                this.downstreamMessageSender.Object,
                 this.frameCounterStrategyProvider,
                 NullLogger<DefaultClassCDevicesMessageSender>.Instance,
                 TestMeter.Instance);
 
             Assert.True(await target.SendAsync(c2dToDeviceMessage));
 
-            this.packetForwarder.Verify(x => x.SendDownstreamAsync(It.IsNotNull<DownlinkMessage>()), Times.Once());
+            this.downstreamMessageSender.Verify(x => x.SendDownstreamAsync(It.IsNotNull<DownlinkMessage>()), Times.Once());
 
             EnsureDownlinkIsCorrect(receivedDownlinkMessage, simDevice, c2dToDeviceMessage);
             Assert.Equal(DataRateIndex.DR10, receivedDownlinkMessage.Rx2.DataRate);
             Assert.Equal(Hertz.Mega(923.3), receivedDownlinkMessage.Rx2.Frequency);
 
-            this.packetForwarder.VerifyAll();
+            this.downstreamMessageSender.VerifyAll();
             this.deviceApi.VerifyAll();
             this.deviceClient.VerifyAll();
         }
@@ -432,14 +432,14 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var target = new DefaultClassCDevicesMessageSender(
                 this.serverConfiguration,
                 this.loRaDeviceRegistry,
-                this.packetForwarder.Object,
+                this.downstreamMessageSender.Object,
                 this.frameCounterStrategyProvider,
                 NullLogger<DefaultClassCDevicesMessageSender>.Instance,
                 TestMeter.Instance);
 
             Assert.False(await target.SendAsync(c2dToDeviceMessage));
 
-            this.packetForwarder.VerifyAll();
+            this.downstreamMessageSender.VerifyAll();
             this.deviceApi.VerifyAll();
             this.deviceClient.VerifyAll();
         }

--- a/Tests/Unit/NetworkServer/FcntLimitTest.cs
+++ b/Tests/Unit/NetworkServer/FcntLimitTest.cs
@@ -120,8 +120,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 {
                     Assert.NotNull(req.ResponseDownlink);
                     Assert.True(req.ProcessingSucceeded);
-                    Assert.Single(PacketForwarder.DownlinkMessages);
-                    var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+                    Assert.Single(DownstreamMessageSender.DownlinkMessages);
+                    var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
                     var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
                     payloadDataDown.Serialize(simulatedDevice.AppSKey.Value);
                     Assert.Equal(expectedFcntDown, payloadDataDown.Fcnt);

--- a/Tests/Unit/NetworkServer/LnsProtocolMessageProcessorTests.cs
+++ b/Tests/Unit/NetworkServer/LnsProtocolMessageProcessorTests.cs
@@ -26,7 +26,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
     {
         private readonly Mock<IBasicsStationConfigurationService> basicsStationConfigurationMock;
         private readonly Mock<IMessageDispatcher> messageDispatcher;
-        private readonly Mock<IPacketForwarder> packetForwarder;
+        private readonly Mock<IDownstreamMessageSender> downstreamMessageSender;
         private readonly LnsProtocolMessageProcessor lnsMessageProcessorMock;
         private readonly Mock<WebSocket> socketMock;
         private readonly Mock<HttpContext> httpContextMock;
@@ -41,11 +41,11 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             _ = this.basicsStationConfigurationMock.Setup(m => m.GetRegionAsync(It.IsAny<StationEui>(), It.IsAny<CancellationToken>()))
                                           .Returns(Task.FromResult(RegionManager.EU868));
             this.messageDispatcher = new Mock<IMessageDispatcher>();
-            this.packetForwarder = new Mock<IPacketForwarder>();
+            this.downstreamMessageSender = new Mock<IDownstreamMessageSender>();
 
             this.lnsMessageProcessorMock = new LnsProtocolMessageProcessor(this.basicsStationConfigurationMock.Object,
                                                                            new WebSocketWriterRegistry<StationEui, string>(Mock.Of<ILogger<WebSocketWriterRegistry<StationEui, string>>>(), null),
-                                                                           this.packetForwarder.Object,
+                                                                           this.downstreamMessageSender.Object,
                                                                            this.messageDispatcher.Object,
                                                                            loggerMock,
                                                                            new RegistryMetricTagBag(new NetworkServerConfiguration { GatewayID = "foogateway" }),
@@ -328,7 +328,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.Equal(MacMessageType.ConfirmedDataUp, loRaRequest.Payload.MessageType);
             Assert.Equal(expectedMhdr, loRaRequest.Payload.MHdr);
             Assert.Equal(expectedMic, loRaRequest.Payload.Mic);
-            Assert.Equal(packetForwarder.Object, loRaRequest.PacketForwarder);
+            Assert.Equal(downstreamMessageSender.Object, loRaRequest.DownstreamMessageSender);
             Assert.Equal(RegionManager.EU868, loRaRequest.Region);
         }
 
@@ -368,7 +368,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.Equal(expectedJoinEui, ((LoRaPayloadJoinRequest)loRaRequest.Payload).AppEui);
             Assert.Equal(expectedDevEui, ((LoRaPayloadJoinRequest)loRaRequest.Payload).DevEUI);
             Assert.Equal(expectedDevNonce, ((LoRaPayloadJoinRequest)loRaRequest.Payload).DevNonce);
-            Assert.Equal(packetForwarder.Object, loRaRequest.PacketForwarder);
+            Assert.Equal(downstreamMessageSender.Object, loRaRequest.DownstreamMessageSender);
             Assert.Equal(RegionManager.EU868, loRaRequest.Region);
         }
 

--- a/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
+++ b/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
@@ -93,9 +93,9 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             messageProcessor.DispatchRequest(request);
             Assert.True(await request.WaitCompleteAsync());
             Assert.NotNull(request.ResponseDownlink);
-            Assert.Single(PacketForwarder.DownlinkMessages);
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
 
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var joinAccept = new LoRaPayloadJoinAccept(downlinkMessage.Data, simulatedDevice.AppKey.Value);
 
             Assert.Equal(1, DeviceCache.RegistrationCount(joinAccept.DevAddr));
@@ -145,7 +145,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             messageProcessor.DispatchRequest(request);
             Assert.True(await request.WaitCompleteAsync());
             Assert.Null(request.ResponseDownlink);
-            Assert.Empty(PacketForwarder.DownlinkMessages);
+            Assert.Empty(DownstreamMessageSender.DownlinkMessages);
             Assert.Equal(LoRaDeviceRequestFailedReason.ReceiveWindowMissed, request.ProcessingFailedReason);
 
             // Device frame counts were not modified
@@ -332,8 +332,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             messageProcessor.DispatchRequest(request);
             Assert.True(await request.WaitCompleteAsync());
             Assert.NotNull(request.ResponseDownlink);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var joinAccept = new LoRaPayloadJoinAccept(downlinkMessage.Data, simulatedDevice.LoRaDevice.AppKey.Value);
             Assert.Equal(joinAccept.DevAddr.ToString(), afterJoinDevAddr);
 
@@ -430,8 +430,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             messageProcessor.DispatchRequest(request);
             Assert.True(await request.WaitCompleteAsync());
             Assert.NotNull(request.ResponseDownlink);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var joinAccept = new LoRaPayloadJoinAccept(downlinkMessage.Data, simulatedDevice.LoRaDevice.AppKey.Value);
             Assert.Equal(rx1DROffset, joinAccept.Rx1DrOffset);
             Assert.Equal(rx2datarate, joinAccept.Rx2Dr);
@@ -512,8 +512,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             messageProcessor.DispatchRequest(request);
             Assert.True(await request.WaitCompleteAsync());
             Assert.NotNull(request.ResponseDownlink);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var joinAccept = new LoRaPayloadJoinAccept(downlinkMessage.Data, simulatedDevice.LoRaDevice.AppKey.Value);
             if (rx2datarate is > DR0 and < DR8)
             {
@@ -536,7 +536,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.True(await confirmedRequest.WaitCompleteAsync());
             Assert.True(confirmedRequest.ProcessingSucceeded);
             Assert.NotNull(confirmedRequest.ResponseDownlink);
-            Assert.Equal(2, PacketForwarder.DownlinkMessages.Count);
+            Assert.Equal(2, DownstreamMessageSender.DownlinkMessages.Count);
 
             TestUtils.CheckDRAndFrequencies(request, downlinkMessage);
         }
@@ -624,7 +624,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             twin.Properties.Desired[TwinProperty.RX2DataRate] = 3;
             await Task.Delay(TimeSpan.FromMilliseconds(10));
 
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var joinAccept = new LoRaPayloadJoinAccept(downlinkMessage.Data, simulatedDevice.LoRaDevice.AppKey.Value);
             Assert.Equal((DataRateIndex)afterJoinValues, joinAccept.Rx2Dr);
             Assert.Equal(afterJoinValues, joinAccept.Rx1DrOffset);
@@ -711,8 +711,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             messageProcessor.DispatchRequest(request);
             Assert.True(await request.WaitCompleteAsync());
             Assert.NotNull(request.ResponseDownlink);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var joinAccept = new LoRaPayloadJoinAccept(downlinkMessage.Data, simulatedDevice.LoRaDevice.AppKey.Value);
             if (rx1offset is > 0 and < 6)
             {
@@ -735,7 +735,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.True(await confirmedRequest.WaitCompleteAsync());
             Assert.True(confirmedRequest.ProcessingSucceeded);
             Assert.NotNull(confirmedRequest.ResponseDownlink);
-            Assert.Equal(2, PacketForwarder.DownlinkMessages.Count);
+            Assert.Equal(2, DownstreamMessageSender.DownlinkMessages.Count);
 
             var euRegion = RegionManager.EU868;
 
@@ -824,8 +824,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             messageProcessor.DispatchRequest(request);
             Assert.True(await request.WaitCompleteAsync());
             Assert.NotNull(request.ResponseDownlink);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkMessage = PacketForwarder.DownlinkMessages[0];
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages[0];
             var joinAccept = new LoRaPayloadJoinAccept(downlinkMessage.Data, simulatedDevice.LoRaDevice.AppKey.Value);
             if (rxDelay is >= 0 and < 16)
             {
@@ -848,7 +848,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.True(await confirmedRequest.WaitCompleteAsync());
             Assert.True(confirmedRequest.ProcessingSucceeded);
             Assert.NotNull(confirmedRequest.ResponseDownlink);
-            Assert.Equal(2, PacketForwarder.DownlinkMessages.Count);
+            Assert.Equal(2, DownstreamMessageSender.DownlinkMessages.Count);
         }
     }
 }

--- a/Tests/Unit/NetworkServer/MessageProcessorMultipleGatewayTest.cs
+++ b/Tests/Unit/NetworkServer/MessageProcessorMultipleGatewayTest.cs
@@ -71,8 +71,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var payload = simulatedDevice.CreateUnconfirmedDataUpMessage("1234", fcnt: 1);
 
             // Create Rxpk
-            using var request1 = CreateWaitableRequest(payload, PacketForwarder);
-            using var request2 = CreateWaitableRequest(payload, SecondPacketForwarder);
+            using var request1 = CreateWaitableRequest(payload, DownstreamMessageSender);
+            using var request2 = CreateWaitableRequest(payload, SecondDownstreamMessageSender);
             messageProcessor1.DispatchRequest(request1);
             messageProcessor2.DispatchRequest(request2);
 

--- a/Tests/Unit/NetworkServer/MessageProcessorSingleGatewayTest.cs
+++ b/Tests/Unit/NetworkServer/MessageProcessorSingleGatewayTest.cs
@@ -279,8 +279,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // 3. Return is downstream message
             Assert.NotNull(request.ResponseDownlink);
             Assert.True(request.ProcessingSucceeded);
-            Assert.Single(PacketForwarder.DownlinkMessages);
-            var downlinkMessage = PacketForwarder.DownlinkMessages.First();
+            Assert.Single(DownstreamMessageSender.DownlinkMessages);
+            var downlinkMessage = DownstreamMessageSender.DownlinkMessages.First();
             var payloadDataDown = new LoRaPayloadData(downlinkMessage.Data);
             Assert.Equal(payloadDataDown.DevAddr, loraDevice.DevAddr);
             Assert.False(payloadDataDown.IsConfirmed);


### PR DESCRIPTION
# PR for issue #1431

## What is being addressed

This PR closes #1431 by renaming all IPacketForwarder to IDownstreamMessageSender