### PR TITLE
Standalone discovery service: observability

### DIFF
--- a/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/LoRaWan.NetworkServerDiscovery.csproj
+++ b/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/LoRaWan.NetworkServerDiscovery.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="$(ApplicationInsightsVersion)" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="$(MicrosoftAzureDevicesVersion)" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="$(PrometheusNetVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/LoRaWan.NetworkServerDiscovery.csproj
+++ b/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/LoRaWan.NetworkServerDiscovery.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>$(TargetFramework)</TargetFramework>
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="$(ApplicationInsightsVersion)" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="$(MicrosoftAzureDevicesVersion)" />
   </ItemGroup>
 

--- a/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/Program.cs
+++ b/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/Program.cs
@@ -10,11 +10,10 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 
 builder.Configuration.AddJsonFile("appsettings.local.json", optional: true);
-builder.Logging.ClearProviders();
-builder.Logging.AddConsole();
 builder.Services.AddSingleton<DiscoveryService>()
                 .AddSingleton<ILnsDiscovery, TagBasedLnsDiscovery>()
-                .AddMemoryCache();
+                .AddMemoryCache()
+                .AddApplicationInsightsTelemetry();
 
 var app = builder.Build();
 

--- a/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/Program.cs
+++ b/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/Program.cs
@@ -4,6 +4,7 @@
 using LoRaTools.NetworkServerDiscovery;
 using LoRaWan;
 using LoRaWan.NetworkServerDiscovery;
+using Prometheus;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -30,5 +31,7 @@ app.MapGet(ILnsDiscovery.EndpointName, async (DiscoveryService discoveryService,
     catch (Exception ex) when (ExceptionFilterUtility.False(() => logger.LogError(ex, "Exception when executing discovery endpoint: '{Exception}'.", ex)))
     { }
 });
+
+app.MapMetrics();
 
 app.Run();

--- a/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/appsettings.json
+++ b/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/appsettings.json
@@ -3,6 +3,11 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "ApplicationInsights": {
+      "LogLevel": {
+        "Default": "Information"
+      }
     }
   },
   "ConnectionStrings": {


### PR DESCRIPTION
# PR for issue #1512

## What is being addressed

With this PR we introduce essential observability features to the standalone discovery service.
We:
- Ship metrics, logs and traces to AppInsights
- Expose ASP.NET Core standard metrics in Prometheus format (relevant for on-prem deployment)
- Make the log levels (AppInsights and Console) configurable via environment variables

Since the IoT Hub operations are executed via HTTP, the trace to IoT Hub works out of the box:

![image](https://user-images.githubusercontent.com/22341213/154635699-336de433-00e8-49df-9b34-06b9725e042a.png)
