### PR TITLE
Display correct creation date of docs

### DIFF
--- a/.github/workflows/publish-docs-dev.yml
+++ b/.github/workflows/publish-docs-dev.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          #set excplicitly to 0 to get full history (see https://github.com/actions/checkout#usage)
+          fetch-depth: '0'
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x      

--- a/.github/workflows/publish-docs-new-version.yml
+++ b/.github/workflows/publish-docs-new-version.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          #set excplicitly to 0 to get full history (see https://github.com/actions/checkout#usage)
+          fetch-depth: '0'
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x      


### PR DESCRIPTION
Update the fetch depth on the checkout action, so the plugin can determine the correct creation date for docs.

fixes #1449

Explanation:
The fetch-depth in the checkout is for getting all commits to `main/docs`, this is needed so that the plugin can determine the age of a document (it does this at `mkdocs build` time)

The second one on line 18 is for `mike` itself, as it is pushing to `gh-pages` branch and needs a local instance. This fetch ensures there is at least 1 commit (see also https://github.com/jimporter/mike#deploying-via-ci)