### PR TITLE
Improve discovery misconfiguration error messages

### DIFF
--- a/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/TagBasedLnsDiscovery.cs
+++ b/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/TagBasedLnsDiscovery.cs
@@ -27,13 +27,12 @@ namespace LoRaWan.NetworkServerDiscovery
         private static readonly IJsonReader<LnsHostAddressParseResult> HostAddressReader =
             JsonReader.Object(JsonReader.Property("hostAddress",
                                                   from s in JsonReader.String()
-                                                  select Uri.TryCreate(s, default, out var uri) ? uri : null,
+                                                  select Uri.TryCreate(s, UriKind.Absolute, out var uri)
+                                                      && uri.Scheme is "ws" or "wss"
+                                                       ? uri : null,
                                                   (true, null)),
                               JsonReader.Property("deviceId", JsonReader.String()),
-                              (hostAddress, deviceId) => new LnsHostAddressParseResult(hostAddress is { } someHostAddress
-                                                                                                       && someHostAddress.IsAbsoluteUri
-                                                                                                       && someHostAddress.Scheme is "ws" or "wss" ? someHostAddress : null,
-                                                                                       deviceId));
+                              (hostAddress, deviceId) => new LnsHostAddressParseResult(hostAddress, deviceId));
 
         private readonly ILogger<TagBasedLnsDiscovery> logger;
         private readonly IMemoryCache memoryCache;

--- a/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/TagBasedLnsDiscovery.cs
+++ b/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/TagBasedLnsDiscovery.cs
@@ -24,11 +24,16 @@ namespace LoRaWan.NetworkServerDiscovery
         private const string NetworkByStationCacheKey = "NetworkByStation";
 
         private static readonly TimeSpan CacheItemExpiration = TimeSpan.FromHours(6);
-        private static readonly IJsonReader<Uri?> HostAddressReader =
+        private static readonly IJsonReader<LnsHostAddressParseResult> HostAddressReader =
             JsonReader.Object(JsonReader.Property("hostAddress",
                                                   from s in JsonReader.String()
-                                                  select string.IsNullOrEmpty(s) ? null : new Uri(s),
-                                                  (true, null)));
+                                                  select Uri.TryCreate(s, default, out var uri) ? uri : null,
+                                                  (true, null)),
+                              JsonReader.Property("deviceId", JsonReader.String()),
+                              (hostAddress, deviceId) => new LnsHostAddressParseResult(hostAddress is { } someHostAddress
+                                                                                                       && someHostAddress.IsAbsoluteUri
+                                                                                                       && someHostAddress.Scheme is "ws" or "wss" ? someHostAddress : null,
+                                                                                       deviceId));
 
         private readonly ILogger<TagBasedLnsDiscovery> logger;
         private readonly IMemoryCache memoryCache;
@@ -93,18 +98,27 @@ namespace LoRaWan.NetworkServerDiscovery
                 $"{LnsByNetworkCacheKey}:{networkId}",
                 async _ =>
                 {
-                    var query = this.registryManager.CreateQuery($"SELECT properties.desired.hostAddress FROM devices.modules WHERE tags.network = '{networkId}'");
+                    var query = this.registryManager.CreateQuery($"SELECT properties.desired.hostAddress, deviceId FROM devices.modules WHERE tags.network = '{networkId}'");
                     var results = new List<Uri>();
+                    var parseFailures = new List<string>();
                     while (query.HasMoreResults)
                     {
                         var matches = await query.GetNextAsJsonAsync();
-                        results.AddRange(from hostAddressInfo in matches
-                                         select HostAddressReader.Read(hostAddressInfo) into uri
-                                         where uri != null
-                                         select uri);
+
+                        var parseResult = matches.Select(hostAddressInfo => HostAddressReader.Read(hostAddressInfo)).ToList();
+
+                        results.AddRange(parseResult.Select(r => r.HostAddress)
+                                                    .Where(hostAddress => hostAddress != null)
+                                                    .Cast<Uri>());
+
+                        parseFailures.AddRange(parseResult.Where(r => r.HostAddress is null)
+                                                          .Select(r => r.DeviceId));
                     }
 
                     this.logger.LogInformation("Loaded {Count} LNS candidates for network '{NetworkId}'", results.Count, networkId);
+
+                    if (parseFailures.Count > 0)
+                        this.logger.LogWarning("The following LNS in network '{NetworkId}' have a misconfigured host address: {DeviceIds}.", networkId, string.Join(',', parseFailures));
 
                     // Also cache if no LNS URIs are found for the given network.
                     // This makes sure that rogue LBS do not cause too many registry operations.
@@ -150,5 +164,7 @@ namespace LoRaWan.NetworkServerDiscovery
         }
 
         public void Dispose() => this.lnsByNetworkCacheSemaphore.Dispose();
+
+        private record struct LnsHostAddressParseResult(Uri? HostAddress, string DeviceId);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/NetworkServerDiscovery/DiscoveryService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/NetworkServerDiscovery/DiscoveryService.cs
@@ -69,13 +69,6 @@ namespace LoRaTools.NetworkServerDiscovery
                                               Id6.FormatOptions.FixedWidth);
 
                         var lnsUri = await this.lnsDiscovery.ResolveLnsAsync(stationEui, cancellationToken);
-
-                        if (!lnsUri.IsAbsoluteUri)
-                            throw new LoRaProcessingException("LNS host address must be an absolute URI.", LoRaProcessingErrorCode.InvalidDeviceConfiguration);
-
-                        if (lnsUri.Scheme is not "ws" and not "wss")
-                            throw new LoRaProcessingException("LNS host address scheme must either be 'ws' or 'wss'.", LoRaProcessingErrorCode.InvalidDeviceConfiguration);
-
                         var url = new Uri($"{lnsUri.Scheme}://{lnsUri.Host}:{lnsUri.Port}{DataEndpointPath}/{stationEui}");
                         var response = Write(w => WriteResponse(w, stationEui, muxs, url));
                         await s.SendAsync(response, WebSocketMessageType.Text,

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/NetworkServerDiscovery/DiscoveryService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/NetworkServerDiscovery/DiscoveryService.cs
@@ -73,7 +73,7 @@ namespace LoRaTools.NetworkServerDiscovery
 
                         // Ensure resilience against duplicate specification of `router-data` and make sure that LNS host address ends with slash
                         // to make sure that URI composes as expected.
-                        var lnsUriSanitized = Regex.Replace(lnsUri.AbsoluteUri, @"/router-data/?$", string.Empty, RegexOptions.IgnoreCase);
+                        var lnsUriSanitized = Regex.Replace(lnsUri.AbsoluteUri, @"/router-data/?$", string.Empty, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
                         lnsUriSanitized = lnsUriSanitized.EndsWith('/') ? lnsUriSanitized : $"{lnsUriSanitized}/";
 
                         var url = new Uri(new Uri(lnsUriSanitized), $"{DataEndpointPath}/{stationEui}");

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/NetworkServerDiscovery/DiscoveryService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/NetworkServerDiscovery/DiscoveryService.cs
@@ -69,6 +69,13 @@ namespace LoRaTools.NetworkServerDiscovery
                                               Id6.FormatOptions.FixedWidth);
 
                         var lnsUri = await this.lnsDiscovery.ResolveLnsAsync(stationEui, cancellationToken);
+
+                        if (!lnsUri.IsAbsoluteUri)
+                            throw new LoRaProcessingException("LNS host address must be an absolute URI.", LoRaProcessingErrorCode.InvalidDeviceConfiguration);
+
+                        if (lnsUri.Scheme is not "ws" and not "wss")
+                            throw new LoRaProcessingException("LNS host address scheme must either be 'ws' or 'wss'.", LoRaProcessingErrorCode.InvalidDeviceConfiguration);
+
                         var url = new Uri($"{lnsUri.Scheme}://{lnsUri.Host}:{lnsUri.Port}{DataEndpointPath}/{stationEui}");
                         var response = Write(w => WriteResponse(w, stationEui, muxs, url));
                         await s.SendAsync(response, WebSocketMessageType.Text,

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/NetworkServerDiscovery/DiscoveryService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/NetworkServerDiscovery/DiscoveryService.cs
@@ -73,7 +73,7 @@ namespace LoRaTools.NetworkServerDiscovery
 
                         // Ensure resilience against duplicate specification of `router-data` and make sure that LNS host address ends with slash
                         // to make sure that URI composes as expected.
-                        var lnsUriSanitized = Regex.Replace(lnsUri.AbsoluteUri, @"/router-data/?", string.Empty, RegexOptions.IgnoreCase);
+                        var lnsUriSanitized = Regex.Replace(lnsUri.AbsoluteUri, @"/router-data/?$", string.Empty, RegexOptions.IgnoreCase);
                         lnsUriSanitized = lnsUriSanitized.EndsWith('/') ? lnsUriSanitized : $"{lnsUriSanitized}/";
 
                         var url = new Uri(new Uri(lnsUriSanitized), $"{DataEndpointPath}/{stationEui}");

--- a/Tests/Integration/LnsDiscoveryIntegrationTests.cs
+++ b/Tests/Integration/LnsDiscoveryIntegrationTests.cs
@@ -44,6 +44,8 @@ namespace LoRaWan.Tests.Integration
                 services.AddSingleton<ILnsDiscovery>(sp => new TagBasedLnsDiscovery(sp.GetRequiredService<IMemoryCache>(), RegistryManagerMock.Object, sp.GetRequiredService<ILogger<TagBasedLnsDiscovery>>()));
             });
 
+            builder.ConfigureLogging(hostBuilder => hostBuilder.ClearProviders());
+
             return base.CreateHost(builder);
         }
     }

--- a/Tests/Unit/LoRaTools/DiscoveryServiceTests.cs
+++ b/Tests/Unit/LoRaTools/DiscoveryServiceTests.cs
@@ -15,7 +15,6 @@ namespace LoRaWan.Tests.Unit.LoRaTools
     using System.Threading;
     using System.Threading.Tasks;
     using global::LoRaTools.NetworkServerDiscovery;
-    using LoRaWan.Tests.Common;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
@@ -114,28 +113,6 @@ namespace LoRaWan.Tests.Unit.LoRaTools
             Assert.Contains(errorMessage, actualResponse, StringComparison.Ordinal);
             webSocketMock.Verify(ws => ws.SendAsync(It.IsAny<ArraySegment<byte>>(), WebSocketMessageType.Text,
                                                     true, cts.Token), Times.Once);
-        }
-
-        public static TheoryData<Uri> HandleDiscoveryRequestAsync_Detects_Uri_Misconfiguration_TheoryData() => TheoryDataFactory.From(new[]
-        {
-            new Uri("mylns", UriKind.Relative),
-            new Uri("http://mylns:1234")
-        });
-
-        [Theory]
-        [MemberData(nameof(HandleDiscoveryRequestAsync_Detects_Uri_Misconfiguration_TheoryData))]
-        public async Task HandleDiscoveryRequestAsync_Detects_Uri_Misconfiguration(Uri hostAddress)
-        {
-            // arrange
-            var (httpContextMock, webSocketMock) = SetupWebSocketConnection();
-
-            SetupDiscoveryRequest(webSocketMock, new StationEui(1));
-            this.lnsDiscoveryMock.Setup(d => d.ResolveLnsAsync(It.IsAny<StationEui>(), It.IsAny<CancellationToken>()))
-                                 .ReturnsAsync(hostAddress);
-
-            // act + assert
-            var ex = await Assert.ThrowsAsync<LoRaProcessingException>(() => this.subject.HandleDiscoveryRequestAsync(httpContextMock.Object, CancellationToken.None));
-            Assert.Equal(LoRaProcessingErrorCode.InvalidDeviceConfiguration, ex.ErrorCode);
         }
 
         private static void SetupDiscoveryRequest(Mock<WebSocket> webSocketMock, StationEui stationEui)

--- a/Tests/Unit/LoRaTools/DiscoveryServiceTests.cs
+++ b/Tests/Unit/LoRaTools/DiscoveryServiceTests.cs
@@ -57,6 +57,8 @@ namespace LoRaWan.Tests.Unit.LoRaTools
             (new Uri("ws://localhost:5000/some-path/router-data"), true, new Uri("ws://localhost:5000/some-path/router-data/")),
             (new Uri("ws://localhost:5000/some-path/router-data/"), true, new Uri("ws://localhost:5000/some-path/router-data/")),
             (new Uri("ws://localhost:5000/some-path/ROUTER-data/"), true, new Uri("ws://localhost:5000/some-path/router-data/")),
+            (new Uri("ws://localhost:5000/router-data/some-path"), true, new Uri("ws://localhost:5000/router-data/some-path/router-data/")),
+            (new Uri("ws://localhost:5000/router-data/some-path/router-data"), true, new Uri("ws://localhost:5000/router-data/some-path/router-data/")),
         });
 
         [Theory]

--- a/Tests/Unit/LoRaTools/DiscoveryServiceTests.cs
+++ b/Tests/Unit/LoRaTools/DiscoveryServiceTests.cs
@@ -15,6 +15,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools
     using System.Threading;
     using System.Threading.Tasks;
     using global::LoRaTools.NetworkServerDiscovery;
+    using LoRaWan.Tests.Common;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
@@ -113,6 +114,28 @@ namespace LoRaWan.Tests.Unit.LoRaTools
             Assert.Contains(errorMessage, actualResponse, StringComparison.Ordinal);
             webSocketMock.Verify(ws => ws.SendAsync(It.IsAny<ArraySegment<byte>>(), WebSocketMessageType.Text,
                                                     true, cts.Token), Times.Once);
+        }
+
+        public static TheoryData<Uri> HandleDiscoveryRequestAsync_Detects_Uri_Misconfiguration_TheoryData() => TheoryDataFactory.From(new[]
+        {
+            new Uri("mylns", UriKind.Relative),
+            new Uri("http://mylns:1234")
+        });
+
+        [Theory]
+        [MemberData(nameof(HandleDiscoveryRequestAsync_Detects_Uri_Misconfiguration_TheoryData))]
+        public async Task HandleDiscoveryRequestAsync_Detects_Uri_Misconfiguration(Uri hostAddress)
+        {
+            // arrange
+            var (httpContextMock, webSocketMock) = SetupWebSocketConnection();
+
+            SetupDiscoveryRequest(webSocketMock, new StationEui(1));
+            this.lnsDiscoveryMock.Setup(d => d.ResolveLnsAsync(It.IsAny<StationEui>(), It.IsAny<CancellationToken>()))
+                                 .ReturnsAsync(hostAddress);
+
+            // act + assert
+            var ex = await Assert.ThrowsAsync<LoRaProcessingException>(() => this.subject.HandleDiscoveryRequestAsync(httpContextMock.Object, CancellationToken.None));
+            Assert.Equal(LoRaProcessingErrorCode.InvalidDeviceConfiguration, ex.ErrorCode);
         }
 
         private static void SetupDiscoveryRequest(Mock<WebSocket> webSocketMock, StationEui stationEui)


### PR DESCRIPTION
# PR for issue #1489

## What is being addressed

With the initial version of the standalone discovery endpoint the error messages in case of misconfigured host addresses for LNS were cryptic. With this PR we improve the error messages that are logged/thrown/responded in the presence of misconfigured LNS.

We also fix a bug where URI paths are ignored in the host address specification in configuration.

## How is this addressed

The general approach is to:

- throw if there are no or only misconfigured LNS and provide a helpful error message in that case
- continue and only use the valid LNS configurations in case there is a mix of valid and invalid LNS configurations. The LNS with a misconfigured `hostAddress` are logged and ignored.

All changes rely on the fact that the IoT Hub query always returns a `deviceId` for each element in a query result.
