### PR TITLE
Fix naming convention inconsistencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,33 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.cs]
+dotnet_naming_rule.private_constants_rule.severity = warning
+dotnet_naming_rule.private_constants_rule.style = upper_camel_case_style
+dotnet_naming_rule.private_constants_rule.symbols = private_constants_symbols
+dotnet_naming_rule.private_instance_fields_rule.severity = warning
+dotnet_naming_rule.private_instance_fields_rule.style = lower_camel_case_style
+dotnet_naming_rule.private_instance_fields_rule.symbols = private_instance_fields_symbols
+dotnet_naming_rule.private_static_fields_rule.severity = warning
+dotnet_naming_rule.private_static_fields_rule.style = lower_camel_case_style
+dotnet_naming_rule.private_static_fields_rule.symbols = private_static_fields_symbols
+dotnet_naming_rule.private_static_readonly_rule.severity = warning
+dotnet_naming_rule.private_static_readonly_rule.style = upper_camel_case_style
+dotnet_naming_rule.private_static_readonly_rule.symbols = private_static_readonly_symbols
+dotnet_naming_style.lower_camel_case_style.capitalization = camel_case
+dotnet_naming_style.upper_camel_case_style.capitalization = pascal_case
+dotnet_naming_symbols.private_constants_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_constants_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_constants_symbols.required_modifiers = const
+dotnet_naming_symbols.private_instance_fields_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_instance_fields_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields_symbols.required_modifiers = static
+dotnet_naming_symbols.private_static_readonly_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_readonly_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_readonly_symbols.required_modifiers = static,readonly
+
 [*.md]
 charset = utf-8
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ConcentratorDeduplication.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ConcentratorDeduplication.cs
@@ -16,7 +16,7 @@ namespace LoRaWan.NetworkServer
 
         private readonly IMemoryCache cache;
         private readonly ILogger<IConcentratorDeduplication> logger;
-        private static readonly object cacheLock = new object();
+        private static readonly object CacheLock = new object();
 
         internal sealed record DataMessageKey(DevEui DevEui, Mic Mic, ushort FCnt);
 
@@ -71,7 +71,7 @@ namespace LoRaWan.NetworkServer
         {
             var stationEui = loRaRequest.StationEui;
 
-            lock (cacheLock)
+            lock (CacheLock)
             {
                 if (!this.cache.TryGetValue(key, out previousStation))
                 {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FunctionBundler/FunctionBundlerProvider.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/FunctionBundler/FunctionBundlerProvider.cs
@@ -13,7 +13,7 @@ namespace LoRaWan.NetworkServer
         private readonly LoRaDeviceAPIServiceBase deviceApi;
         private readonly ILoggerFactory loggerFactory;
         private readonly ILogger<FunctionBundlerProvider> logger;
-        private static readonly List<IFunctionBundlerExecutionItem> functionItems = new List<IFunctionBundlerExecutionItem>
+        private static readonly List<IFunctionBundlerExecutionItem> FunctionItems = new List<IFunctionBundlerExecutionItem>
         {
             new FunctionBundlerDeduplicationExecutionItem(),
             new FunctionBundlerADRExecutionItem(),
@@ -48,10 +48,10 @@ namespace LoRaWan.NetworkServer
             var context = new FunctionBundlerExecutionContext(gatewayId, loRaPayload.Fcnt, loRaDevice.FCntDown,
                                                               loRaPayload, loRaDevice, deduplicationFactory, request);
 
-            var qualifyingExecutionItems = new List<IFunctionBundlerExecutionItem>(functionItems.Count);
-            for (var i = 0; i < functionItems.Count; i++)
+            var qualifyingExecutionItems = new List<IFunctionBundlerExecutionItem>(FunctionItems.Count);
+            for (var i = 0; i < FunctionItems.Count; i++)
             {
-                var itm = functionItems[i];
+                var itm = FunctionItems[i];
                 if (itm.RequiresExecution(context))
                 {
                     qualifyingExecutionItems.Add(itm);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JsonReader.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JsonReader.cs
@@ -322,10 +322,10 @@ namespace LoRaWan.NetworkServer
 
         private sealed class DelegatingJsonReader<T> : IJsonReader<T>
         {
-            private readonly ReadHandler<T> _func;
+            private readonly ReadHandler<T> func;
 
-            public DelegatingJsonReader(ReadHandler<T> func) => _func = func;
-            public T Read(ref Utf8JsonReader reader) => _func(ref reader);
+            public DelegatingJsonReader(ReadHandler<T> func) => this.func = func;
+            public T Read(ref Utf8JsonReader reader) => this.func(ref reader);
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
@@ -20,7 +20,7 @@ namespace LoRaWan.NetworkServer
     /// </summary>
     public sealed class LoRaDeviceClient : ILoRaDeviceClient
     {
-        private static readonly TimeSpan twinUpdateTimeout = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan TwinUpdateTimeout = TimeSpan.FromSeconds(10);
         private readonly string connectionString;
         private readonly ITransportSettings[] transportSettings;
         private readonly ILogger<LoRaDeviceClient> logger;
@@ -82,7 +82,7 @@ namespace LoRaWan.NetworkServer
             {
                 if (cancellationToken == default)
                 {
-                    cts = new CancellationTokenSource(twinUpdateTimeout);
+                    cts = new CancellationTokenSource(TwinUpdateTimeout);
                     cancellationToken = cts.Token;
                 }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NullDisposable.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NullDisposable.cs
@@ -10,9 +10,7 @@ namespace LoRaWan.NetworkServer
     /// </summary>
     internal class NullDisposable : IDisposable
     {
-        private static readonly NullDisposable instance = new NullDisposable();
-
-        internal static IDisposable Instance => instance;
+        internal static readonly IDisposable Instance = new NullDisposable();
 
         private NullDisposable()
         {

--- a/Tests/E2E/C2DMessageTest.cs
+++ b/Tests/E2E/C2DMessageTest.cs
@@ -24,7 +24,7 @@ namespace LoRaWan.Tests.E2E
         /// </summary>
         private const int CloudToDeviceMessageReceiveCountThreshold = 2;
 
-        private static readonly Random random = new Random();
+        private static readonly Random Random = new Random();
 
         public C2DMessageTest(IntegrationTestFixtureCi testFixture)
             : base(testFixture)
@@ -95,7 +95,7 @@ namespace LoRaWan.Tests.E2E
             }
 
             // sends C2D - between 10 and 99
-            var c2dMessageBody = (100 + random.Next(90)).ToString(CultureInfo.InvariantCulture);
+            var c2dMessageBody = (100 + Random.Next(90)).ToString(CultureInfo.InvariantCulture);
             var c2dMessage = new LoRaCloudToDeviceMessage()
             {
                 Payload = c2dMessageBody,
@@ -216,7 +216,7 @@ namespace LoRaWan.Tests.E2E
             }
 
             // sends C2D - between 10 and 99
-            var c2dMessageBody = (100 + random.Next(90)).ToString(CultureInfo.InvariantCulture);
+            var c2dMessageBody = (100 + Random.Next(90)).ToString(CultureInfo.InvariantCulture);
             var c2dMessage = new LoRaCloudToDeviceMessage()
             {
                 Payload = c2dMessageBody,
@@ -354,7 +354,7 @@ namespace LoRaWan.Tests.E2E
             }
 
             // sends C2D - between 10 and 99
-            var c2dMessageBody = (100 + random.Next(90)).ToString(CultureInfo.InvariantCulture);
+            var c2dMessageBody = (100 + Random.Next(90)).ToString(CultureInfo.InvariantCulture);
             var c2dMessage = new LoRaCloudToDeviceMessage()
             {
                 Payload = c2dMessageBody,
@@ -490,7 +490,7 @@ namespace LoRaWan.Tests.E2E
             }
 
             // sends C2D - between 10 and 99
-            var c2dMessageBody = (100 + random.Next(90)).ToString(CultureInfo.InvariantCulture);
+            var c2dMessageBody = (100 + Random.Next(90)).ToString(CultureInfo.InvariantCulture);
             var msgId = Guid.NewGuid().ToString();
             var c2dMessage = new LoRaCloudToDeviceMessage()
             {
@@ -603,7 +603,7 @@ namespace LoRaWan.Tests.E2E
             }
 
             // sends C2D - between 10 and 99
-            var c2dMessageBody = (100 + random.Next(90)).ToString(CultureInfo.InvariantCulture);
+            var c2dMessageBody = (100 + Random.Next(90)).ToString(CultureInfo.InvariantCulture);
             var msgId = Guid.NewGuid().ToString();
             var c2dMessage = new LoRaCloudToDeviceMessage()
             {

--- a/Tests/Integration/ConcentratorDeduplicationJoinRequestsIntegrationTests.cs
+++ b/Tests/Integration/ConcentratorDeduplicationJoinRequestsIntegrationTests.cs
@@ -22,7 +22,7 @@ namespace LoRaWan.Tests.Integration
         private readonly SimulatedDevice simulatedDevice;
         private readonly Mock<LoRaDevice> deviceMock;
         private readonly TestOutputLoggerFactory testOutputLoggerFactory;
-        private bool _disposedValue;
+        private bool disposedValue;
 
         public ConcentratorDeduplicationJoinRequestsIntegrationTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
         {
@@ -83,7 +83,7 @@ namespace LoRaWan.Tests.Integration
 
         protected override void Dispose(bool disposing)
         {
-            if (!this._disposedValue)
+            if (!this.disposedValue)
             {
                 if (disposing)
                 {
@@ -91,7 +91,7 @@ namespace LoRaWan.Tests.Integration
                     this.testOutputLoggerFactory.Dispose();
                 }
 
-                this._disposedValue = true;
+                this.disposedValue = true;
             }
 
             // Call base class implementation.

--- a/Tests/Unit/LoRaTools/RegionAS923TestData.cs
+++ b/Tests/Unit/LoRaTools/RegionAS923TestData.cs
@@ -11,31 +11,31 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
 
     public static class RegionAS923TestData
     {
-        private static readonly List<DataRateIndex> dataRates = new() { DR0, DR1, DR2, DR3, DR4, DR5, DR6, DR7 };
+        private static readonly List<DataRateIndex> DataRates = new() { DR0, DR1, DR2, DR3, DR4, DR5, DR6, DR7 };
 
-        private static readonly List<Hertz> frequencies =
+        private static readonly List<Hertz> Frequencies =
             new List<ulong> { 923_200_000, 923_400_000, 921_400_000, 916_600_000, 917_500_000 }
             .Select(fr => new Hertz(fr)).ToList();
 
-        private static readonly DwellTimeLimitedRegion region;
-        private static readonly DwellTimeLimitedRegion regionWithDwellTime;
+        private static readonly DwellTimeLimitedRegion Region;
+        private static readonly DwellTimeLimitedRegion RegionWithDwellTime;
 
 #pragma warning disable CA1810 // Initialize reference type static fields inline (test code is not performance-sensitive)
         static RegionAS923TestData()
 #pragma warning restore CA1810 // Initialize reference type static fields inline
         {
-            region = new RegionAS923().WithFrequencyOffset(frequencies[0], frequencies[1]);
-            region.UseDwellTimeSetting(new DwellTimeSetting(false, false, 0));
-            regionWithDwellTime = new RegionAS923().WithFrequencyOffset(frequencies[0], frequencies[1]);
-            regionWithDwellTime.UseDwellTimeSetting(new DwellTimeSetting(true, true, 0));
+            Region = new RegionAS923().WithFrequencyOffset(Frequencies[0], Frequencies[1]);
+            Region.UseDwellTimeSetting(new DwellTimeSetting(false, false, 0));
+            RegionWithDwellTime = new RegionAS923().WithFrequencyOffset(Frequencies[0], Frequencies[1]);
+            RegionWithDwellTime.UseDwellTimeSetting(new DwellTimeSetting(true, true, 0));
         }
 
         public static IEnumerable<object[]> TestRegionFrequencyData()
         {
-            foreach (var dr in dataRates)
+            foreach (var dr in DataRates)
             {
-                foreach (var freq in frequencies)
-                    yield return new object[] { region, freq, dr, freq };
+                foreach (var freq in Frequencies)
+                    yield return new object[] { Region, freq, dr, freq };
             }
         }
 
@@ -43,33 +43,33 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
             new List<object[]>
             {
                 // No DwellTime limit
-                new object[] { region, 0, 0, 0 },
-                new object[] { region, 1, 1, 0 },
-                new object[] { region, 6, 6, 0 },
-                new object[] { region, 2, 1, 1 },
-                new object[] { region, 3, 1, 2 },
-                new object[] { region, 4, 2, 2 },
-                new object[] { region, 5, 7, 7 },
-                new object[] { region, 6, 7, 6 },
-                new object[] { region, 3, 4, 6 },
+                new object[] { Region, 0, 0, 0 },
+                new object[] { Region, 1, 1, 0 },
+                new object[] { Region, 6, 6, 0 },
+                new object[] { Region, 2, 1, 1 },
+                new object[] { Region, 3, 1, 2 },
+                new object[] { Region, 4, 2, 2 },
+                new object[] { Region, 5, 7, 7 },
+                new object[] { Region, 6, 7, 6 },
+                new object[] { Region, 3, 4, 6 },
                 // With DwellTime limit
-                new object[] { regionWithDwellTime, 0, 2, 0 },
-                new object[] { regionWithDwellTime, 1, 2, 0 },
-                new object[] { regionWithDwellTime, 6, 6, 0 },
-                new object[] { regionWithDwellTime, 2, 2, 1 },
-                new object[] { regionWithDwellTime, 3, 2, 2 },
-                new object[] { regionWithDwellTime, 4, 2, 2 },
-                new object[] { regionWithDwellTime, 5, 7, 7 },
-                new object[] { regionWithDwellTime, 6, 7, 6 },
-                new object[] { regionWithDwellTime, 3, 4, 6 },
+                new object[] { RegionWithDwellTime, 0, 2, 0 },
+                new object[] { RegionWithDwellTime, 1, 2, 0 },
+                new object[] { RegionWithDwellTime, 6, 6, 0 },
+                new object[] { RegionWithDwellTime, 2, 2, 1 },
+                new object[] { RegionWithDwellTime, 3, 2, 2 },
+                new object[] { RegionWithDwellTime, 4, 2, 2 },
+                new object[] { RegionWithDwellTime, 5, 7, 7 },
+                new object[] { RegionWithDwellTime, 6, 7, 6 },
+                new object[] { RegionWithDwellTime, 3, 4, 6 },
             };
 
         public static IEnumerable<object[]> TestRegionDataRateData_InvalidOffset =>
            new List<object[]>
            {
-               new object[] { region, 1, 8 },
-               new object[] { region, 1, 9 },
-               new object[] { regionWithDwellTime, 1, 10 },
+               new object[] { Region, 1, 8 },
+               new object[] { Region, 1, 9 },
+               new object[] { RegionWithDwellTime, 1, 10 },
            };
 
         public static IEnumerable<object[]> TestRegionLimitData =>
@@ -82,25 +82,25 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                 (Mega(928.5),  90),
                 (Mega(928.2), 100),
             }
-            select new object[] { region, x.Frequency, x.DataRate };
+            select new object[] { Region, x.Frequency, x.DataRate };
 
         public static IEnumerable<object[]> TestRegionMaxPayloadLengthData =>
            new List<object[]>
            {
-               new object[] { region, 0, 59 },
-               new object[] { region, 1, 59 },
-               new object[] { region, 2, 123 },
-               new object[] { region, 3, 123 },
-               new object[] { region, 4, 230 },
-               new object[] { region, 5, 230 },
-               new object[] { region, 6, 230 },
-               new object[] { region, 7, 230 },
-               new object[] { regionWithDwellTime, 2, 19 },
-               new object[] { regionWithDwellTime, 3, 61 },
-               new object[] { regionWithDwellTime, 4, 133 },
-               new object[] { regionWithDwellTime, 5, 230 },
-               new object[] { regionWithDwellTime, 6, 230 },
-               new object[] { regionWithDwellTime, 7, 230 },
+               new object[] { Region, 0, 59 },
+               new object[] { Region, 1, 59 },
+               new object[] { Region, 2, 123 },
+               new object[] { Region, 3, 123 },
+               new object[] { Region, 4, 230 },
+               new object[] { Region, 5, 230 },
+               new object[] { Region, 6, 230 },
+               new object[] { Region, 7, 230 },
+               new object[] { RegionWithDwellTime, 2, 19 },
+               new object[] { RegionWithDwellTime, 3, 61 },
+               new object[] { RegionWithDwellTime, 4, 133 },
+               new object[] { RegionWithDwellTime, 5, 230 },
+               new object[] { RegionWithDwellTime, 6, 230 },
+               new object[] { RegionWithDwellTime, 7, 230 },
            };
 
         public static IEnumerable<object[]> TestDownstreamRX2FrequencyData =>
@@ -110,56 +110,56 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                (Mega(923.4), Mega(923.4)),
                (Mega(925.0), Mega(925.0)),
            }
-           select new object[] { region, x.NwkSrvRx2Freq, x.ExpectedFreq };
+           select new object[] { Region, x.NwkSrvRx2Freq, x.ExpectedFreq };
 
         public static IEnumerable<object[]> TestDownstreamRX2DataRateData =>
             new List<object[]>
             {
-                new object[] { region, null, null, 2 },
-                new object[] { region, null, DR2, 2 },
-                new object[] { region, null, DR5, 5 },
-                new object[] { region, DR3, null, 3 },
-                new object[] { region, DR3, DR4, 4 },
-                new object[] { region, DR2, DR3, 3 },
-                new object[] { region, null, DR9, 2 },
+                new object[] { Region, null, null, 2 },
+                new object[] { Region, null, DR2, 2 },
+                new object[] { Region, null, DR5, 5 },
+                new object[] { Region, DR3, null, 3 },
+                new object[] { Region, DR3, DR4, 4 },
+                new object[] { Region, DR2, DR3, 3 },
+                new object[] { Region, null, DR9, 2 },
             };
 
         public static IEnumerable<object[]> TestTranslateToRegionData =>
            new List<object[]>
            {
-                new object[] { region, LoRaRegionType.AS923 },
+                new object[] { Region, LoRaRegionType.AS923 },
            };
 
         public static IEnumerable<object[]> TestTryGetJoinChannelIndexData =>
             from freq in new Hertz[] { Mega(923.4), Mega(928.0) }
-            select new object[] { region, freq, /* expected index */ -1 };
+            select new object[] { Region, freq, /* expected index */ -1 };
 
         public static IEnumerable<object[]> TestIsValidRX1DROffsetData =>
            new List<object[]>
            {
-                new object[] { region, 0, true },
-                new object[] { region, 7, true },
-                new object[] { region, 8, false },
-                new object[] { region, 10, false },
+                new object[] { Region, 0, true },
+                new object[] { Region, 7, true },
+                new object[] { Region, 8, false },
+                new object[] { Region, 10, false },
            };
 
         public static IEnumerable<object[]> TestIsDRIndexWithinAcceptableValuesData =>
             new List<object[]>
             {
-                new object[] { region, DR0, true, true },
-                new object[] { region, DR2, true, true },
-                new object[] { region, DR7, true, true },
-                new object[] { region, DR0, false, true },
-                new object[] { region, DR2, false, true },
-                new object[] { region, DR7, false, true },
-                new object[] { region, DR9, true, false },
-                new object[] { region, DR10, false, false },
-                new object[] { regionWithDwellTime, DR0, false, false },
-                new object[] { regionWithDwellTime, DR0, true, true },
-                new object[] { regionWithDwellTime, DR1, false, false },
-                new object[] { regionWithDwellTime, DR1, true, true },
-                new object[] { regionWithDwellTime, DR2, false, true },
-                new object[] { regionWithDwellTime, DR2, true, true }
+                new object[] { Region, DR0, true, true },
+                new object[] { Region, DR2, true, true },
+                new object[] { Region, DR7, true, true },
+                new object[] { Region, DR0, false, true },
+                new object[] { Region, DR2, false, true },
+                new object[] { Region, DR7, false, true },
+                new object[] { Region, DR9, true, false },
+                new object[] { Region, DR10, false, false },
+                new object[] { RegionWithDwellTime, DR0, false, false },
+                new object[] { RegionWithDwellTime, DR0, true, true },
+                new object[] { RegionWithDwellTime, DR1, false, false },
+                new object[] { RegionWithDwellTime, DR1, true, true },
+                new object[] { RegionWithDwellTime, DR2, false, true },
+                new object[] { RegionWithDwellTime, DR2, true, true }
             };
     }
 }

--- a/Tests/Unit/LoRaTools/RegionCN470RP1TestData.cs
+++ b/Tests/Unit/LoRaTools/RegionCN470RP1TestData.cs
@@ -11,7 +11,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
 
     public static class RegionCN470RP1TestData
     {
-        private static readonly Region region = RegionManager.CN470RP1;
+        private static readonly Region Region = RegionManager.CN470RP1;
 
         public static IEnumerable<object[]> TestRegionFrequencyData =>
             from f in new (Hertz Input, Hertz Output)[]
@@ -28,28 +28,28 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                 (Mega(484.1), Mega(504.5)),
                 (Mega(489.3), Mega(509.7)),
             }
-            select new object[] { region, f.Input, /* data rate */ 0, f.Output };
+            select new object[] { Region, f.Input, /* data rate */ 0, f.Output };
 
         public static IEnumerable<object[]> TestRegionDataRateData =>
            new List<object[]>
            {
-               new object[] { region, 0, 0, 0 },
-               new object[] { region, 1, 1, 0 },
-               new object[] { region, 2, 2, 0 },
-               new object[] { region, 5, 5, 0 },
-               new object[] { region, 1, 0, 5 },
-               new object[] { region, 2, 1, 1 },
-               new object[] { region, 3, 1, 2 },
-               new object[] { region, 3, 0, 3 },
-               new object[] { region, 4, 2, 2 },
-               new object[] { region, 5, 2, 3 },
+               new object[] { Region, 0, 0, 0 },
+               new object[] { Region, 1, 1, 0 },
+               new object[] { Region, 2, 2, 0 },
+               new object[] { Region, 5, 5, 0 },
+               new object[] { Region, 1, 0, 5 },
+               new object[] { Region, 2, 1, 1 },
+               new object[] { Region, 3, 1, 2 },
+               new object[] { Region, 3, 0, 3 },
+               new object[] { Region, 4, 2, 2 },
+               new object[] { Region, 5, 2, 3 },
            };
 
         public static IEnumerable<object[]> TestRegionDataRateData_InvalidOffset =>
            new List<object[]>
            {
-               new object[] { region, 0, 6 },
-               new object[] { region, 2, 10 },
+               new object[] { Region, 0, 6 },
+               new object[] { Region, 2, 10 },
            };
 
         public static IEnumerable<object[]> TestRegionLimitData =>
@@ -60,17 +60,17 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                 (Mega(510.8),  20),
                 (Mega(512.3), 110),
             }
-            select new object[] { region, x.Frequency, x.DataRate };
+            select new object[] { Region, x.Frequency, x.DataRate };
 
         public static IEnumerable<object[]> TestRegionMaxPayloadLengthData =>
            new List<object[]>
            {
-               new object[] { region, 0, 59 },
-               new object[] { region, 1, 59 },
-               new object[] { region, 2, 59 },
-               new object[] { region, 3, 123 },
-               new object[] { region, 4, 230 },
-               new object[] { region, 5, 230 },
+               new object[] { Region, 0, 59 },
+               new object[] { Region, 1, 59 },
+               new object[] { Region, 2, 59 },
+               new object[] { Region, 3, 123 },
+               new object[] { Region, 4, 230 },
+               new object[] { Region, 5, 230 },
            };
 
         public static IEnumerable<object[]> TestDownstreamRX2FrequencyData =>
@@ -81,49 +81,49 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                (Mega(500.3), Mega(500.3)),
                (Mega(509.7), Mega(509.7)),
            }
-           select new object[] { region, x.NwkSrvRx2Freq, x.ExpectedFreq };
+           select new object[] { Region, x.NwkSrvRx2Freq, x.ExpectedFreq };
 
         public static IEnumerable<object[]> TestDownstreamRX2DataRateData =>
             new List<object[]>
             {
-                new object[] { region, null, null, DR0 },
-                new object[] { region, null, DR2, DR2 },
-                new object[] { region, null, DR5, DR5 },
-                new object[] { region, null, DR6, DR0 },
-                new object[] { region, DR4, null, DR4 },
-                new object[] { region, DR4, DR5, DR5 },
+                new object[] { Region, null, null, DR0 },
+                new object[] { Region, null, DR2, DR2 },
+                new object[] { Region, null, DR5, DR5 },
+                new object[] { Region, null, DR6, DR0 },
+                new object[] { Region, DR4, null, DR4 },
+                new object[] { Region, DR4, DR5, DR5 },
             };
 
         public static IEnumerable<object[]> TestTranslateToRegionData =>
            new List<object[]>
            {
-                new object[] { region, LoRaRegionType.CN470RP1 },
+                new object[] { Region, LoRaRegionType.CN470RP1 },
            };
 
         public static IEnumerable<object[]> TestTryGetJoinChannelIndexData =>
             from freq in new Hertz[] { Mega(470.3), Mega(489.3), Mega(509.7) }
-            select new object[] { region, freq, /* expected index */ -1 };
+            select new object[] { Region, freq, /* expected index */ -1 };
 
         public static IEnumerable<object[]> TestIsValidRX1DROffsetData =>
            new List<object[]>
            {
-                new object[] { region, 0, true },
-                new object[] { region, 5, true },
-                new object[] { region, 6, false },
+                new object[] { Region, 0, true },
+                new object[] { Region, 5, true },
+                new object[] { Region, 6, false },
            };
 
         public static IEnumerable<object[]> TestIsDRIndexWithinAcceptableValuesData =>
             new List<object[]>
             {
-                new object[] { region, DR0, true, true },
-                new object[] { region, DR2, true, true },
-                new object[] { region, DR5, true, true },
-                new object[] { region, DR6, true, false },
-                new object[] { region, DR0, false, true },
-                new object[] { region, DR2, false, true },
-                new object[] { region, DR5, false, true },
-                new object[] { region, DR6, false, false },
-                new object[] { region, DR10, false, false },
+                new object[] { Region, DR0, true, true },
+                new object[] { Region, DR2, true, true },
+                new object[] { Region, DR5, true, true },
+                new object[] { Region, DR6, true, false },
+                new object[] { Region, DR0, false, true },
+                new object[] { Region, DR2, false, true },
+                new object[] { Region, DR5, false, true },
+                new object[] { Region, DR6, false, false },
+                new object[] { Region, DR10, false, false },
             };
     }
 }

--- a/Tests/Unit/LoRaTools/RegionCN470RP2TestData.cs
+++ b/Tests/Unit/LoRaTools/RegionCN470RP2TestData.cs
@@ -11,7 +11,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
 
     public static class RegionCN470RP2TestData
     {
-        private static readonly Region region = RegionManager.CN470RP2;
+        private static readonly Region Region = RegionManager.CN470RP2;
 
         public static IEnumerable<object[]> TestRegionFrequencyData =>
             from p in new[]
@@ -40,26 +40,26 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                 new { Frequency = new { Input = Mega(489.7), Output = Mega(504.7) }, JoinChannel = 18 },
                 new { Frequency = new { Input = Mega(488.9), Output = Mega(503.9) }, JoinChannel = 19 },
             }
-            select new object[] { region, p.Frequency.Input, /* data rate */ 0, p.Frequency.Output, p.JoinChannel };
+            select new object[] { Region, p.Frequency.Input, /* data rate */ 0, p.Frequency.Output, p.JoinChannel };
 
         public static IEnumerable<object[]> TestRegionDataRateData =>
            new List<object[]>
            {
-               new object[] { region, 0, 0, 0 },
-               new object[] { region, 1, 1, 0 },
-               new object[] { region, 2, 2, 0 },
-               new object[] { region, 6, 6, 0 },
-               new object[] { region, 2, 1, 1 },
-               new object[] { region, 3, 1, 2 },
-               new object[] { region, 4, 2, 2 },
-               new object[] { region, 6, 3, 3 },
+               new object[] { Region, 0, 0, 0 },
+               new object[] { Region, 1, 1, 0 },
+               new object[] { Region, 2, 2, 0 },
+               new object[] { Region, 6, 6, 0 },
+               new object[] { Region, 2, 1, 1 },
+               new object[] { Region, 3, 1, 2 },
+               new object[] { Region, 4, 2, 2 },
+               new object[] { Region, 6, 3, 3 },
            };
 
         public static IEnumerable<object[]> TestRegionDataRateData_InvalidOffset =>
            new List<object[]>
            {
-               new object[] { region, 0, 6 },
-               new object[] { region, 2, 10 },
+               new object[] { Region, 0, 6 },
+               new object[] { Region, 2, 10 },
            };
 
         public static IEnumerable<object[]> TestRegionLimitData =>
@@ -70,18 +70,18 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                 (Mega(509.8), 100),
                 (Mega(469.9), 110),
             }
-            select new object[] { region, x.Frequency, x.DataRate, 0 };
+            select new object[] { Region, x.Frequency, x.DataRate, 0 };
 
         public static IEnumerable<object[]> TestRegionMaxPayloadLengthData =>
            new List<object[]>
            {
-               new object[] { region, 1, 31 },
-               new object[] { region, 2, 94 },
-               new object[] { region, 3, 192 },
-               new object[] { region, 4, 250 },
-               new object[] { region, 5, 250 },
-               new object[] { region, 6, 250 },
-               new object[] { region, 7, 250 },
+               new object[] { Region, 1, 31 },
+               new object[] { Region, 2, 94 },
+               new object[] { Region, 3, 192 },
+               new object[] { Region, 4, 250 },
+               new object[] { Region, 5, 250 },
+               new object[] { Region, 6, 250 },
+               new object[] { Region, 7, 250 },
            };
 
         public static IEnumerable<object[]> TestDownstreamRX2FrequencyData =>
@@ -113,7 +113,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
            }
            select new object[]
            {
-               region,
+               Region,
                !double.IsNaN(x.NwkSrvRx2Freq) ? Hertz.Mega(x.NwkSrvRx2Freq) : (Hertz?)null,
                Hertz.Mega(x.ExpectedFreq),
                x.JoinChannel.Reported,
@@ -123,24 +123,24 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
         public static IEnumerable<object[]> TestDownstreamRX2DataRateData =>
             new List<object[]>
             {
-                new object[] { region, null, null, DR1, 0, null },
-                new object[] { region, null, null, DR1, 8, null },
-                new object[] { region, null, null, DR1, 10, null },
-                new object[] { region, null, null, DR1, 19, null },
-                new object[] { region, null, null, DR1, null, 5 },
-                new object[] { region, null, null, DR1, null, 12 },
-                new object[] { region, null, null, DR1, 10, 14 },
-                new object[] { region, null, DR2 , DR2, 0, null },
-                new object[] { region, DR3 , null, DR3, 0, null },
-                new object[] { region, DR3 , DR2 , DR2, 0, null },
-                new object[] { region, DR4 , DR3 , DR3, 0, 8 },
-                new object[] { region, null, DR9 , DR1, 11, null },
+                new object[] { Region, null, null, DR1, 0, null },
+                new object[] { Region, null, null, DR1, 8, null },
+                new object[] { Region, null, null, DR1, 10, null },
+                new object[] { Region, null, null, DR1, 19, null },
+                new object[] { Region, null, null, DR1, null, 5 },
+                new object[] { Region, null, null, DR1, null, 12 },
+                new object[] { Region, null, null, DR1, 10, 14 },
+                new object[] { Region, null, DR2 , DR2, 0, null },
+                new object[] { Region, DR3 , null, DR3, 0, null },
+                new object[] { Region, DR3 , DR2 , DR2, 0, null },
+                new object[] { Region, DR4 , DR3 , DR3, 0, 8 },
+                new object[] { Region, null, DR9 , DR1, 11, null },
             };
 
         public static IEnumerable<object[]> TestTranslateToRegionData =>
            new List<object[]>
            {
-                new object[] { region, LoRaRegionType.CN470RP2 },
+                new object[] { Region, LoRaRegionType.CN470RP2 },
            };
 
         public static IEnumerable<object[]> TestTryGetJoinChannelIndexData =>
@@ -159,7 +159,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
             }
             select new object[]
             {
-                region,
+                Region,
                 Hertz.Mega(x.Freq),
                 x.ExpectedIndex,
             };
@@ -167,22 +167,22 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
         public static IEnumerable<object[]> TestIsValidRX1DROffsetData =>
            new List<object[]>
            {
-                new object[] { region, 0, true },
-                new object[] { region, 5, true },
-                new object[] { region, 6, false },
+                new object[] { Region, 0, true },
+                new object[] { Region, 5, true },
+                new object[] { Region, 6, false },
            };
 
         public static IEnumerable<object[]> TestIsDRIndexWithinAcceptableValuesData =>
             new List<object[]>
             {
-                new object[] { region, DR0, true, true },
-                new object[] { region, DR2, true, true },
-                new object[] { region, DR7, true, true },
-                new object[] { region, DR0, false, true },
-                new object[] { region, DR2, false, true },
-                new object[] { region, DR7, false, true },
-                new object[] { region, DR9, true, false },
-                new object[] { region, DR10, false, false },
+                new object[] { Region, DR0, true, true },
+                new object[] { Region, DR2, true, true },
+                new object[] { Region, DR7, true, true },
+                new object[] { Region, DR0, false, true },
+                new object[] { Region, DR2, false, true },
+                new object[] { Region, DR7, false, true },
+                new object[] { Region, DR9, true, false },
+                new object[] { Region, DR10, false, false },
             };
     }
 }

--- a/Tests/Unit/LoRaTools/RegionEU868TestData.cs
+++ b/Tests/Unit/LoRaTools/RegionEU868TestData.cs
@@ -11,29 +11,29 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
 
     public static class RegionEU868TestData
     {
-        private static readonly Region region = RegionManager.EU868;
-        private static readonly ushort[] dataRates = { 0, 1, 2, 3, 4, 5, 6 };
-        private static readonly Hertz[] frequencies = { Mega(868.1), Mega(868.3), Mega(868.5) };
+        private static readonly Region Region = RegionManager.EU868;
+        private static readonly ushort[] DataRates = { 0, 1, 2, 3, 4, 5, 6 };
+        private static readonly Hertz[] Frequencies = { Mega(868.1), Mega(868.3), Mega(868.5) };
 
         public static IEnumerable<object[]> TestRegionFrequencyData()
         {
-            foreach (var dr in dataRates)
+            foreach (var dr in DataRates)
             {
-                foreach (var freq in frequencies)
-                    yield return new object[] { region, freq, dr, freq };
+                foreach (var freq in Frequencies)
+                    yield return new object[] { Region, freq, dr, freq };
             }
         }
 
         public static IEnumerable<object[]> TestRegionDataRateData() {
-            foreach (var dr in dataRates)
-                yield return new object[] { region, dr, dr };
+            foreach (var dr in DataRates)
+                yield return new object[] { Region, dr, dr };
         }
 
         public static IEnumerable<object[]> TestRegionDataRateData_InvalidOffset =>
           new List<object[]>
           {
-               new object[] { region, 0, 6 },
-               new object[] { region, 1, 10 },
+               new object[] { Region, 0, 6 },
+               new object[] { Region, 1, 10 },
           };
 
         public static IEnumerable<object[]> TestRegionLimitData =>
@@ -45,19 +45,19 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                 (Mega( 860.3), 100),
                 (Mega( 880  ), 100),
             }
-            select new object[] { region, x.Frequency, x.DataRate };
+            select new object[] { Region, x.Frequency, x.DataRate };
 
         public static IEnumerable<object[]> TestRegionMaxPayloadLengthData =>
            new List<object[]>
            {
-               new object[] { region, 0, 59 },
-               new object[] { region, 1, 59 },
-               new object[] { region, 2, 59 },
-               new object[] { region, 3, 123 },
-               new object[] { region, 4, 230 },
-               new object[] { region, 5, 230 },
-               new object[] { region, 6, 230 },
-               new object[] { region, 7, 230 },
+               new object[] { Region, 0, 59 },
+               new object[] { Region, 1, 59 },
+               new object[] { Region, 2, 59 },
+               new object[] { Region, 3, 123 },
+               new object[] { Region, 4, 230 },
+               new object[] { Region, 5, 230 },
+               new object[] { Region, 6, 230 },
+               new object[] { Region, 7, 230 },
            };
 
         public static IEnumerable<object[]> TestDownstreamRX2FrequencyData =>
@@ -66,46 +66,46 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                (null         , Mega(869.525)),
                (Mega(868.250), Mega(868.250)),
            }
-           select new object[] { region, x.NwkSrvRx2Freq, x.ExpectedFreq };
+           select new object[] { Region, x.NwkSrvRx2Freq, x.ExpectedFreq };
 
         public static IEnumerable<object[]> TestDownstreamRX2DataRateData =>
             new List<object[]>
             {
-                new object[] { region, null, null, DR0 }, // Standard EU.
-                new object[] { region, DR3, null, DR3 }, // nwksrvDR is correctly applied if no device twins.
-                new object[] { region, DR3, DR6, DR6 }, // device twins are applied in priority.
+                new object[] { Region, null, null, DR0 }, // Standard EU.
+                new object[] { Region, DR3, null, DR3 }, // nwksrvDR is correctly applied if no device twins.
+                new object[] { Region, DR3, DR6, DR6 }, // device twins are applied in priority.
             };
 
         public static IEnumerable<object[]> TestTranslateToRegionData =>
            new List<object[]>
            {
-                new object[] { region, LoRaRegionType.EU868 },
-                new object[] { region, LoRaRegionType.EU863 },
+                new object[] { Region, LoRaRegionType.EU868 },
+                new object[] { Region, LoRaRegionType.EU863 },
            };
 
         public static IEnumerable<object[]> TestTryGetJoinChannelIndexData =>
             from freq in new Hertz[] { Mega(863), Mega(870) }
-            select new object[] { region, freq, /* expected index */ -1 };
+            select new object[] { Region, freq, /* expected index */ -1 };
 
         public static IEnumerable<object[]> TestIsValidRX1DROffsetData =>
            new List<object[]>
            {
-                new object[] { region, 0, true },
-                new object[] { region, 5, true },
-                new object[] { region, 6, false },
+                new object[] { Region, 0, true },
+                new object[] { Region, 5, true },
+                new object[] { Region, 6, false },
            };
 
         public static IEnumerable<object[]> TestIsDRIndexWithinAcceptableValuesData =>
             new List<object[]>
             {
-                new object[] { region, DR0, true, true },
-                new object[] { region, DR1, true, true },
-                new object[] { region, DR3, true, true },
-                new object[] { region, DR5, false, true },
-                new object[] { region, DR8, true, false },
-                new object[] { region, DR8, false, false },
-                new object[] { region, DR10, true, false },
-                new object[] { region, DR10, false, false },
+                new object[] { Region, DR0, true, true },
+                new object[] { Region, DR1, true, true },
+                new object[] { Region, DR3, true, true },
+                new object[] { Region, DR5, false, true },
+                new object[] { Region, DR8, true, false },
+                new object[] { Region, DR8, false, false },
+                new object[] { Region, DR10, true, false },
+                new object[] { Region, DR10, false, false },
             };
     }
 }

--- a/Tests/Unit/LoRaTools/RegionUS915TestData.cs
+++ b/Tests/Unit/LoRaTools/RegionUS915TestData.cs
@@ -11,7 +11,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
 
     public static class RegionUS915TestData
     {
-        private static readonly Region region = RegionManager.US915;
+        private static readonly Region Region = RegionManager.US915;
 
         public static readonly IEnumerable<object[]> TestRegionFrequencyDataDR1To3 =
             from dr in new ushort[] { 0, 1, 2, 3 }
@@ -29,7 +29,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                 (904.1, 923.9),
                 (904.3, 924.5),
             }
-            select new object[] { region, Hertz.Mega(freq.Input), dr, Hertz.Mega(freq.Output) };
+            select new object[] { Region, Hertz.Mega(freq.Input), dr, Hertz.Mega(freq.Output) };
 
         public static readonly IEnumerable<object[]> TestRegionFrequencyDataDR4 =
             from freq in new (Hertz Input, Hertz Output)[]
@@ -43,7 +43,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                 (Mega(912.6), Mega(926.9)),
                 (Mega(914.2), Mega(927.5)),
             }
-            select new object[] { region, freq.Input, /* data rate */ 4, freq.Output };
+            select new object[] { Region, freq.Input, /* data rate */ 4, freq.Output };
 
         public static IEnumerable<object[]> TestRegionDataRateDataDR1To3()
         {
@@ -58,20 +58,20 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
             };
 
             foreach (var dr in dataRates)
-                yield return new object[] { region, dr, inputDrToExpectedDr[dr] };
+                yield return new object[] { Region, dr, inputDrToExpectedDr[dr] };
         }
 
         public static IEnumerable<object[]> TestRegionDataRateDataDR4() =>
             new List<object[]>
             {
-                new object[]{ region, 4, 13 }
+                new object[]{ Region, 4, 13 }
             };
 
         public static IEnumerable<object[]> TestRegionDataRateData_InvalidOffset =>
            new List<object[]>
            {
-               new object[] { region, 0, 4 },
-               new object[] { region, 0, 5 },
+               new object[] { Region, 0, 4 },
+               new object[] { Region, 0, 5 },
            };
 
         public static IEnumerable<object[]> TestRegionLimitData =>
@@ -82,21 +82,21 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                 (Mega( 901.2),  90),
                 (Mega( 928.5), 100),
             }
-            select new object[] { region, x.Frequency, x.DataRate };
+            select new object[] { Region, x.Frequency, x.DataRate };
 
         public static IEnumerable<object[]> TestRegionMaxPayloadLengthData =>
            new List<object[]>
            {
-               new object[] { region, 0, 19 },
-               new object[] { region, 1, 61 },
-               new object[] { region, 2, 133 },
-               new object[] { region, 3, 250 },
-               new object[] { region, 4, 250 },
-               new object[] { region, 8, 61 },
-               new object[] { region, 9, 137 },
-               new object[] { region, 10, 250 },
-               new object[] { region, 11, 250 },
-               new object[] { region, 13, 250 },
+               new object[] { Region, 0, 19 },
+               new object[] { Region, 1, 61 },
+               new object[] { Region, 2, 133 },
+               new object[] { Region, 3, 250 },
+               new object[] { Region, 4, 250 },
+               new object[] { Region, 8, 61 },
+               new object[] { Region, 9, 137 },
+               new object[] { Region, 10, 250 },
+               new object[] { Region, 11, 250 },
+               new object[] { Region, 13, 250 },
            };
 
         public static IEnumerable<object[]> TestDownstreamRX2FrequencyData =>
@@ -105,49 +105,49 @@ namespace LoRaWan.Tests.Unit.LoRaTools.Regions
                (null       , Mega(923.3)),
                (Mega(920.0), Mega(920.0)),
            }
-           select new object[] { region, x.NwkSrvRx2Freq, x.ExpectedFreq };
+           select new object[] { Region, x.NwkSrvRx2Freq, x.ExpectedFreq };
 
         public static IEnumerable<object[]> TestDownstreamRX2DataRateData =>
            new List<object[]>
            {
-                new object[] { region, null, null, DR8 },
-                new object[] { region, DR11, null, DR11 },
-                new object[] { region, DR11, DR12, DR12 },
+                new object[] { Region, null, null, DR8 },
+                new object[] { Region, DR11, null, DR11 },
+                new object[] { Region, DR11, DR12, DR12 },
            };
 
         public static IEnumerable<object[]> TestTranslateToRegionData =>
            new List<object[]>
            {
-                new object[] { region, LoRaRegionType.US915 },
-                new object[] { region, LoRaRegionType.US902 },
+                new object[] { Region, LoRaRegionType.US915 },
+                new object[] { Region, LoRaRegionType.US902 },
            };
 
         public static IEnumerable<object[]> TestTryGetJoinChannelIndexData =>
             from freq in new Hertz[] { Mega(902.3), Mega(927.5) }
-            select new object[] { region, freq, /* expected index */ -1 };
+            select new object[] { Region, freq, /* expected index */ -1 };
 
         public static IEnumerable<object[]> TestIsValidRX1DROffsetData =>
            new List<object[]>
            {
-                new object[] { region, 0, true },
-                new object[] { region, 3, true },
-                new object[] { region, 4, false },
+                new object[] { Region, 0, true },
+                new object[] { Region, 3, true },
+                new object[] { Region, 4, false },
            };
 
         public static IEnumerable<object[]> TestIsDRIndexWithinAcceptableValuesData =>
             new List<object[]>
             {
-                new object[] { region, DR0, true, true },
-                new object[] { region, DR2, true, true },
-                new object[] { region, DR4, true, true },
-                new object[] { region, DR10, false, true },
-                new object[] { region, DR13, false, true },
-                new object[] { region, DR2, false, false },
-                new object[] { region, DR5, true, false },
-                new object[] { region, DR7, true, false },
-                new object[] { region, DR10, true, false },
-                new object[] { region, DR12, true, false },
-                new object[] { region, DR14, true, false },
+                new object[] { Region, DR0, true, true },
+                new object[] { Region, DR2, true, true },
+                new object[] { Region, DR4, true, true },
+                new object[] { Region, DR10, false, true },
+                new object[] { Region, DR13, false, true },
+                new object[] { Region, DR2, false, false },
+                new object[] { Region, DR5, true, false },
+                new object[] { Region, DR7, true, false },
+                new object[] { Region, DR10, true, false },
+                new object[] { Region, DR12, true, false },
+                new object[] { Region, DR14, true, false },
             };
     }
 }

--- a/Tests/Unit/LoraKeysManagerFacade/ConcentratorFirmwareFunctionTests.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/ConcentratorFirmwareFunctionTests.cs
@@ -27,7 +27,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
     {
         private const string BlobContent = "testcontents";
 
-        private readonly StationEui TestStationEui = StationEui.Parse("11-11-11-11-11-11-11-11");
+        private readonly StationEui testStationEui = StationEui.Parse("11-11-11-11-11-11-11-11");
 
         private readonly Mock<RegistryManager> registryManager;
         private readonly Mock<BlobClient> blobClient;
@@ -62,7 +62,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var httpRequest = new Mock<HttpRequest>();
             var queryCollection = new QueryCollection(new Dictionary<string, StringValues>()
             {
-                { "StationEui", new StringValues(this.TestStationEui.ToString()) }
+                { "StationEui", new StringValues(this.testStationEui.ToString()) }
             });
             httpRequest.SetupGet(x => x.Query).Returns(queryCollection);
 
@@ -102,7 +102,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var httpRequest = new Mock<HttpRequest>();
             var queryCollection = new QueryCollection(new Dictionary<string, StringValues>()
             {
-                { "StationEui", new StringValues(this.TestStationEui.ToString()) }
+                { "StationEui", new StringValues(this.testStationEui.ToString()) }
             });
             httpRequest.SetupGet(x => x.Query).Returns(queryCollection);
 
@@ -142,7 +142,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var httpRequest = new Mock<HttpRequest>();
             var queryCollection = new QueryCollection(new Dictionary<string, StringValues>()
             {
-                { "StationEui", new StringValues(this.TestStationEui.ToString()) }
+                { "StationEui", new StringValues(this.testStationEui.ToString()) }
             });
             httpRequest.SetupGet(x => x.Query).Returns(queryCollection);
 
@@ -164,7 +164,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var httpRequest = new Mock<HttpRequest>();
             var queryCollection = new QueryCollection(new Dictionary<string, StringValues>()
             {
-                { "StationEui", new StringValues(this.TestStationEui.ToString()) }
+                { "StationEui", new StringValues(this.testStationEui.ToString()) }
             });
             httpRequest.SetupGet(x => x.Query).Returns(queryCollection);
 
@@ -190,7 +190,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var httpRequest = new Mock<HttpRequest>();
             var queryCollection = new QueryCollection(new Dictionary<string, StringValues>()
             {
-                { "StationEui", new StringValues(this.TestStationEui.ToString()) }
+                { "StationEui", new StringValues(this.testStationEui.ToString()) }
             });
             httpRequest.SetupGet(x => x.Query).Returns(queryCollection);
 

--- a/Tests/Unit/NetworkServer/BasicsStation/DownstreamSenderTests.cs
+++ b/Tests/Unit/NetworkServer/BasicsStation/DownstreamSenderTests.cs
@@ -19,7 +19,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
 
     public class DownstreamSenderTests
     {
-        private const string loraDataBase64 = "REFUQQ==";
+        private const string LoraDataBase64 = "REFUQQ==";
         private readonly StationEui stationEui = new StationEui(ulong.MaxValue);
         private readonly DevEui devEui = new DevEui(ulong.MaxValue);
         private readonly Mock<IWebSocketWriter<string>> webSocketWriter;
@@ -37,7 +37,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
 
             socketWriterRegistry.Register(stationEui, this.webSocketWriter.Object);
 
-            loraDataByteArray = Encoding.UTF8.GetBytes(loraDataBase64);
+            loraDataByteArray = Encoding.UTF8.GetBytes(LoraDataBase64);
 
             downlinkSender = new DownstreamMessageSender(socketWriterRegistry,
                                                   basicStationConfigurationService.Object,

--- a/Tests/Unit/NetworkServer/JoinDeviceLoaderTest.cs
+++ b/Tests/Unit/NetworkServer/JoinDeviceLoaderTest.cs
@@ -18,10 +18,10 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         {
             using var cache = LoRaDeviceCacheDefault.CreateDefault();
             var factory = new Mock<ILoRaDeviceFactory>();
-            using var joinDeviceLoader = new JoinDeviceLoader(DefaultDeviceInfo, factory.Object, cache, NullLogger<JoinDeviceLoader>.Instance);
+            using var joinDeviceLoader = new JoinDeviceLoader(defaultDeviceInfo, factory.Object, cache, NullLogger<JoinDeviceLoader>.Instance);
 
             await joinDeviceLoader.LoadAsync();
-            factory.Verify(x => x.CreateAndRegisterAsync(DefaultDeviceInfo, It.IsAny<CancellationToken>()), Times.Once);
+            factory.Verify(x => x.CreateAndRegisterAsync(defaultDeviceInfo, It.IsAny<CancellationToken>()), Times.Once);
             Assert.True(joinDeviceLoader.CanCache);
         }
 
@@ -30,13 +30,13 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         {
             using var cache = LoRaDeviceCacheDefault.CreateDefault();
             var factory = new Mock<ILoRaDeviceFactory>();
-            using var joinDeviceLoader = new JoinDeviceLoader(DefaultDeviceInfo, factory.Object, cache, NullLogger<JoinDeviceLoader>.Instance);
+            using var joinDeviceLoader = new JoinDeviceLoader(defaultDeviceInfo, factory.Object, cache, NullLogger<JoinDeviceLoader>.Instance);
 
-            using var device = new LoRaDevice(DefaultDeviceInfo.DevAddr, DefaultDeviceInfo.DevEUI, null);
+            using var device = new LoRaDevice(defaultDeviceInfo.DevAddr, defaultDeviceInfo.DevEUI, null);
             cache.Register(device);
 
             Assert.Equal(device, await joinDeviceLoader.LoadAsync());
-            factory.Verify(x => x.CreateAndRegisterAsync(DefaultDeviceInfo, It.IsAny<CancellationToken>()), Times.Never);
+            factory.Verify(x => x.CreateAndRegisterAsync(defaultDeviceInfo, It.IsAny<CancellationToken>()), Times.Never);
             Assert.True(joinDeviceLoader.CanCache);
         }
 
@@ -45,10 +45,10 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         {
             using var cache = LoRaDeviceCacheDefault.CreateDefault();
             var factory = new Mock<ILoRaDeviceFactory>();
-            factory.Setup(x => x.CreateAndRegisterAsync(DefaultDeviceInfo, It.IsAny<CancellationToken>()))
+            factory.Setup(x => x.CreateAndRegisterAsync(defaultDeviceInfo, It.IsAny<CancellationToken>()))
                    .ThrowsAsync(new LoRaProcessingException());
 
-            using var joinDeviceLoader = new JoinDeviceLoader(DefaultDeviceInfo, factory.Object, cache, NullLogger<JoinDeviceLoader>.Instance);
+            using var joinDeviceLoader = new JoinDeviceLoader(defaultDeviceInfo, factory.Object, cache, NullLogger<JoinDeviceLoader>.Instance);
 
             Assert.Null(await joinDeviceLoader.LoadAsync());
             Assert.False(joinDeviceLoader.CanCache);
@@ -60,25 +60,25 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             using var cache = LoRaDeviceCacheDefault.CreateDefault();
             var factory = new Mock<ILoRaDeviceFactory>();
 
-            using var device = new LoRaDevice(DefaultDeviceInfo.DevAddr, DefaultDeviceInfo.DevEUI, null);
+            using var device = new LoRaDevice(defaultDeviceInfo.DevAddr, defaultDeviceInfo.DevEUI, null);
 
-            factory.Setup(x => x.CreateAndRegisterAsync(DefaultDeviceInfo, It.IsAny<CancellationToken>()))
+            factory.Setup(x => x.CreateAndRegisterAsync(defaultDeviceInfo, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(() =>
                     {
                         cache.Register(device);
                         return device;
                     });
 
-            using var joinDeviceLoader = new JoinDeviceLoader(DefaultDeviceInfo, factory.Object, cache, NullLogger<JoinDeviceLoader>.Instance);
+            using var joinDeviceLoader = new JoinDeviceLoader(defaultDeviceInfo, factory.Object, cache, NullLogger<JoinDeviceLoader>.Instance);
 
             var t1 = joinDeviceLoader.LoadAsync();
             var t2 = joinDeviceLoader.LoadAsync();
 
             Assert.All(await Task.WhenAll(t1, t2), x => Assert.Equal(device, x));
-            factory.Verify(x => x.CreateAndRegisterAsync(DefaultDeviceInfo, It.IsAny<CancellationToken>()), Times.Once);
+            factory.Verify(x => x.CreateAndRegisterAsync(defaultDeviceInfo, It.IsAny<CancellationToken>()), Times.Once);
         }
 
-        private readonly IoTHubDeviceInfo DefaultDeviceInfo = new()
+        private readonly IoTHubDeviceInfo defaultDeviceInfo = new()
         {
             DevEUI = new DevEui(0),
             PrimaryKey = "AAAA",

--- a/Tests/Unit/NetworkServer/LoRaDeviceFactoryTest.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceFactoryTest.cs
@@ -22,12 +22,12 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         public void Throws_When_Missing_DeviceInfo()
         {
             var factory = new TestDeviceFactory();
-            var deviceInfo = DefaultDeviceInfo;
+            var deviceInfo = defaultDeviceInfo;
             deviceInfo.PrimaryKey = null;
 
             Assert.ThrowsAsync<ArgumentException>(() => factory.CreateAndRegisterAsync(deviceInfo, CancellationToken.None));
 
-            deviceInfo = DefaultDeviceInfo;
+            deviceInfo = defaultDeviceInfo;
             deviceInfo.DevEUI = new DevEui(0);
             Assert.ThrowsAsync<ArgumentException>(() => factory.CreateAndRegisterAsync(deviceInfo, this.cancellationToken));
         }
@@ -35,7 +35,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [Fact]
         public void Throws_When_Device_Is_Already_Registered()
         {
-            var deviceInfo = DefaultDeviceInfo;
+            var deviceInfo = defaultDeviceInfo;
             using var cache = CreateDefaultCache();
             var factory = new TestDeviceFactory(loRaDeviceCache: cache);
 
@@ -49,14 +49,14 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         {
             var connectionManager = new Mock<ILoRaDeviceClientConnectionManager>();
             using var cache = CreateDefaultCache();
-            var factory = new TestDeviceFactory(DefaultConfiguration, connectionManager.Object, cache, meter: TestMeter.Instance);
+            var factory = new TestDeviceFactory(defaultConfiguration, connectionManager.Object, cache, meter: TestMeter.Instance);
 
-            var device = await factory.CreateAndRegisterAsync(DefaultDeviceInfo, this.cancellationToken);
+            var device = await factory.CreateAndRegisterAsync(defaultDeviceInfo, this.cancellationToken);
 
-            Assert.True(cache.TryGetByDevEui(this.DefaultDeviceInfo.DevEUI, out var cachedDevice));
+            Assert.True(cache.TryGetByDevEui(this.defaultDeviceInfo.DevEUI, out var cachedDevice));
             Assert.Equal(device, cachedDevice);
 
-            factory.LastDeviceMock.Verify(x => x.InitializeAsync(DefaultConfiguration, this.cancellationToken), Times.Once);
+            factory.LastDeviceMock.Verify(x => x.InitializeAsync(defaultConfiguration, this.cancellationToken), Times.Once);
             connectionManager.VerifySuccess(device);
         }
 
@@ -65,11 +65,11 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         {
             var connectionManager = new Mock<ILoRaDeviceClientConnectionManager>();
             using var cache = CreateDefaultCache();
-            var factory = new TestDeviceFactory(DefaultConfiguration, connectionManager.Object, cache, x => x.Object.GatewayID = "OtherGw", TestMeter.Instance);
+            var factory = new TestDeviceFactory(defaultConfiguration, connectionManager.Object, cache, x => x.Object.GatewayID = "OtherGw", TestMeter.Instance);
 
-            var device = await factory.CreateAndRegisterAsync(DefaultDeviceInfo, this.cancellationToken);
+            var device = await factory.CreateAndRegisterAsync(defaultDeviceInfo, this.cancellationToken);
 
-            factory.LastDeviceMock.Verify(x => x.InitializeAsync(DefaultConfiguration, this.cancellationToken), Times.Never);
+            factory.LastDeviceMock.Verify(x => x.InitializeAsync(defaultConfiguration, this.cancellationToken), Times.Never);
             connectionManager.VerifySuccess(device);
         }
 
@@ -78,20 +78,20 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         {
             var connectionManager = new Mock<ILoRaDeviceClientConnectionManager>();
             using var cache = CreateDefaultCache();
-            var factory = new TestDeviceFactory(DefaultConfiguration, connectionManager.Object, cache, x => x.Setup(y => y.InitializeAsync(DefaultConfiguration, this.cancellationToken)).ReturnsAsync(false), TestMeter.Instance);
-            await Assert.ThrowsAsync<LoRaProcessingException>(() => factory.CreateAndRegisterAsync(DefaultDeviceInfo, this.cancellationToken));
+            var factory = new TestDeviceFactory(defaultConfiguration, connectionManager.Object, cache, x => x.Setup(y => y.InitializeAsync(defaultConfiguration, this.cancellationToken)).ReturnsAsync(false), TestMeter.Instance);
+            await Assert.ThrowsAsync<LoRaProcessingException>(() => factory.CreateAndRegisterAsync(defaultDeviceInfo, this.cancellationToken));
 
-            Assert.False(cache.TryGetByDevEui(this.DefaultDeviceInfo.DevEUI, out _));
+            Assert.False(cache.TryGetByDevEui(this.defaultDeviceInfo.DevEUI, out _));
             connectionManager.VerifyFailure(factory.LastDeviceMock.Object);
             factory.LastDeviceMock.Protected().Verify(nameof(LoRaDevice.Dispose), Times.Once(), true, true);
         }
 
-        private readonly NetworkServerConfiguration DefaultConfiguration = new NetworkServerConfiguration { EnableGateway = true, IoTHubHostName = "TestHub", GatewayHostName = "testGw" };
+        private readonly NetworkServerConfiguration defaultConfiguration = new NetworkServerConfiguration { EnableGateway = true, IoTHubHostName = "TestHub", GatewayHostName = "testGw" };
 
         private static LoRaDeviceCache CreateDefaultCache()
             => LoRaDeviceCacheDefault.CreateDefault();
 
-        private readonly IoTHubDeviceInfo DefaultDeviceInfo = new IoTHubDeviceInfo
+        private readonly IoTHubDeviceInfo defaultDeviceInfo = new IoTHubDeviceInfo
         {
             DevEUI = new DevEui(1),
             PrimaryKey = "AAAA",


### PR DESCRIPTION
## What is being addressed

Inconsistencies in naming conventions.

## How is this addressed

Added rules in `.editorconfig` to prevent them in the future and addressed violations of [IDE1006](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/naming-rules#rule-id-ide1006-naming-rule-violation).
