### PR TITLE
Synchronize device operations

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/AsyncDisposable.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/AsyncDisposable.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaWan.NetworkServer
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal sealed class AsyncDisposable : IAsyncDisposable
+    {
+        public static readonly IAsyncDisposable Nop = new AsyncDisposable(_ => ValueTask.CompletedTask);
+
+        private Func<CancellationToken, ValueTask>? handler;
+
+        public AsyncDisposable(Func<CancellationToken, ValueTask> handler) => this.handler = handler;
+
+        public CancellationToken CancellationToken { get; set; }
+
+        public ValueTask DisposeAsync() =>
+            Interlocked.CompareExchange(ref this.handler, null, this.handler) is { } handler
+                ? handler(CancellationToken)
+                : ValueTask.CompletedTask;
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DefaultLoRaDataRequestHandler.cs
@@ -69,7 +69,7 @@ namespace LoRaWan.NetworkServer
             if (loRaDevice is null) throw new ArgumentNullException(nameof(loRaDevice));
 
             var timeWatcher = request.GetTimeWatcher();
-            using var deviceConnectionActivity = loRaDevice.BeginDeviceClientConnectionActivity();
+            await using var deviceConnectionActivity = loRaDevice.BeginDeviceClientConnectionActivity();
             if (deviceConnectionActivity == null)
             {
                 return new LoRaDeviceRequestProcessResult(loRaDevice, request, LoRaDeviceRequestFailedReason.DeviceClientConnectionFailed);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExclusiveProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExclusiveProcessor.cs
@@ -53,6 +53,8 @@ namespace LoRaWan.NetworkServer
 #pragma warning restore CA1062 // Validate arguments of public methods
         }
 
+#pragma warning restore CA1034 // Nested types should not be visible
+
         private sealed record ProcessingTaskOutcome<TResult> :
             ProcessingOutcome<Task<TResult>>,
             IProcessingOutcome
@@ -66,8 +68,6 @@ namespace LoRaWan.NetworkServer
 
             Task IProcessingOutcome.Task => Result;
         }
-
-#pragma warning restore CA1034 // Nested types should not be visible
 
         public async Task<ProcessingOutcome<TResult>> ProcessAsync<TResult>(T processor, Func<Task<TResult>> function)
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExclusiveProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExclusiveProcessor.cs
@@ -78,7 +78,7 @@ namespace LoRaWan.NetworkServer
 
         public async Task<ProcessingOutcome<Task<TResult>>> TryProcessAsync<TResult>(T processor, Func<Task<TResult>> function)
         {
-            if (function == null) throw new ArgumentNullException(nameof(function));
+            ArgumentNullException.ThrowIfNull(function, nameof(function));
 
             var submissionTime = DateTimeOffset.Now;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExclusiveProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExclusiveProcessor.cs
@@ -94,7 +94,7 @@ namespace LoRaWan.NetworkServer
         {
             ArgumentNullException.ThrowIfNull(function, nameof(function));
 
-            var submissionTime = DateTimeOffset.Now;
+            var submissionTime = DateTime.UtcNow;
 
             lock (this.queue)
                 this.queue.Add(processor);
@@ -125,9 +125,9 @@ namespace LoRaWan.NetworkServer
                     else
                     {
                         Processing?.Invoke(this, processor);
-                        var startTime = DateTimeOffset.Now;
+                        var startTime = DateTime.UtcNow;
                         var task = await Task.WhenAny(function());
-                        var endTime = DateTimeOffset.Now;
+                        var endTime = DateTime.UtcNow;
                         var outcome = new ProcessingTaskOutcome<TResult>(task, submissionTime, startTime - submissionTime, endTime - startTime);
                         Processed?.Invoke(this, (processor, outcome));
                         return outcome;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExclusiveProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExclusiveProcessor.cs
@@ -19,6 +19,7 @@ namespace LoRaWan.NetworkServer
         private readonly SemaphoreSlim processingLock = new(1);
         private readonly List<T> queue = new();
 
+        public event EventHandler<T>? Submitted;
         public event EventHandler<(T InterruptedProcessor, T InterruptingProcessor)>? Interrupted;
         public event EventHandler<T>? Processing;
         public event EventHandler<(T Processor, IProcessingOutcome Outcome)>? Processed;
@@ -83,6 +84,8 @@ namespace LoRaWan.NetworkServer
 
             lock (this.queue)
                 this.queue.Add(processor);
+
+            Submitted?.Invoke(this, processor);
 
             while (true)
             {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExclusiveProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExclusiveProcessor.cs
@@ -21,7 +21,7 @@ namespace LoRaWan.NetworkServer
 
         public event EventHandler<(T InterruptedProcessor, T InterruptingProcessor)>? Interrupted;
         public event EventHandler<T>? Processing;
-        public event EventHandler<IProcessingOutcome>? Processed;
+        public event EventHandler<(T Processor, IProcessingOutcome Outcome)>? Processed;
 
         public ExclusiveProcessor() : this(ps => ps[0]) { }
 
@@ -112,7 +112,7 @@ namespace LoRaWan.NetworkServer
                         var task = await Task.WhenAny(function());
                         var endTime = DateTimeOffset.Now;
                         var outcome = new ProcessingTaskOutcome<TResult>(task, submissionTime, startTime - submissionTime, endTime - startTime);
-                        Processed?.Invoke(this, outcome);
+                        Processed?.Invoke(this, (processor, outcome));
                         return outcome;
                     }
                 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExclusiveProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ExclusiveProcessor.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+#pragma warning disable CA1003 // Use generic event handler instances (suppressed for performance)
+
+namespace LoRaWan.NetworkServer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public sealed class ExclusiveProcessor<T>
+    {
+        private readonly Func<IReadOnlyList<T>, T> scheduler;
+        private readonly IEqualityComparer<T> comparer;
+        private readonly SemaphoreSlim processingLock = new(1);
+        private readonly List<T> queue = new();
+
+        public event EventHandler<(T InterruptedProcessor, T InterruptingProcessor)>? Interrupted;
+        public event EventHandler<T>? Processing;
+        public event EventHandler<IProcessingOutcome>? Processed;
+
+        public ExclusiveProcessor() : this(ps => ps[0]) { }
+
+        public ExclusiveProcessor(Func<IReadOnlyList<T>, T> scheduler) : this(scheduler, null) { }
+
+        public ExclusiveProcessor(Func<IReadOnlyList<T>, T> scheduler, IEqualityComparer<T>? comparer)
+        {
+            this.scheduler = scheduler;
+            this.comparer = comparer ?? EqualityComparer<T>.Default;
+        }
+
+#pragma warning disable CA1034 // Nested types should not be visible (by design)
+
+        public interface IProcessingOutcome
+        {
+            Task Task { get; }
+            DateTimeOffset SubmissionTime { get; }
+            TimeSpan WaitDuration { get; }
+            TimeSpan RunDuration { get; }
+        }
+
+        public record ProcessingOutcome<TResult>(TResult Result,
+                                                 DateTimeOffset SubmissionTime,
+                                                 TimeSpan WaitDuration,
+                                                 TimeSpan RunDuration)
+        {
+#pragma warning disable CA1062 // Validate arguments of public methods (operators don't usually throw)
+            public static implicit operator TResult(ProcessingOutcome<TResult> outcome) => outcome.Result;
+#pragma warning restore CA1062 // Validate arguments of public methods
+        }
+
+        private sealed record ProcessingTaskOutcome<TResult> :
+            ProcessingOutcome<Task<TResult>>,
+            IProcessingOutcome
+        {
+            public ProcessingTaskOutcome(Task<TResult> task,
+                                         DateTimeOffset submissionTime,
+                                         TimeSpan waitDuration,
+                                         TimeSpan runDuration) :
+                base(task, submissionTime, waitDuration, runDuration)
+            { }
+
+            Task IProcessingOutcome.Task => Result;
+        }
+
+#pragma warning restore CA1034 // Nested types should not be visible
+
+        public async Task<ProcessingOutcome<TResult>> ProcessAsync<TResult>(T processor, Func<Task<TResult>> function)
+        {
+            var outcome = await TryProcessAsync(processor, function);
+            return new ProcessingOutcome<TResult>(await outcome.Result, outcome.SubmissionTime, outcome.WaitDuration, outcome.RunDuration);
+        }
+
+        public async Task<ProcessingOutcome<Task<TResult>>> TryProcessAsync<TResult>(T processor, Func<Task<TResult>> function)
+        {
+            if (function == null) throw new ArgumentNullException(nameof(function));
+
+            var submissionTime = DateTimeOffset.Now;
+
+            lock (this.queue)
+                this.queue.Add(processor);
+
+            while (true)
+            {
+                await this.processingLock.WaitAsync();
+
+                try
+                {
+                    (bool, T) next = default;
+
+                    lock (this.queue)
+                    {
+                        var nextProcessor = this.scheduler(this.queue);
+                        if (!this.comparer.Equals(nextProcessor, processor))
+                            next = (true, nextProcessor);
+                        else
+                            _ = this.queue.Remove(processor);
+                    }
+
+                    if (next is (true, { } someNextProcessor))
+                    {
+                        Interrupted?.Invoke(this, (processor, someNextProcessor));
+                    }
+                    else
+                    {
+                        Processing?.Invoke(this, processor);
+                        var startTime = DateTimeOffset.Now;
+                        var task = await Task.WhenAny(function());
+                        var endTime = DateTimeOffset.Now;
+                        var outcome = new ProcessingTaskOutcome<TResult>(task, submissionTime, startTime - submissionTime, endTime - startTime);
+                        Processed?.Invoke(this, outcome);
+                        return outcome;
+                    }
+                }
+                finally
+                {
+                    _ = this.processingLock.Release();
+                }
+            }
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClient.cs
@@ -54,7 +54,7 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Disconnects device client.
         /// </summary>
-        bool Disconnect();
+        Task DisconnectAsync();
 
         /// <summary>
         /// Ensures the device client is connected.

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClientConnectionManager.cs
@@ -6,7 +6,6 @@
 namespace LoRaWan.NetworkServer
 {
     using System;
-    using System.Threading.Tasks;
 
     public interface ILoRaDeviceClientConnectionManager : IDisposable
     {
@@ -16,22 +15,6 @@ namespace LoRaWan.NetworkServer
 
         void Register(LoRaDevice loRaDevice, ILoRaDeviceClient loraDeviceClient);
 
-        Task<T> UseAsync<T>(DevEui devEui, Func<ILoRaDeviceClient, Task<T>> processor);
-
         IAsyncDisposable ReserveConnection(DevEui devEui);
-    }
-
-    public static class LoRaDeviceClientConnectionManagerExtensions
-    {
-        public static Task UseAsync(this ILoRaDeviceClientConnectionManager connectionManager, DevEui devEui, Func<ILoRaDeviceClient, Task> processor)
-        {
-            if (connectionManager == null) throw new ArgumentNullException(nameof(connectionManager));
-
-            return connectionManager.UseAsync(devEui, async client =>
-            {
-                await processor(client);
-                return 0;
-            });
-        }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClientConnectionManager.cs
@@ -15,6 +15,6 @@ namespace LoRaWan.NetworkServer
 
         void Register(LoRaDevice loRaDevice, ILoRaDeviceClient loraDeviceClient);
 
-        IAsyncDisposable BeginDeviceClientConnectionActivity(DevEui devEui);
+        IAsyncDisposable BeginDeviceClientConnectionActivity(LoRaDevice loRaDevice);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClientConnectionManager.cs
@@ -15,6 +15,6 @@ namespace LoRaWan.NetworkServer
 
         void Register(LoRaDevice loRaDevice, ILoRaDeviceClient loraDeviceClient);
 
-        IAsyncDisposable ReserveConnection(DevEui devEui);
+        IAsyncDisposable BeginDeviceClientConnectionActivity(DevEui devEui);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClientConnectionManager.cs
@@ -6,11 +6,7 @@
 namespace LoRaWan.NetworkServer
 {
     using System;
-    using System.Collections.Generic;
-    using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Devices.Client;
-    using Microsoft.Azure.Devices.Shared;
 
     public interface ILoRaDeviceClientConnectionManager : IDisposable
     {
@@ -36,132 +32,6 @@ namespace LoRaWan.NetworkServer
                 await processor(client);
                 return 0;
             });
-        }
-    }
-
-    public sealed partial class LoRaDeviceClientConnectionManager
-    {
-        public void Dispose()
-        {
-            foreach (var client in this.clientByDevEui.Values)
-                client.Dispose();
-        }
-
-        public Task<T> UseAsync<T>(DevEui devEui, Func<ILoRaDeviceClient, Task<T>> processor)
-        {
-            if (processor == null) throw new ArgumentNullException(nameof(processor));
-
-            ILoRaDeviceClient client;
-            lock (this.clientByDevEui)
-                client = this.clientByDevEui[devEui];
-            return processor(client);
-        }
-
-        public IAsyncDisposable ReserveConnection(DevEui devEui)
-        {
-            ILoRaDeviceClient client;
-            lock (this.clientByDevEui)
-                client = this.clientByDevEui[devEui];
-            return ((LoRaDeviceClient)client).BeginDeviceClientConnectionActivity();
-        }
-
-        private sealed class LoRaDeviceClient : ILoRaDeviceClient
-        {
-            private readonly LoRaDeviceClientConnectionManager connectionManager;
-            private readonly ILoRaDeviceClient client;
-            private readonly LoRaDevice device;
-            private int pid;
-            private readonly ExclusiveProcessor<int> exclusiveProcessor = new();
-            private bool shouldDisconnect;
-            private int activities;
-
-            public LoRaDeviceClient(LoRaDeviceClientConnectionManager connectionManager, ILoRaDeviceClient client, LoRaDevice device)
-            {
-                this.connectionManager = connectionManager;
-                this.client = client;
-                this.device = device;
-            }
-
-            public DevEui DevEui => this.device.DevEUI;
-            public TimeSpan KeepAliveTimeout => TimeSpan.FromSeconds(this.device.KeepAliveTimeout);
-
-            public void Dispose() => this.client?.Dispose();
-
-            private Task<T> InvokeExclusivelyAsync<T>(Func<ILoRaDeviceClient, Task<T>> processor) =>
-                InvokeExclusivelyAsync(doesNotRequireOpenConnection: false, processor);
-
-            private async Task<T> InvokeExclusivelyAsync<T>(bool doesNotRequireOpenConnection, Func<ILoRaDeviceClient, Task<T>> processor)
-            {
-                _ = Interlocked.Increment(ref this.pid);
-                return await this.exclusiveProcessor.ProcessAsync(this.pid, async () =>
-                {
-                    if (!doesNotRequireOpenConnection && this.device.KeepAliveTimeout > 0)
-                    {
-                        _ = EnsureConnected();
-                        this.connectionManager.SetupSchedule(this);
-                    }
-
-                    return await processor(this.client);
-                });
-            }
-
-            public Task<Twin> GetTwinAsync(CancellationToken cancellationToken) =>
-                InvokeExclusivelyAsync(client => client.GetTwinAsync(cancellationToken));
-
-            public Task<bool> SendEventAsync(LoRaDeviceTelemetry telemetry, Dictionary<string, string> properties) =>
-                InvokeExclusivelyAsync(client => client.SendEventAsync(telemetry, properties));
-
-            public Task<bool> UpdateReportedPropertiesAsync(TwinCollection reportedProperties, CancellationToken cancellationToken) =>
-                InvokeExclusivelyAsync(client => client.UpdateReportedPropertiesAsync(reportedProperties, cancellationToken));
-
-            public Task<Message> ReceiveAsync(TimeSpan timeout) =>
-                InvokeExclusivelyAsync(client => client.ReceiveAsync(timeout));
-
-            public Task<bool> CompleteAsync(Message cloudToDeviceMessage) =>
-                InvokeExclusivelyAsync(client => client.CompleteAsync(cloudToDeviceMessage));
-
-            public Task<bool> AbandonAsync(Message cloudToDeviceMessage) =>
-                InvokeExclusivelyAsync(client => client.AbandonAsync(cloudToDeviceMessage));
-
-            public Task<bool> RejectAsync(Message cloudToDeviceMessage) =>
-                InvokeExclusivelyAsync(client => client.RejectAsync(cloudToDeviceMessage));
-
-            public bool EnsureConnected() =>
-                this.client.EnsureConnected();
-
-            public Task DisconnectAsync() =>
-                DisconnectAsync(deferred: false);
-
-            private enum DisconnectionResult { Disconnected, Deferred, AlreadyDisconnected }
-
-            private Task<DisconnectionResult> DisconnectAsync(bool deferred) =>
-                InvokeExclusivelyAsync(doesNotRequireOpenConnection: true, async client =>
-                {
-                    if (Interlocked.Add(ref this.activities, 0) > 0)
-                    {
-                        this.shouldDisconnect = true;
-                        return DisconnectionResult.Deferred;
-                    }
-
-                    if (deferred && !this.shouldDisconnect)
-                        return DisconnectionResult.AlreadyDisconnected;
-
-                    this.shouldDisconnect = false;
-                    await client.DisconnectAsync();
-                    return DisconnectionResult.Disconnected;
-                });
-
-            public IAsyncDisposable BeginDeviceClientConnectionActivity()
-            {
-                _ = Interlocked.Increment(ref this.activities);
-                return new AsyncDisposable(async cancellationToken =>
-                {
-                    if (Interlocked.Decrement(ref this.activities) > 0)
-                        return;
-
-                    _ = await DisconnectAsync(deferred: true);
-                });
-            }
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ILoRaDeviceClientConnectionManager.cs
@@ -1,18 +1,167 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 namespace LoRaWan.NetworkServer
 {
     using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Shared;
 
     public interface ILoRaDeviceClientConnectionManager : IDisposable
     {
-        bool EnsureConnected(LoRaDevice loRaDevice);
-
         ILoRaDeviceClient GetClient(LoRaDevice loRaDevice);
 
         void Release(LoRaDevice loRaDevice);
 
         void Register(LoRaDevice loRaDevice, ILoRaDeviceClient loraDeviceClient);
+
+        Task<T> UseAsync<T>(DevEui devEui, Func<ILoRaDeviceClient, Task<T>> processor);
+
+        IAsyncDisposable ReserveConnection(DevEui devEui);
+    }
+
+    public static class LoRaDeviceClientConnectionManagerExtensions
+    {
+        public static Task UseAsync(this ILoRaDeviceClientConnectionManager connectionManager, DevEui devEui, Func<ILoRaDeviceClient, Task> processor)
+        {
+            if (connectionManager == null) throw new ArgumentNullException(nameof(connectionManager));
+
+            return connectionManager.UseAsync(devEui, async client =>
+            {
+                await processor(client);
+                return 0;
+            });
+        }
+    }
+
+    public sealed partial class LoRaDeviceClientConnectionManager
+    {
+        public void Dispose()
+        {
+            foreach (var client in this.clientByDevEui.Values)
+                client.Dispose();
+        }
+
+        public Task<T> UseAsync<T>(DevEui devEui, Func<ILoRaDeviceClient, Task<T>> processor)
+        {
+            if (processor == null) throw new ArgumentNullException(nameof(processor));
+
+            ILoRaDeviceClient client;
+            lock (this.clientByDevEui)
+                client = this.clientByDevEui[devEui];
+            return processor(client);
+        }
+
+        public IAsyncDisposable ReserveConnection(DevEui devEui)
+        {
+            ILoRaDeviceClient client;
+            lock (this.clientByDevEui)
+                client = this.clientByDevEui[devEui];
+            return ((LoRaDeviceClient)client).BeginDeviceClientConnectionActivity();
+        }
+
+        private sealed class LoRaDeviceClient : ILoRaDeviceClient
+        {
+            private readonly LoRaDeviceClientConnectionManager connectionManager;
+            private readonly ILoRaDeviceClient client;
+            private readonly LoRaDevice device;
+            private int pid;
+            private readonly ExclusiveProcessor<int> exclusiveProcessor = new();
+            private bool shouldDisconnect;
+            private int activities;
+
+            public LoRaDeviceClient(LoRaDeviceClientConnectionManager connectionManager, ILoRaDeviceClient client, LoRaDevice device)
+            {
+                this.connectionManager = connectionManager;
+                this.client = client;
+                this.device = device;
+            }
+
+            public DevEui DevEui => this.device.DevEUI;
+            public TimeSpan KeepAliveTimeout => TimeSpan.FromSeconds(this.device.KeepAliveTimeout);
+
+            public void Dispose() => this.client?.Dispose();
+
+            private Task<T> InvokeExclusivelyAsync<T>(Func<ILoRaDeviceClient, Task<T>> processor) =>
+                InvokeExclusivelyAsync(false, processor);
+
+            private async Task<T> InvokeExclusivelyAsync<T>(bool isConnectionRequired, Func<ILoRaDeviceClient, Task<T>> processor)
+            {
+                _ = Interlocked.Increment(ref this.pid);
+                return await this.exclusiveProcessor.ProcessAsync(this.pid, async () =>
+                {
+                    if (isConnectionRequired)
+                    {
+                        _ = EnsureConnected();
+                        this.connectionManager.SetupSchedule(this);
+                    }
+
+                    return await processor(this.client);
+                });
+            }
+
+            public Task<Twin> GetTwinAsync(CancellationToken cancellationToken) =>
+                InvokeExclusivelyAsync(client => client.GetTwinAsync(cancellationToken));
+
+            public Task<bool> SendEventAsync(LoRaDeviceTelemetry telemetry, Dictionary<string, string> properties) =>
+                InvokeExclusivelyAsync(client => client.SendEventAsync(telemetry, properties));
+
+            public Task<bool> UpdateReportedPropertiesAsync(TwinCollection reportedProperties, CancellationToken cancellationToken) =>
+                InvokeExclusivelyAsync(client => client.UpdateReportedPropertiesAsync(reportedProperties, cancellationToken));
+
+            public Task<Message> ReceiveAsync(TimeSpan timeout) =>
+                InvokeExclusivelyAsync(client => client.ReceiveAsync(timeout));
+
+            public Task<bool> CompleteAsync(Message cloudToDeviceMessage) =>
+                InvokeExclusivelyAsync(client => client.CompleteAsync(cloudToDeviceMessage));
+
+            public Task<bool> AbandonAsync(Message cloudToDeviceMessage) =>
+                InvokeExclusivelyAsync(client => client.AbandonAsync(cloudToDeviceMessage));
+
+            public Task<bool> RejectAsync(Message cloudToDeviceMessage) =>
+                InvokeExclusivelyAsync(client => client.RejectAsync(cloudToDeviceMessage));
+
+            public bool EnsureConnected() =>
+                this.client.EnsureConnected();
+
+            public Task DisconnectAsync() =>
+                DisconnectAsync(deferred: false);
+
+            private enum DisconnectionResult { Disconnected, Deferred, AlreadyDisconnected }
+
+            private Task<DisconnectionResult> DisconnectAsync(bool deferred) =>
+                InvokeExclusivelyAsync(isConnectionRequired: false, async client =>
+                {
+                    if (Interlocked.Add(ref this.activities, 0) > 0)
+                    {
+                        this.shouldDisconnect = true;
+                        return DisconnectionResult.Deferred;
+                    }
+
+                    if (deferred && !this.shouldDisconnect)
+                        return DisconnectionResult.AlreadyDisconnected;
+
+                    this.shouldDisconnect = false;
+                    await client.DisconnectAsync();
+                    return DisconnectionResult.Disconnected;
+                });
+
+            public IAsyncDisposable BeginDeviceClientConnectionActivity()
+            {
+                _ = Interlocked.Increment(ref this.activities);
+                return new AsyncDisposable(async cancellationToken =>
+                {
+                    if (Interlocked.Decrement(ref this.activities) > 0)
+                        return;
+
+                    _ = await DisconnectAsync(deferred: true);
+                });
+            }
+        }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -633,17 +633,12 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Ensures that the device is connected. Calls the connection manager that keeps track of device connection lifetime.
         /// </summary>
-        internal virtual IAsyncDisposable BeginDeviceClientConnectionActivity()
-        {
+        internal virtual IAsyncDisposable BeginDeviceClientConnectionActivity() =>
             // Most devices won't have a connection timeout
             // In that case check without lock and return a cached disposable
-            if (KeepAliveTimeout == 0)
-            {
-                return AsyncDisposable.Nop;
-            }
-
-            return this.connectionManager.BeginDeviceClientConnectionActivity(this);
-        }
+            KeepAliveTimeout == 0
+                ? AsyncDisposable.Nop
+                : this.connectionManager.BeginDeviceClientConnectionActivity(this);
 
         /// <summary>
         /// Indicates whether or not we can resubmit an ack for the confirmation up message.

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -487,7 +487,7 @@ namespace LoRaWan.NetworkServer
                         return false;
                     }
 
-                    var result = await ProcessAsync(client => client.UpdateReportedPropertiesAsync(reportedProperties, default));
+                    var result = await Client.UpdateReportedPropertiesAsync(reportedProperties, default);
                     if (result)
                     {
                         InternalAcceptFrameCountChanges(savedFcntUp, savedFcntDown);
@@ -672,18 +672,17 @@ namespace LoRaWan.NetworkServer
             }
         }
 
-        private Task<T> ProcessAsync<T>(Func<ILoRaDeviceClient, Task<T>> processor) =>
-            this.connectionManager.UseAsync(DevEUI, processor);
+        private ILoRaDeviceClient Client => this.connectionManager.GetClient(this);
 
-        public Task<bool> SendEventAsync(LoRaDeviceTelemetry telemetry, Dictionary<string, string> properties = null) => ProcessAsync(client => client.SendEventAsync(telemetry, properties));
+        public Task<bool> SendEventAsync(LoRaDeviceTelemetry telemetry, Dictionary<string, string> properties = null) => Client.SendEventAsync(telemetry, properties);
 
-        public Task<Message> ReceiveCloudToDeviceAsync(TimeSpan timeout) => ProcessAsync(client => client.ReceiveAsync(timeout));
+        public Task<Message> ReceiveCloudToDeviceAsync(TimeSpan timeout) => Client.ReceiveAsync(timeout);
 
-        public Task<bool> CompleteCloudToDeviceMessageAsync(Message cloudToDeviceMessage) => ProcessAsync(client => client.CompleteAsync(cloudToDeviceMessage));
+        public Task<bool> CompleteCloudToDeviceMessageAsync(Message cloudToDeviceMessage) => Client.CompleteAsync(cloudToDeviceMessage);
 
-        public Task<bool> AbandonCloudToDeviceMessageAsync(Message cloudToDeviceMessage) => ProcessAsync(client => client.AbandonAsync(cloudToDeviceMessage));
+        public Task<bool> AbandonCloudToDeviceMessageAsync(Message cloudToDeviceMessage) => Client.AbandonAsync(cloudToDeviceMessage);
 
-        public Task<bool> RejectCloudToDeviceMessageAsync(Message cloudToDeviceMessage) => ProcessAsync(client => client.RejectAsync(cloudToDeviceMessage));
+        public Task<bool> RejectCloudToDeviceMessageAsync(Message cloudToDeviceMessage) => Client.RejectAsync(cloudToDeviceMessage);
 
         /// <summary>
         /// Updates device on the server after a join succeeded.
@@ -771,7 +770,7 @@ namespace LoRaWan.NetworkServer
             }
 
             var devAddrBeforeSave = DevAddr;
-            var succeeded = await ProcessAsync(client => client.UpdateReportedPropertiesAsync(reportedProperties, cancellationToken));
+            var succeeded = await Client.UpdateReportedPropertiesAsync(reportedProperties, cancellationToken);
 
             // Only save if the devAddr remains the same, otherwise ignore the save
             if (succeeded && devAddrBeforeSave == DevAddr)

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -642,7 +642,7 @@ namespace LoRaWan.NetworkServer
                 return AsyncDisposable.Nop;
             }
 
-            return this.connectionManager.ReserveConnection(DevEUI);
+            return this.connectionManager.BeginDeviceClientConnectionActivity(DevEUI);
         }
 
         /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -642,7 +642,7 @@ namespace LoRaWan.NetworkServer
                 return AsyncDisposable.Nop;
             }
 
-            return this.connectionManager.BeginDeviceClientConnectionActivity(DevEUI);
+            return this.connectionManager.BeginDeviceClientConnectionActivity(this);
         }
 
         /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceCache.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceCache.cs
@@ -113,7 +113,7 @@ namespace LoRaWan.NetworkServer
         protected virtual async Task RefreshDeviceAsync(LoRaDevice device, CancellationToken cancellationToken)
         {
             _ = device ?? throw new ArgumentNullException(nameof(device));
-            using (device.BeginDeviceClientConnectionActivity())
+            await using (device.BeginDeviceClientConnectionActivity())
                 _ = await device.InitializeAsync(this.configuration, cancellationToken);
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClient.cs
@@ -219,11 +219,11 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Disconnects device client.
         /// </summary>
-        public bool Disconnect()
+        public async Task DisconnectAsync()
         {
             if (this.deviceClient != null)
             {
-                this.deviceClient.Dispose();
+                await this.deviceClient.DisposeAsync();
                 this.deviceClient = null;
 
                 this.logger.LogDebug("device client disconnected");
@@ -232,8 +232,6 @@ namespace LoRaWan.NetworkServer
             {
                 this.logger.LogDebug("device client was already disconnected");
             }
-
-            return true;
         }
 
         /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -62,7 +62,7 @@ namespace LoRaWan.NetworkServer
                 {
                     var keepAliveTimeout = client.KeepAliveTimeout;
                     ce.SlidingExpiration = keepAliveTimeout;
-                    _ = ce.RegisterPostEvictionCallback((_, value, _, _) => _ = ((LoRaDeviceClient)value).DisconnectAsync());
+                    _ = ce.RegisterPostEvictionCallback(static (_, value, _, _) => _ = ((LoRaDeviceClient)value).DisconnectAsync());
                     this.logger.LogDebug($"client connection timeout set to {keepAliveTimeout.TotalSeconds} seconds (sliding expiration)");
                     return client;
                 });

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -23,7 +23,7 @@ namespace LoRaWan.NetworkServer
     {
         private readonly IMemoryCache cache;
         private readonly ILoggerFactory? loggerFactory;
-        private readonly ILogger<LoRaDeviceClientConnectionManager> logger;
+        private readonly ILogger logger;
         private readonly ConcurrentDictionary<DevEui, SynchronizedLoRaDeviceClient> clientByDevEui = new();
 
         private record struct ScheduleKey(DevEui DevEui);
@@ -35,7 +35,7 @@ namespace LoRaWan.NetworkServer
 
         public LoRaDeviceClientConnectionManager(IMemoryCache cache,
                                                  ILoggerFactory? loggerFactory,
-                                                 ILogger<LoRaDeviceClientConnectionManager> logger)
+                                                 ILogger<ILoRaDeviceClientConnectionManager> logger)
         {
             this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
             this.loggerFactory = loggerFactory;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -256,6 +256,12 @@ namespace LoRaWan.NetworkServer
 
             private enum DisconnectionResult { Disconnected, Deferred, NotDisconnected }
 
+            /// <remarks>
+            /// This method is either called by an explicit call to <see cref="DisconnectAsync"/>
+            /// or when an activity is ending (when <see cref="isActivityEnding"/> is <c>true</c>)
+            /// to issue a disconnection if it was deferred and no other activities are
+            /// outstanding.
+            /// </remarks>
             private Task<DisconnectionResult> DisconnectAsync(bool isActivityEnding) =>
                 InvokeExclusivelyAsync(doesNotRequireOpenConnection: true, async client =>
                 {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 namespace LoRaWan.NetworkServer
 {
     using System;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -98,11 +98,6 @@ namespace LoRaWan.NetworkServer
                 client.Dispose();
         }
 
-        public Task<T> UseAsync<T>(DevEui devEui, Func<ILoRaDeviceClient, Task<T>> processor) =>
-            processor == null
-                ? throw new ArgumentNullException(nameof(processor))
-                : processor(this.clientByDevEui[devEui]);
-
         public IAsyncDisposable ReserveConnection(DevEui devEui) =>
             this.clientByDevEui[devEui].BeginDeviceClientConnectionActivity();
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -135,14 +135,12 @@ namespace LoRaWan.NetworkServer
                     this.exclusiveProcessor.Processing += (_, p) =>
                     {
                         var (id, name) = p;
-                        using var scope = someLogger.BeginDeviceScope(device.DevEUI);
                         someLogger.LogDebug(@"Invoking ""{Name}"" ({Id})", name, id);
                     };
 
                     this.exclusiveProcessor.Processed += (_, args) =>
                     {
                         var ((id, name), outcome) = args;
-                        using var scope = someLogger.BeginDeviceScope(device.DevEUI);
                         someLogger.LogDebug(@"Invoked ""{Name}"" ({Id}); status = {Status}, run-time = {RunTime}, wait-time = {WaitTime}",
                                             name, id, outcome.Task.Status, outcome.RunDuration, outcome.WaitDuration);
                     };
@@ -150,7 +148,6 @@ namespace LoRaWan.NetworkServer
                     this.exclusiveProcessor.Interrupted += (_, p) =>
                     {
                         var (interrupted, interrupting) = p;
-                        using var scope = someLogger.BeginDeviceScope(device.DevEUI);
                         someLogger.LogDebug(@"Interrupted ""{Name}"" ({Id}) by {InterruptingName} ({InterruptingId})",
                                             interrupted.Name, interrupted.Id,
                                             interrupting.Name, interrupting.Id);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -109,8 +109,11 @@ namespace LoRaWan.NetworkServer
                 client.Dispose();
         }
 
-        public IAsyncDisposable BeginDeviceClientConnectionActivity(DevEui devEui) =>
-            this.clientByDevEui[devEui].BeginDeviceClientConnectionActivity();
+        public IAsyncDisposable BeginDeviceClientConnectionActivity(LoRaDevice loRaDevice)
+        {
+            if (loRaDevice == null) throw new ArgumentNullException(nameof(loRaDevice));
+            return this.clientByDevEui[loRaDevice.DevEUI].BeginDeviceClientConnectionActivity();
+        }
 
         private sealed class SynchronizedLoRaDeviceClient : ILoRaDeviceClient
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -145,7 +145,7 @@ namespace LoRaWan.NetworkServer
             private readonly ILoRaDeviceClient client;
             private readonly LoRaDevice device;
             private readonly ILogger? logger;
-            private int pid;
+            private int operationSequenceNumber;
             private readonly ExclusiveProcessor<Process> exclusiveProcessor = new();
             private bool disconnectedDuringActivity;
             private int activities;
@@ -204,8 +204,8 @@ namespace LoRaWan.NetworkServer
                                                             Func<ILoRaDeviceClient, Task<T>> processor,
                                                             [CallerMemberName] string? callerName = null)
             {
-                _ = Interlocked.Increment(ref this.pid);
-                return await this.exclusiveProcessor.ProcessAsync(new Process(this.pid, callerName!), async () =>
+                _ = Interlocked.Increment(ref this.operationSequenceNumber);
+                return await this.exclusiveProcessor.ProcessAsync(new Process(this.operationSequenceNumber, callerName!), async () =>
                 {
                     if (!doesNotRequireOpenConnection)
                         _ = EnsureConnected();

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -17,17 +17,6 @@ namespace LoRaWan.NetworkServer
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
 
-#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-    public sealed record LoRaDeviceClientSynchronizedEventArgs(int Id, string Name);
-#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
-
-    public interface ILoRaDeviceClientSynchronizedEventSource
-    {
-        event EventHandler<LoRaDeviceClientSynchronizedEventArgs> Queued;
-        event EventHandler<LoRaDeviceClientSynchronizedEventArgs> Processing;
-        event EventHandler<LoRaDeviceClientSynchronizedEventArgs> Processed;
-    }
-
     /// <summary>
     /// Manages <see cref="ILoRaDeviceClient"/> connections for <see cref="LoRaDevice"/>.
     /// </summary>
@@ -388,5 +377,16 @@ namespace LoRaWan.NetworkServer
                 this.processedEventHandler?.Invoke(this, new LoRaDeviceClientSynchronizedEventArgs(id, name));
             }
         }
+    }
+
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+    public sealed record LoRaDeviceClientSynchronizedEventArgs(int Id, string Name);
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
+
+    public interface ILoRaDeviceClientSynchronizedEventSource
+    {
+        event EventHandler<LoRaDeviceClientSynchronizedEventArgs> Queued;
+        event EventHandler<LoRaDeviceClientSynchronizedEventArgs> Processing;
+        event EventHandler<LoRaDeviceClientSynchronizedEventArgs> Processed;
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -134,7 +134,7 @@ namespace LoRaWan.NetworkServer
             return this.clientByDevEui[loRaDevice.DevEUI].BeginDeviceClientConnectionActivity();
         }
 
-        private sealed class SynchronizedLoRaDeviceClient : ILoRaDeviceClient, ILoRaDeviceClientSynchronizedEventSource
+        private sealed class SynchronizedLoRaDeviceClient : ILoRaDeviceClient, ILoRaDeviceClientSynchronizedOperationEventSource
         {
             private readonly ILoRaDeviceClient client;
             private readonly LoRaDevice device;
@@ -307,11 +307,11 @@ namespace LoRaWan.NetworkServer
                 });
             }
 
-            private EventHandler<LoRaDeviceClientSynchronizedEventArgs>? submittedEventHandler;
-            private EventHandler<LoRaDeviceClientSynchronizedEventArgs>? processingEventHandler;
-            private EventHandler<LoRaDeviceClientSynchronizedEventArgs>? processedEventHandler;
+            private EventHandler<LoRaDeviceClientSynchronizedOperationEventArgs>? submittedEventHandler;
+            private EventHandler<LoRaDeviceClientSynchronizedOperationEventArgs>? processingEventHandler;
+            private EventHandler<LoRaDeviceClientSynchronizedOperationEventArgs>? processedEventHandler;
 
-            event EventHandler<LoRaDeviceClientSynchronizedEventArgs>? ILoRaDeviceClientSynchronizedEventSource.Queued
+            event EventHandler<LoRaDeviceClientSynchronizedOperationEventArgs>? ILoRaDeviceClientSynchronizedOperationEventSource.Queued
             {
                 add
                 {
@@ -330,9 +330,9 @@ namespace LoRaWan.NetworkServer
             }
 
             private void OnSubmitted(object? sender, Process process) =>
-                this.submittedEventHandler?.Invoke(this, new LoRaDeviceClientSynchronizedEventArgs(process.Id, process.Name));
+                this.submittedEventHandler?.Invoke(this, new LoRaDeviceClientSynchronizedOperationEventArgs(process.Id, process.Name));
 
-            event EventHandler<LoRaDeviceClientSynchronizedEventArgs>? ILoRaDeviceClientSynchronizedEventSource.Processing
+            event EventHandler<LoRaDeviceClientSynchronizedOperationEventArgs>? ILoRaDeviceClientSynchronizedOperationEventSource.Processing
             {
                 add
                 {
@@ -351,9 +351,9 @@ namespace LoRaWan.NetworkServer
             }
 
             private void OnProcessing(object? sender, Process process) =>
-                this.processingEventHandler?.Invoke(this, new LoRaDeviceClientSynchronizedEventArgs(process.Id, process.Name));
+                this.processingEventHandler?.Invoke(this, new LoRaDeviceClientSynchronizedOperationEventArgs(process.Id, process.Name));
 
-            event EventHandler<LoRaDeviceClientSynchronizedEventArgs>? ILoRaDeviceClientSynchronizedEventSource.Processed
+            event EventHandler<LoRaDeviceClientSynchronizedOperationEventArgs>? ILoRaDeviceClientSynchronizedOperationEventSource.Processed
             {
                 add
                 {
@@ -374,19 +374,19 @@ namespace LoRaWan.NetworkServer
             private void OnProcessed(object? sender, (Process, ExclusiveProcessor<Process>.IProcessingOutcome) args)
             {
                 var ((id, name), _) = args;
-                this.processedEventHandler?.Invoke(this, new LoRaDeviceClientSynchronizedEventArgs(id, name));
+                this.processedEventHandler?.Invoke(this, new LoRaDeviceClientSynchronizedOperationEventArgs(id, name));
             }
         }
     }
 
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-    public sealed record LoRaDeviceClientSynchronizedEventArgs(int Id, string Name);
+    public sealed record LoRaDeviceClientSynchronizedOperationEventArgs(int Id, string Name);
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 
-    public interface ILoRaDeviceClientSynchronizedEventSource
+    public interface ILoRaDeviceClientSynchronizedOperationEventSource
     {
-        event EventHandler<LoRaDeviceClientSynchronizedEventArgs> Queued;
-        event EventHandler<LoRaDeviceClientSynchronizedEventArgs> Processing;
-        event EventHandler<LoRaDeviceClientSynchronizedEventArgs> Processed;
+        event EventHandler<LoRaDeviceClientSynchronizedOperationEventArgs> Queued;
+        event EventHandler<LoRaDeviceClientSynchronizedOperationEventArgs> Processing;
+        event EventHandler<LoRaDeviceClientSynchronizedOperationEventArgs> Processed;
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -47,7 +47,7 @@ namespace LoRaWan.NetworkServer
 
             var loRaDeviceClient = new LoRaDeviceClient(loraDeviceClient, loRaDevice);
 
-            loRaDeviceClient.EnsureConnectedSuceeded += (sender, args) =>
+            loRaDeviceClient.EnsureConnectedSucceeded += (sender, args) =>
             {
                 var client = (LoRaDeviceClient)sender!;
 
@@ -121,7 +121,7 @@ namespace LoRaWan.NetworkServer
 
             public void Dispose() => this.client?.Dispose();
 
-            public event EventHandler? EnsureConnectedSuceeded;
+            public event EventHandler? EnsureConnectedSucceeded;
 
             private Task<T> InvokeExclusivelyAsync<T>(Func<ILoRaDeviceClient, Task<T>> processor) =>
                 InvokeExclusivelyAsync(doesNotRequireOpenConnection: false, processor);
@@ -163,7 +163,7 @@ namespace LoRaWan.NetworkServer
             {
                 var connected = this.client.EnsureConnected();
                 if (connected)
-                    EnsureConnectedSuceeded?.Invoke(this, EventArgs.Empty);
+                    EnsureConnectedSucceeded?.Invoke(this, EventArgs.Empty);
                 return connected;
             }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -212,7 +212,7 @@ namespace LoRaWan.NetworkServer
             public Task DisconnectAsync() =>
                 DisconnectAsync(deferred: false);
 
-            private enum DisconnectionResult { Disconnected, Deferred, AlreadyDisconnected }
+            private enum DisconnectionResult { Disconnected, Deferred, NotDisconnected }
 
             private Task<DisconnectionResult> DisconnectAsync(bool deferred) =>
                 InvokeExclusivelyAsync(doesNotRequireOpenConnection: true, async client =>
@@ -226,7 +226,7 @@ namespace LoRaWan.NetworkServer
                     }
                     else if (deferred && !this.shouldDisconnect)
                     {
-                        result = DisconnectionResult.AlreadyDisconnected;
+                        result = DisconnectionResult.NotDisconnected;
                     }
                     else
                     {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -136,7 +136,7 @@ namespace LoRaWan.NetworkServer
 
         public IAsyncDisposable BeginDeviceClientConnectionActivity(LoRaDevice loRaDevice)
         {
-            if (loRaDevice == null) throw new ArgumentNullException(nameof(loRaDevice));
+            ArgumentNullException.ThrowIfNull(loRaDevice, nameof(loRaDevice));
             return this.clientByDevEui[loRaDevice.DevEUI].BeginDeviceClientConnectionActivity();
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -213,8 +213,16 @@ namespace LoRaWan.NetworkServer
             public bool EnsureConnected()
             {
                 var connected = this.client.EnsureConnected();
+
+                if (this.logger?.IsEnabled(LogLevel.Debug) ?? false)
+                {
+                    const string message = $"{nameof(EnsureConnected)} = {{Connected}}";
+                    this.logger.LogDebug(message, connected);
+                }
+
                 if (connected)
                     EnsureConnectedSucceeded?.Invoke(this, EventArgs.Empty);
+
                 return connected;
             }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -109,7 +109,7 @@ namespace LoRaWan.NetworkServer
                 client.Dispose();
         }
 
-        public IAsyncDisposable ReserveConnection(DevEui devEui) =>
+        public IAsyncDisposable BeginDeviceClientConnectionActivity(DevEui devEui) =>
             this.clientByDevEui[devEui].BeginDeviceClientConnectionActivity();
 
         private sealed class SynchronizedLoRaDeviceClient : ILoRaDeviceClient

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -48,7 +48,7 @@ namespace LoRaWan.NetworkServer
         [ActivatorUtilitiesConstructor]
         public LoRaDeviceClientConnectionManager(IMemoryCache cache,
                                                  ILoggerFactory? loggerFactory,
-                                                 ILogger<ILoRaDeviceClientConnectionManager> logger)
+                                                 ILogger<LoRaDeviceClientConnectionManager> logger)
         {
             this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
             this.loggerFactory = loggerFactory;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -5,14 +5,18 @@ namespace LoRaWan.NetworkServer
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Caching.Memory;
     using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Manages <see cref="ILoRaDeviceClient"/> connections for <see cref="LoRaDevice"/>.
     /// </summary>
-    public sealed partial class LoRaDeviceClientConnectionManager : ILoRaDeviceClientConnectionManager
+    public sealed class LoRaDeviceClientConnectionManager : ILoRaDeviceClientConnectionManager
     {
         private readonly IMemoryCache cache;
         private readonly ILogger<LoRaDeviceClientConnectionManager> logger;
@@ -88,6 +92,129 @@ namespace LoRaWan.NetworkServer
         public void TryScanExpiredItems()
         {
             _ = this.cache.TryGetValue(string.Empty, out _);
+        }
+
+        public void Dispose()
+        {
+            foreach (var client in this.clientByDevEui.Values)
+                client.Dispose();
+        }
+
+        public Task<T> UseAsync<T>(DevEui devEui, Func<ILoRaDeviceClient, Task<T>> processor)
+        {
+            if (processor == null) throw new ArgumentNullException(nameof(processor));
+
+            ILoRaDeviceClient client;
+            lock (this.clientByDevEui)
+                client = this.clientByDevEui[devEui];
+            return processor(client);
+        }
+
+        public IAsyncDisposable ReserveConnection(DevEui devEui)
+        {
+            ILoRaDeviceClient client;
+            lock (this.clientByDevEui)
+                client = this.clientByDevEui[devEui];
+            return ((LoRaDeviceClient)client).BeginDeviceClientConnectionActivity();
+        }
+
+        private sealed class LoRaDeviceClient : ILoRaDeviceClient
+        {
+            private readonly LoRaDeviceClientConnectionManager connectionManager;
+            private readonly ILoRaDeviceClient client;
+            private readonly LoRaDevice device;
+            private int pid;
+            private readonly ExclusiveProcessor<int> exclusiveProcessor = new();
+            private bool shouldDisconnect;
+            private int activities;
+
+            public LoRaDeviceClient(LoRaDeviceClientConnectionManager connectionManager, ILoRaDeviceClient client, LoRaDevice device)
+            {
+                this.connectionManager = connectionManager;
+                this.client = client;
+                this.device = device;
+            }
+
+            public DevEui DevEui => this.device.DevEUI;
+            public TimeSpan KeepAliveTimeout => TimeSpan.FromSeconds(this.device.KeepAliveTimeout);
+
+            public void Dispose() => this.client?.Dispose();
+
+            private Task<T> InvokeExclusivelyAsync<T>(Func<ILoRaDeviceClient, Task<T>> processor) =>
+                InvokeExclusivelyAsync(doesNotRequireOpenConnection: false, processor);
+
+            private async Task<T> InvokeExclusivelyAsync<T>(bool doesNotRequireOpenConnection, Func<ILoRaDeviceClient, Task<T>> processor)
+            {
+                _ = Interlocked.Increment(ref this.pid);
+                return await this.exclusiveProcessor.ProcessAsync(this.pid, async () =>
+                {
+                    if (!doesNotRequireOpenConnection && this.device.KeepAliveTimeout > 0)
+                    {
+                        _ = EnsureConnected();
+                        this.connectionManager.SetupSchedule(this);
+                    }
+
+                    return await processor(this.client);
+                });
+            }
+
+            public Task<Twin> GetTwinAsync(CancellationToken cancellationToken) =>
+                InvokeExclusivelyAsync(client => client.GetTwinAsync(cancellationToken));
+
+            public Task<bool> SendEventAsync(LoRaDeviceTelemetry telemetry, Dictionary<string, string> properties) =>
+                InvokeExclusivelyAsync(client => client.SendEventAsync(telemetry, properties));
+
+            public Task<bool> UpdateReportedPropertiesAsync(TwinCollection reportedProperties, CancellationToken cancellationToken) =>
+                InvokeExclusivelyAsync(client => client.UpdateReportedPropertiesAsync(reportedProperties, cancellationToken));
+
+            public Task<Message> ReceiveAsync(TimeSpan timeout) =>
+                InvokeExclusivelyAsync(client => client.ReceiveAsync(timeout));
+
+            public Task<bool> CompleteAsync(Message cloudToDeviceMessage) =>
+                InvokeExclusivelyAsync(client => client.CompleteAsync(cloudToDeviceMessage));
+
+            public Task<bool> AbandonAsync(Message cloudToDeviceMessage) =>
+                InvokeExclusivelyAsync(client => client.AbandonAsync(cloudToDeviceMessage));
+
+            public Task<bool> RejectAsync(Message cloudToDeviceMessage) =>
+                InvokeExclusivelyAsync(client => client.RejectAsync(cloudToDeviceMessage));
+
+            public bool EnsureConnected() =>
+                this.client.EnsureConnected();
+
+            public Task DisconnectAsync() =>
+                DisconnectAsync(deferred: false);
+
+            private enum DisconnectionResult { Disconnected, Deferred, AlreadyDisconnected }
+
+            private Task<DisconnectionResult> DisconnectAsync(bool deferred) =>
+                InvokeExclusivelyAsync(doesNotRequireOpenConnection: true, async client =>
+                {
+                    if (Interlocked.Add(ref this.activities, 0) > 0)
+                    {
+                        this.shouldDisconnect = true;
+                        return DisconnectionResult.Deferred;
+                    }
+
+                    if (deferred && !this.shouldDisconnect)
+                        return DisconnectionResult.AlreadyDisconnected;
+
+                    this.shouldDisconnect = false;
+                    await client.DisconnectAsync();
+                    return DisconnectionResult.Disconnected;
+                });
+
+            public IAsyncDisposable BeginDeviceClientConnectionActivity()
+            {
+                _ = Interlocked.Increment(ref this.activities);
+                return new AsyncDisposable(async cancellationToken =>
+                {
+                    if (Interlocked.Decrement(ref this.activities) > 0)
+                        return;
+
+                    _ = await DisconnectAsync(deferred: true);
+                });
+            }
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -27,7 +27,13 @@ namespace LoRaWan.NetworkServer
         private readonly ILogger logger;
         private readonly ConcurrentDictionary<DevEui, SynchronizedLoRaDeviceClient> clientByDevEui = new();
 
-        private record struct ScheduleKey(DevEui DevEui);
+        /// <remarks>
+        /// This record could be a "record struct" but since it is used as a key in a
+        /// <see cref="IMemoryCache"/>, which treats all keys as objects, it will always get boxed.
+        /// As a result, it might as well be kept as a reference to avoid superfluous allocations
+        /// (via unboxing and re-boxing).
+        /// </remarks>
+        private record ScheduleKey(DevEui DevEui);
 
         public LoRaDeviceClientConnectionManager(IMemoryCache cache,
                                                  ILogger<LoRaDeviceClientConnectionManager> logger) :

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -135,6 +135,12 @@ namespace LoRaWan.NetworkServer
 
                 if (logger is { } someLogger && someLogger.IsEnabled(LogLevel.Debug))
                 {
+                    this.exclusiveProcessor.Submitted += (_, p) =>
+                    {
+                        var (id, name) = p;
+                        someLogger.LogDebug(@"Queued ""{Name}"" ({Id})", name, id);
+                    };
+
                     this.exclusiveProcessor.Processing += (_, p) =>
                     {
                         var (id, name) = p;

--- a/Tests/Common/MessageProcessorMultipleGatewayBase.cs
+++ b/Tests/Common/MessageProcessorMultipleGatewayBase.cs
@@ -85,7 +85,7 @@ namespace LoRaWan.Tests.Common
                                                                           this.testOutputLoggerFactory.CreateLogger<DefaultLoRaDataRequestHandler>(),
                                                                           meter: null);
 
-            SecondConnectionManager = new LoRaDeviceClientConnectionManager(this.cache, this.testOutputLoggerFactory.CreateLogger<LoRaDeviceClientConnectionManager>());
+            SecondConnectionManager = new LoRaDeviceClientConnectionManager(this.cache, this.testOutputLoggerFactory, this.testOutputLoggerFactory.CreateLogger<LoRaDeviceClientConnectionManager>());
             SecondLoRaDeviceFactory = new TestLoRaDeviceFactory(SecondServerConfiguration, SecondLoRaDeviceClient.Object, SecondConnectionManager, DeviceCache, defaultRequestHandler);
         }
 

--- a/Tests/Common/MessageProcessorTestBase.cs
+++ b/Tests/Common/MessageProcessorTestBase.cs
@@ -86,7 +86,7 @@ namespace LoRaWan.Tests.Common
 
             LoRaDeviceClient = new Mock<ILoRaDeviceClient>();
             this.cache = new MemoryCache(new MemoryCacheOptions() { ExpirationScanFrequency = TimeSpan.FromSeconds(5) });
-            ConnectionManager = new LoRaDeviceClientConnectionManager(this.cache, this.testOutputLoggerFactory.CreateLogger<LoRaDeviceClientConnectionManager>());
+            ConnectionManager = new LoRaDeviceClientConnectionManager(this.cache, this.testOutputLoggerFactory, this.testOutputLoggerFactory.CreateLogger<LoRaDeviceClientConnectionManager>());
             ConcentratorDeduplication = new ConcentratorDeduplication(this.cache, this.testOutputLoggerFactory.CreateLogger<IConcentratorDeduplication>());
             RequestHandlerImplementation = new DefaultLoRaDataRequestHandler(ServerConfiguration,
                                                                              FrameCounterUpdateStrategyProvider,

--- a/Tests/Common/SingleDeviceConnectionManager.cs
+++ b/Tests/Common/SingleDeviceConnectionManager.cs
@@ -3,6 +3,8 @@
 
 namespace LoRaWan.Tests.Common
 {
+    using System;
+    using System.Threading.Tasks;
     using LoRaWan.NetworkServer;
 
     /// <summary>
@@ -17,12 +19,20 @@ namespace LoRaWan.Tests.Common
             this.singleDeviceClient = deviceClient;
         }
 
-        public bool EnsureConnected(LoRaDevice loRaDevice) => true;
-
         public ILoRaDeviceClient GetClient(LoRaDevice loRaDevice) => this.singleDeviceClient;
 
         public void Register(LoRaDevice loRaDevice, ILoRaDeviceClient loraDeviceClient)
         {
+        }
+
+        public Task<T> UseAsync<T>(DevEui devEui, Func<ILoRaDeviceClient, Task<T>> processor)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncDisposable ReserveConnection(DevEui devEui)
+        {
+            throw new NotImplementedException();
         }
 
         public void Release(LoRaDevice loRaDevice)

--- a/Tests/Common/SingleDeviceConnectionManager.cs
+++ b/Tests/Common/SingleDeviceConnectionManager.cs
@@ -24,7 +24,7 @@ namespace LoRaWan.Tests.Common
         {
         }
 
-        public IAsyncDisposable ReserveConnection(DevEui devEui)
+        public IAsyncDisposable BeginDeviceClientConnectionActivity(DevEui devEui)
         {
             throw new NotImplementedException();
         }

--- a/Tests/Common/SingleDeviceConnectionManager.cs
+++ b/Tests/Common/SingleDeviceConnectionManager.cs
@@ -24,7 +24,7 @@ namespace LoRaWan.Tests.Common
         {
         }
 
-        public IAsyncDisposable BeginDeviceClientConnectionActivity(DevEui devEui)
+        public IAsyncDisposable BeginDeviceClientConnectionActivity(LoRaDevice loRaDevice)
         {
             throw new NotImplementedException();
         }

--- a/Tests/Common/SingleDeviceConnectionManager.cs
+++ b/Tests/Common/SingleDeviceConnectionManager.cs
@@ -4,7 +4,6 @@
 namespace LoRaWan.Tests.Common
 {
     using System;
-    using System.Threading.Tasks;
     using LoRaWan.NetworkServer;
 
     /// <summary>
@@ -23,11 +22,6 @@ namespace LoRaWan.Tests.Common
 
         public void Register(LoRaDevice loRaDevice, ILoRaDeviceClient loraDeviceClient)
         {
-        }
-
-        public Task<T> UseAsync<T>(DevEui devEui, Func<ILoRaDeviceClient, Task<T>> processor)
-        {
-            return processor(this.singleDeviceClient);
         }
 
         public IAsyncDisposable ReserveConnection(DevEui devEui)

--- a/Tests/Common/SingleDeviceConnectionManager.cs
+++ b/Tests/Common/SingleDeviceConnectionManager.cs
@@ -27,7 +27,7 @@ namespace LoRaWan.Tests.Common
 
         public Task<T> UseAsync<T>(DevEui devEui, Func<ILoRaDeviceClient, Task<T>> processor)
         {
-            throw new NotImplementedException();
+            return processor(this.singleDeviceClient);
         }
 
         public IAsyncDisposable ReserveConnection(DevEui devEui)

--- a/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
+++ b/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
@@ -56,7 +56,7 @@ namespace LoRaWan.Tests.Integration
             this.testOutputLoggerFactory = new TestOutputLoggerFactory(testOutputHelper);
 
             this.cache = new MemoryCache(new MemoryCacheOptions());
-            this.connectionManager = new LoRaDeviceClientConnectionManager(this.cache, testOutputLoggerFactory.CreateLogger<LoRaDeviceClientConnectionManager>());
+            this.connectionManager = new LoRaDeviceClientConnectionManager(this.cache, this.testOutputLoggerFactory, this.testOutputLoggerFactory.CreateLogger<LoRaDeviceClientConnectionManager>());
             this.loRaDeviceFactory = new TestLoRaDeviceFactory(this.deviceClient.Object, this.deviceCache, this.connectionManager);
 
             this.loRaDeviceRegistry = new LoRaDeviceRegistry(this.serverConfiguration, this.cache, this.deviceApi.Object, this.loRaDeviceFactory, this.deviceCache);

--- a/Tests/Integration/DeduplicationStrategyIntegrationTests.cs
+++ b/Tests/Integration/DeduplicationStrategyIntegrationTests.cs
@@ -167,7 +167,7 @@ namespace LoRaWan.Tests.Integration
             {
 #pragma warning disable CA2000 // Dispose objects before losing scope (ownership transferred to caller)
                 var cache = EmptyMemoryCache();
-                var connectionManager = new LoRaDeviceClientConnectionManager(cache, new TestOutputLogger<LoRaDeviceClientConnectionManager>(this.testOutputHelper));
+                var connectionManager = new LoRaDeviceClientConnectionManager(cache, new TestOutputLoggerFactory(this.testOutputHelper), new TestOutputLogger<LoRaDeviceClientConnectionManager>(this.testOutputHelper));
                 var concentratorDeduplication = new ConcentratorDeduplication(cache, new TestOutputLogger<IConcentratorDeduplication>(this.testOutputHelper));
                 var requestHandler = CreateDefaultLoRaDataRequestHandler(networkServerConfiguration, frameCounterUpdateStrategyProvider, loRaDeviceApi, concentratorDeduplication);
                 var loRaDevice = TestUtils.CreateFromSimulatedDevice(this.simulatedDevice, connectionManager, requestHandler.Value);

--- a/Tests/Integration/KeepAliveConnectionTests.cs
+++ b/Tests/Integration/KeepAliveConnectionTests.cs
@@ -81,9 +81,9 @@ namespace LoRaWan.Tests.Integration
 
             // will disconnected client
             using var disconnectedEvent = new SemaphoreSlim(0, 1);
-            LoRaDeviceClient.Setup(x => x.Disconnect())
+            LoRaDeviceClient.Setup(x => x.DisconnectAsync())
                 .Callback(() => disconnectedEvent.Release())
-                .Returns(true);
+                .Returns(Task.CompletedTask);
 
             var cachedDevice = CreateLoRaDevice(simulatedDevice);
             cachedDevice.KeepAliveTimeout = 3;
@@ -137,13 +137,13 @@ namespace LoRaWan.Tests.Integration
 
             // will disconnected client
             using var disconnectedEvent = new SemaphoreSlim(0, 1);
-            LoRaDeviceClient.Setup(x => x.Disconnect())
+            LoRaDeviceClient.Setup(x => x.DisconnectAsync())
                 .Callback(() =>
                 {
                     disconnectedEvent.Release();
                     isDisconnected = true;
                 })
-                .Returns(true);
+                .Returns(Task.CompletedTask);
 
             var cachedDevice = CreateLoRaDevice(simulatedDevice);
             cachedDevice.KeepAliveTimeout = 3;
@@ -204,13 +204,13 @@ namespace LoRaWan.Tests.Integration
 
             // will disconnected client
             using var disconnectedEvent = new SemaphoreSlim(0, 1);
-            LoRaDeviceClient.Setup(x => x.Disconnect())
+            LoRaDeviceClient.Setup(x => x.DisconnectAsync())
                 .Callback(() =>
                 {
                     disconnectedEvent.Release();
                     isDisconnected = true;
                 })
-                .Returns(true);
+                .Returns(Task.CompletedTask);
 
             var cachedDevice = CreateLoRaDevice(simulatedDevice);
             cachedDevice.KeepAliveTimeout = 3;
@@ -241,7 +241,7 @@ namespace LoRaWan.Tests.Integration
 
             await EnsureDisconnectedAsync(disconnectedEvent);
 
-            LoRaDeviceClient.Verify(x => x.Disconnect(), Times.Exactly(2));
+            LoRaDeviceClient.Verify(x => x.DisconnectAsync(), Times.Exactly(2));
             LoRaDeviceClient.Verify(x => x.EnsureConnected(), Times.Exactly(2));
 
             LoRaDeviceClient.VerifyAll();
@@ -282,9 +282,9 @@ namespace LoRaWan.Tests.Integration
 
             // will disconnected client
             using var disconnectedEvent = new SemaphoreSlim(0, 1);
-            LoRaDeviceClient.Setup(x => x.Disconnect())
+            LoRaDeviceClient.Setup(x => x.DisconnectAsync())
                 .Callback(() => disconnectedEvent.Release())
-                .Returns(true);
+                .Returns(Task.CompletedTask);
 
             using var cache = NewMemoryCache();
             using var deviceRegistry = new LoRaDeviceRegistry(ServerConfiguration, cache, LoRaDeviceApi.Object, LoRaDeviceFactory, DeviceCache);
@@ -318,12 +318,12 @@ namespace LoRaWan.Tests.Integration
 
             // will disconnected client
             using var disconnectedEvent = new SemaphoreSlim(0, 1);
-            LoRaDeviceClient.Setup(x => x.Disconnect())
+            LoRaDeviceClient.Setup(x => x.DisconnectAsync())
                 .Callback(() =>
                 {
                     disconnectedEvent.Release();
                 })
-                .Returns(true);
+                .Returns(Task.CompletedTask);
 
             // will check client connection
             LoRaDeviceClient.Setup(x => x.EnsureConnected())

--- a/Tests/Integration/KeepAliveConnectionTests.cs
+++ b/Tests/Integration/KeepAliveConnectionTests.cs
@@ -242,8 +242,7 @@ namespace LoRaWan.Tests.Integration
             await EnsureDisconnectedAsync(disconnectedEvent);
 
             LoRaDeviceClient.Verify(x => x.DisconnectAsync(), Times.Exactly(2));
-            LoRaDeviceClient.Verify(x => x.EnsureConnected(), Times.Exactly(2));
-
+            LoRaDeviceClient.Verify(x => x.EnsureConnected(), Times.Exactly(2 * /* send + receive */ 2));
             LoRaDeviceClient.VerifyAll();
             LoRaDeviceApi.VerifyAll();
         }

--- a/Tests/Integration/ProcessingTests.cs
+++ b/Tests/Integration/ProcessingTests.cs
@@ -1290,8 +1290,8 @@ namespace LoRaWan.Tests.Integration
 
             deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(simulatedDevice.CreateABPTwin());
 
-            deviceClient.Setup(x => x.Disconnect())
-               .Returns(true);
+            deviceClient.Setup(x => x.DisconnectAsync())
+               .Returns(Task.CompletedTask);
 
             deviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                .ReturnsAsync((Message)null);

--- a/Tests/Integration/ProcessingTests.cs
+++ b/Tests/Integration/ProcessingTests.cs
@@ -1288,6 +1288,8 @@ namespace LoRaWan.Tests.Integration
             LoRaDeviceApi.Setup(x => x.SearchByDevAddrAsync(devAddr))
                 .ReturnsAsync(searchDevicesResult);
 
+            deviceClient.Setup(x => x.EnsureConnected()).Returns(true);
+
             deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(simulatedDevice.CreateABPTwin());
 
             deviceClient.Setup(x => x.DisconnectAsync())

--- a/Tests/Unit/NetworkServer/DeviceLoaderSynchronizerTest.cs
+++ b/Tests/Unit/NetworkServer/DeviceLoaderSynchronizerTest.cs
@@ -197,7 +197,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             loRaDeviceClient.Verify(x => x.GetTwinAsync(CancellationToken.None), Times.Never());
 
             // device should not be disconnected (was never connected)
-            loRaDeviceClient.Verify(x => x.Disconnect(), Times.Never());
+            loRaDeviceClient.Verify(x => x.DisconnectAsync(), Times.Never());
 
             // Device was searched by DevAddr
             apiService.VerifyAll();

--- a/Tests/Unit/NetworkServer/LoRaDeviceCacheTest.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceCacheTest.cs
@@ -24,14 +24,14 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var moqCallback = new Mock<Action<LoRaDevice>>();
             using var cache = new TestDeviceCache(moqCallback.Object, this.quickRefreshOptions, true);
             var deviceMock = CreateMockDevice();
-            var disposableMock = new Mock<IDisposable>();
+            var disposableMock = new Mock<IAsyncDisposable>();
             deviceMock.Setup(x => x.BeginDeviceClientConnectionActivity())
                       .Returns(disposableMock.Object);
             var device = deviceMock.Object;
             cache.Register(device);
             await cache.WaitForRefreshAsync(CancellationToken.None);
             moqCallback.Verify(x => x.Invoke(device));
-            disposableMock.Verify(x => x.Dispose(), Times.Once);
+            disposableMock.Verify(x => x.DisposeAsync(), Times.Once);
         }
 
         [Fact]

--- a/Tests/Unit/NetworkServer/LoRaDeviceClientConnectionManagerTests.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceClientConnectionManagerTests.cs
@@ -1,19 +1,48 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 namespace LoRaWan.Tests.Unit.NetworkServer
 {
     using System;
+    using System.IO;
     using System.Linq;
+    using System.Threading;
     using LoRaWan.NetworkServer;
     using LoRaWan.Tests.Common;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Caching.Memory;
-    using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
     using Xunit;
+    using Xunit.Abstractions;
 
-    public class LoRaDeviceClientConnectionManagerTests
+    public sealed class LoRaDeviceClientConnectionManagerTests : IDisposable
     {
+        private readonly MemoryCache cache;
+        private readonly LoRaDeviceClientConnectionManager subject;
+        private readonly TestOutputLoggerFactory loggerFactory;
+        private LoRaDevice? testDevice;
+
+        public LoRaDeviceClientConnectionManagerTests(ITestOutputHelper testOutputHelper)
+        {
+            this.cache = new MemoryCache(new MemoryCacheOptions());
+            this.loggerFactory = new TestOutputLoggerFactory(testOutputHelper);
+            var logger = new TestOutputLogger<LoRaDeviceClientConnectionManager>(testOutputHelper);
+            this.subject = new LoRaDeviceClientConnectionManager(this.cache, logger);
+        }
+
+        public void Dispose()
+        {
+            this.subject.Dispose();
+            this.testDevice?.Dispose();
+            this.cache.Dispose();
+            this.loggerFactory.Dispose();
+        }
+
+        private LoRaDevice TestDevice => this.testDevice ??= new LoRaDevice(null, new DevEui(42), null);
+
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
@@ -21,24 +50,24 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         public void When_Disposing_Should_Dispose_All_Managed_Connections(int numberOfDevices)
         {
             // arrange
-            using var cache = new MemoryCache(new MemoryCacheOptions());
-            using var connectionManager = new LoRaDeviceClientConnectionManager(cache, NullLogger<LoRaDeviceClientConnectionManager>.Instance);
 
             var deviceRegistrations =
                 Enumerable.Range(0, numberOfDevices)
-                          .Select(i => TestUtils.CreateFromSimulatedDevice(new SimulatedDevice(TestDeviceInfo.CreateABPDevice((uint)i)), connectionManager))
+                          .Select(i => TestUtils.CreateFromSimulatedDevice(new SimulatedDevice(TestDeviceInfo.CreateABPDevice((uint)i)), this.subject))
                           .Select(d => (d, new Mock<ILoRaDeviceClient>()))
                           .ToList();
 
             foreach (var (d, c) in deviceRegistrations)
             {
-                connectionManager.Register(d, c.Object);
+                this.subject.Register(d, c.Object);
             }
 
             // act
-            connectionManager.Dispose();
+
+            this.subject.Dispose();
 
             // assert
+
             foreach (var (_, c) in deviceRegistrations)
             {
                 c.Verify(client => client.Dispose(), Times.Exactly(1));
@@ -48,13 +77,80 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [Fact]
         public void When_Registering_Existing_Connection_Throws()
         {
-            // arrange
-            using var cache = new MemoryCache(new MemoryCacheOptions());
-            using var connectionManager = new LoRaDeviceClientConnectionManager(cache, NullLogger<LoRaDeviceClientConnectionManager>.Instance);
+            var device = TestDevice;
+            this.subject.Register(device, new Mock<ILoRaDeviceClient>().Object);
+            Assert.Throws<InvalidOperationException>(() => this.subject.Register(device, new Mock<ILoRaDeviceClient>().Object));
+        }
 
-            using var loraDevice = new LoRaDevice(null, new DevEui(0), null);
-            connectionManager.Register(loraDevice, new Mock<ILoRaDeviceClient>().Object);
-            Assert.Throws<InvalidOperationException>(() => connectionManager.Register(loraDevice, new Mock<ILoRaDeviceClient>().Object));
+        [Fact]
+        public void GetClient_Returns_Registered_Client_Of_Device()
+        {
+            var device = TestDevice;
+            this.subject.Register(device, new Mock<ILoRaDeviceClient>().Object);
+            Assert.NotNull(this.subject.GetClient(device));
+        }
+
+        [Fact]
+        public void GetClient_Returns_Client_That_Invokes_Underlying_Client()
+        {
+            // arrange
+
+            var device = TestDevice;
+            var clientMock = new Mock<ILoRaDeviceClient>();
+            this.subject.Register(device, clientMock.Object);
+            var client = this.subject.GetClient(device);
+
+            // act
+
+            client.GetTwinAsync(CancellationToken.None);
+
+            var telemetry = new LoRaDeviceTelemetry();
+            var properties = new System.Collections.Generic.Dictionary<string, string>();
+            client.SendEventAsync(telemetry, properties);
+
+            var reportedProperties = new TwinCollection();
+            client.UpdateReportedPropertiesAsync(reportedProperties, CancellationToken.None);
+
+            var timeout = TimeSpan.FromSeconds(5);
+            client.ReceiveAsync(timeout);
+
+            using var message = new Message(Stream.Null);
+            client.CompleteAsync(message);
+            client.AbandonAsync(message);
+            client.RejectAsync(message);
+
+            client.EnsureConnected();
+
+            // assert
+
+            clientMock.Verify(x => x.GetTwinAsync(CancellationToken.None), Times.Once);
+            clientMock.Verify(x => x.SendEventAsync(telemetry, properties), Times.Once);
+            clientMock.Verify(x => x.UpdateReportedPropertiesAsync(reportedProperties, CancellationToken.None), Times.Once);
+            clientMock.Verify(x => x.ReceiveAsync(timeout), Times.Once);
+            clientMock.Verify(x => x.CompleteAsync(message), Times.Once);
+            clientMock.Verify(x => x.AbandonAsync(message), Times.Once);
+            clientMock.Verify(x => x.RejectAsync(message), Times.Once);
+            clientMock.Verify(x => x.EnsureConnected(), Times.Exactly(8));
+        }
+
+        [Fact]
+        public void Client_DisconnectAsync_Does_Not_Invoke_EnsureConnected()
+        {
+            // arrange
+
+            var device = TestDevice;
+            var clientMock = new Mock<ILoRaDeviceClient>();
+            this.subject.Register(device, clientMock.Object);
+            var client = this.subject.GetClient(device);
+
+            // act
+
+            client.DisconnectAsync();
+
+            // assert
+
+            clientMock.Verify(x => x.DisconnectAsync(), Times.Once);
+            clientMock.Verify(x => x.EnsureConnected(), Times.Never);
         }
     }
 }

--- a/Tests/Unit/NetworkServer/LoRaDeviceClientConnectionManagerTests.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceClientConnectionManagerTests.cs
@@ -306,7 +306,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var queuedOperations = new List<(int Id, string Name)>();
             var completedOperations = new List<(int Id, string Name)>();
 
-            var eventSource = (ILoRaDeviceClientSynchronizedEventSource)client;
+            var eventSource = (ILoRaDeviceClientSynchronizedOperationEventSource)client;
             eventSource.Queued += (_, args) => queuedOperations.Add((args.Id, args.Name));
             eventSource.Processed += (_, args) => completedOperations.Add((args.Id, args.Name));
 

--- a/Tests/Unit/NetworkServer/LoRaDeviceClientConnectionManagerTests.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceClientConnectionManagerTests.cs
@@ -26,7 +26,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         private readonly Mock<IMemoryCache> cacheMock;
         private readonly LoRaDeviceClientConnectionManager subject;
         private readonly TestOutputLoggerFactory loggerFactory;
-        private readonly ILogger<ILoRaDeviceClientConnectionManager> logger;
+        private readonly ILogger<LoRaDeviceClientConnectionManager> logger;
         private LoRaDevice? testDevice;
 
         public LoRaDeviceClientConnectionManagerTests(ITestOutputHelper testOutputHelper)

--- a/Tests/Unit/NetworkServer/LoRaDeviceClientConnectionManagerTests.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceClientConnectionManagerTests.cs
@@ -41,7 +41,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // assert
             foreach (var (_, c) in deviceRegistrations)
             {
-                c.Verify(client => client.Dispose(), Times.Exactly(2));
+                c.Verify(client => client.Dispose(), Times.Exactly(1));
             }
         }
 

--- a/Tests/Unit/NetworkServer/LoRaDeviceRegistryTest.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceRegistryTest.cs
@@ -343,7 +343,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // Device should not be connected
             LoRaDeviceClient.VerifyAll();
             LoRaDeviceClient.Verify(x => x.GetTwinAsync(CancellationToken.None), Times.Never());
-            LoRaDeviceClient.Verify(x => x.Disconnect(), Times.Never());
+            LoRaDeviceClient.Verify(x => x.DisconnectAsync(), Times.Never());
 
             // device is in cache
             Assert.True(DeviceCache.TryGetForPayload(request1.Payload, out var loRaDevice));


### PR DESCRIPTION
# PR for issue #1501

## What is being addressed

- Synchronization of device operations over the connection
- Avoiding connection closes while the connection is in use by an operation

## How is this addressed

All device operations are synchronized such that only one operation uses the device connection at any given time. The way this is done is that `LoRaDeviceClientConnectionManager` wraps the original `ILoRaDeviceClient` implementation with one that synchronizes around each asynchronous operation such that only one executes at any given time. The private wrapper (called `SynchronizedLoRaDeviceClient`) is what's returned from the `GetClient` method. This strategy allowed most changes to be concentrated closest to the management of the client connection. The following asynchronous operations synchronized are:

- `GetTwinAsync`
- `SendEventAsync`
- `UpdateReportedPropertiesAsync`
- `ReceiveAsync`
- `CompleteAsync`
- `AbandonAsync`
- `RejectAsync`
- `DisconnectAsync` (used to synchronous previously)

The only synchronous method that's not synchronized with the above is `EnusureConnected` since it's not a true operation on the client connection (that is, one that _uses_ the underlying connection). Note also that `DisconnectAsync` used to synchronous previously, but is now asynchronous because it's synchronized with other operations of the client.

The actual synchronization code is implemented in a separate, general and and generic, class called `ExclusiveProcessor<>`. It simply creates a semaphore of 1 that can be awaited. It also raises a number of events that are used by `SynchronizedLoRaDeviceClient` for the purpose of logging. Below is a sample of what such logging looks like:

    Queued "GetTwinAsync" (1)
    Invoking "GetTwinAsync" (1)
    Invoked "GetTwinAsync" (1); status = RanToCompletion, run-time = 00:00:00.0195538, wait-time = 00:00:00.0055340
    Queued "DisconnectAsync" (2)
    Invoking "DisconnectAsync" (2)
    DisconnectAsync = Disconnected
    Invoked "DisconnectAsync" (2); status = RanToCompletion, run-time = 00:00:00.0063517, wait-time = 00:00:00.0001069

The most complex area of `SynchronizedLoRaDeviceClient` is with respect to disconnection and activity management. An _activity_ allows a client connection to be _reserved for multiple operations_. An activity is started via `BeginDeviceClientConnectionActivity` and `SynchronizedLoRaDeviceClient` keeps track of how many activities are outstanding. Each activity is represented by a disposable object, which when disposed, decrements the activity counter. While activities are outstanding on the client connection, calls to `DisconnectAsync` are deferred until the activity counter drops to zero and then a single disconnection is issued to the actual and underlying/wrapped client connection. The activity design used to exist on `LoRaDevice` previously, but is now moved into `SynchronizedLoRaDeviceClient` where it's easier to manage and reason about in one place.

`SynchronizedLoRaDeviceClient` also calls `EnsureConnected` for all asynchronous operations except `DisconnectAsync`. If `EnsureConnected` succeeds, the client is cached with a sliding expiration where it will be disconnected at the time of cache entry eviction. Again, if there are outstanding activities then this disconnection will be deferred until all activities have ended (via disposal of the activity object).

## ~~Pending work~~

The following work is pending before this PR can be put out of draft:

- [x] Address ABP E2E tests that are failing (currently only `LoRaWan.Tests.E2E.ABPTest.Test_ABP_Device_With_Connection_Timeout`)
- [x] Add unit tests (to the extent possible) to exercise the new synchronized operations and deferred disconnection when activities are outstanding
- [x] Re-work some of the tests removed on `LoRaDevice` because the functionality has been moved into `LoRaDeviceClientConnectionManager` and `SynchronizedLoRaDeviceClient`.
