### PR TITLE
Update solution version to VS 2022

### DIFF
--- a/LoRaEngine.sln
+++ b/LoRaEngine.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29025.244
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32126.317
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LoraKeysManagerFacade", "LoRaEngine\LoraKeysManagerFacade\LoraKeysManagerFacade.csproj", "{7E3FDAAC-242D-40CD-9782-0A8487FD0070}"
 EndProject


### PR DESCRIPTION
This PR is an addendum to PR #852 when the Starter Kit was updated to use .NET 6.

## What is being addressed

The Visual Studio solution file was still for VS 2019, which does not officially support .NET 6.

## How is this addressed

The Visual Studio solution file was changed to require VS 2022, which officially supports .NET 6.
