### PR TITLE
Unify test twin setup in `LoRaDeviceTest`

### DIFF
--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -80,7 +80,7 @@ namespace LoRaWan.Tests.Common
         public bool? AbpRelaxMode { get; init; }
         public uint? FCntUpStart { get; init; }
         public uint? FCntDownStart { get; init; }
-        public int? FCntResetCounter { get; init; }
+        public uint? FCntResetCounter { get; init; }
         public int? Rx1DROffset { get; init; }
         public DataRateIndex? Rx2DataRate { get; init; }
         public ReceiveWindowNumber? PreferredWindow { get; init; }
@@ -90,30 +90,30 @@ namespace LoRaWan.Tests.Common
 
         public override IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
         {
-            yield return KeyValuePair.Create(TwinProperty.DevEUI, (object?)DevEui);
-            yield return KeyValuePair.Create(TwinProperty.DevAddr, (object?)DevAddr);
-            yield return KeyValuePair.Create(TwinProperty.AppEui, (object?)JoinEui);
-            yield return KeyValuePair.Create(TwinProperty.AppKey, (object?)AppKey);
-            yield return KeyValuePair.Create(TwinProperty.AppSKey, (object?)AppSessionKey);
-            yield return KeyValuePair.Create(TwinProperty.NwkSKey, (object?)NetworkSessionKey);
-            yield return KeyValuePair.Create(TwinProperty.GatewayID, (object?)GatewayId);
-            yield return KeyValuePair.Create(TwinProperty.SensorDecoder, (object?)SensorDecoder);
-            yield return KeyValuePair.Create(TwinProperty.Supports32BitFCnt, (object?)Supports32BitFCnt);
-            yield return KeyValuePair.Create(TwinProperty.ABPRelaxMode, (object?)AbpRelaxMode);
-            yield return KeyValuePair.Create(TwinProperty.FCntUpStart, (object?)FCntUpStart);
-            yield return KeyValuePair.Create(TwinProperty.FCntDownStart, (object?)FCntDownStart);
-            yield return KeyValuePair.Create(TwinProperty.FCntResetCounter, (object?)FCntResetCounter);
-            yield return KeyValuePair.Create(TwinProperty.RX1DROffset, (object?)Rx1DROffset);
-            yield return KeyValuePair.Create(TwinProperty.RX2DataRate, (object?)Rx2DataRate);
-            yield return KeyValuePair.Create(TwinProperty.PreferredWindow, PreferredWindow switch
+            yield return KeyValuePair.Create("DevEUI", (object?)DevEui);
+            yield return KeyValuePair.Create("DevAddr", (object?)DevAddr);
+            yield return KeyValuePair.Create("AppEUI", (object?)JoinEui);
+            yield return KeyValuePair.Create("AppKey", (object?)AppKey);
+            yield return KeyValuePair.Create("AppSKey", (object?)AppSessionKey);
+            yield return KeyValuePair.Create("NwkSKey", (object?)NetworkSessionKey);
+            yield return KeyValuePair.Create("GatewayID", (object?)GatewayId);
+            yield return KeyValuePair.Create("SensorDecoder", (object?)SensorDecoder);
+            yield return KeyValuePair.Create("Supports32BitFCnt", (object?)Supports32BitFCnt);
+            yield return KeyValuePair.Create("ABPRelaxMode", (object?)AbpRelaxMode);
+            yield return KeyValuePair.Create("FCntUpStart", (object?)FCntUpStart);
+            yield return KeyValuePair.Create("FCntDownStart", (object?)FCntDownStart);
+            yield return KeyValuePair.Create("FCntResetCounter", (object?)FCntResetCounter);
+            yield return KeyValuePair.Create("RX1DROffset", (object?)Rx1DROffset);
+            yield return KeyValuePair.Create("RX2DataRate", (object?)Rx2DataRate);
+            yield return KeyValuePair.Create("PreferredWindow", PreferredWindow switch
             {
                 ReceiveWindowNumber.ReceiveWindow1 => 1,
                 ReceiveWindowNumber.ReceiveWindow2 => 2,
                 _ => (object?)null
             });
-            yield return KeyValuePair.Create(TwinProperty.RXDelay, (object?)RxDelay);
-            yield return KeyValuePair.Create(TwinProperty.ClassType, (object?)ClassType);
-            yield return KeyValuePair.Create(TwinProperty.KeepAliveTimeout, (object?)KeepAliveTimeout?.TotalSeconds);
+            yield return KeyValuePair.Create("RXDelay", (object?)RxDelay);
+            yield return KeyValuePair.Create("ClassType", (object?)ClassType);
+            yield return KeyValuePair.Create("KeepAliveTimeout", (object?)KeepAliveTimeout?.TotalSeconds);
         }
     }
 
@@ -127,7 +127,7 @@ namespace LoRaWan.Tests.Common
         public NetworkSessionKey? NetworkSessionKey { get; init; }
         public DevAddr? DevAddr { get; init; }
         public DevNonce? DevNonce { get; init; }
-        public int? FCntResetCounter { get; init; }
+        public uint? FCntResetCounter { get; init; }
         public string? PreferredGatewayId { get; init; }
         public LoRaRegionType? Region { get; init; }
         public NetId? NetId { get; init; }
@@ -136,20 +136,20 @@ namespace LoRaWan.Tests.Common
 
         public override IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
         {
-            yield return KeyValuePair.Create(TwinProperty.FCntUp, (object?)FCntUp);
-            yield return KeyValuePair.Create(TwinProperty.FCntUpStart, (object?)FCntUpStart);
-            yield return KeyValuePair.Create(TwinProperty.FCntDown, (object?)FCntDown);
-            yield return KeyValuePair.Create(TwinProperty.FCntDownStart, (object?)FCntDownStart);
-            yield return KeyValuePair.Create(TwinProperty.AppSKey, (object?)AppSessionKey);
-            yield return KeyValuePair.Create(TwinProperty.NwkSKey, (object?)NetworkSessionKey);
-            yield return KeyValuePair.Create(TwinProperty.DevAddr, (object?)DevAddr);
-            yield return KeyValuePair.Create(TwinProperty.DevNonce, (object?)DevNonce);
-            yield return KeyValuePair.Create(TwinProperty.FCntResetCounter, (object?)FCntResetCounter);
-            yield return KeyValuePair.Create(TwinProperty.PreferredGatewayID, (object?)PreferredGatewayId);
-            yield return KeyValuePair.Create(TwinProperty.Region, (object?)Region);
-            yield return KeyValuePair.Create(TwinProperty.NetId, (object?)NetId);
-            yield return KeyValuePair.Create(TwinProperty.RX2DataRate, (object?)Rx2DataRate);
-            yield return KeyValuePair.Create(TwinProperty.LastProcessingStationEui, (object?)LastProcessingStation);
+            yield return KeyValuePair.Create("FCntUp", (object?)FCntUp);
+            yield return KeyValuePair.Create("FCntUpStart", (object?)FCntUpStart);
+            yield return KeyValuePair.Create("FCntDown", (object?)FCntDown);
+            yield return KeyValuePair.Create("FCntDownStart", (object?)FCntDownStart);
+            yield return KeyValuePair.Create("AppSKey", (object?)AppSessionKey);
+            yield return KeyValuePair.Create("NwkSKey", (object?)NetworkSessionKey);
+            yield return KeyValuePair.Create("DevAddr", (object?)DevAddr);
+            yield return KeyValuePair.Create("DevNonce", (object?)DevNonce);
+            yield return KeyValuePair.Create("FCntResetCounter", (object?)FCntResetCounter);
+            yield return KeyValuePair.Create("PreferredGatewayID", (object?)PreferredGatewayId);
+            yield return KeyValuePair.Create("Region", (object?)Region);
+            yield return KeyValuePair.Create("NetId", (object?)NetId);
+            yield return KeyValuePair.Create("RX2DataRate", (object?)Rx2DataRate);
+            yield return KeyValuePair.Create("LastProcessingStationEui", (object?)LastProcessingStation);
         }
     }
 

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -11,7 +11,6 @@ namespace LoRaWan.Tests.Common
     using System.Globalization;
     using System.Linq;
     using LoRaTools.Regions;
-    using LoRaWan.NetworkServer;
     using Microsoft.Azure.Devices.Shared;
 
     public static class LoRaDeviceTwin
@@ -39,6 +38,9 @@ namespace LoRaWan.Tests.Common
                 switch (value)
                 {
                     case null:
+                        break;
+                    case LoRaRegionType region:
+                        target[key] = region.ToString();
                         break;
                     case uint:
                     case int:
@@ -87,6 +89,9 @@ namespace LoRaWan.Tests.Common
         public int? RxDelay { get; init; }
         public char? ClassType { get; init; }
         public TimeSpan? KeepAliveTimeout { get; init; }
+        public uint? Version { get; init; }
+        public bool? DownlinkEnabled { get; init; }
+        public int? Cn470JoinChannel { get; init; }
 
         public override IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
         {
@@ -114,6 +119,9 @@ namespace LoRaWan.Tests.Common
             yield return KeyValuePair.Create("RXDelay", (object?)RxDelay);
             yield return KeyValuePair.Create("ClassType", (object?)ClassType);
             yield return KeyValuePair.Create("KeepAliveTimeout", (object?)KeepAliveTimeout?.TotalSeconds);
+            yield return KeyValuePair.Create("$version", (object?)Version);
+            yield return KeyValuePair.Create("Downlink", (object?)DownlinkEnabled);
+            yield return KeyValuePair.Create("CN470JoinChannel", (object?)Cn470JoinChannel);
         }
     }
 
@@ -133,6 +141,8 @@ namespace LoRaWan.Tests.Common
         public NetId? NetId { get; init; }
         public DataRateIndex? Rx2DataRate { get; init; }
         public StationEui? LastProcessingStation { get; init; }
+        public uint? Version { get; init; }
+        public int? Cn470JoinChannel { get; init; }
 
         public override IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
         {
@@ -150,6 +160,8 @@ namespace LoRaWan.Tests.Common
             yield return KeyValuePair.Create("NetId", (object?)NetId);
             yield return KeyValuePair.Create("RX2DataRate", (object?)Rx2DataRate);
             yield return KeyValuePair.Create("LastProcessingStationEui", (object?)LastProcessingStation);
+            yield return KeyValuePair.Create("$version", (object?)Version);
+            yield return KeyValuePair.Create("CN470JoinChannel", (object?)Cn470JoinChannel);
         }
     }
 

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -39,13 +39,7 @@ namespace LoRaWan.Tests.Common
                 {
                     case null:
                         break;
-                    case LoRaRegionType region:
-                        target[key] = region.ToString();
-                        break;
-                    case uint:
-                    case int:
-                    case Enum:
-                    case bool:
+                    case uint or int or bool or (Enum and not LoRaRegionType):
                         target[key] = value;
                         break;
                     case IConvertible convertible:

--- a/Tests/Common/LoRaDeviceTwin.cs
+++ b/Tests/Common/LoRaDeviceTwin.cs
@@ -11,6 +11,7 @@ namespace LoRaWan.Tests.Common
     using System.Globalization;
     using System.Linq;
     using LoRaTools.Regions;
+    using LoRaWan.NetworkServer;
     using Microsoft.Azure.Devices.Shared;
 
     public static class LoRaDeviceTwin
@@ -39,7 +40,7 @@ namespace LoRaWan.Tests.Common
                 {
                     case null:
                         break;
-                    case uint or int or bool or (Enum and not LoRaRegionType):
+                    case uint or int or bool or (Enum and not (LoRaRegionType or LoRaDeviceClassType)):
                         target[key] = value;
                         break;
                     case IConvertible convertible:
@@ -81,7 +82,7 @@ namespace LoRaWan.Tests.Common
         public DataRateIndex? Rx2DataRate { get; init; }
         public ReceiveWindowNumber? PreferredWindow { get; init; }
         public int? RxDelay { get; init; }
-        public char? ClassType { get; init; }
+        public LoRaDeviceClassType? ClassType { get; init; }
         public TimeSpan? KeepAliveTimeout { get; init; }
         public uint? Version { get; init; }
         public bool? DownlinkEnabled { get; init; }

--- a/Tests/Common/SimulatedDevice.cs
+++ b/Tests/Common/SimulatedDevice.cs
@@ -56,7 +56,7 @@ namespace LoRaWan.Tests.Common
 
         public JoinEui? AppEui => LoRaDevice.AppEui;
 
-        public char ClassType => LoRaDevice.ClassType;
+        public LoRaDeviceClassType ClassType => LoRaDevice.ClassType;
 
         public DevAddr? DevAddr
         {

--- a/Tests/Common/TestDeviceInfo.cs
+++ b/Tests/Common/TestDeviceInfo.cs
@@ -52,7 +52,7 @@ namespace LoRaWan.Tests.Common
 
         public ReceiveWindowNumber PreferredWindow { get; set; } = ReceiveWindow1;
 
-        public char ClassType { get; set; } = 'A';
+        public LoRaDeviceClassType ClassType { get; set; } = LoRaDeviceClassType.A;
 
         public int RX2DataRate { get; set; }
 
@@ -102,7 +102,7 @@ namespace LoRaWan.Tests.Common
 
             desiredProperties[TwinProperty.PreferredWindow] = (int)PreferredWindow;
 
-            if (char.ToLower(ClassType, CultureInfo.InvariantCulture) != 'a')
+            if (ClassType != LoRaDeviceClassType.A)
                 desiredProperties[TwinProperty.ClassType] = ClassType.ToString();
 
             desiredProperties[TwinProperty.RX1DROffset] = RX1DROffset;
@@ -123,7 +123,13 @@ namespace LoRaWan.Tests.Common
         /// <summary>
         /// Creates a <see cref="TestDeviceInfo"/> with ABP authentication.
         /// </summary>
-        public static TestDeviceInfo CreateABPDevice(uint deviceID, string prefix = null, string gatewayID = null, string sensorDecoder = "DecoderValueSensor", int netId = 1, char deviceClassType = 'A', bool supports32BitFcnt = false)
+        public static TestDeviceInfo CreateABPDevice(uint deviceID,
+                                                     string prefix = null,
+                                                     string gatewayID = null,
+                                                     string sensorDecoder = "DecoderValueSensor",
+                                                     int netId = 1,
+                                                     LoRaDeviceClassType deviceClassType = LoRaDeviceClassType.A,
+                                                     bool supports32BitFcnt = false)
         {
             var value8 = deviceID.ToString("00000000", CultureInfo.InvariantCulture);
             var value16 = deviceID.ToString("0000000000000000", CultureInfo.InvariantCulture);
@@ -155,7 +161,11 @@ namespace LoRaWan.Tests.Common
         /// Creates a <see cref="TestDeviceInfo"/> with OTAA authentication.
         /// </summary>
         /// <param name="deviceID">Device identifier. It will padded with 0's.</param>
-        public static TestDeviceInfo CreateOTAADevice(uint deviceID, string prefix = null, string gatewayID = null, string sensorDecoder = "DecoderValueSensor", char deviceClassType = 'A')
+        public static TestDeviceInfo CreateOTAADevice(uint deviceID,
+                                                      string prefix = null,
+                                                      string gatewayID = null,
+                                                      string sensorDecoder = "DecoderValueSensor",
+                                                      LoRaDeviceClassType deviceClassType = LoRaDeviceClassType.A)
         {
             var value16 = deviceID.ToString("0000000000000000", CultureInfo.InvariantCulture);
             var value32 = deviceID.ToString("00000000000000000000000000000000", CultureInfo.InvariantCulture);

--- a/Tests/Common/TestKeys.cs
+++ b/Tests/Common/TestKeys.cs
@@ -3,8 +3,14 @@
 
 namespace LoRaWan.Tests.Common
 {
+    using System.Security.Cryptography;
+
     public static class TestKeys
     {
+        private static ulong GenerateKey() => (ulong)RandomNumberGenerator.GetInt32(0, int.MaxValue);
+
+        public static NetworkSessionKey CreateNetworkSessionKey() => CreateNetworkSessionKey(GenerateKey());
+
         public static NetworkSessionKey CreateNetworkSessionKey(ulong value) => CreateNetworkSessionKey(0, value);
 
         public static NetworkSessionKey CreateNetworkSessionKey(ulong hi, ulong low)
@@ -15,6 +21,8 @@ namespace LoRaWan.Tests.Common
             return NetworkSessionKey.Read(buffer);
         }
 
+        public static AppSessionKey CreateAppSessionKey() => CreateAppSessionKey(GenerateKey());
+
         public static AppSessionKey CreateAppSessionKey(ulong value) => CreateAppSessionKey(0, value);
 
         public static AppSessionKey CreateAppSessionKey(ulong hi, ulong low)
@@ -24,6 +32,8 @@ namespace LoRaWan.Tests.Common
             _ = data128.Write(buffer);
             return AppSessionKey.Read(buffer);
         }
+
+        public static AppKey CreateAppKey() => CreateAppKey(GenerateKey());
 
         public static AppKey CreateAppKey(ulong value) => CreateAppKey(0, value);
 

--- a/Tests/Common/TestUtils.cs
+++ b/Tests/Common/TestUtils.cs
@@ -36,7 +36,7 @@ namespace LoRaWan.Tests.Common
                 NwkSKey = simulatedDevice.LoRaDevice.NwkSKey,
                 GatewayID = simulatedDevice.LoRaDevice.GatewayID,
                 IsOurDevice = true,
-                ClassType = simulatedDevice.ClassType == LoRaDeviceClassType.C ? LoRaDeviceClassType.C : LoRaDeviceClassType.A,
+                ClassType = simulatedDevice.ClassType,
             };
 
             result.SetFcntDown(simulatedDevice.FrmCntDown);

--- a/Tests/Common/TestUtils.cs
+++ b/Tests/Common/TestUtils.cs
@@ -36,7 +36,7 @@ namespace LoRaWan.Tests.Common
                 NwkSKey = simulatedDevice.LoRaDevice.NwkSKey,
                 GatewayID = simulatedDevice.LoRaDevice.GatewayID,
                 IsOurDevice = true,
-                ClassType = (simulatedDevice.ClassType is 'C' or 'c') ? LoRaDeviceClassType.C : LoRaDeviceClassType.A,
+                ClassType = simulatedDevice.ClassType == LoRaDeviceClassType.C ? LoRaDeviceClassType.C : LoRaDeviceClassType.A,
             };
 
             result.SetFcntDown(simulatedDevice.FrmCntDown);

--- a/Tests/Common/TestUtils.cs
+++ b/Tests/Common/TestUtils.cs
@@ -14,7 +14,6 @@ namespace LoRaWan.Tests.Common
     using LoRaWan.NetworkServer;
     using LoRaWan.NetworkServer.BasicsStation;
     using Microsoft.Azure.Devices.Client;
-    using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Logging.Abstractions;
     using Newtonsoft.Json;
     using Xunit;
@@ -48,28 +47,6 @@ namespace LoRaWan.Tests.Common
                 result.SetRequestHandler(requestHandler);
 
             return result;
-        }
-
-        public static Twin CreateTwin(Dictionary<string, object> desired = null, Dictionary<string, object> reported = null)
-        {
-            var twin = new Twin();
-            if (desired != null)
-            {
-                foreach (var kv in desired)
-                {
-                    twin.Properties.Desired[kv.Key] = kv.Value;
-                }
-            }
-
-            if (reported != null)
-            {
-                foreach (var kv in reported)
-                {
-                    twin.Properties.Reported[kv.Key] = kv.Value;
-                }
-            }
-
-            return twin;
         }
 
         /// <summary>

--- a/Tests/E2E/IntegrationTestFixtureCI.cs
+++ b/Tests/E2E/IntegrationTestFixtureCI.cs
@@ -510,7 +510,7 @@ namespace LoRaWan.Tests.E2E
                 NwkSKey = GetNetworkSessionKey(24),
                 DevAddr = new DevAddr(0x00000024),
                 IsIoTHubDevice = true,
-                ClassType = 'C',
+                ClassType = LoRaDeviceClassType.C,
             };
 
             // Device25_ABP: Connection timeout

--- a/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
+++ b/Tests/Integration/ClassCCloudToDeviceMessageSizeLimitTests.cs
@@ -83,7 +83,7 @@ namespace LoRaWan.Tests.Integration
         {
             var simulatedDevice = new SimulatedDevice(
                 TestDeviceInfo.CreateABPDevice(
-                    1, deviceClassType: 'c', gatewayID: this.serverConfiguration.GatewayID));
+                    1, deviceClassType: LoRaDeviceClassType.C, gatewayID: this.serverConfiguration.GatewayID));
 
             var devEUI = simulatedDevice.DevEUI;
 
@@ -172,7 +172,7 @@ namespace LoRaWan.Tests.Integration
         {
             var simulatedDevice = new SimulatedDevice(
                 TestDeviceInfo.CreateABPDevice(
-                    1, deviceClassType: 'c', gatewayID: this.serverConfiguration.GatewayID));
+                    1, deviceClassType: LoRaDeviceClassType.C, gatewayID: this.serverConfiguration.GatewayID));
 
             var devEUI = simulatedDevice.DevEUI;
 

--- a/Tests/Integration/ClassCIntegrationTests.cs
+++ b/Tests/Integration/ClassCIntegrationTests.cs
@@ -60,7 +60,7 @@ namespace LoRaWan.Tests.Integration
         {
             const uint payloadFcnt = 2; // to avoid relax mode reset
 
-            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID, deviceClassType: 'c'), frmCntDown: fcntDownFromTwin);
+            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID, deviceClassType: LoRaDeviceClassType.C), frmCntDown: fcntDownFromTwin);
 
             LoRaDeviceClient.Setup(x => x.UpdateReportedPropertiesAsync(It.IsNotNull<TwinCollection>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -157,7 +157,7 @@ namespace LoRaWan.Tests.Integration
         [InlineData(ServerGatewayID)]
         public async Task When_OTAA_Join_Then_Sends_Upstream_DirectMethod_Should_Send_Downstream(string deviceGatewayID)
         {
-            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: 'c', gatewayID: deviceGatewayID));
+            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: LoRaDeviceClassType.C, gatewayID: deviceGatewayID));
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(LoRaDeviceTwin.Create(simDevice.LoRaDevice.GetOtaaDesiredTwinProperties(),
@@ -348,7 +348,7 @@ namespace LoRaWan.Tests.Integration
             [CombinatorialValues(null, ServerGatewayID, "another-gateway")] string initialPreferredGatewayID,
             [CombinatorialValues(null, LoRaRegionType.EU868, LoRaRegionType.US915)] LoRaRegionType? initialLoRaRegion)
         {
-            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: 'c', gatewayID: deviceGatewayID));
+            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: LoRaDeviceClassType.C, gatewayID: deviceGatewayID));
 
             LoRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(LoRaDeviceTwin.Create(simDevice.LoRaDevice.GetOtaaDesiredTwinProperties(),
@@ -435,7 +435,7 @@ namespace LoRaWan.Tests.Integration
             const uint InitialDeviceFcntDown = 20;
 
             var simulatedDevice = new SimulatedDevice(
-                TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID, deviceClassType: 'c'),
+                TestDeviceInfo.CreateABPDevice(1, gatewayID: deviceGatewayID, deviceClassType: LoRaDeviceClassType.C),
                 frmCntUp: InitialDeviceFcntUp,
                 frmCntDown: InitialDeviceFcntDown);
 
@@ -536,7 +536,7 @@ namespace LoRaWan.Tests.Integration
             const uint InitialDeviceFcntDown = 20;
 
             var simulatedDevice = new SimulatedDevice(
-                TestDeviceInfo.CreateABPDevice(1, deviceClassType: 'c'),
+                TestDeviceInfo.CreateABPDevice(1, deviceClassType: LoRaDeviceClassType.C),
                 frmCntUp: InitialDeviceFcntUp,
                 frmCntDown: InitialDeviceFcntDown);
 

--- a/Tests/Integration/KeepAliveConnectionTests.cs
+++ b/Tests/Integration/KeepAliveConnectionTests.cs
@@ -310,7 +310,7 @@ namespace LoRaWan.Tests.Integration
         {
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1,
                                                                                      gatewayID: ServerConfiguration.GatewayID,
-                                                                                     deviceClassType: 'c'));
+                                                                                     deviceClassType: LoRaDeviceClassType.C));
             var devEui = simulatedDevice.DevEUI;
 
             // will disconnected client

--- a/Tests/Unit/NetworkServer/DefaultClassCDevicesMessageSenderTest.cs
+++ b/Tests/Unit/NetworkServer/DefaultClassCDevicesMessageSenderTest.cs
@@ -73,7 +73,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [InlineData(ServerGatewayID)]
         public async Task When_Sending_Message_Should_Send_Downlink_To_DownstreamMessageSender(string deviceGatewayID)
         {
-            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, deviceClassType: 'c', gatewayID: deviceGatewayID));
+            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, deviceClassType: LoRaDeviceClassType.C, gatewayID: deviceGatewayID));
             var devEUI = simDevice.DevEUI;
 
             this.deviceApi.Setup(x => x.GetPrimaryKeyByEuiAsync(devEUI))
@@ -190,7 +190,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [Fact]
         public async Task When_Device_Is_Not_Joined_Should_Fail()
         {
-            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: 'c', gatewayID: ServerGatewayID));
+            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: LoRaDeviceClassType.C, gatewayID: ServerGatewayID));
             var devEUI = simDevice.DevEUI;
 
             this.deviceApi.Setup(x => x.GetPrimaryKeyByEuiAsync(devEUI))
@@ -225,7 +225,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [Fact]
         public async Task When_Fails_To_Get_FcntDown_Should_Fail()
         {
-            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, deviceClassType: 'c'));
+            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, deviceClassType: LoRaDeviceClassType.C));
             var devEUI = simDevice.DevEUI;
 
             this.deviceApi.Setup(x => x.GetPrimaryKeyByEuiAsync(devEUI))
@@ -271,7 +271,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [Fact]
         public async Task When_Message_Is_Invalid_Should_Fail()
         {
-            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, deviceClassType: 'c', gatewayID: ServerGatewayID));
+            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, deviceClassType: LoRaDeviceClassType.C, gatewayID: ServerGatewayID));
             var devEUI = simDevice.DevEUI;
 
             var c2dToDeviceMessage = new ReceivedLoRaCloudToDeviceMessage()
@@ -300,7 +300,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [Fact]
         public async Task When_Regions_Is_Not_Defined_Should_Fail()
         {
-            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, deviceClassType: 'c', gatewayID: ServerGatewayID));
+            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateABPDevice(1, deviceClassType: LoRaDeviceClassType.C, gatewayID: ServerGatewayID));
             var devEUI = simDevice.DevEUI;
 
             var c2dToDeviceMessage = new ReceivedLoRaCloudToDeviceMessage()
@@ -332,7 +332,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var devAddr = new DevAddr(0x023637F8);
             var appSKey = TestKeys.CreateAppSessionKey(0xABC0200000000000, 0x09);
             var nwkSKey = TestKeys.CreateNetworkSessionKey(0xABC0200000000000, 0x09);
-            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: 'c', gatewayID: ServerGatewayID));
+            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: LoRaDeviceClassType.C, gatewayID: ServerGatewayID));
             var devEUI = simDevice.DevEUI;
             simDevice.SetupJoin(appSKey, nwkSKey, devAddr);
 
@@ -398,7 +398,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var devAddr = new DevAddr(0x023637F8);
             var appSKey = TestKeys.CreateAppSessionKey(0xABC0200000000000, 0x09);
             var nwkSKey = TestKeys.CreateNetworkSessionKey(0xABC0200000000000, 0x09);
-            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: 'c', gatewayID: ServerGatewayID));
+            var simDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, deviceClassType: LoRaDeviceClassType.C, gatewayID: ServerGatewayID));
             var devEUI = simDevice.DevEUI;
             simDevice.SetupJoin(appSKey, nwkSKey, devAddr);
 

--- a/Tests/Unit/NetworkServer/FcntLimitTest.cs
+++ b/Tests/Unit/NetworkServer/FcntLimitTest.cs
@@ -148,15 +148,15 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
         [Theory]
         // not saving, reported match, reset counter is lower
-        [InlineData(11, 10U, 10U, 10U, 10U, 1, 3, 10, 10, false)]
+        [InlineData(11, 10U, 10U, 10U, 10U, 1U, 3U, 10, 10, false)]
         // saving, reported match, but reset counter is set, reported null
-        [InlineData(11, 10U, 10U, 10U, 10U, 1, null, 10, 10, true)]
+        [InlineData(11, 10U, 10U, 10U, 10U, 1U, null, 10, 10, true)]
         // saving, reported match, but reset counter is set
-        [InlineData(11, 10U, 10U, 10U, 10U, 1, 0, 10, 10, true)]
+        [InlineData(11, 10U, 10U, 10U, 10U, 1U, 0U, 10, 10, true)]
         // save reporting do not match
-        [InlineData(2, 1U, 1U, 0U, 0U, 0, 0, 1U, 1U, true)]
+        [InlineData(2, 1U, 1U, 0U, 0U, 0U, 0U, 1U, 1U, true)]
         // save reporting do not match
-        [InlineData(11, 10U, 20U, 0U, 0U, 0, 0, 10U, 20U, true)]
+        [InlineData(11, 10U, 20U, 0U, 0U, 0U, 0U, 10U, 20U, true)]
         public async Task ValidateFcnt_Start_Values_And_ResetCounter(
             short fcntUp,
             uint startFcntUpDesired,

--- a/Tests/Unit/NetworkServer/FcntLimitTest.cs
+++ b/Tests/Unit/NetworkServer/FcntLimitTest.cs
@@ -163,8 +163,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             uint startFcntDownDesired,
             uint? startFcntUpReported,
             uint? startFcntDownReported,
-            int? fcntResetCounterDesired,
-            int? fcntResetCounterReported,
+            uint? fcntResetCounterDesired,
+            uint? fcntResetCounterReported,
             uint startUpExpected,
             uint startDownExpected,
             bool saveExpected)

--- a/Tests/Unit/NetworkServer/LoRaDeviceTest.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceTest.cs
@@ -140,16 +140,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         public async Task When_Initialized_New_OTAA_Device_Should_Have_All_Properties()
         {
             const string gateway = "mygateway";
-            var twin = CreateTwin(
-                desired: new()
-                {
-                    ["AppEUI"] = OtaaDesiredTwinProperties.JoinEui.ToString(),
-                    ["AppKey"] = OtaaDesiredTwinProperties.AppKey.ToString(),
-                    ["GatewayID"] = gateway,
-                    ["SensorDecoder"] = OtaaDesiredTwinProperties.SensorDecoder,
-                    ["$version"] = 1,
-                },
-                reported: new() { ["$version"] = 1 });
+            var twin = LoRaDeviceTwin.Create(OtaaDesiredTwinProperties with { GatewayId = gateway },
+                                             new LoRaReportedTwinProperties { Version = 1 });
 
             this.loRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);
@@ -180,23 +172,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         public async Task When_Initialized_Joined_OTAA_Device_Should_Have_All_Properties()
         {
             const string gatewayId = "mygateway";
-            var twin = CreateTwin(
-                desired: new()
-                {
-                    ["AppEUI"] = OtaaDesiredTwinProperties.JoinEui.ToString(),
-                    ["AppKey"] = OtaaDesiredTwinProperties.AppKey.ToString(),
-                    ["GatewayID"] = gatewayId,
-                    ["SensorDecoder"] = OtaaDesiredTwinProperties.SensorDecoder,
-                    ["$version"] = 1,
-                },
-                reported: new()
-                {
-                    ["$version"] = 1,
-                    ["NwkSKey"] = OtaaReportedTwinProperties.NetworkSessionKey.ToString(),
-                    ["AppSKey"] = OtaaReportedTwinProperties.AppSessionKey.ToString(),
-                    ["DevNonce"] = OtaaReportedTwinProperties.DevNonce.ToString(),
-                    ["DevAddr"] = OtaaReportedTwinProperties.DevAddr.ToString(),
-                });
+            var twin = LoRaDeviceTwin.Create(OtaaDesiredTwinProperties with { GatewayId = gatewayId },
+                                             OtaaReportedTwinProperties);
 
             this.loRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);
@@ -220,23 +197,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [Fact]
         public async Task When_Initialized_ABP_Device_Should_Have_All_Properties()
         {
-            var twin = CreateTwin(
-                desired: new()
-                {
-                    ["NwkSKey"] = AbpDesiredTwinProperties.NetworkSessionKey.ToString(),
-                    ["AppSKey"] = AbpDesiredTwinProperties.AppSessionKey.ToString(),
-                    ["DevAddr"] = AbpDesiredTwinProperties.DevAddr.ToString(),
-                    ["GatewayID"] = AbpDesiredTwinProperties.GatewayId,
-                    ["SensorDecoder"] = AbpDesiredTwinProperties.SensorDecoder,
-                    ["$version"] = 1,
-                },
-                reported: new()
-                {
-                    ["$version"] = 1,
-                    ["NwkSKey"] = AbpReportedTwinProperties.NetworkSessionKey.ToString(),
-                    ["AppSKey"] = AbpReportedTwinProperties.AppSessionKey.ToString(),
-                    ["DevAddr"] = AbpReportedTwinProperties.DevAddr.ToString(),
-                });
+            var twin = LoRaDeviceTwin.Create(AbpDesiredTwinProperties, AbpReportedTwinProperties);
 
             this.loRaDeviceClient.Setup(x => x.GetTwinAsync(CancellationToken.None))
                 .ReturnsAsync(twin);
@@ -866,28 +827,6 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             // assert
             connectionManagerMock.Verify(x => x.BeginDeviceClientConnectionActivity(target),
                                          Times.Exactly(timeoutSeconds > 0 ? 1 : 0));
-        }
-
-        private static Twin CreateTwin(Dictionary<string, object> desired = null, Dictionary<string, object> reported = null)
-        {
-            var twin = new Twin();
-            if (desired != null)
-            {
-                foreach (var kv in desired)
-                {
-                    twin.Properties.Desired[kv.Key] = kv.Value;
-                }
-            }
-
-            if (reported != null)
-            {
-                foreach (var kv in reported)
-                {
-                    twin.Properties.Reported[kv.Key] = kv.Value;
-                }
-            }
-
-            return twin;
         }
     }
 }

--- a/Tests/Unit/NetworkServer/LoRaDeviceTest.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceTest.cs
@@ -28,8 +28,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
     /// </summary>
     public class LoRaDeviceTest
     {
-        private static readonly NetworkServerConfiguration Configuration = new NetworkServerConfiguration { GatewayID = "test-gateway" };
-        private static readonly LoRaDesiredTwinProperties OtaaDesiredTwinProperties = new LoRaDesiredTwinProperties
+        private static readonly NetworkServerConfiguration Configuration = new() { GatewayID = "test-gateway" };
+        private static readonly LoRaDesiredTwinProperties OtaaDesiredTwinProperties = new()
         {
             JoinEui = new JoinEui((ulong)RandomNumberGenerator.GetInt32(0, int.MaxValue)),
             AppKey = TestKeys.CreateAppKey(),
@@ -37,7 +37,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             SensorDecoder = "DecoderValueSensor",
             Version = 1,
         };
-        private static readonly LoRaReportedTwinProperties OtaaReportedTwinProperties = new LoRaReportedTwinProperties
+        private static readonly LoRaReportedTwinProperties OtaaReportedTwinProperties = new()
         {
             Version = 1,
             NetworkSessionKey = TestKeys.CreateNetworkSessionKey(),
@@ -45,7 +45,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             DevNonce = new DevNonce((ushort)RandomNumberGenerator.GetInt32(0, ushort.MaxValue)),
             DevAddr = new DevAddr((uint)RandomNumberGenerator.GetInt32(0, int.MaxValue)),
         };
-        private static readonly LoRaDesiredTwinProperties AbpDesiredTwinProperties = new LoRaDesiredTwinProperties
+        private static readonly LoRaDesiredTwinProperties AbpDesiredTwinProperties = new()
         {
             NetworkSessionKey = TestKeys.CreateNetworkSessionKey(),
             AppSessionKey = TestKeys.CreateAppSessionKey(),
@@ -54,7 +54,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             SensorDecoder = "DecoderValueSensor",
             Version = 1,
         };
-        private static readonly LoRaReportedTwinProperties AbpReportedTwinProperties = new LoRaReportedTwinProperties
+        private static readonly LoRaReportedTwinProperties AbpReportedTwinProperties = new()
         {
             Version = 1,
             NetworkSessionKey = TestKeys.CreateNetworkSessionKey(),

--- a/Tests/Unit/NetworkServer/LoRaDeviceTest.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceTest.cs
@@ -5,6 +5,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 {
     using System;
     using System.Collections.Generic;
+    using System.Security.Cryptography;
     using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
@@ -30,8 +31,8 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         private static readonly NetworkServerConfiguration Configuration = new NetworkServerConfiguration { GatewayID = "test-gateway" };
         private static readonly LoRaDesiredTwinProperties OtaaDesiredTwinProperties = new LoRaDesiredTwinProperties
         {
-            JoinEui = new JoinEui(0xABC0200000000009),
-            AppKey = TestKeys.CreateAppKey(0xABC0200000000000, 0x09),
+            JoinEui = new JoinEui((ulong)RandomNumberGenerator.GetInt32(0, int.MaxValue)),
+            AppKey = TestKeys.CreateAppKey(),
             GatewayId = Configuration.GatewayID,
             SensorDecoder = "DecoderValueSensor",
             Version = 1,
@@ -39,16 +40,16 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         private static readonly LoRaReportedTwinProperties OtaaReportedTwinProperties = new LoRaReportedTwinProperties
         {
             Version = 1,
-            NetworkSessionKey = TestKeys.CreateNetworkSessionKey(0xABC0200000000000, 0x09),
-            AppSessionKey = TestKeys.CreateAppSessionKey(0xABCD200000000000, 0x09),
-            DevNonce = new DevNonce(0x0123),
-            DevAddr = new DevAddr(0xAABB),
+            NetworkSessionKey = TestKeys.CreateNetworkSessionKey(),
+            AppSessionKey = TestKeys.CreateAppSessionKey(),
+            DevNonce = new DevNonce((ushort)RandomNumberGenerator.GetInt32(0, ushort.MaxValue)),
+            DevAddr = new DevAddr((uint)RandomNumberGenerator.GetInt32(0, int.MaxValue)),
         };
         private static readonly LoRaDesiredTwinProperties AbpDesiredTwinProperties = new LoRaDesiredTwinProperties
         {
-            NetworkSessionKey = TestKeys.CreateNetworkSessionKey(0xABC0200000000000, 0x09),
-            AppSessionKey = TestKeys.CreateAppSessionKey(0xABCD200000000000, 0x09),
-            DevAddr = DevAddr.Parse("0000AABB"),
+            NetworkSessionKey = TestKeys.CreateNetworkSessionKey(),
+            AppSessionKey = TestKeys.CreateAppSessionKey(),
+            DevAddr = new DevAddr((uint)RandomNumberGenerator.GetInt32(0, int.MaxValue)),
             GatewayId = Configuration.GatewayID,
             SensorDecoder = "DecoderValueSensor",
             Version = 1,
@@ -56,9 +57,9 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         private static readonly LoRaReportedTwinProperties AbpReportedTwinProperties = new LoRaReportedTwinProperties
         {
             Version = 1,
-            NetworkSessionKey = TestKeys.CreateNetworkSessionKey(0xABC0200000000000, 0x09),
-            AppSessionKey = TestKeys.CreateAppSessionKey(0xABCD200000000000, 0x09),
-            DevAddr = new DevAddr(0xAABB),
+            NetworkSessionKey = TestKeys.CreateNetworkSessionKey(),
+            AppSessionKey = TestKeys.CreateAppSessionKey(),
+            DevAddr = AbpDesiredTwinProperties.DevAddr,
         };
 
         private readonly Mock<ILoRaDeviceClient> loRaDeviceClient;
@@ -254,10 +255,10 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.Equal(0U, loRaDevice.FCntUp);
             Assert.Equal(0U, loRaDevice.LastSavedFCntUp);
             Assert.False(loRaDevice.HasFrameCountChanges);
-            Assert.Equal(AbpReportedTwinProperties.NetworkSessionKey, loRaDevice.NwkSKey);
-            Assert.Equal(AbpReportedTwinProperties.AppSessionKey, loRaDevice.AppSKey);
+            Assert.Equal(AbpDesiredTwinProperties.NetworkSessionKey, loRaDevice.NwkSKey);
+            Assert.Equal(AbpDesiredTwinProperties.AppSessionKey, loRaDevice.AppSKey);
             Assert.Null(loRaDevice.DevNonce);
-            Assert.Equal(new DevAddr(0x0000aabb), loRaDevice.DevAddr);
+            Assert.Equal(AbpDesiredTwinProperties.DevAddr, loRaDevice.DevAddr);
             Assert.Null(loRaDevice.ReportedDwellTimeSetting);
         }
 


### PR DESCRIPTION
# PR for issue #1532

## What is being addressed

With this PR we use the common mechanism to set up test twins also for the tests in `LoRaDeviceTest`. We also take the chance to improve the test device randomness, since previously there were collisions between different keys, and it was not always clear whether reported or desired properties were expected as part of test assertions.

## How is this addressed

For each test case in `LoRaDeviceTest` we distinguish whether the test asserts on the property *contract*, or whether it requires a twin but has an assertion that is unrelated to the contract. If it asserts the data contract, we keep the existing strategy of setting up the device twins "manually". If it only asserts part of the contract, we start with a common way of creating device twins for OTAA/ABP devices and manually amend the properties on which the test asserts.

Furthermore, we increase the case coverage that we get from our tests by not relying on the `TwinProperty` when creating device twins in `LoRaDeviceTwin`. By hardcoding the `string` property keys, we know that unit tests will break should we change the name of some device twin properties (breaking change detector).

We fix the wrong representation of a `LoRaRegionType` in a twin created via `LoRaDeviceTwin` - even though it is an enum, it's an exception that is serialized as string instead of a number.
