### PR TITLE
Remove unused `ILoRaDeviceClient.IsMatchingKey`

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClient.cs
@@ -60,7 +60,5 @@ namespace LoRaWan.NetworkServer
         /// Ensures the device client is connected.
         /// </summary>
         bool EnsureConnected();
-
-        bool IsMatchingKey(string primaryKey);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
@@ -27,24 +27,18 @@ namespace LoRaWan.NetworkServer
         private readonly Counter<int> twinLoadRequests;
         private DeviceClient deviceClient;
 
-        private readonly string primaryKey;
-
-        public LoRaDeviceClient(string connectionString, ITransportSettings[] transportSettings, string primaryKey, ILogger<LoRaDeviceClient> logger, Meter meter)
+        public LoRaDeviceClient(string connectionString, ITransportSettings[] transportSettings, ILogger<LoRaDeviceClient> logger, Meter meter)
         {
             if (string.IsNullOrEmpty(connectionString)) throw new ArgumentException($"'{nameof(connectionString)}' cannot be null or empty.", nameof(connectionString));
-            if (string.IsNullOrEmpty(primaryKey)) throw new ArgumentException($"'{nameof(primaryKey)}' cannot be null or empty.", nameof(primaryKey));
             if (meter is null) throw new ArgumentNullException(nameof(meter));
 
             this.transportSettings = transportSettings ?? throw new ArgumentNullException(nameof(transportSettings));
 
             this.connectionString = connectionString;
-            this.primaryKey = primaryKey;
             this.logger = logger;
             this.twinLoadRequests = meter.CreateCounter<int>(MetricRegistry.TwinLoadRequests);
             this.deviceClient = CreateDeviceClient();
         }
-
-        public bool IsMatchingKey(string primaryKey) => this.primaryKey == primaryKey;
 
         public async Task<Twin> GetTwinAsync(CancellationToken cancellationToken = default)
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceFactory.cs
@@ -145,7 +145,7 @@ namespace LoRaWan.NetworkServer
                     }
                 };
 
-                return new LoRaDeviceClient(deviceConnectionStr, transportSettings, primaryKey, this.loggerFactory.CreateLogger<LoRaDeviceClient>(), this.meter);
+                return new LoRaDeviceClient(deviceConnectionStr, transportSettings, this.loggerFactory.CreateLogger<LoRaDeviceClient>(), this.meter);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## What is being addressed

`IsMatchingKey` of `ILoRaDeviceClient` was not used anywhere.

## How is this addressed

Removed the interface member, including implementation and the primary key in `LoRaDeviceClient` that was used only for this member.