### PR TITLE
Track direct or gateway mode with each IoT Hub dependency trace

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApplicationInsightsTracing.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApplicationInsightsTracing.cs
@@ -22,18 +22,20 @@ namespace LoRaWan.NetworkServer
 
         private readonly TelemetryClient telemetryClient;
         private readonly string iotHubHostName;
+        private readonly string iotHubDependencySuffix;
 
         public ApplicationInsightsTracing(TelemetryClient telemetryClient, NetworkServerConfiguration networkServerConfiguration)
         {
             this.telemetryClient = telemetryClient;
             this.iotHubHostName = networkServerConfiguration.IoTHubHostName;
+            this.iotHubDependencySuffix = networkServerConfiguration.EnableGateway ? "(Gateway)" : "(Direct)";
         }
 
         public IDisposable TrackDataMessage() => this.telemetryClient.StartOperation<RequestTelemetry>("Data message");
 
         public IDisposable TrackIotHubDependency(string dependencyName, string data)
         {
-            var dependencyTelemetry = new DependencyTelemetry(IotHubDependencyTypeName, this.iotHubHostName, dependencyName, data);
+            var dependencyTelemetry = new DependencyTelemetry(IotHubDependencyTypeName, this.iotHubHostName, $"{dependencyName} {this.iotHubDependencySuffix}", data);
             return this.telemetryClient.StartOperation(dependencyTelemetry);
         }
     }


### PR DESCRIPTION
# PR for issue #1542

## What is being addressed

With this PR we make it easier for users of the starter kit to see whether an IoT Hub request was made to the local Edge gateway (suffixed with `(Gateway)`) or directly to IoT Hub (suffixed with `(Direct)`), for all AMQP/MQTT calls. These suffixes do not apply to the dependencies from the Azure Functions to IoT Hub, but only to the dependencies of the LNS.
