### PR TITLE
Changes default level of IoTHub log search to error

### DIFF
--- a/Tests/E2E/MultiGatewayTests.cs
+++ b/Tests/E2E/MultiGatewayTests.cs
@@ -123,8 +123,8 @@ namespace LoRaWan.Tests.E2E
                     {
                         case "Mark":
                             var expectedProperty = "dupmsg";
-                            await TestFixture.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, expectedProperty, "true", new SearchLogOptions(expectedProperty) { SourceIdFilter = duplicateResult.MatchedEvent.SourceId, TreatAsError = true });
-                            await TestFixture.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, expectedProperty, "true", new SearchLogOptions(expectedProperty) { SourceIdFilter = notDuplicateResult.MatchedEvent.SourceId, TreatAsError = true });
+                            await TestFixture.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, expectedProperty, "true", new SearchLogOptions(expectedProperty) { SourceIdFilter = duplicateResult.MatchedEvent.SourceId });
+                            await TestFixture.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, expectedProperty, "true", new SearchLogOptions(expectedProperty) { SourceIdFilter = notDuplicateResult.MatchedEvent.SourceId });
                             break;
                         case "Drop":
                             var logMsg = $"{device.DeviceID}: duplication strategy indicated to not process message";
@@ -132,7 +132,7 @@ namespace LoRaWan.Tests.E2E
                             Assert.NotNull(droppedLog.MatchedEvent);
 
                             var expectedPayload = $"{{\"value\":{msg}}}";
-                            await TestFixtureCi.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, expectedPayload, new SearchLogOptions(expectedPayload) { TreatAsError = true });
+                            await TestFixtureCi.AssertIoTHubDeviceMessageExistsAsync(device.DeviceID, expectedPayload, new SearchLogOptions(expectedPayload));
                             break;
                         default:
                             throw new SwitchExpressionException();

--- a/Tests/E2E/appsettings.json
+++ b/Tests/E2E/appsettings.json
@@ -7,7 +7,7 @@
     "EnsureHasEventMaximumTries": "#{E2ETESTS_EnsureHasEventMaximumTries}#",
     "LeafDeviceSerialPort": "#{E2ETESTS_LeafDeviceSerialPort}#",
     "NetworkServerModuleLogAssertLevel": "Error",
-    "IoTHubAssertLevel": "Warning",
+    "IoTHubAssertLevel": "Error",
     "TcpLog": "true",
     "CreateDevices": true,
     "LeafDeviceGatewayID": "#{E2ETESTS_LeafDeviceGatewayID}#",


### PR DESCRIPTION
# PR for issue #1420

## What is being addressed


## How is this addressed

## Verification

Test manual run (only tests): https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/1762604034
Checked the failed tests and they are not due to the new assertion level. 