### PR TITLE
Unify test twin creation

### DIFF
--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -7,6 +7,7 @@ namespace LoRaWan.Tests.Common
 {
     using System;
     using System.Globalization;
+    using LoRaTools.Regions;
     using LoRaWan.NetworkServer;
     using Microsoft.Azure.Devices.Shared;
 
@@ -35,6 +36,7 @@ namespace LoRaWan.Tests.Common
                 SetDesiredPropertyIfExists(twin, TwinProperty.RX2DataRate, someDesiredProperties.Rx2DataRate?.ToString());
                 SetDesiredPropertyIfExists(twin, TwinProperty.PreferredWindow, someDesiredProperties.PreferredWindow?.ToString(CultureInfo.InvariantCulture));
                 SetDesiredPropertyIfExists(twin, TwinProperty.RXDelay, someDesiredProperties.RxDelay?.ToString(CultureInfo.InvariantCulture));
+                SetDesiredPropertyIfExists(twin, TwinProperty.ClassType, someDesiredProperties.ClassType?.ToString());
             }
 
             if (reportedProperties is { } someReportedProperties)
@@ -48,6 +50,11 @@ namespace LoRaWan.Tests.Common
                 SetReportedPropertyIfExists(twin, TwinProperty.DevAddr, someReportedProperties.DevAddr?.ToString());
                 SetReportedPropertyIfExists(twin, TwinProperty.DevNonce, someReportedProperties.DevNonce?.ToString());
                 SetReportedPropertyIfExists(twin, TwinProperty.FCntResetCounter, someReportedProperties.FCntResetCounter?.ToString(CultureInfo.InvariantCulture));
+                SetReportedPropertyIfExists(twin, TwinProperty.PreferredGatewayID, someReportedProperties.PreferredGatewayId?.ToString());
+                SetReportedPropertyIfExists(twin, TwinProperty.Region, someReportedProperties.Region?.ToString());
+                SetReportedPropertyIfExists(twin, TwinProperty.NetId, someReportedProperties.NetId?.ToString());
+                SetReportedPropertyIfExists(twin, TwinProperty.RX2DataRate, someReportedProperties.Rx2DataRate?.ToString());
+                SetReportedPropertyIfExists(twin, TwinProperty.LastProcessingStationEui, someReportedProperties.LastProcessingStation?.ToString());
             }
 
             return twin;
@@ -89,6 +96,7 @@ namespace LoRaWan.Tests.Common
         public DataRateIndex? Rx2DataRate { get; init; }
         public int? PreferredWindow { get; init; }
         public int? RxDelay { get; init; }
+        public char? ClassType { get; init; }
     }
 
     public sealed record LoRaReportedTwinProperties
@@ -102,6 +110,11 @@ namespace LoRaWan.Tests.Common
         public DevAddr? DevAddr { get; init; }
         public DevNonce? DevNonce { get; init; }
         public int? FCntResetCounter { get; init; }
+        public string? PreferredGatewayId { get; init; }
+        public LoRaRegionType? Region { get; init; }
+        public NetId? NetId { get; init; }
+        public DataRateIndex? Rx2DataRate { get; init; }
+        public StationEui? LastProcessingStation { get; init; }
     }
 
     public static class LoRaDeviceTwinExtensions
@@ -113,7 +126,20 @@ namespace LoRaWan.Tests.Common
                 JoinEui = testDeviceInfo.AppEui ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.AppEui)} must not be null."),
                 AppKey = testDeviceInfo.AppKey ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.AppKey)} must not be null."),
                 SensorDecoder = testDeviceInfo.SensorDecoder ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.SensorDecoder)} must not be null."),
+                ClassType = testDeviceInfo.ClassType,
                 GatewayId = testDeviceInfo.GatewayID,
+            };
+
+        public static LoRaReportedTwinProperties GetOtaaReportedTwinProperties(this SimulatedDevice simulatedDevice) =>
+            new LoRaReportedTwinProperties
+            {
+                DevAddr = simulatedDevice.DevAddr,
+                AppSessionKey = simulatedDevice.AppSKey,
+                NetworkSessionKey = simulatedDevice.NwkSKey,
+                DevNonce = simulatedDevice.DevNonce,
+                NetId = simulatedDevice.NetId,
+                FCntDown = simulatedDevice.FrmCntDown,
+                FCntUp = simulatedDevice.FrmCntUp
             };
 
         public static LoRaDesiredTwinProperties GetAbpTwinProperties(this TestDeviceInfo testDeviceInfo) =>
@@ -123,6 +149,7 @@ namespace LoRaWan.Tests.Common
                 NetworkSessionKey = testDeviceInfo.NwkSKey ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.NwkSKey)} must not be null."),
                 DevAddr = testDeviceInfo.DevAddr ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.DevAddr)} must not be null."),
                 SensorDecoder = testDeviceInfo.SensorDecoder ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.SensorDecoder)} must not be null."),
+                ClassType = testDeviceInfo.ClassType,
                 GatewayId = testDeviceInfo.GatewayID,
             };
     }

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -69,7 +69,7 @@ namespace LoRaWan.Tests.Common
             {
                 if (value is { } someValue)
                 {
-                    twinCollection[key] = value;
+                    twinCollection[key] = someValue;
                 }
             }
         }

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -31,6 +31,10 @@ namespace LoRaWan.Tests.Common
                 SetDesiredPropertyIfExists(twin, TwinProperty.FCntUpStart, someDesiredProperties.FCntUpStart?.ToString(CultureInfo.InvariantCulture));
                 SetDesiredPropertyIfExists(twin, TwinProperty.FCntDownStart, someDesiredProperties.FCntDownStart?.ToString(CultureInfo.InvariantCulture));
                 SetDesiredPropertyIfExists(twin, TwinProperty.FCntResetCounter, someDesiredProperties.FCntResetCounter?.ToString(CultureInfo.InvariantCulture));
+                SetDesiredPropertyIfExists(twin, TwinProperty.RX1DROffset, someDesiredProperties.Rx1DROffset?.ToString(CultureInfo.InvariantCulture));
+                SetDesiredPropertyIfExists(twin, TwinProperty.RX2DataRate, someDesiredProperties.Rx2DataRate?.ToString());
+                SetDesiredPropertyIfExists(twin, TwinProperty.PreferredWindow, someDesiredProperties.PreferredWindow?.ToString(CultureInfo.InvariantCulture));
+                SetDesiredPropertyIfExists(twin, TwinProperty.RXDelay, someDesiredProperties.RxDelay?.ToString(CultureInfo.InvariantCulture));
             }
 
             if (reportedProperties is { } someReportedProperties)
@@ -81,6 +85,10 @@ namespace LoRaWan.Tests.Common
         public uint? FCntUpStart { get; init; }
         public uint? FCntDownStart { get; init; }
         public int? FCntResetCounter { get; init; }
+        public int? Rx1DROffset { get; init; }
+        public DataRateIndex? Rx2DataRate { get; init; }
+        public int? PreferredWindow { get; init; }
+        public int? RxDelay { get; init; }
     }
 
     public sealed record LoRaReportedTwinProperties
@@ -101,10 +109,11 @@ namespace LoRaWan.Tests.Common
         public static LoRaDesiredTwinProperties GetOtaaTwinProperties(this TestDeviceInfo testDeviceInfo) =>
             new LoRaDesiredTwinProperties
             {
+                DevEui = testDeviceInfo.DevEui,
                 JoinEui = testDeviceInfo.AppEui ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.AppEui)} must not be null."),
                 AppKey = testDeviceInfo.AppKey ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.AppKey)} must not be null."),
                 SensorDecoder = testDeviceInfo.SensorDecoder ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.SensorDecoder)} must not be null."),
-                GatewayId = testDeviceInfo.GatewayID ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.GatewayID)} must not be null."),
+                GatewayId = testDeviceInfo.GatewayID,
             };
 
         public static LoRaDesiredTwinProperties GetAbpTwinProperties(this TestDeviceInfo testDeviceInfo) =>
@@ -114,7 +123,7 @@ namespace LoRaWan.Tests.Common
                 NetworkSessionKey = testDeviceInfo.NwkSKey ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.NwkSKey)} must not be null."),
                 DevAddr = testDeviceInfo.DevAddr ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.DevAddr)} must not be null."),
                 SensorDecoder = testDeviceInfo.SensorDecoder ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.SensorDecoder)} must not be null."),
-                GatewayId = testDeviceInfo.GatewayID ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.GatewayID)} must not be null."),
+                GatewayId = testDeviceInfo.GatewayID,
             };
     }
 }

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -12,7 +12,7 @@ namespace LoRaWan.Tests.Common
 
     public static class LoRaDeviceTwin
     {
-        public static Twin Create(LoRaDesiredTwinProperties? desiredProperties = null, LoRaReportTwinProperties? reportedProperties = null)
+        public static Twin Create(LoRaDesiredTwinProperties? desiredProperties = null, LoRaReportedTwinProperties? reportedProperties = null)
         {
             var twin = new Twin();
 
@@ -26,18 +26,26 @@ namespace LoRaWan.Tests.Common
                 SetDesiredPropertyIfExists(twin, TwinProperty.NwkSKey, someDesiredProperties.NetworkSessionKey?.ToString());
                 SetDesiredPropertyIfExists(twin, TwinProperty.GatewayID, someDesiredProperties.GatewayId?.ToString());
                 SetDesiredPropertyIfExists(twin, TwinProperty.SensorDecoder, someDesiredProperties.SensorDecoder?.ToString());
+                SetDesiredPropertyIfExists(twin, TwinProperty.Supports32BitFCnt, someDesiredProperties.Supports32BitFCnt?.ToString());
+                SetDesiredPropertyIfExists(twin, TwinProperty.ABPRelaxMode, someDesiredProperties.AbpRelaxMode?.ToString());
+                SetDesiredPropertyIfExists(twin, TwinProperty.FCntUpStart, someDesiredProperties.FCntUpStart?.ToString(CultureInfo.InvariantCulture));
+                SetDesiredPropertyIfExists(twin, TwinProperty.FCntDownStart, someDesiredProperties.FCntDownStart?.ToString(CultureInfo.InvariantCulture));
+                SetDesiredPropertyIfExists(twin, TwinProperty.FCntResetCounter, someDesiredProperties.FCntResetCounter?.ToString(CultureInfo.InvariantCulture));
             }
 
             if (reportedProperties is { } someReportedProperties)
             {
                 SetReportedPropertyIfExists(twin, TwinProperty.FCntUp, someReportedProperties.FCntUp?.ToString(CultureInfo.InvariantCulture));
+                SetReportedPropertyIfExists(twin, TwinProperty.FCntUpStart, someReportedProperties.FCntUpStart?.ToString(CultureInfo.InvariantCulture));
                 SetReportedPropertyIfExists(twin, TwinProperty.FCntDown, someReportedProperties.FCntDown?.ToString(CultureInfo.InvariantCulture));
+                SetReportedPropertyIfExists(twin, TwinProperty.FCntDownStart, someReportedProperties.FCntDownStart?.ToString(CultureInfo.InvariantCulture));
                 SetReportedPropertyIfExists(twin, TwinProperty.AppSKey, someReportedProperties.AppSessionKey?.ToString());
                 SetReportedPropertyIfExists(twin, TwinProperty.NwkSKey, someReportedProperties.NetworkSessionKey?.ToString());
                 SetReportedPropertyIfExists(twin, TwinProperty.DevAddr, someReportedProperties.DevAddr?.ToString());
                 SetReportedPropertyIfExists(twin, TwinProperty.DevNonce, someReportedProperties.DevNonce?.ToString());
+                SetReportedPropertyIfExists(twin, TwinProperty.FCntResetCounter, someReportedProperties.FCntResetCounter?.ToString(CultureInfo.InvariantCulture));
             }
-            
+
             return twin;
 
             static void SetDesiredPropertyIfExists(Twin twin, string propertyName, string? value)
@@ -68,16 +76,24 @@ namespace LoRaWan.Tests.Common
         public NetworkSessionKey? NetworkSessionKey { get; init; }
         public string? GatewayId { get; init; }
         public string? SensorDecoder { get; init; }
+        public bool? Supports32BitFCnt { get; init; }
+        public bool? AbpRelaxMode { get; init; }
+        public uint? FCntUpStart { get; init; }
+        public uint? FCntDownStart { get; init; }
+        public int? FCntResetCounter { get; init; }
     }
 
-    public sealed record LoRaReportTwinProperties
+    public sealed record LoRaReportedTwinProperties
     {
         public uint? FCntUp { get; init; }
+        public uint? FCntUpStart { get; init; }
         public uint? FCntDown { get; init; }
+        public uint? FCntDownStart { get; init; }
         public AppSessionKey? AppSessionKey { get; init; }
         public NetworkSessionKey? NetworkSessionKey { get; init; }
         public DevAddr? DevAddr { get; init; }
         public DevNonce? DevNonce { get; init; }
+        public int? FCntResetCounter { get; init; }
     }
 
     public static class LoRaDeviceTwinExtensions
@@ -88,6 +104,7 @@ namespace LoRaWan.Tests.Common
                 JoinEui = testDeviceInfo.AppEui ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.AppEui)} must not be null."),
                 AppKey = testDeviceInfo.AppKey ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.AppKey)} must not be null."),
                 SensorDecoder = testDeviceInfo.SensorDecoder ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.SensorDecoder)} must not be null."),
+                GatewayId = testDeviceInfo.GatewayID ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.GatewayID)} must not be null."),
             };
 
         public static LoRaDesiredTwinProperties GetAbpTwinProperties(this TestDeviceInfo testDeviceInfo) =>
@@ -97,6 +114,7 @@ namespace LoRaWan.Tests.Common
                 NetworkSessionKey = testDeviceInfo.NwkSKey ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.NwkSKey)} must not be null."),
                 DevAddr = testDeviceInfo.DevAddr ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.DevAddr)} must not be null."),
                 SensorDecoder = testDeviceInfo.SensorDecoder ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.SensorDecoder)} must not be null."),
+                GatewayId = testDeviceInfo.GatewayID ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.GatewayID)} must not be null."),
             };
     }
 }

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaWan.Tests.Common
+{
+    using System;
+    using System.Globalization;
+    using LoRaWan.NetworkServer;
+    using Microsoft.Azure.Devices.Shared;
+
+    public static class LoRaDeviceTwin
+    {
+        public static Twin Create(LoRaDesiredTwinProperties? desiredProperties = null, LoRaReportTwinProperties? reportedProperties = null)
+        {
+            var twin = new Twin();
+
+            if (desiredProperties is { } someDesiredProperties)
+            {
+                SetDesiredPropertyIfExists(twin, TwinProperty.DevEUI, someDesiredProperties.DevEui?.ToString());
+                SetDesiredPropertyIfExists(twin, TwinProperty.DevAddr, someDesiredProperties.DevAddr?.ToString());
+                SetDesiredPropertyIfExists(twin, TwinProperty.AppEui, someDesiredProperties.JoinEui?.ToString());
+                SetDesiredPropertyIfExists(twin, TwinProperty.AppKey, someDesiredProperties.AppKey?.ToString());
+                SetDesiredPropertyIfExists(twin, TwinProperty.AppSKey, someDesiredProperties.AppSessionKey?.ToString());
+                SetDesiredPropertyIfExists(twin, TwinProperty.NwkSKey, someDesiredProperties.NetworkSessionKey?.ToString());
+                SetDesiredPropertyIfExists(twin, TwinProperty.GatewayID, someDesiredProperties.GatewayId?.ToString());
+                SetDesiredPropertyIfExists(twin, TwinProperty.SensorDecoder, someDesiredProperties.SensorDecoder?.ToString());
+            }
+
+            if (reportedProperties is { } someReportedProperties)
+            {
+                SetReportedPropertyIfExists(twin, TwinProperty.FCntUp, someReportedProperties.FCntUp?.ToString(CultureInfo.InvariantCulture));
+                SetReportedPropertyIfExists(twin, TwinProperty.FCntDown, someReportedProperties.FCntDown?.ToString(CultureInfo.InvariantCulture));
+                SetReportedPropertyIfExists(twin, TwinProperty.AppSKey, someReportedProperties.AppSessionKey?.ToString());
+                SetReportedPropertyIfExists(twin, TwinProperty.NwkSKey, someReportedProperties.NetworkSessionKey?.ToString());
+                SetReportedPropertyIfExists(twin, TwinProperty.DevAddr, someReportedProperties.DevAddr?.ToString());
+                SetReportedPropertyIfExists(twin, TwinProperty.DevNonce, someReportedProperties.DevNonce?.ToString());
+            }
+            
+            return twin;
+
+            static void SetDesiredPropertyIfExists(Twin twin, string propertyName, string? value)
+            {
+                if (value is { } someValue)
+                {
+                    twin.Properties.Desired[propertyName] = value;
+                }
+            }
+
+            static void SetReportedPropertyIfExists(Twin twin, string propertyName, string? value)
+            {
+                if (value is { } someValue)
+                {
+                    twin.Properties.Reported[propertyName] = value;
+                }
+            }
+        }
+    }
+
+    public sealed record LoRaDesiredTwinProperties
+    {
+        public DevEui? DevEui { get; init; }
+        public DevAddr? DevAddr { get; init; }
+        public JoinEui? JoinEui { get; init; }
+        public AppKey? AppKey { get; init; }
+        public AppSessionKey? AppSessionKey { get; init; }
+        public NetworkSessionKey? NetworkSessionKey { get; init; }
+        public string? GatewayId { get; init; }
+        public string? SensorDecoder { get; init; }
+    }
+
+    public sealed record LoRaReportTwinProperties
+    {
+        public uint? FCntUp { get; init; }
+        public uint? FCntDown { get; init; }
+        public AppSessionKey? AppSessionKey { get; init; }
+        public NetworkSessionKey? NetworkSessionKey { get; init; }
+        public DevAddr? DevAddr { get; init; }
+        public DevNonce? DevNonce { get; init; }
+    }
+
+    public static class LoRaDeviceTwinExtensions
+    {
+        public static LoRaDesiredTwinProperties GetOtaaTwinProperties(this TestDeviceInfo testDeviceInfo) =>
+            new LoRaDesiredTwinProperties
+            {
+                JoinEui = testDeviceInfo.AppEui ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.AppEui)} must not be null."),
+                AppKey = testDeviceInfo.AppKey ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.AppKey)} must not be null."),
+                SensorDecoder = testDeviceInfo.SensorDecoder ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.SensorDecoder)} must not be null."),
+            };
+
+        public static LoRaDesiredTwinProperties GetAbpTwinProperties(this TestDeviceInfo testDeviceInfo) =>
+            new LoRaDesiredTwinProperties
+            {
+                AppSessionKey = testDeviceInfo.AppSKey ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.AppSKey)} must not be null."),
+                NetworkSessionKey = testDeviceInfo.NwkSKey ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.NwkSKey)} must not be null."),
+                DevAddr = testDeviceInfo.DevAddr ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.DevAddr)} must not be null."),
+                SensorDecoder = testDeviceInfo.SensorDecoder ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.SensorDecoder)} must not be null."),
+            };
+    }
+}

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -6,7 +6,10 @@
 namespace LoRaWan.Tests.Common
 {
     using System;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Globalization;
+    using System.Linq;
     using LoRaTools.Regions;
     using LoRaWan.NetworkServer;
     using Microsoft.Azure.Devices.Shared;

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -34,9 +34,16 @@ namespace LoRaWan.Tests.Common
                 SetDesiredPropertyIfExists(twin, TwinProperty.FCntResetCounter, someDesiredProperties.FCntResetCounter?.ToString(CultureInfo.InvariantCulture));
                 SetDesiredPropertyIfExists(twin, TwinProperty.RX1DROffset, someDesiredProperties.Rx1DROffset?.ToString(CultureInfo.InvariantCulture));
                 SetDesiredPropertyIfExists(twin, TwinProperty.RX2DataRate, someDesiredProperties.Rx2DataRate?.ToString());
-                SetDesiredPropertyIfExists(twin, TwinProperty.PreferredWindow, someDesiredProperties.PreferredWindow?.ToString());
+                var receiveWindow = someDesiredProperties.PreferredWindow switch
+                {
+                    ReceiveWindowNumber.ReceiveWindow1 => 1,
+                    ReceiveWindowNumber.ReceiveWindow2 => 2,
+                    _ => (int?)null
+                };
+                SetDesiredPropertyIfExists(twin, TwinProperty.PreferredWindow, receiveWindow?.ToString(CultureInfo.InvariantCulture));
                 SetDesiredPropertyIfExists(twin, TwinProperty.RXDelay, someDesiredProperties.RxDelay?.ToString(CultureInfo.InvariantCulture));
                 SetDesiredPropertyIfExists(twin, TwinProperty.ClassType, someDesiredProperties.ClassType?.ToString());
+                SetDesiredPropertyIfExists(twin, TwinProperty.KeepAliveTimeout, someDesiredProperties.KeepAliveTimeout?.TotalSeconds.ToString(CultureInfo.InvariantCulture));
             }
 
             if (reportedProperties is { } someReportedProperties)
@@ -95,6 +102,7 @@ namespace LoRaWan.Tests.Common
         public ReceiveWindowNumber? PreferredWindow { get; init; }
         public int? RxDelay { get; init; }
         public char? ClassType { get; init; }
+        public TimeSpan? KeepAliveTimeout { get; init; }
     }
 
     public sealed record LoRaReportedTwinProperties
@@ -150,5 +158,15 @@ namespace LoRaWan.Tests.Common
                 ClassType = testDeviceInfo.ClassType,
                 GatewayId = testDeviceInfo.GatewayID,
             };
+
+        public static LoRaReportedTwinProperties GetAbpReportedTwinProperties(this SimulatedDevice simulatedDevice) =>
+            new LoRaReportedTwinProperties
+            {
+                FCntDown = simulatedDevice.FrmCntDown,
+                FCntUp = simulatedDevice.FrmCntUp,
+            };
+
+        public static Twin GetDefaultAbpTwin(this SimulatedDevice simulatedDevice) =>
+            LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetAbpDesiredTwinProperties(), simulatedDevice.GetAbpReportedTwinProperties());
     }
 }

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -34,7 +34,7 @@ namespace LoRaWan.Tests.Common
                 SetDesiredPropertyIfExists(twin, TwinProperty.FCntResetCounter, someDesiredProperties.FCntResetCounter?.ToString(CultureInfo.InvariantCulture));
                 SetDesiredPropertyIfExists(twin, TwinProperty.RX1DROffset, someDesiredProperties.Rx1DROffset?.ToString(CultureInfo.InvariantCulture));
                 SetDesiredPropertyIfExists(twin, TwinProperty.RX2DataRate, someDesiredProperties.Rx2DataRate?.ToString());
-                SetDesiredPropertyIfExists(twin, TwinProperty.PreferredWindow, someDesiredProperties.PreferredWindow?.ToString(CultureInfo.InvariantCulture));
+                SetDesiredPropertyIfExists(twin, TwinProperty.PreferredWindow, someDesiredProperties.PreferredWindow?.ToString());
                 SetDesiredPropertyIfExists(twin, TwinProperty.RXDelay, someDesiredProperties.RxDelay?.ToString(CultureInfo.InvariantCulture));
                 SetDesiredPropertyIfExists(twin, TwinProperty.ClassType, someDesiredProperties.ClassType?.ToString());
             }
@@ -92,7 +92,7 @@ namespace LoRaWan.Tests.Common
         public int? FCntResetCounter { get; init; }
         public int? Rx1DROffset { get; init; }
         public DataRateIndex? Rx2DataRate { get; init; }
-        public int? PreferredWindow { get; init; }
+        public ReceiveWindowNumber? PreferredWindow { get; init; }
         public int? RxDelay { get; init; }
         public char? ClassType { get; init; }
     }

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -40,6 +40,12 @@ namespace LoRaWan.Tests.Common
                 {
                     case null:
                         break;
+                    case uint:
+                    case int:
+                    case Enum:
+                    case bool:
+                        target[key] = value;
+                        break;
                     case IConvertible convertible:
                         target[key] = convertible.ToString(CultureInfo.InvariantCulture);
                         break;

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -25,8 +25,8 @@ namespace LoRaWan.Tests.Common
                 SetDesiredPropertyIfExists(twin, TwinProperty.AppKey, someDesiredProperties.AppKey?.ToString());
                 SetDesiredPropertyIfExists(twin, TwinProperty.AppSKey, someDesiredProperties.AppSessionKey?.ToString());
                 SetDesiredPropertyIfExists(twin, TwinProperty.NwkSKey, someDesiredProperties.NetworkSessionKey?.ToString());
-                SetDesiredPropertyIfExists(twin, TwinProperty.GatewayID, someDesiredProperties.GatewayId?.ToString());
-                SetDesiredPropertyIfExists(twin, TwinProperty.SensorDecoder, someDesiredProperties.SensorDecoder?.ToString());
+                SetDesiredPropertyIfExists(twin, TwinProperty.GatewayID, someDesiredProperties.GatewayId);
+                SetDesiredPropertyIfExists(twin, TwinProperty.SensorDecoder, someDesiredProperties.SensorDecoder);
                 SetDesiredPropertyIfExists(twin, TwinProperty.Supports32BitFCnt, someDesiredProperties.Supports32BitFCnt?.ToString());
                 SetDesiredPropertyIfExists(twin, TwinProperty.ABPRelaxMode, someDesiredProperties.AbpRelaxMode?.ToString());
                 SetDesiredPropertyIfExists(twin, TwinProperty.FCntUpStart, someDesiredProperties.FCntUpStart?.ToString(CultureInfo.InvariantCulture));
@@ -57,7 +57,7 @@ namespace LoRaWan.Tests.Common
                 SetReportedPropertyIfExists(twin, TwinProperty.DevAddr, someReportedProperties.DevAddr?.ToString());
                 SetReportedPropertyIfExists(twin, TwinProperty.DevNonce, someReportedProperties.DevNonce?.ToString());
                 SetReportedPropertyIfExists(twin, TwinProperty.FCntResetCounter, someReportedProperties.FCntResetCounter?.ToString(CultureInfo.InvariantCulture));
-                SetReportedPropertyIfExists(twin, TwinProperty.PreferredGatewayID, someReportedProperties.PreferredGatewayId?.ToString());
+                SetReportedPropertyIfExists(twin, TwinProperty.PreferredGatewayID, someReportedProperties.PreferredGatewayId);
                 SetReportedPropertyIfExists(twin, TwinProperty.Region, someReportedProperties.Region?.ToString());
                 SetReportedPropertyIfExists(twin, TwinProperty.NetId, someReportedProperties.NetId?.ToString());
                 SetReportedPropertyIfExists(twin, TwinProperty.RX2DataRate, someReportedProperties.Rx2DataRate?.ToString());

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -59,19 +59,17 @@ namespace LoRaWan.Tests.Common
 
             return twin;
 
-            static void SetDesiredPropertyIfExists(Twin twin, string propertyName, string? value)
-            {
-                if (value is { } someValue)
-                {
-                    twin.Properties.Desired[propertyName] = value;
-                }
-            }
+            static void SetDesiredPropertyIfExists(Twin twin, string key, string? value) =>
+                SetPropertyIfExists(twin.Properties.Desired, key, value);
 
-            static void SetReportedPropertyIfExists(Twin twin, string propertyName, string? value)
+            static void SetReportedPropertyIfExists(Twin twin, string key, string? value) =>
+                SetPropertyIfExists(twin.Properties.Reported, key, value);
+
+            static void SetPropertyIfExists(TwinCollection twinCollection, string key, string? value)
             {
                 if (value is { } someValue)
                 {
-                    twin.Properties.Reported[propertyName] = value;
+                    twinCollection[key] = value;
                 }
             }
         }

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -119,7 +119,7 @@ namespace LoRaWan.Tests.Common
 
     public static class LoRaDeviceTwinExtensions
     {
-        public static LoRaDesiredTwinProperties GetOtaaTwinProperties(this TestDeviceInfo testDeviceInfo) =>
+        public static LoRaDesiredTwinProperties GetOtaaDesiredTwinProperties(this TestDeviceInfo testDeviceInfo) =>
             new LoRaDesiredTwinProperties
             {
                 DevEui = testDeviceInfo.DevEui,
@@ -139,10 +139,10 @@ namespace LoRaWan.Tests.Common
                 DevNonce = simulatedDevice.DevNonce,
                 NetId = simulatedDevice.NetId,
                 FCntDown = simulatedDevice.FrmCntDown,
-                FCntUp = simulatedDevice.FrmCntUp
+                FCntUp = simulatedDevice.FrmCntUp,
             };
 
-        public static LoRaDesiredTwinProperties GetAbpTwinProperties(this TestDeviceInfo testDeviceInfo) =>
+        public static LoRaDesiredTwinProperties GetAbpDesiredTwinProperties(this TestDeviceInfo testDeviceInfo) =>
             new LoRaDesiredTwinProperties
             {
                 AppSessionKey = testDeviceInfo.AppSKey ?? throw new InvalidOperationException($"{nameof(testDeviceInfo.AppSKey)} must not be null."),

--- a/Tests/Common/TestUtils.cs
+++ b/Tests/Common/TestUtils.cs
@@ -112,50 +112,6 @@ namespace LoRaWan.Tests.Common
             return CreateTwin(desired: finalDesiredProperties, reported: finalReportedProperties);
         }
 
-        public static Twin CreateOTAATwin(
-            this SimulatedDevice simulatedDevice,
-            Dictionary<string, object> desiredProperties = null,
-            Dictionary<string, object> reportedProperties = null)
-        {
-            var finalDesiredProperties = new Dictionary<string, object>
-                {
-                    { TwinProperty.AppEui, simulatedDevice.AppEui?.ToString() },
-                    { TwinProperty.AppKey, simulatedDevice.AppKey?.ToString() },
-                    { TwinProperty.GatewayID, simulatedDevice.LoRaDevice.GatewayID },
-                    { TwinProperty.SensorDecoder, simulatedDevice.LoRaDevice.SensorDecoder },
-                    { TwinProperty.ClassType, simulatedDevice.ClassType.ToString() },
-                };
-
-            if (desiredProperties != null)
-            {
-                foreach (var kv in desiredProperties)
-                {
-                    finalDesiredProperties[kv.Key] = kv.Value;
-                }
-            }
-
-            var finalReportedProperties = new Dictionary<string, object>
-            {
-                { TwinProperty.DevAddr, simulatedDevice.DevAddr?.ToString() },
-                { TwinProperty.AppSKey, simulatedDevice.AppSKey?.ToString() },
-                { TwinProperty.NwkSKey, simulatedDevice.NwkSKey?.ToString() },
-                { TwinProperty.DevNonce, simulatedDevice.DevNonce.ToString() },
-                { TwinProperty.NetId, simulatedDevice.NetId?.ToString() },
-                { TwinProperty.FCntDown, simulatedDevice.FrmCntDown },
-                { TwinProperty.FCntUp, simulatedDevice.FrmCntUp }
-            };
-
-            if (reportedProperties != null)
-            {
-                foreach (var kv in reportedProperties)
-                {
-                    finalReportedProperties[kv.Key] = kv.Value;
-                }
-            }
-
-            return CreateTwin(desired: finalDesiredProperties, reported: finalReportedProperties);
-        }
-
         /// <summary>
         /// Helper to create a <see cref="Message"/> from a <see cref="LoRaCloudToDeviceMessage"/>.
         /// </summary>

--- a/Tests/Common/TestUtils.cs
+++ b/Tests/Common/TestUtils.cs
@@ -72,46 +72,6 @@ namespace LoRaWan.Tests.Common
             return twin;
         }
 
-        public static Twin CreateABPTwin(
-            this SimulatedDevice simulatedDevice,
-            Dictionary<string, object> desiredProperties = null,
-            Dictionary<string, object> reportedProperties = null)
-        {
-            var finalDesiredProperties = new Dictionary<string, object>
-                {
-                    { TwinProperty.DevAddr, simulatedDevice.DevAddr.ToString() },
-                    { TwinProperty.AppSKey, simulatedDevice.AppSKey?.ToString() },
-                    { TwinProperty.NwkSKey, simulatedDevice.NwkSKey?.ToString() },
-                    { TwinProperty.GatewayID, simulatedDevice.LoRaDevice.GatewayID },
-                    { TwinProperty.SensorDecoder, simulatedDevice.LoRaDevice.SensorDecoder },
-                    { TwinProperty.ClassType, simulatedDevice.ClassType.ToString() },
-                };
-
-            if (desiredProperties != null)
-            {
-                foreach (var kv in desiredProperties)
-                {
-                    finalDesiredProperties[kv.Key] = kv.Value;
-                }
-            }
-
-            var finalReportedProperties = new Dictionary<string, object>
-            {
-                { TwinProperty.FCntDown, simulatedDevice.FrmCntDown },
-                { TwinProperty.FCntUp, simulatedDevice.FrmCntUp }
-            };
-
-            if (reportedProperties != null)
-            {
-                foreach (var kv in reportedProperties)
-                {
-                    finalReportedProperties[kv.Key] = kv.Value;
-                }
-            }
-
-            return CreateTwin(desired: finalDesiredProperties, reported: finalReportedProperties);
-        }
-
         /// <summary>
         /// Helper to create a <see cref="Message"/> from a <see cref="LoRaCloudToDeviceMessage"/>.
         /// </summary>

--- a/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
+++ b/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
@@ -90,11 +90,12 @@ namespace LoRaWan.Tests.Integration
             this.deviceApi.Setup(x => x.GetPrimaryKeyByEuiAsync(devEUI))
                 .ReturnsAsync("123");
 
-            var twin = simulatedDevice.CreateABPTwin(reportedProperties: new Dictionary<string, object>
-            {
-                { TwinProperty.Region, LoRaRegionType.EU868.ToString() },
-                { TwinProperty.LastProcessingStationEui, new StationEui(ulong.MaxValue).ToString() }
-            });
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetAbpDesiredTwinProperties(),
+                                             simulatedDevice.GetAbpReportedTwinProperties() with
+                                             {
+                                                 Region = LoRaRegionType.EU868,
+                                                 LastProcessingStation = new StationEui(ulong.MaxValue)
+                                             });
             this.deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);
 
@@ -179,7 +180,7 @@ namespace LoRaWan.Tests.Integration
                 .ReturnsAsync("123");
 
             this.deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(simulatedDevice.CreateABPTwin());
+                .ReturnsAsync(simulatedDevice.GetDefaultAbpTwin());
 
             var c2dMessageMacCommand = new DevStatusRequest();
             var c2dMessageMacCommandSize = hasMacInC2D ? c2dMessageMacCommand.Length : 0;

--- a/Tests/Integration/ClassCIntegrationTests.cs
+++ b/Tests/Integration/ClassCIntegrationTests.cs
@@ -65,10 +65,8 @@ namespace LoRaWan.Tests.Integration
             LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
 
-            var twin = simDevice.CreateABPTwin(reportedProperties: new Dictionary<string, object>
-                {
-                    { TwinProperty.Region, region.LoRaRegion.ToString() }
-                });
+            var twin = LoRaDeviceTwin.Create(simDevice.LoRaDevice.GetAbpDesiredTwinProperties(),
+                                             simDevice.GetAbpReportedTwinProperties() with { Region = region.LoRaRegion });
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);

--- a/Tests/Integration/ClassCIntegrationTests.cs
+++ b/Tests/Integration/ClassCIntegrationTests.cs
@@ -162,7 +162,7 @@ namespace LoRaWan.Tests.Integration
             var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: 'c', gatewayID: deviceGatewayID));
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(LoRaDeviceTwin.Create(simDevice.LoRaDevice.GetOtaaTwinProperties(),
+                .ReturnsAsync(LoRaDeviceTwin.Create(simDevice.LoRaDevice.GetOtaaDesiredTwinProperties(),
                                                     simDevice.GetOtaaReportedTwinProperties()));
 
             AppSessionKey? savedAppSKey = null;
@@ -353,7 +353,7 @@ namespace LoRaWan.Tests.Integration
             var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: 'c', gatewayID: deviceGatewayID));
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(LoRaDeviceTwin.Create(simDevice.LoRaDevice.GetOtaaTwinProperties(),
+                .ReturnsAsync(LoRaDeviceTwin.Create(simDevice.LoRaDevice.GetOtaaDesiredTwinProperties(),
                                                     new LoRaReportedTwinProperties
                                                     {
                                                         // reported: { 'PreferredGateway': '' } -> if device is for multiple gateways and one initial was defined

--- a/Tests/Integration/CloudToDeviceMessageTests.cs
+++ b/Tests/Integration/CloudToDeviceMessageTests.cs
@@ -328,8 +328,7 @@ namespace LoRaWan.Tests.Integration
             var devEUI = simulatedDevice.DevEUI;
 
             // Will get twin to initialize LoRaDevice
-            var deviceTwin = TestUtils.CreateABPTwin(simulatedDevice);
-            LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(deviceTwin);
+            LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(simulatedDevice.GetDefaultAbpTwin());
 
             LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
@@ -415,8 +414,7 @@ namespace LoRaWan.Tests.Integration
             var devEUI = simulatedDevice.DevEUI;
 
             // Will get twin to initialize LoRaDevice
-            var deviceTwin = TestUtils.CreateABPTwin(simulatedDevice);
-            LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(deviceTwin);
+            LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(simulatedDevice.GetDefaultAbpTwin());
 
             LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
@@ -501,14 +499,10 @@ namespace LoRaWan.Tests.Integration
             var devEUI = simulatedDevice.DevEUI;
 
             // Will get twin to initialize LoRaDevice
-            var deviceTwin = TestUtils.CreateABPTwin(
-                simulatedDevice,
-                desiredProperties: new Dictionary<string, object>
-                {
-                    { TwinProperty.PreferredWindow, 2 }
-                });
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetAbpDesiredTwinProperties() with { PreferredWindow = ReceiveWindow2 },
+                                             simulatedDevice.GetAbpReportedTwinProperties());
 
-            LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(deviceTwin);
+            LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
             LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -935,9 +929,8 @@ namespace LoRaWan.Tests.Integration
             var devEUI = simulatedDevice.DevEUI;
 
             // Will get twin to initialize LoRaDevice
-            var deviceTwin = TestUtils.CreateABPTwin(simulatedDevice);
-            this.LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(deviceTwin);
-            this.LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(simulatedDevice.GetDefaultAbpTwin());
+            LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
             LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);

--- a/Tests/Integration/JoinSlowGetTwinTests.cs
+++ b/Tests/Integration/JoinSlowGetTwinTests.cs
@@ -32,12 +32,12 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried twice, 1st time will take 7 seconds, 2nd time 0.1 second
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            if (deviceGatewayID != null) twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
+            var twin = LoRaDeviceTwin.Create(
+                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+                {
+                    DevEui = devEui,
+                    GatewayId = deviceGatewayID,
+                });
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);
 

--- a/Tests/Integration/JoinSlowGetTwinTests.cs
+++ b/Tests/Integration/JoinSlowGetTwinTests.cs
@@ -32,12 +32,7 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried twice, 1st time will take 7 seconds, 2nd time 0.1 second
-            var twin = LoRaDeviceTwin.Create(
-                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
-                {
-                    DevEui = devEui,
-                    GatewayId = deviceGatewayID,
-                });
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties());
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);
 

--- a/Tests/Integration/JoinSlowTwinUpdateTests.cs
+++ b/Tests/Integration/JoinSlowTwinUpdateTests.cs
@@ -35,12 +35,7 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = LoRaDeviceTwin.Create(
-                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
-                {
-                    DevEui = devEui,
-                    GatewayId = deviceGatewayID
-                });
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties());
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);
 

--- a/Tests/Integration/JoinSlowTwinUpdateTests.cs
+++ b/Tests/Integration/JoinSlowTwinUpdateTests.cs
@@ -35,12 +35,12 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
+            var twin = LoRaDeviceTwin.Create(
+                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+                {
+                    DevEui = devEui,
+                    GatewayId = deviceGatewayID
+                });
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);
 

--- a/Tests/Integration/JoinTests.cs
+++ b/Tests/Integration/JoinTests.cs
@@ -64,14 +64,17 @@ namespace LoRaWan.Tests.Integration
 
             ServerConfiguration.NetId = new NetId(netId);
             // Device twin will be queried
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            if (deviceGatewayID != null) twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            twin.Properties.Reported[TwinProperty.FCntUp] = initialFcntUp;
-            twin.Properties.Reported[TwinProperty.FCntDown] = initialFcntDown;
+            var twin = LoRaDeviceTwin.Create(
+                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+                {
+                    DevEui = devEui,
+                    GatewayId = deviceGatewayID,
+                },
+                new LoRaReportTwinProperties
+                {
+                    FCntUp = initialFcntUp,
+                    FCntDown = initialFcntDown
+                });
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
             // Device twin will be updated
@@ -260,12 +263,12 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            if (deviceGatewayID != null) twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
+            var twin = LoRaDeviceTwin.Create(
+                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+                {
+                    DevEui = devEui,
+                    GatewayId = deviceGatewayID
+                });
             LoRaDeviceClient.SetupSequence(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync((Twin)null)
                 .ReturnsAsync(twin);
@@ -361,12 +364,13 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = "012345678901234567890123456789FF";
-            twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey;
-            twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
+            var twin = LoRaDeviceTwin.Create(
+                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+                {
+                    DevEui = devEui,
+                    JoinEui = new JoinEui(01213147654),
+                    GatewayId = deviceGatewayID
+                });
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
             // Lora device api will be search by devices with matching deveui,
@@ -407,12 +411,13 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            twin.Properties.Desired[TwinProperty.AppKey] = "012345678901234567890123456789FF";
-            twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
+            var twin = LoRaDeviceTwin.Create(
+                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+                {
+                    DevEui = devEui,
+                    AppKey = TestKeys.CreateAppKey(121314765654),
+                    GatewayId = deviceGatewayID
+                });
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
             // Lora device api will be search by devices with matching deveui,
@@ -459,12 +464,12 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
+            var twin = LoRaDeviceTwin.Create(
+               simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+               {
+                   DevEui = devEui,
+                   GatewayId = deviceGatewayID
+               });
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
             // Device twin will be updated
@@ -513,12 +518,12 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
+            var twin = LoRaDeviceTwin.Create(
+               simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+               {
+                   DevEui = devEui,
+                   GatewayId = deviceGatewayID
+               });
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);
 

--- a/Tests/Integration/JoinTests.cs
+++ b/Tests/Integration/JoinTests.cs
@@ -65,11 +65,7 @@ namespace LoRaWan.Tests.Integration
             ServerConfiguration.NetId = new NetId(netId);
             // Device twin will be queried
             var twin = LoRaDeviceTwin.Create(
-                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
-                {
-                    DevEui = devEui,
-                    GatewayId = deviceGatewayID,
-                },
+                simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties(),
                 new LoRaReportedTwinProperties
                 {
                     FCntUp = initialFcntUp,
@@ -263,12 +259,7 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = LoRaDeviceTwin.Create(
-                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
-                {
-                    DevEui = devEui,
-                    GatewayId = deviceGatewayID
-                });
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties());
             LoRaDeviceClient.SetupSequence(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync((Twin)null)
                 .ReturnsAsync(twin);
@@ -364,13 +355,10 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = LoRaDeviceTwin.Create(
-                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
-                {
-                    DevEui = devEui,
-                    JoinEui = new JoinEui(01213147654),
-                    GatewayId = deviceGatewayID
-                });
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties() with
+            {
+                JoinEui = new JoinEui(01213147654)
+            });
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
             // Lora device api will be search by devices with matching deveui,
@@ -411,13 +399,10 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = LoRaDeviceTwin.Create(
-                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
-                {
-                    DevEui = devEui,
-                    AppKey = TestKeys.CreateAppKey(121314765654),
-                    GatewayId = deviceGatewayID
-                });
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties() with
+            {
+                AppKey = TestKeys.CreateAppKey(121314765654),
+            });
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
             // Lora device api will be search by devices with matching deveui,
@@ -464,12 +449,7 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = LoRaDeviceTwin.Create(
-               simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
-               {
-                   DevEui = devEui,
-                   GatewayId = deviceGatewayID
-               });
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties());
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
             // Device twin will be updated
@@ -518,12 +498,7 @@ namespace LoRaWan.Tests.Integration
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = LoRaDeviceTwin.Create(
-               simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
-               {
-                   DevEui = devEui,
-                   GatewayId = deviceGatewayID
-               });
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties());
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);
 

--- a/Tests/Integration/JoinTests.cs
+++ b/Tests/Integration/JoinTests.cs
@@ -70,7 +70,7 @@ namespace LoRaWan.Tests.Integration
                     DevEui = devEui,
                     GatewayId = deviceGatewayID,
                 },
-                new LoRaReportTwinProperties
+                new LoRaReportedTwinProperties
                 {
                     FCntUp = initialFcntUp,
                     FCntDown = initialFcntDown

--- a/Tests/Integration/KeepAliveConnectionTests.cs
+++ b/Tests/Integration/KeepAliveConnectionTests.cs
@@ -257,10 +257,8 @@ namespace LoRaWan.Tests.Integration
                 .ReturnsAsync(new SearchDevicesResult(new IoTHubDeviceInfo(simulatedDevice.DevAddr, simulatedDevice.DevEUI, "ada").AsList()));
 
             // will read the device twins
-            var twin = simulatedDevice.CreateABPTwin(desiredProperties: new Dictionary<string, object>
-            {
-                { TwinProperty.KeepAliveTimeout, 3 }
-            });
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetAbpDesiredTwinProperties() with { KeepAliveTimeout = TimeSpan.FromSeconds(3) },
+                                             simulatedDevice.GetAbpReportedTwinProperties());
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);

--- a/Tests/Integration/MultiGatewayTests.cs
+++ b/Tests/Integration/MultiGatewayTests.cs
@@ -110,7 +110,7 @@ namespace LoRaWan.Tests.Integration
 
             // twin will be loaded
             var initialTwin = LoRaDeviceTwin.Create(
-                simulatedDevice.LoRaDevice.GetAbpTwinProperties() with
+                simulatedDevice.LoRaDevice.GetAbpDesiredTwinProperties() with
                 {
                     DevEui = devEui,
                     GatewayId = twinGatewayID

--- a/Tests/Integration/MultiGatewayTests.cs
+++ b/Tests/Integration/MultiGatewayTests.cs
@@ -115,7 +115,7 @@ namespace LoRaWan.Tests.Integration
                     DevEui = devEui,
                     GatewayId = twinGatewayID
                 },
-                new LoRaReportTwinProperties
+                new LoRaReportedTwinProperties
                 {
                     FCntDown = deviceTwinFcntDown,
                     FCntUp = deviceTwinFcntUp,

--- a/Tests/Integration/MultiGatewayTests.cs
+++ b/Tests/Integration/MultiGatewayTests.cs
@@ -109,20 +109,17 @@ namespace LoRaWan.Tests.Integration
                 .ReturnsAsync((Message)null);
 
             // twin will be loaded
-            var initialTwin = new Twin();
-            initialTwin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            initialTwin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            initialTwin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            initialTwin.Properties.Desired[TwinProperty.NwkSKey] = simulatedDevice.LoRaDevice.NwkSKey?.ToString();
-            initialTwin.Properties.Desired[TwinProperty.AppSKey] = simulatedDevice.LoRaDevice.AppSKey?.ToString();
-            initialTwin.Properties.Desired[TwinProperty.DevAddr] = devAddr.ToString();
-            if (twinGatewayID != null)
-                initialTwin.Properties.Desired[TwinProperty.GatewayID] = twinGatewayID;
-            initialTwin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            if (deviceTwinFcntDown.HasValue)
-                initialTwin.Properties.Reported[TwinProperty.FCntDown] = deviceTwinFcntDown.Value;
-            if (deviceTwinFcntUp.HasValue)
-                initialTwin.Properties.Reported[TwinProperty.FCntUp] = deviceTwinFcntUp.Value;
+            var initialTwin = LoRaDeviceTwin.Create(
+                simulatedDevice.LoRaDevice.GetAbpTwinProperties() with
+                {
+                    DevEui = devEui,
+                    GatewayId = twinGatewayID
+                },
+                new LoRaReportTwinProperties
+                {
+                    FCntDown = deviceTwinFcntDown,
+                    FCntUp = deviceTwinFcntUp,
+                });
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(initialTwin);
 

--- a/Tests/Integration/ParallelProcessingTests.cs
+++ b/Tests/Integration/ParallelProcessingTests.cs
@@ -128,7 +128,7 @@ namespace LoRaWan.Tests.Integration
 
             // twin will be loaded
             var initialTwin = LoRaDeviceTwin.Create(
-                simulatedDevice.LoRaDevice.GetAbpTwinProperties() with
+                simulatedDevice.LoRaDevice.GetAbpDesiredTwinProperties() with
                 {
                     DevEui = devEui,
                     GatewayId = parallelTestConfiguration.GatewayID
@@ -304,7 +304,7 @@ namespace LoRaWan.Tests.Integration
             var device2Twin = TestUtils.CreateABPTwin(device2);
             var device3 = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(3));
             device3.SetupJoin(TestKeys.CreateAppSessionKey(0x88), TestKeys.CreateNetworkSessionKey(0x88), new DevAddr(0x02000088));
-            var device3Twin = LoRaDeviceTwin.Create(device3.LoRaDevice.GetOtaaTwinProperties(), device3.GetOtaaReportedTwinProperties());
+            var device3Twin = LoRaDeviceTwin.Create(device3.LoRaDevice.GetOtaaDesiredTwinProperties(), device3.GetOtaaReportedTwinProperties());
             var device4 = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(4));
             var device4Twin = TestUtils.CreateABPTwin(device4);
 

--- a/Tests/Integration/ParallelProcessingTests.cs
+++ b/Tests/Integration/ParallelProcessingTests.cs
@@ -127,20 +127,17 @@ namespace LoRaWan.Tests.Integration
                 });
 
             // twin will be loaded
-            var initialTwin = new Twin();
-            initialTwin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            initialTwin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            initialTwin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            initialTwin.Properties.Desired[TwinProperty.NwkSKey] = simulatedDevice.LoRaDevice.NwkSKey?.ToString();
-            initialTwin.Properties.Desired[TwinProperty.AppSKey] = simulatedDevice.LoRaDevice.AppSKey?.ToString();
-            initialTwin.Properties.Desired[TwinProperty.DevAddr] = devAddr.ToString();
-            if (parallelTestConfiguration.GatewayID != null)
-                initialTwin.Properties.Desired[TwinProperty.GatewayID] = parallelTestConfiguration.GatewayID;
-            initialTwin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            if (parallelTestConfiguration.DeviceTwinFcntDown.HasValue)
-                initialTwin.Properties.Reported[TwinProperty.FCntDown] = parallelTestConfiguration.DeviceTwinFcntDown.Value;
-            if (parallelTestConfiguration.DeviceTwinFcntUp.HasValue)
-                initialTwin.Properties.Reported[TwinProperty.FCntUp] = parallelTestConfiguration.DeviceTwinFcntUp.Value;
+            var initialTwin = LoRaDeviceTwin.Create(
+                simulatedDevice.LoRaDevice.GetAbpTwinProperties() with
+                {
+                    DevEui = devEui,
+                    GatewayId = parallelTestConfiguration.GatewayID
+                },
+                new LoRaReportTwinProperties
+                {
+                    FCntDown = parallelTestConfiguration.DeviceTwinFcntDown,
+                    FCntUp = parallelTestConfiguration.DeviceTwinFcntUp,
+                });
 
             looseDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .Returns(() =>

--- a/Tests/Integration/ParallelProcessingTests.cs
+++ b/Tests/Integration/ParallelProcessingTests.cs
@@ -296,17 +296,17 @@ namespace LoRaWan.Tests.Integration
             const int payloadInitialFcnt = 2;
 
             var device1 = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
-            var device1Twin = TestUtils.CreateABPTwin(device1);
+            var device1Twin = device1.GetDefaultAbpTwin();
             var device2 = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(2))
             {
                 DevAddr = device1.DevAddr
             };
-            var device2Twin = TestUtils.CreateABPTwin(device2);
+            var device2Twin = device2.GetDefaultAbpTwin();
             var device3 = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(3));
             device3.SetupJoin(TestKeys.CreateAppSessionKey(0x88), TestKeys.CreateNetworkSessionKey(0x88), new DevAddr(0x02000088));
             var device3Twin = LoRaDeviceTwin.Create(device3.LoRaDevice.GetOtaaDesiredTwinProperties(), device3.GetOtaaReportedTwinProperties());
             var device4 = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(4));
-            var device4Twin = TestUtils.CreateABPTwin(device4);
+            var device4Twin = device4.GetDefaultAbpTwin();
 
             var device1And2Result = new IoTHubDeviceInfo[]
             {

--- a/Tests/Integration/ParallelProcessingTests.cs
+++ b/Tests/Integration/ParallelProcessingTests.cs
@@ -304,7 +304,7 @@ namespace LoRaWan.Tests.Integration
             var device2Twin = TestUtils.CreateABPTwin(device2);
             var device3 = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(3));
             device3.SetupJoin(TestKeys.CreateAppSessionKey(0x88), TestKeys.CreateNetworkSessionKey(0x88), new DevAddr(0x02000088));
-            var device3Twin = TestUtils.CreateOTAATwin(device3);
+            var device3Twin = LoRaDeviceTwin.Create(device3.LoRaDevice.GetOtaaTwinProperties(), device3.GetOtaaReportedTwinProperties());
             var device4 = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(4));
             var device4Twin = TestUtils.CreateABPTwin(device4);
 

--- a/Tests/Integration/ParallelProcessingTests.cs
+++ b/Tests/Integration/ParallelProcessingTests.cs
@@ -133,7 +133,7 @@ namespace LoRaWan.Tests.Integration
                     DevEui = devEui,
                     GatewayId = parallelTestConfiguration.GatewayID
                 },
-                new LoRaReportTwinProperties
+                new LoRaReportedTwinProperties
                 {
                     FCntDown = parallelTestConfiguration.DeviceTwinFcntDown,
                     FCntUp = parallelTestConfiguration.DeviceTwinFcntUp,

--- a/Tests/Integration/ProcessingTests.cs
+++ b/Tests/Integration/ProcessingTests.cs
@@ -886,7 +886,7 @@ namespace LoRaWan.Tests.Integration
             var devAddr = simulatedDevice.DevAddr.Value;
 
             // Device twin will be queried
-            var twin = simulatedDevice.CreateABPTwin();
+            var twin = simulatedDevice.GetDefaultAbpTwin();
             LoRaDeviceClient.SetupSequence(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync((Twin)null)
                 .ReturnsAsync(twin);
@@ -979,7 +979,7 @@ namespace LoRaWan.Tests.Integration
             if (!isAlreadyInDeviceRegistryCache)
             {
                 LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                    .ReturnsAsync(simulatedDevice.CreateABPTwin());
+                    .ReturnsAsync(simulatedDevice.GetDefaultAbpTwin());
             }
 
             // C2D message will be checked
@@ -1054,7 +1054,7 @@ namespace LoRaWan.Tests.Integration
             loRaDevice.SensorDecoder = "DecoderValueSensor";
 
             // will get the device twin without AppSKey
-            var twin = TestUtils.CreateABPTwin(simulatedDevice);
+            var twin = simulatedDevice.GetDefaultAbpTwin();
             twin.Properties.Desired[missingProperty] = null;
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                     .ReturnsAsync(twin);
@@ -1285,7 +1285,7 @@ namespace LoRaWan.Tests.Integration
 
             deviceClient.Setup(x => x.EnsureConnected()).Returns(true);
 
-            deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(simulatedDevice.CreateABPTwin());
+            deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(simulatedDevice.GetDefaultAbpTwin());
 
             deviceClient.Setup(x => x.DisconnectAsync())
                .Returns(Task.CompletedTask);
@@ -1356,7 +1356,7 @@ namespace LoRaWan.Tests.Integration
             deviceClient1.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
-            deviceClient1.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(simulatedDevice1.CreateABPTwin());
+            deviceClient1.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(simulatedDevice1.GetDefaultAbpTwin());
 
             if (isResetingDevice)
             {
@@ -1367,7 +1367,7 @@ namespace LoRaWan.Tests.Integration
             // Device client 2
             // - Get Twin
             var deviceClient2 = new Mock<ILoRaDeviceClient>();
-            deviceClient2.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(simulatedDevice2.CreateABPTwin());
+            deviceClient2.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(simulatedDevice2.GetDefaultAbpTwin());
 
             // device api will be searched for payload
             var searchDevicesResult = new SearchDevicesResult(new[]
@@ -1473,7 +1473,7 @@ namespace LoRaWan.Tests.Integration
             deviceClient1.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))
                 .ReturnsAsync((Message)null);
 
-            deviceClient1.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(simulatedDevice1.CreateABPTwin());
+            deviceClient1.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(simulatedDevice1.GetDefaultAbpTwin());
 
             // If the framecounter is higher than 10 it will trigger an update of the framcounter in the reported properties.
             if (payloadFcntUp > 10)
@@ -1670,7 +1670,7 @@ namespace LoRaWan.Tests.Integration
 
             LoRaDeviceClient.SetupSequence(x => x.GetTwinAsync(CancellationToken.None))
                 .ThrowsAsync(new TimeoutException())
-                .ReturnsAsync(simDevice.CreateABPTwin());
+                .ReturnsAsync(simDevice.GetDefaultAbpTwin());
 
             LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
@@ -1724,7 +1724,7 @@ namespace LoRaWan.Tests.Integration
             }
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(simDevice.CreateABPTwin());
+                .ReturnsAsync(simDevice.GetDefaultAbpTwin());
 
             LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);

--- a/Tests/Integration/ProcessingTests.cs
+++ b/Tests/Integration/ProcessingTests.cs
@@ -680,19 +680,14 @@ namespace LoRaWan.Tests.Integration
 
             simulatedDevice.SetupJoin(appSKey, nwkSKey, devAddr);
 
-            var updatedTwin = TestUtils.CreateTwin(
-                desired: new Dictionary<string, object>
+            var updatedTwin = LoRaDeviceTwin.Create(
+                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with { SensorDecoder = nameof(LoRaPayloadDecoder.DecoderValueSensor) },
+                new LoRaReportTwinProperties
                 {
-                    { TwinProperty.AppEui, simulatedDevice.AppEui?.ToString() },
-                    { TwinProperty.AppKey, simulatedDevice.AppKey?.ToString() },
-                    { TwinProperty.SensorDecoder, nameof(LoRaPayloadDecoder.DecoderValueSensor) },
-                },
-                reported: new Dictionary<string, object>
-                {
-                    { TwinProperty.AppSKey, appSKey.ToString() },
-                    { TwinProperty.NwkSKey, nwkSKey.ToString() },
-                    { TwinProperty.DevAddr, devAddr.ToString() },
-                    { TwinProperty.DevNonce, "ABCD" },
+                    AppSessionKey = appSKey,
+                    NetworkSessionKey = nwkSKey,
+                    DevAddr = devAddr,
+                    DevNonce = new DevNonce(0xABCD)
                 });
 
             // Twin will be loaded once

--- a/Tests/Integration/ProcessingTests.cs
+++ b/Tests/Integration/ProcessingTests.cs
@@ -682,7 +682,7 @@ namespace LoRaWan.Tests.Integration
 
             var updatedTwin = LoRaDeviceTwin.Create(
                 simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with { SensorDecoder = nameof(LoRaPayloadDecoder.DecoderValueSensor) },
-                new LoRaReportTwinProperties
+                new LoRaReportedTwinProperties
                 {
                     AppSessionKey = appSKey,
                     NetworkSessionKey = nwkSKey,

--- a/Tests/Integration/ProcessingTests.cs
+++ b/Tests/Integration/ProcessingTests.cs
@@ -681,7 +681,7 @@ namespace LoRaWan.Tests.Integration
             simulatedDevice.SetupJoin(appSKey, nwkSKey, devAddr);
 
             var updatedTwin = LoRaDeviceTwin.Create(
-                simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with { SensorDecoder = nameof(LoRaPayloadDecoder.DecoderValueSensor) },
+                simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties() with { SensorDecoder = nameof(LoRaPayloadDecoder.DecoderValueSensor) },
                 new LoRaReportedTwinProperties
                 {
                     AppSessionKey = appSKey,

--- a/Tests/Unit/NetworkServer/DefaultClassCDevicesMessageSenderTest.cs
+++ b/Tests/Unit/NetworkServer/DefaultClassCDevicesMessageSenderTest.cs
@@ -196,7 +196,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync("123");
 
             this.deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(simDevice.CreateOTAATwin());
+                .ReturnsAsync(LoRaDeviceTwin.Create(simDevice.LoRaDevice.GetOtaaTwinProperties(), simDevice.GetOtaaReportedTwinProperties()));
 
             var c2dToDeviceMessage = new ReceivedLoRaCloudToDeviceMessage()
             {
@@ -337,20 +337,20 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             this.deviceApi.Setup(x => x.GetPrimaryKeyByEuiAsync(devEUI))
                 .ReturnsAsync("123");
 
-            var twin = simDevice.CreateOTAATwin(
-                desiredProperties: new Dictionary<string, object>
+            var twin = LoRaDeviceTwin.Create(
+                simDevice.LoRaDevice.GetOtaaTwinProperties() with
                 {
-                    { TwinProperty.RX2DataRate, "10" }
+                    Rx2DataRate = DataRateIndex.DR10
                 },
-                reportedProperties: new Dictionary<string, object>
+                simDevice.GetOtaaReportedTwinProperties() with
                 {
-                    { TwinProperty.RX2DataRate, 10 },
-                    { TwinProperty.Region, LoRaRegionType.US915.ToString() },
+                    Rx2DataRate = DataRateIndex.DR10,
+                    Region = LoRaRegionType.US915,
                     // OTAA device, already joined
-                    { TwinProperty.DevAddr, devAddr.ToString() },
-                    { TwinProperty.AppSKey, appSKey.ToString() },
-                    { TwinProperty.NwkSKey, nwkSKey.ToString() },
-                    { TwinProperty.LastProcessingStationEui, new StationEui(ulong.MaxValue).ToString() }
+                    DevAddr = devAddr,
+                    AppSessionKey = appSKey,
+                    NetworkSessionKey = nwkSKey,
+                    LastProcessingStation = new StationEui(ulong.MaxValue)
                 });
 
             this.deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
@@ -403,19 +403,19 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             this.deviceApi.Setup(x => x.GetPrimaryKeyByEuiAsync(devEUI))
                 .ReturnsAsync("123");
 
-            var twin = simDevice.CreateOTAATwin(
-                desiredProperties: new Dictionary<string, object>
+            var twin = LoRaDeviceTwin.Create(
+                simDevice.LoRaDevice.GetOtaaTwinProperties() with
                 {
-                    { TwinProperty.RX2DataRate, "10" }
+                    Rx2DataRate = DataRateIndex.DR10
                 },
-                reportedProperties: new Dictionary<string, object>
+                simDevice.GetOtaaReportedTwinProperties() with
                 {
-                    { TwinProperty.RX2DataRate, 10 },
-                    { TwinProperty.Region, LoRaRegionType.US915.ToString() },
+                    Rx2DataRate = DataRateIndex.DR10,
+                    Region = LoRaRegionType.US915,
                     // OTAA device, already joined
-                    { TwinProperty.DevAddr, devAddr.ToString() },
-                    { TwinProperty.AppSKey, appSKey.ToString() },
-                    { TwinProperty.NwkSKey, nwkSKey.ToString() },
+                    DevAddr = devAddr,
+                    AppSessionKey = appSKey,
+                    NetworkSessionKey = nwkSKey
                 });
 
             this.deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))

--- a/Tests/Unit/NetworkServer/DefaultClassCDevicesMessageSenderTest.cs
+++ b/Tests/Unit/NetworkServer/DefaultClassCDevicesMessageSenderTest.cs
@@ -79,11 +79,12 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             this.deviceApi.Setup(x => x.GetPrimaryKeyByEuiAsync(devEUI))
                 .ReturnsAsync("123");
 
-            var twin = simDevice.CreateABPTwin(reportedProperties: new Dictionary<string, object>
-                {
-                    { TwinProperty.Region, LoRaRegionType.EU868.ToString() },
-                    { TwinProperty.LastProcessingStationEui, new StationEui(ulong.MaxValue).ToString() }
-                });
+            var twin = LoRaDeviceTwin.Create(simDevice.LoRaDevice.GetAbpDesiredTwinProperties(),
+                                             simDevice.GetAbpReportedTwinProperties() with
+                                             {
+                                                 Region = LoRaRegionType.EU868,
+                                                 LastProcessingStation = new StationEui(ulong.MaxValue)
+                                             });
 
             this.deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);
@@ -136,7 +137,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync("123");
 
             this.deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(simDevice.CreateABPTwin());
+                .ReturnsAsync(simDevice.GetDefaultAbpTwin());
 
             var c2dToDeviceMessage = new ReceivedLoRaCloudToDeviceMessage()
             {
@@ -230,11 +231,12 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             this.deviceApi.Setup(x => x.GetPrimaryKeyByEuiAsync(devEUI))
                 .ReturnsAsync("123");
 
-            var twin = simDevice.CreateABPTwin(reportedProperties: new Dictionary<string, object>
-                {
-                    { TwinProperty.Region, LoRaRegionType.EU868.ToString() },
-                    { TwinProperty.LastProcessingStationEui, new StationEui(ulong.MaxValue).ToString() }
-                });
+            var twin = LoRaDeviceTwin.Create(simDevice.LoRaDevice.GetAbpDesiredTwinProperties(),
+                                             simDevice.GetAbpReportedTwinProperties() with
+                                             {
+                                                 Region = LoRaRegionType.EU868,
+                                                 LastProcessingStation = new StationEui(ulong.MaxValue)
+                                             });
 
             this.deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);

--- a/Tests/Unit/NetworkServer/DefaultClassCDevicesMessageSenderTest.cs
+++ b/Tests/Unit/NetworkServer/DefaultClassCDevicesMessageSenderTest.cs
@@ -196,7 +196,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync("123");
 
             this.deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(LoRaDeviceTwin.Create(simDevice.LoRaDevice.GetOtaaTwinProperties(), simDevice.GetOtaaReportedTwinProperties()));
+                .ReturnsAsync(LoRaDeviceTwin.Create(simDevice.LoRaDevice.GetOtaaDesiredTwinProperties(), simDevice.GetOtaaReportedTwinProperties()));
 
             var c2dToDeviceMessage = new ReceivedLoRaCloudToDeviceMessage()
             {
@@ -338,7 +338,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync("123");
 
             var twin = LoRaDeviceTwin.Create(
-                simDevice.LoRaDevice.GetOtaaTwinProperties() with
+                simDevice.LoRaDevice.GetOtaaDesiredTwinProperties() with
                 {
                     Rx2DataRate = DataRateIndex.DR10
                 },
@@ -404,7 +404,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync("123");
 
             var twin = LoRaDeviceTwin.Create(
-                simDevice.LoRaDevice.GetOtaaTwinProperties() with
+                simDevice.LoRaDevice.GetOtaaDesiredTwinProperties() with
                 {
                     Rx2DataRate = DataRateIndex.DR10
                 },

--- a/Tests/Unit/NetworkServer/DeviceLoaderSynchronizerTest.cs
+++ b/Tests/Unit/NetworkServer/DeviceLoaderSynchronizerTest.cs
@@ -221,7 +221,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // Will get device twin
             var loRaDeviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Loose);
             loRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(TestUtils.CreateABPTwin(simulatedDevice));
+                .ReturnsAsync(simulatedDevice.GetDefaultAbpTwin());
 
             using var deviceCache = LoRaDeviceCacheDefault.CreateDefault();
             var deviceFactory = new TestLoRaDeviceFactory(loRaDeviceClient.Object, deviceCache, this.connectionManager);

--- a/Tests/Unit/NetworkServer/FcntLimitTest.cs
+++ b/Tests/Unit/NetworkServer/FcntLimitTest.cs
@@ -59,7 +59,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null)).ReturnsAsync(true);
 
             var initialTwin = LoRaDeviceTwin.Create(
-                simulatedDevice.LoRaDevice.GetAbpTwinProperties() with
+                simulatedDevice.LoRaDevice.GetAbpDesiredTwinProperties() with
                 {
                     DevEui = devEui,
                     AbpRelaxMode = abpRelaxed,
@@ -177,7 +177,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null)).ReturnsAsync(true);
 
             var initialTwin = LoRaDeviceTwin.Create(
-                simulatedDevice.LoRaDevice.GetAbpTwinProperties() with
+                simulatedDevice.LoRaDevice.GetAbpDesiredTwinProperties() with
                 {
                     DevEui = devEui,
                     AbpRelaxMode = true,

--- a/Tests/Unit/NetworkServer/LoRaDeviceRegistryTest.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceRegistryTest.cs
@@ -82,7 +82,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             // device will be initialized
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(simulatedDevice.CreateABPTwin());
+                .ReturnsAsync(simulatedDevice.GetDefaultAbpTwin());
 
             using var request = WaitableLoRaRequest.Create(payload);
             var requestHandler = new Mock<ILoRaDataRequestHandler>(MockBehavior.Strict);
@@ -128,7 +128,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             // device will be initialized
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(simulatedDevice.CreateABPTwin());
+                .ReturnsAsync(simulatedDevice.GetDefaultAbpTwin());
 
             using var target = new LoRaDeviceRegistry(ServerConfiguration, this.cache, apiService.Object, this.loraDeviceFactoryMock.Object, DeviceCache);
 
@@ -233,7 +233,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             var loRaDeviceClient1 = new Mock<ILoRaDeviceClient>(MockBehavior.Loose);
             loRaDeviceClient1.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(simulatedDevice1.CreateABPTwin());
+                .ReturnsAsync(simulatedDevice1.GetDefaultAbpTwin());
 
             using var connectionManager1 = new SingleDeviceConnectionManager(loRaDeviceClient1.Object);
             using var loraDevice1 = TestUtils.CreateFromSimulatedDevice(simulatedDevice1, connectionManager1);
@@ -249,7 +249,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             simulatedDevice2.LoRaDevice.NwkSKey = TestKeys.CreateNetworkSessionKey(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF);
             var loRaDeviceClient2 = new Mock<ILoRaDeviceClient>(MockBehavior.Loose);
             loRaDeviceClient2.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(simulatedDevice2.CreateABPTwin());
+                .ReturnsAsync(simulatedDevice2.GetDefaultAbpTwin());
             using var connectionManager2 = new SingleDeviceConnectionManager(loRaDeviceClient2.Object);
             using var loraDevice2 = TestUtils.CreateFromSimulatedDevice(simulatedDevice2, connectionManager2);
 
@@ -443,7 +443,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             var deviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Loose);
             deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(simDevice.CreateABPTwin());
+                .ReturnsAsync(simDevice.GetDefaultAbpTwin());
 
             var handlerImplementation = new Mock<ILoRaDataRequestHandler>(MockBehavior.Strict);
             var deviceFactory = new TestLoRaDeviceFactory(deviceClient.Object, handlerImplementation.Object, DeviceCache, ConnectionManager);
@@ -480,7 +480,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             var deviceClient = new Mock<ILoRaDeviceClient>(MockBehavior.Loose);
             deviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(simDevice.CreateABPTwin());
+                .ReturnsAsync(simDevice.GetDefaultAbpTwin());
 
             var handlerImplementation = new Mock<ILoRaDataRequestHandler>(MockBehavior.Strict);
             handlerImplementation.Setup(x => x.ProcessRequestAsync(It.IsNotNull<LoRaRequest>(), It.IsNotNull<LoRaDevice>()))

--- a/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
+++ b/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
@@ -80,7 +80,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync(true);
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties()));
+                .ReturnsAsync(LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties()));
 
             using var cache = NewMemoryCache();
             using var deviceRegistry = new LoRaDeviceRegistry(ServerConfiguration, cache, LoRaDeviceApi.Object, LoRaDeviceFactory, DeviceCache);
@@ -305,7 +305,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties());
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties());
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
             // Device twin will be updated
@@ -407,7 +407,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties() with
             {
                 Rx1DROffset = rx1DROffset,
                 Rx2DataRate = rx2datarate
@@ -479,7 +479,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync((Message)null);
 
             // Device twin will be queried
-            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties() with
             {
                 Rx2DataRate = rx2datarate,
                 PreferredWindow = 2
@@ -572,7 +572,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync((Message)null);
 
             // Device twin will be queried
-            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties() with
             {
                 Rx2DataRate = (DataRateIndex)afterJoinValues,
                 Rx1DROffset = afterJoinValues,
@@ -674,7 +674,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync((Message)null);
 
             // Device twin will be queried
-            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties() with
             {
                 Rx1DROffset = rx1offset,
                 PreferredWindow = 1
@@ -785,7 +785,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync((Message)null);
 
             // Device twin will be queried
-            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties() with
             {
                 RxDelay = rxDelay,
                 PreferredWindow = 1

--- a/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
+++ b/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
@@ -80,7 +80,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync(true);
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(simulatedDevice.CreateOTAATwin());
+                .ReturnsAsync(LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties()));
 
             using var cache = NewMemoryCache();
             using var deviceRegistry = new LoRaDeviceRegistry(ServerConfiguration, cache, LoRaDeviceApi.Object, LoRaDeviceFactory, DeviceCache);

--- a/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
+++ b/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
@@ -305,12 +305,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            if (deviceGatewayID != null) twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties());
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
             // Device twin will be updated
@@ -412,14 +407,11 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var devEui = simulatedDevice.LoRaDevice.DevEui;
 
             // Device twin will be queried
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            twin.Properties.Desired[TwinProperty.RX1DROffset] = rx1DROffset;
-            twin.Properties.Desired[TwinProperty.RX2DataRate] = rx2datarate;
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+            {
+                Rx1DROffset = rx1DROffset,
+                Rx2DataRate = rx2datarate
+            });
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
@@ -487,14 +479,11 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync((Message)null);
 
             // Device twin will be queried
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            twin.Properties.Desired[TwinProperty.RX2DataRate] = rx2datarate;
-            twin.Properties.Desired[TwinProperty.PreferredWindow] = 2;
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+            {
+                Rx2DataRate = rx2datarate,
+                PreferredWindow = 2
+            });
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
@@ -583,15 +572,12 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync((Message)null);
 
             // Device twin will be queried
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            twin.Properties.Desired[TwinProperty.RX2DataRate] = afterJoinValues;
-            twin.Properties.Desired[TwinProperty.RX1DROffset] = afterJoinValues;
-            twin.Properties.Desired[TwinProperty.RXDelay] = afterJoinValues;
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+            {
+                Rx2DataRate = (DataRateIndex)afterJoinValues,
+                Rx1DROffset = afterJoinValues,
+                RxDelay = afterJoinValues
+            });
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
             LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>(), It.IsAny<CancellationToken>()))
@@ -688,14 +674,11 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync((Message)null);
 
             // Device twin will be queried
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            twin.Properties.Desired[TwinProperty.RX1DROffset] = rx1offset;
-            twin.Properties.Desired[TwinProperty.PreferredWindow] = 1;
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+            {
+                Rx1DROffset = rx1offset,
+                PreferredWindow = 1
+            });
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 
@@ -802,14 +785,11 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync((Message)null);
 
             // Device twin will be queried
-            var twin = new Twin();
-            twin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            twin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            twin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            twin.Properties.Desired[TwinProperty.GatewayID] = deviceGatewayID;
-            twin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            twin.Properties.Desired[TwinProperty.RXDelay] = rxDelay;
-            twin.Properties.Desired[TwinProperty.PreferredWindow] = 1;
+            var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaTwinProperties() with
+            {
+                RxDelay = rxDelay,
+                PreferredWindow = 1
+            });
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
 

--- a/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
+++ b/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
@@ -482,7 +482,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties() with
             {
                 Rx2DataRate = rx2datarate,
-                PreferredWindow = 2
+                PreferredWindow = ReceiveWindowNumber.ReceiveWindow2
             });
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
@@ -677,7 +677,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties() with
             {
                 Rx1DROffset = rx1offset,
-                PreferredWindow = 1
+                PreferredWindow = ReceiveWindowNumber.ReceiveWindow1
             });
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);
@@ -788,7 +788,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var twin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetOtaaDesiredTwinProperties() with
             {
                 RxDelay = rxDelay,
-                PreferredWindow = 1
+                PreferredWindow = ReceiveWindowNumber.ReceiveWindow1
             });
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(twin);

--- a/Tests/Unit/NetworkServer/MessageProcessorSingleGatewayTest.cs
+++ b/Tests/Unit/NetworkServer/MessageProcessorSingleGatewayTest.cs
@@ -88,7 +88,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             }
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(TestUtils.CreateABPTwin(simulatedDevice));
+                .ReturnsAsync(simulatedDevice.GetDefaultAbpTwin());
 
             using var cache = NewMemoryCache();
             using var deviceRegistry = new LoRaDeviceRegistry(ServerConfiguration, cache, LoRaDeviceApi.Object, LoRaDeviceFactory, DeviceCache);
@@ -484,7 +484,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // - send event
             // - receive c2d
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
-                .ReturnsAsync(simulatedDevice.CreateABPTwin());
+                .ReturnsAsync(simulatedDevice.GetDefaultAbpTwin());
             LoRaDeviceClient.Setup(x => x.SendEventAsync(It.IsNotNull<LoRaDeviceTelemetry>(), null))
                 .ReturnsAsync(true);
             LoRaDeviceClient.Setup(x => x.ReceiveAsync(It.IsNotNull<TimeSpan>()))

--- a/Tests/Unit/NetworkServer/MessageProcessorSingleGatewayTest.cs
+++ b/Tests/Unit/NetworkServer/MessageProcessorSingleGatewayTest.cs
@@ -550,7 +550,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync((Message)null);
 
             // twin will be loaded
-            var initialTwin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetAbpTwinProperties() with { DevEui = devEui },
+            var initialTwin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetAbpDesiredTwinProperties() with { DevEui = devEui },
             new LoRaReportedTwinProperties { FCntDown = deviceTwinFcntDown, FCntUp = deviceTwinFcntUp });
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(initialTwin);

--- a/Tests/Unit/NetworkServer/MessageProcessorSingleGatewayTest.cs
+++ b/Tests/Unit/NetworkServer/MessageProcessorSingleGatewayTest.cs
@@ -534,7 +534,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             uint? deviceTwinFcntUp,
             uint? deviceTwinFcntDown)
         {
-            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1));
+            var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: ServerConfiguration.GatewayID));
 
             var devEui = simulatedDevice.LoRaDevice.DevEui;
             var devAddr = simulatedDevice.LoRaDevice.DevAddr.Value;
@@ -550,19 +550,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
                 .ReturnsAsync((Message)null);
 
             // twin will be loaded
-            var initialTwin = new Twin();
-            initialTwin.Properties.Desired[TwinProperty.DevEUI] = devEui.ToString();
-            initialTwin.Properties.Desired[TwinProperty.AppEui] = simulatedDevice.LoRaDevice.AppEui?.ToString();
-            initialTwin.Properties.Desired[TwinProperty.AppKey] = simulatedDevice.LoRaDevice.AppKey?.ToString();
-            initialTwin.Properties.Desired[TwinProperty.NwkSKey] = simulatedDevice.LoRaDevice.NwkSKey?.ToString();
-            initialTwin.Properties.Desired[TwinProperty.AppSKey] = simulatedDevice.LoRaDevice.AppSKey?.ToString();
-            initialTwin.Properties.Desired[TwinProperty.DevAddr] = devAddr.ToString();
-            initialTwin.Properties.Desired[TwinProperty.GatewayID] = ServerConfiguration.GatewayID;
-            initialTwin.Properties.Desired[TwinProperty.SensorDecoder] = simulatedDevice.LoRaDevice.SensorDecoder;
-            if (deviceTwinFcntDown.HasValue)
-                initialTwin.Properties.Reported[TwinProperty.FCntDown] = deviceTwinFcntDown.Value;
-            if (deviceTwinFcntUp.HasValue)
-                initialTwin.Properties.Reported[TwinProperty.FCntUp] = deviceTwinFcntUp.Value;
+            var initialTwin = LoRaDeviceTwin.Create(simulatedDevice.LoRaDevice.GetAbpTwinProperties() with { DevEui = devEui },
+            new LoRaReportedTwinProperties { FCntDown = deviceTwinFcntDown, FCntUp = deviceTwinFcntUp });
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None)).ReturnsAsync(initialTwin);
 


### PR DESCRIPTION
# PR for issue #1532

## What is being addressed

In several tests, if we must set up device twins as part of the test setup, we set these twins up in a manner that involves some duplication:

- we duplicate how we represent certain types, e.g. a `DevEui`, `NetworkSessionKey`, etc, in a device twin
- we duplicate how the device twin properties are named (albeit relying on constants)
- we duplicate the twin structures for OTAA/ABP devices

With this PR we introduce a mechanism for test device twin creation. The new mechanism helps us:

- using strong types for device twin properties
- compose similar twin properties by supproting nondestructive mutation
- encapsulating how certain properties are represented in a LoRa device twin

In this PR we introduce the mechanism for only a part of all twins used in the test code, to get early feedback. The rest of the occurrences of the legacy twin creation methods will be replaced in a separate PR.
