### PR TITLE
Docs/1544 Fixing missing ADR pages in navigation

### DIFF
--- a/docs/adr/009_discovery.md
+++ b/docs/adr/009_discovery.md
@@ -1,7 +1,7 @@
 # 009. LoRaWAN Network Server (LNS) discovery
 
-**Feature**: [#1480](https://github.com/Azure/iotedge-lorawan-starterkit/issues/1480)
-**Authors**: Bastian Burger, Daniele Maggio, Maggie Salak
+**Feature**: [#1480](https://github.com/Azure/iotedge-lorawan-starterkit/issues/1480)  
+**Authors**: Bastian Burger, Daniele Antonio Maggio, Maggie Salak  
 **Status**: Accepted
 
 Service (or LNS) discovery is part of the LNS protocol. When a LoRa Basics Station (LBS) connects for the first time to a LNS, it invokes the service discovery endpoint (`/router-info`). We want to provide the users with the option to (potentially) increase availability by automatically rebalancing connection attempts to different LNS.

--- a/docs/adr/010_lns_affinity.md
+++ b/docs/adr/010_lns_affinity.md
@@ -1,10 +1,8 @@
 # 010. LNS sticky affinity over multiple sessions
 
 **Feature**: [#1475](https://github.com/Azure/iotedge-lorawan-starterkit/issues/1475)  
-
-**Authors**: Spyros Giannakakis, Daniele Antonio Maggio, Patrick Schuler
-
-**Status**: Accepted
+**Authors**: Spyros Giannakakis, Daniele Antonio Maggio, Patrick Schuler  
+**Status**: Accepted  
 __________
 
 ## Problem statement

--- a/docs/adr/011_device_request_queue.md
+++ b/docs/adr/011_device_request_queue.md
@@ -1,7 +1,8 @@
-# Device Request Queue
+# 011. Device Request Queue
 
-- **Feature**: [#1479]
-- **Status**: Proposed
+**Feature**: [#1479]  
+**Authors**: Atif Aziz  
+**Status**: Accepted  
 
 ## Context
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,9 @@ nav:
     - adr/006_cups.md
     - adr/007_message_deduplication.md
     - adr/008_cups_firmware_upgrade.md
+    - adr/009_discovery.md
+    - adr/010_lns_affinity.md
+    - adr/011_device_request_queue.md
   - About:
     - release-notes.md
     - 'Known Issues': issues.md


### PR DESCRIPTION
# PR for issue #1544

## What is being addressed

- [x] Fixing missing ADR pages in navigation of decision logs submenu
- [x] Fixed ordering of ADR documents (there were 2x "010")
- [x] Fixed and uniformed formatting of first part of ADR 9,10,11   