### PR TITLE
Remove unused members of `ILoRaDeviceClientConnectionManager`

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClientConnectionManager.cs
@@ -10,16 +10,9 @@ namespace LoRaWan.NetworkServer
         bool EnsureConnected(LoRaDevice loRaDevice);
 
         ILoRaDeviceClient GetClient(LoRaDevice loRaDevice);
-        ILoRaDeviceClient GetClient(DevEui devEui);
 
         void Release(LoRaDevice loRaDevice);
-        void Release(DevEui devEui);
 
         void Register(LoRaDevice loRaDevice, ILoRaDeviceClient loraDeviceClient);
-
-        /// <summary>
-        /// Tries to trigger scanning of expired items.
-        /// </summary>
-        void TryScanExpiredItems();
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -108,15 +108,10 @@ namespace LoRaWan.NetworkServer
         public ILoRaDeviceClient GetClient(LoRaDevice loRaDevice)
         {
             if (loRaDevice is null) throw new ArgumentNullException(nameof(loRaDevice));
-            return GetClient(loRaDevice.DevEUI);
-        }
 
-        public ILoRaDeviceClient GetClient(DevEui devEui)
-        {
-            if (this.managedConnections.TryGetValue(GetConnectionCacheKey(devEui), out var managedConnection))
-                return managedConnection.DeviceClient;
-
-            throw new ManagedConnectionException($"Connection for device {devEui} was not found");
+            return this.managedConnections.TryGetValue(GetConnectionCacheKey(loRaDevice.DevEUI), out var managedConnection)
+                 ? managedConnection.DeviceClient
+                 : throw new ManagedConnectionException($"Connection for device {loRaDevice.DevEUI} was not found");
         }
 
         public void Register(LoRaDevice loRaDevice, ILoRaDeviceClient loraDeviceClient)
@@ -138,12 +133,8 @@ namespace LoRaWan.NetworkServer
         public void Release(LoRaDevice loRaDevice)
         {
             _ = loRaDevice ?? throw new ArgumentNullException(nameof(loRaDevice));
-            Release(loRaDevice.DevEUI);
-        }
 
-        public void Release(DevEui devEui)
-        {
-            if (this.managedConnections.TryRemove(GetConnectionCacheKey(devEui), out var removedItem))
+            if (this.managedConnections.TryRemove(GetConnectionCacheKey(loRaDevice.DevEUI), out var removedItem))
             {
                 removedItem.Dispose();
             }

--- a/Tests/Common/SingleDeviceConnectionManager.cs
+++ b/Tests/Common/SingleDeviceConnectionManager.cs
@@ -30,20 +30,6 @@ namespace LoRaWan.Tests.Common
             this.singleDeviceClient.Dispose();
         }
 
-        public void TryScanExpiredItems()
-        {
-        }
-
         public void Dispose() => this.singleDeviceClient.Dispose();
-
-        public ILoRaDeviceClient GetClient(DevEui devEui)
-        {
-            return this.singleDeviceClient;
-        }
-
-        public void Release(DevEui devEui)
-        {
-            this.singleDeviceClient.Dispose();
-        }
     }
 }


### PR DESCRIPTION
## What is being addressed

Some members of `ILoRaDeviceClientConnectionManager` were no longer used or never accessed via the interface.

## How is this addressed

The members have been removed from the interface. In the implements the members have been removed or inlined. 
