### PR TITLE
Stabilize test host which crashes due to logging in `TestOutputLogger`

### DIFF
--- a/Tests/Common/TestOutputLogger.cs
+++ b/Tests/Common/TestOutputLogger.cs
@@ -35,7 +35,16 @@ namespace LoRaWan.Tests.Common
             if (!IsEnabled(logLevel)) return;
 
             var message = formatter(state, exception);
-            this.testOutputHelper.WriteLine(message);
+
+            try
+            {
+                this.testOutputHelper.WriteLine(message);
+            }
+            catch (Exception)
+            {
+                // best-effort logging in case testOutputHelper has already been disposed. Fixes:
+                // https://github.com/Azure/iotedge-lorawan-starterkit/issues/1554.
+            }
         }
     }
 

--- a/Tests/Common/TestOutputLogger.cs
+++ b/Tests/Common/TestOutputLogger.cs
@@ -40,7 +40,7 @@ namespace LoRaWan.Tests.Common
             {
                 this.testOutputHelper.WriteLine(message);
             }
-            catch (Exception)
+            catch (InvalidOperationException)
             {
                 // best-effort logging in case testOutputHelper has already been disposed. Fixes:
                 // https://github.com/Azure/iotedge-lorawan-starterkit/issues/1554.


### PR DESCRIPTION
# PR for issue #1554

## What is being addressed

In some cases, logging to a `TestOutputLogger` happens after the test has finished, since the lifetime of some fixtures can be longer than that of a test. If we log e.g. inside a cache eviction of an entry `IMemoryCache`, this will cause a log to the `ITestOutputHelper` after it can be used. This causes the test host to crash.

## How is this addressed

Logging to the `ITestOutputHelper` happens on a best-effort basis. The exceptions in logging due to the `IMemoryCache` eviction will still happen, but we catch them and do not crash the test host.
