### PR TITLE
Disable unstable load test

### DIFF
--- a/Tests/Simulation/SimulatedLoadTests.cs
+++ b/Tests/Simulation/SimulatedLoadTests.cs
@@ -198,7 +198,7 @@ namespace LoRaWan.Tests.Simulation
         // - OTAA devices
         // - Sending confirmed/unconfirmed messages
         // - Goal: N devices in parallel based on configuration
-        [Fact]
+        [Fact(Skip = "Test is only used for manual load tests.")]
         public async Task Multiple_ABP_and_OTAA_Simulated_Devices_Confirmed()
         {
             const int messagesPerDeviceExcludingWarmup = 10;


### PR DESCRIPTION
## What is being addressed

We disable a load test which has been stable in the pipelines. Since we already have resiliency against (some) dropped downstream acknowledgements, and since we do not want to allow any dropped IoT Hub messages, the flakiness can not be improved further easily. Since the load test that fails most frequently is mostly used for manual load tests, we disable it.
