### PR TITLE
Fix duplicate test cases warnings `FrameControlTests`

### DIFF
--- a/Tests/Unit/LoRaWan/FrameControlTests.cs
+++ b/Tests/Unit/LoRaWan/FrameControlTests.cs
@@ -24,6 +24,7 @@ namespace LoRaWan.Tests.Unit
                 from flags in
                     from fs in Enum.GetValues<FrameControlFlags>()
                                    .Where(f => f != FrameControlFlags.None)
+                                   .Distinct()
                                    .Subsets()
                     select fs.Aggregate(FrameControlFlags.None, (fs, f) => fs | f)
                 from optionsLength in MoreEnumerable.Sequence(0, 15)


### PR DESCRIPTION
# PR for issue #1285

## What is being addressed

@MaggieSalak wrote:

> I looked at duplicate test case warnings in `FrameControlTests` for which you opened a bug some time ago. I found that this is because the `FrameControlFlags` enum has two members with the same value (`ClassB` and `DownlinkFramePending`). In the tests we are calling `GetValues()` and then generating all subsets, therefore there are duplicates. I would say that we should use distinct values of the enum to generate subsets, since in any case they don't resolve 'back' to their distinct names - when you check the warnings, all duplicates use `ClassB` and none use `DownlinkFramePending`. Does that make sense? If so I will open a quick PR that fixes that.

## How is this addressed

Only distinct values of the enum are taken (`ClassB` and `DownlinkFramePending` share the same value per the LoRaWAN spec).
