### PR TITLE
Updating documentation for latest Basics Station module changes

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -82,7 +82,7 @@ The template provision an IoT Hub with a [LoRa Basics™ Station](https://github
 
 If you are using the the RAK833-USB, you'll need to build a different LoRa Basics™ Station image. You can find a fork of the official Basic Station repository with support for RAK833-USB [here](https://github.com/danigian/basicstation).
 
-If you are using a SX1302 board via USB, you'll need to build a different LoRa Basics™ Station image. You can find a fork of the official Basic Station repository with support for SX1302 USB boards [here](https://github.com/danigian/basicstation/tree/corecell).
+If you are using a SX1302 (Corecell) board, you'll need to properly configure the built-in deployed module by having a look at the parameters in [Basics™ Station Module Configuration](user-guide/station-module-configuration.md) page.
 
 ## Using a Proxy Server to connect your Concentrator to Azure
 

--- a/docs/user-guide/devguide.md
+++ b/docs/user-guide/devguide.md
@@ -24,7 +24,7 @@ The code is organized into three sections:
 A **.NET 6** solution with the following projects:
 
 - **modules** - Azure IoT Edge modules.
-  - **LoRaBasicsStationModule** packages the Basics Station into an IoT Edge compatible docker container (See <https://github.com/lorabasics/basicstation>). If you are using a RAK833-USB, you need to build your own Basics Station docker image starting from the fork [at this link](https://github.com/danigian/basicstation). At the time of writing, SX1302 boards are supported only through SPI. If you are using a SX1302 board via USB you need to build your own Basics Station docker image starting from the fork [at this link](https://github.com/danigian/basicstation/tree/corecell)
+  - **LoRaBasicsStationModule** packages the Basics Station into an IoT Edge compatible docker container (See <https://github.com/lorabasics/basicstation>). If you are using a RAK833-USB, you need to build your own Basics Station docker image starting from the fork [at this link](https://github.com/danigian/basicstation).
   - **LoRaWanNetworkSrvModule** - is the LoRaWAN network server implementation.
 - **LoraKeysManagerFacade** - An Azure function handling device provisioning (e.g. LoRa network join, OTAA) with Azure IoT Hub as persistence layer.
 

--- a/docs/user-guide/pkt-fwd-to-station.md
+++ b/docs/user-guide/pkt-fwd-to-station.md
@@ -30,17 +30,15 @@ In case you were using the pre-built [Packet Forwarder module](https://github.co
 | SPI_DEV | SPI_DEV | Name is not changing.<br/>In Basics Station module, it is a number identifying the SPI location where the board should be accessed (i.e.: when X, board accessed at /dev/spidevX.0)<br/>Field defaults to 0 |
 | SPI_SPEED | SPI_SPEED | Name and functionality are not changing.<br/>In Basics Station module, default to 8, unique alternative provided is 2 |
 
-A more comprehensive list of allowed variables can be found in the [Basic Station module configuration][module-configuration] page
+Previous Packet Forwarder module was built only for SX1301 based devices using SPI communication. Current LoRaBasicsStationModule is built for both SX1301 and SX1302 based devices (starting from v2.1.0).
 
-As previous Packet Forwarder module, the LoRaBasicsStationModule is currently built only for SX1301 based devices using SPI communication.
+A more comprehensive list of allowed variables can be found in the [Basic Station module configuration][module-configuration] page.
 
 ### Custom built docker module
 
 In case you are not using the pre-built Packet Forwarder module, because of hardware incompatibilities, you can try build your own docker module by starting from the [official Basics Station source code](https://github.com/lorabasics/basicstation).
 
 If you own a USB-FTDI mPCIe RAK833 board, an unofficial and not supported fork of the Basics Station can be found [here](https://github.com/danigian/basicstation)
-
-If you own a SX1302 USB based device, an unofficial and not supported fork of the Basics Station can be found [here](https://github.com/danigian/basicstation/tree/corecell)
 
 ### Industrial device
 

--- a/docs/user-guide/station-module-configuration.md
+++ b/docs/user-guide/station-module-configuration.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 # LBS IoT Edge Module configuration
 
 The following table is providing a list of configuration options, to be provided as environment variables for manual configuration of the `LoRaBasicsStationModule`:
@@ -13,8 +18,10 @@ The following table is providing a list of configuration options, to be provided
 | CUPS_CRT_PATH             | The path to the cups.crt file. Refer to [this file](station-authentication-modes.md) for more information | Only when CUPS is enabled (if not set, defaulting to `/var/lorastarterkit/certs/cups.crt`) |
 | CUPS_KEY_PATH             | The path to the cups.key file. Refer to [this file](station-authentication-modes.md) for more information | Only when CUPS is enabled (if not set, defaulting to `/var/lorastarterkit/certs/cups.key`) |
 | RESET_PIN                 | Pin number for resetting the concentrator. </br> It is board specific. | No (if not set, module will skip the reset of the board)     |
-| RADIODEV                  | A string identifying the location where the board should be accessed (i.e.: `/dev/ttyACM0`) | No (if not set, board will be accessed at /dev/spidevX.0, see following item) |
+| CORECELL                  | A boolean identifying whether to use the Corecell (SX1302) binary | No (if not set, defaults to false) |
+| RADIODEV                  | A string identifying the location where the board should be accessed (i.e.: `/dev/ttyACM0` for SPI devices or `usb:/dev/ttyUSB0` in case of USB-based SX1302 devices). | No (if not set, board will be accessed at /dev/spidevX.0, see following item) |
 | SPI_DEV                   | A number identifying the SPI location where the board should be accessed (i.e.: when X, board accessed at /dev/spidevX.0) | No (defaults to 0)                                           |
 | SPI_SPEED                 | Useful for setting [SPI max clock](https://github.com/Lora-net/lora_gateway/blob/master/libloragw/src/loragw_spi.native.c) | No (default to 8, unique alternative provided is 2)          |
-| FIXED_STATION_EUI         | Provides the ability to start the Basic Station with a fixed EUI | No (if not set, the Basic Station built-in logic will be used for generating a EUI) |
-| STATION_PATH              | A string identifying the path of the folder where the compiled `station.std` binary for Basic Station is located | No (if not set, defaults to `/basicstation` folder)          |
+| FIXED_STATION_EUI         | Provides the ability to start the Basics Station with a fixed EUI | No (if not set, the Basics Station built-in logic will be used for generating a EUI) |
+| STATION_PATH              | A string identifying the path of the folder where the compiled `station.std` binary for Basics Station is located | No (if not set, defaults to `/basicstation` folder)          |
+| LOG_LEVEL                 | A string setting the desired log level for the Basics Station binary. Allowed values: XDEBUG,DEBUG,VERBOSE,INFO,NOTICE,WARNING,ERROR,CRITICAL | No (if not set, defaults to INFO) |

--- a/docs/user-guide/testing/e2e_tests.md
+++ b/docs/user-guide/testing/e2e_tests.md
@@ -128,7 +128,8 @@ can discover them with `ls /dev/ttyACM*`.
     "SshPrivateKeyPath": "path-on-local-host-to-ssh-private-key-used-for-remote-ssh-connection",
     "SharedLnsEndpoint": "wss://IP_or_DNS:5001",
     "SharedCupsEndpoint": "https://IP_OR_DNS:5002",
-    "RadioDev": "the-device-path-for-concentrator (i.e. /dev/ttyUSB0)"
+    "RadioDev": "the-device-path-for-concentrator (i.e. /dev/ttyUSB0)",
+    "IsCorecellBasicStation": false // or true if a SX1302 based concentrator is used
   }
 }
 ```


### PR DESCRIPTION
# PR for issue #1543 

## What is being addressed

Updating documentation for latest Basics Station module changes

## What changed

- [x] Removal of any reference to SX1302 custom built basics station binaries
- [x] Update of station-module-configuration.md with newly added "CORECELL" and "LOG_LEVEL" parameters
- [x] Removed "toc" sidebar from station-module-configuration.md for allowing a better view of the table