### PR TITLE
Fix inconsistent join request counting

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
@@ -32,7 +32,6 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
         private readonly IMessageDispatcher messageDispatcher;
         private readonly ILogger<LnsProtocolMessageProcessor> logger;
         private readonly RegistryMetricTagBag registryMetricTagBag;
-        private readonly Counter<int> joinRequestCounter;
         private readonly Counter<int> uplinkMessageCounter;
         private readonly Counter<int> unhandledExceptionCount;
 
@@ -50,7 +49,6 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
             this.messageDispatcher = messageDispatcher;
             this.logger = logger;
             this.registryMetricTagBag = registryMetricTagBag;
-            this.joinRequestCounter = meter?.CreateCounter<int>(MetricRegistry.JoinRequests);
             this.uplinkMessageCounter = meter?.CreateCounter<int>(MetricRegistry.D2CMessagesReceived);
             this.unhandledExceptionCount = meter?.CreateCounter<int>(MetricRegistry.UnhandledExceptions);
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -70,7 +70,11 @@ namespace LoRaWan.NetworkServer
 
                 this.logger.LogInformation("join request received");
 
-                if (this.concentratorDeduplication.CheckDuplicateJoin(request) is ConcentratorDeduplicationResult.Duplicate)
+                var deduplicationResult = this.concentratorDeduplication.CheckDuplicateJoin(request);
+                if (deduplicationResult is ConcentratorDeduplicationResult.NotDuplicate)
+                    this.joinRequestCounter?.Add(1);
+
+                if (deduplicationResult is ConcentratorDeduplicationResult.Duplicate)
                 {
                     request.NotifyFailed(loRaDevice, LoRaDeviceRequestFailedReason.DeduplicationDrop);
                     // we do not log here as the concentratorDeduplication service already does more detailed logging
@@ -93,8 +97,6 @@ namespace LoRaWan.NetworkServer
                 }
 
                 var appKey = loRaDevice.AppKey.Value;
-
-                this.joinRequestCounter?.Add(1);
 
                 if (loRaDevice.AppEui != joinReq.AppEui)
                 {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MetricRegistry.cs
@@ -57,13 +57,15 @@ namespace LoRaWan.NetworkServer
             new Dictionary<string, CustomMetric>(Registry.ToDictionary(m => m.Name, m => m), StringComparer.OrdinalIgnoreCase);
     }
 
-    internal record CustomMetric(string Name, string Description, MetricType Type, string[] Tags);
+#pragma warning disable CA1819 // Properties should not return arrays (prometheus-net only accepts arrays in their API, done to avoid unnecessary conversion)
+    public record CustomMetric(string Name, string Description, MetricType Type, string[] Tags);
+#pragma warning restore CA1819 // Properties should not return arrays
 
     internal record CustomHistogram(string Name, string Description, MetricType Type, string[] Tags,
                                     double BucketStart, double BucketWidth, int BucketCount)
         : CustomMetric(Name, Description, Type, Tags);
 
-    internal enum MetricType
+    public enum MetricType
     {
         Counter,
         Histogram,

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/PrometheusMetricExporter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/PrometheusMetricExporter.cs
@@ -69,7 +69,7 @@ namespace LoRaWan.NetworkServer
             };
 #pragma warning restore format
 
-            var inOrderTags = MetricExporterHelper.GetTagsInOrder(this.RegistryLookup[instrument.Name].Tags, tags, this.metricTagBag);
+            var inOrderTags = MetricExporterHelper.GetTagsInOrder(RegistryLookup[instrument.Name].Tags, tags, this.metricTagBag);
             trackMetric(instrument.Name, inOrderTags, measurement);
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/PrometheusMetricExporter.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/PrometheusMetricExporter.cs
@@ -42,9 +42,9 @@ namespace LoRaWan.NetworkServer
             this.gauges = GetMetricsFromRegistry(MetricType.ObservableGauge, m => Metrics.CreateGauge(m.Name, m.Description, m.Tags));
 
             IDictionary<string, T> GetMetricsFromRegistry<T>(MetricType metricType, Func<CustomMetric, T> factory) =>
-                this.registryLookup.Values.Where(m => m.Type == metricType)
-                                          .Select(m => KeyValuePair.Create(m.Name, factory(m)))
-                                          .ToDictionary(m => m.Key, m => m.Value);
+                RegistryLookup.Values.Where(m => m.Type == metricType)
+                                     .Select(m => KeyValuePair.Create(m.Name, factory(m)))
+                                     .ToDictionary(m => m.Key, m => m.Value);
             this.metricTagBag = metricTagBag;
         }
 
@@ -69,7 +69,7 @@ namespace LoRaWan.NetworkServer
             };
 #pragma warning restore format
 
-            var inOrderTags = MetricExporterHelper.GetTagsInOrder(this.registryLookup[instrument.Name].Tags, tags, this.metricTagBag);
+            var inOrderTags = MetricExporterHelper.GetTagsInOrder(this.RegistryLookup[instrument.Name].Tags, tags, this.metricTagBag);
             trackMetric(instrument.Name, inOrderTags, measurement);
         }
 

--- a/Tests/Common/TestMetricListener.cs
+++ b/Tests/Common/TestMetricListener.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Common
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Diagnostics.Metrics;
+    using LoRaWan.NetworkServer;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    public sealed class TestMetricListener : RegistryMetricExporter
+    {
+        private readonly ConcurrentBag<(Instrument Instrument, double Value, KeyValuePair<string, object>[] Tags)> recordedMetrics =
+            new ConcurrentBag<(Instrument, double, KeyValuePair<string, object>[])>();
+
+        public IReadOnlyCollection<(Instrument Instrument, double Value, KeyValuePair<string, object>[] Tags)> RecordedMetrics => this.recordedMetrics;
+
+        public TestMetricListener(string metricNamespace)
+            : base(metricNamespace, MetricRegistry.RegistryLookup, NullLogger<RegistryMetricExporter>.Instance)
+        { }
+
+        protected override void TrackValue(Instrument instrument, double measurement, ReadOnlySpan<KeyValuePair<string, object>> tags, object state) =>
+            this.recordedMetrics.Add((instrument, measurement, tags.ToArray()));
+    }
+}

--- a/Tests/Common/WaitableLoRaRequest.cs
+++ b/Tests/Common/WaitableLoRaRequest.cs
@@ -77,8 +77,9 @@ namespace LoRaWan.Tests.Common
             return Create(radioMetadata, new[] { c2dMessageCheckTimeSpan, c2dMessageCheckTimeSpan, additionalMessageCheckTimeSpan, downlinkDeliveryTimeSpan }, downstreamMessageSender: downstreamMessageSender, loRaPayload: loRaPayloadData);
         }
         public static WaitableLoRaRequest CreateWaitableRequest(LoRaPayload loRaPayload,
-                                                           IDownstreamMessageSender downstreamMessageSender = null) =>
-           Create(TestUtils.GenerateTestRadioMetadata(),
+                                                                RadioMetadata radioMetadata = null,
+                                                                IDownstreamMessageSender downstreamMessageSender = null) =>
+           Create(radioMetadata ?? TestUtils.GenerateTestRadioMetadata(),
                   loRaPayload,
                   downstreamMessageSender);
 

--- a/Tests/Unit/NetworkServer/JoinRequestMessageHandlerTests.cs
+++ b/Tests/Unit/NetworkServer/JoinRequestMessageHandlerTests.cs
@@ -39,7 +39,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         private static DisposableValue<JoinRequestMessageHandler> Setup(ConcentratorDeduplicationResult deduplicationResult)
         {
             var deduplicationMock = new Mock<IConcentratorDeduplication>();
-            deduplicationMock.Setup(d => d.CheckDuplicateJoin(It.IsAny<LoRaRequest>())).Returns(deduplicationResult);
+            _ = deduplicationMock.Setup(d => d.CheckDuplicateJoin(It.IsAny<LoRaRequest>())).Returns(deduplicationResult);
 #pragma warning disable CA2000 // Dispose objects before losing scope (dispose handled in DisposableValue)
             var meter = new Meter(MetricNamespace);
 #pragma warning restore CA2000 // Dispose objects before losing scope

--- a/Tests/Unit/NetworkServer/JoinRequestMessageHandlerTests.cs
+++ b/Tests/Unit/NetworkServer/JoinRequestMessageHandlerTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.NetworkServer
+{
+    using System.Diagnostics.Metrics;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using LoRaWan.NetworkServer;
+    using LoRaWan.Tests.Common;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Moq;
+    using Xunit;
+
+    public sealed class JoinRequestMessageHandlerTests
+    {
+        private const string MetricNamespace = nameof(JoinRequestMessageHandlerTests);
+
+        [Theory]
+        [InlineData(ConcentratorDeduplicationResult.Duplicate, 0)]
+        [InlineData(ConcentratorDeduplicationResult.DuplicateDueToResubmission, 0)]
+        [InlineData(ConcentratorDeduplicationResult.SoftDuplicateDueToDeduplicationStrategy, 0)]
+        [InlineData(ConcentratorDeduplicationResult.NotDuplicate, 1)]
+        public async Task Increases_Join_Request_Counter_If_Not_Duplicate(ConcentratorDeduplicationResult deduplicationResult, int joinRequestCount)
+        {
+            // arrange
+            using var subject = Setup(deduplicationResult);
+            using var request = WaitableLoRaRequest.CreateWaitableRequest(new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1)).CreateJoinRequest());
+            using var metricListener = new TestMetricListener(MetricNamespace);
+            metricListener.Start();
+
+            // act
+            await subject.Value.ProcessJoinRequestAsync(request);
+
+            // assert
+            Assert.Equal(joinRequestCount, metricListener.RecordedMetrics.Count(m => m.Instrument.Name == MetricRegistry.JoinRequests.Name && m.Value == 1));
+        }
+
+        private static DisposableValue<JoinRequestMessageHandler> Setup(ConcentratorDeduplicationResult deduplicationResult)
+        {
+            var deduplicationMock = new Mock<IConcentratorDeduplication>();
+            deduplicationMock.Setup(d => d.CheckDuplicateJoin(It.IsAny<LoRaRequest>())).Returns(deduplicationResult);
+#pragma warning disable CA2000 // Dispose objects before losing scope (dispose handled in DisposableValue)
+            var meter = new Meter(MetricNamespace);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            return new DisposableValue<JoinRequestMessageHandler>(
+                new JoinRequestMessageHandler(new NetworkServerConfiguration(),
+                                              deduplicationMock.Object,
+                                              Mock.Of<ILoRaDeviceRegistry>(),
+                                              NullLogger<JoinRequestMessageHandler>.Instance,
+                                              meter),
+                meter);
+        }
+    }
+}


### PR DESCRIPTION
## What is being addressed

Before this PR, the join requests were counted in an inconsistent manner. After this PR, each join request is counted exactly once per gateway (independently of the deduplication strategy selected).

To validate this behavior we also add test infrastructure that can be used to unit test raising metrics.