### PR TITLE
Updating BasicsStation module to v2.0.6

### DIFF
--- a/.github/workflows/e2e-ci.yaml
+++ b/.github/workflows/e2e-ci.yaml
@@ -498,7 +498,7 @@ jobs:
       E2ETESTS_ClientBundleCrc: ${{ needs.certificates_job.outputs.clientbundlecrc }}
       E2ETESTS_CupsSigKeyChecksum: ${{ needs.certificates_job.outputs.clientsigkeycrc }}
       E2ETESTS_CupsFwDigest: ${{ needs.certificates_job.outputs.clientfwdigest }}
-      E2ETESTS_CupsBasicStationVersion: "2.0.5(rak833x64/std)"
+      E2ETESTS_CupsBasicStationVersion: "2.0.6(rak833x64/std)"
       E2ETESTS_CupsBasicStationPackage: ${{ needs.certificates_job.outputs.clientfwversion }}
       E2ETESTS_CupsFwUrl: ${{ secrets.CUPSFIRMWAREBLOBURL }}
       TestsToRun: ${{ needs.env_var.outputs.E2ETestsToRun }}

--- a/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.amd64
+++ b/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.amd64
@@ -4,11 +4,8 @@ FROM amd64/debian:buster as build
 RUN apt-get update
 RUN apt-get install -y git
 RUN apt-get install -y --no-install-recommends apt-utils build-essential
-RUN git clone --branch v2.0.5 --single-branch --depth 1 https://github.com/lorabasics/basicstation.git
+RUN git clone --branch v2.0.6 --single-branch --depth 1 https://github.com/lorabasics/basicstation.git
 WORKDIR /basicstation
-
-# temporary fix for https://github.com/lorabasics/basicstation/issues/142
-RUN sed -i "s|mbedtls-2.6|archive/mbedtls-2.6|g" /basicstation/deps/mbedtls/prep.sh
 
 RUN make platform=linux variant=std
 

--- a/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.arm32v7
@@ -4,7 +4,7 @@ FROM amd64/debian:buster as build
 RUN apt-get update
 RUN apt-get install -y git
 RUN apt-get install -y apt-utils build-essential gcc-arm-linux-gnueabihf
-RUN git clone --branch v2.0.5 --single-branch --depth 1 https://github.com/lorabasics/basicstation.git
+RUN git clone --branch v2.0.6 --single-branch --depth 1 https://github.com/lorabasics/basicstation.git
 RUN mkdir -p ~/toolchain-rpi/bin/
 RUN ln -s /usr/bin/arm-linux-gnueabihf-gcc ~/toolchain-rpi/bin/arm-linux-gnueabihf-gcc
 RUN ln -s /usr/bin/arm-linux-gnueabihf-ld ~/toolchain-rpi/bin/arm-linux-gnueabihf-ld
@@ -12,9 +12,6 @@ RUN ln -s /usr/bin/arm-linux-gnueabihf-ar ~/toolchain-rpi/bin/arm-linux-gnueabih
 RUN ln -s /usr/bin/arm-linux-gnueabihf-objdump ~/toolchain-rpi/bin/arm-linux-gnueabihf-objdump
 RUN ln -s /usr/bin/arm-linux-gnueabihf-objcopy ~/toolchain-rpi/bin/arm-linux-gnueabihf-objcopy
 WORKDIR /basicstation
-
-# temporary fix for https://github.com/lorabasics/basicstation/issues/142
-RUN sed -i "s|mbedtls-2.6|archive/mbedtls-2.6|g" /basicstation/deps/mbedtls/prep.sh
 
 # make standard version
 RUN make platform=rpi variant=std


### PR DESCRIPTION
# PR for issue #1452 

This PR updates BasicStation module binaries to 2.0.6

In addition, a rak833 v2.0.6 based Basic Station has been manually built and replaced the existing binary.
You can see effectiveness of this manual intervention by having a look at these tests outcome: https://github.com/Azure/iotedge-lorawan-starterkit/runs/5050879427?check_suite_focus=true