### PR TITLE
Use Workspace-based Application Insights

### DIFF
--- a/Template/azuredeploy.json
+++ b/Template/azuredeploy.json
@@ -290,13 +290,14 @@
             "type": "Microsoft.Insights/components",
             "kind": "web",
             "name": "[variables('appInsightName')]",
-            "apiVersion": "2015-05-01",
+            "apiVersion": "2020-02-02",
             "location": "[resourceGroup().location]",
             "scale": null,
             "properties": {
-                "ApplicationId": "[variables('appInsightName')]"
+                "ApplicationId": "[variables('appInsightName')]",
+                "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces/', variables('logAnalyticsName'))]"
             },
-            "dependsOn": []
+            "dependsOn": [ "[resourceId('Microsoft.OperationalInsights/workspaces/', variables('logAnalyticsName'))]" ]
         },
         {
             "name": "azuremonitoralerts",
@@ -351,7 +352,6 @@
         {
             "type": "Microsoft.OperationalInsights/workspaces",
             "apiVersion": "2021-06-01",
-            "condition": "[parameters('useAzureMonitorOnEdge')]",
             "name": "[variables('logAnalyticsName')]",
             "location": "[resourceGroup().location]",
             "properties": {


### PR DESCRIPTION
# PR for issue #1454 

## What is being addressed

The classic Application Insights [is deprecated](https://docs.microsoft.com/en-us/azure/azure-monitor/app/create-new-resource), we use the Workspace-based App Insights.
