### PR TITLE
Throttle disposal of devices & clients

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DisposableExtensions.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DisposableExtensions.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaWan.NetworkServer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal static class DisposableExtensions
+    {
+        /// <remarks>
+        /// In general <see cref="IAsyncDisposable.DisposeAsync"/> implementations are not
+        /// expected to throw exceptions. If any of the disposable objects throw exceptions then
+        /// the behaviour of this method is undefined.
+        /// </remarks>
+        public static async ValueTask DisposeAllAsync(this IEnumerable<IAsyncDisposable> disposables, int concurrency)
+        {
+            ArgumentNullException.ThrowIfNull(disposables, nameof(disposables));
+            if (concurrency <= 0) throw new ArgumentOutOfRangeException(nameof(concurrency), concurrency, null);
+
+            var capacity = disposables switch
+            {
+                ICollection<IAsyncDisposable> collection => collection.Count,
+                IReadOnlyCollection<IAsyncDisposable> collection => collection.Count,
+                _ => (int?)null,
+            };
+
+            if (capacity is 0)
+                return;
+
+            using var semaphore = new SemaphoreSlim(concurrency);
+
+            var tasks = capacity is { } someCapacity ? new List<Task>(someCapacity) : new List<Task>();
+            tasks.AddRange(disposables.Select(DisposeAsync));
+
+            // NOTE! "IAsyncDisposable.DisposeAsync" implementations are not meant to throw
+            // and cannot be canceled therefore it is expected that all of the tasks will
+            // always succeed.
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            async Task DisposeAsync(IAsyncDisposable device)
+            {
+                try
+                {
+                    await semaphore.WaitAsync().ConfigureAwait(false);
+                    await device.DisposeAsync();
+                }
+                finally
+                {
+                    _ = semaphore.Release();
+                }
+            }
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DisposableExtensions.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DisposableExtensions.cs
@@ -30,7 +30,7 @@ namespace LoRaWan.NetworkServer
                 _ => (int?)null,
             };
 
-            if (capacity is 0)
+            if (capacity is 0) // disposables collection is empty so bail out early
                 return;
 
             using var semaphore = new SemaphoreSlim(concurrency);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceCache.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceCache.cs
@@ -284,8 +284,7 @@ namespace LoRaWan.NetworkServer
 
             this.logger.LogInformation($"{nameof(LoRaDeviceCache)} cleared.");
 
-            await Parallel.ForEachAsync(devices, new ParallelOptions { MaxDegreeOfParallelism = 20 },
-                                        (device, _) => device.DisposeAsync());
+            await devices.DisposeAllAsync(20);
         }
 
         private class StatisticsTracker

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -9,6 +9,7 @@ namespace LoRaWan.NetworkServer
     using System.Collections.Concurrent;
     using LoRaWan.NetworkServer.Logger;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
@@ -131,7 +132,7 @@ namespace LoRaWan.NetworkServer
 
         public async ValueTask DisposeAsync()
         {
-            await Parallel.ForEachAsync(this.clientByDevEui.Values, (client, _) => client.DisposeAsync());
+            await this.clientByDevEui.Values.DisposeAllAsync(20);
         }
 
         public IAsyncDisposable BeginDeviceClientConnectionActivity(LoRaDevice loRaDevice)

--- a/Tests/Unit/NetworkServer/DisposableExtensionsTests.cs
+++ b/Tests/Unit/NetworkServer/DisposableExtensionsTests.cs
@@ -37,6 +37,13 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             Assert.Equal(concurrency, ex.ActualValue);
         }
 
+        [Fact]
+        public void DisposeAllAsync_With_Empty_Sequence_Completes_Immediately()
+        {
+            var task = Array.Empty<IAsyncDisposable>().DisposeAllAsync(42);
+            Assert.True(task.IsCompletedSuccessfully);
+        }
+
         [Theory]
         [InlineData(10, 1)]
         [InlineData(10, 5)]

--- a/Tests/Unit/NetworkServer/DisposableExtensionsTests.cs
+++ b/Tests/Unit/NetworkServer/DisposableExtensionsTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaWan.Tests.Unit.NetworkServer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using LoRaWan.NetworkServer;
+    using Moq;
+    using Xunit;
+
+    public class DisposableExtensionsTests
+    {
+        [Fact]
+        public async Task DisposeAllAsync_With_Null_Disposables_Throws()
+        {
+            var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await DisposableExtensions.DisposeAllAsync(null!, 0));
+
+            Assert.Equal("disposables", ex.ParamName);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public async Task DisposeAllAsync_With_Invalid_Concurrency_Throws(int concurrency)
+        {
+            var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+                await Enumerable.Empty<IAsyncDisposable>().DisposeAllAsync(concurrency));
+
+            Assert.Equal("concurrency", ex.ParamName);
+            Assert.Equal(concurrency, ex.ActualValue);
+        }
+
+        [Theory]
+        [InlineData(10, 1)]
+        [InlineData(10, 5)]
+        [InlineData(10, 10)]
+        public async Task DisposeAllAsync_Disposes_Each_Disposable(int count, int concurrency)
+        {
+            var disposableMocks = Enumerable.Range(1, count).Select(_ => new Mock<IAsyncDisposable>()).ToArray();
+
+            await disposableMocks.Select(m => m.Object).DisposeAllAsync(concurrency);
+
+            foreach (var disposableMock in disposableMocks)
+                disposableMock.Verify(x => x.DisposeAsync(), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(10, 1)]
+        [InlineData(10, 2)]
+        [InlineData(10, 3)]
+        [InlineData(10, 4)]
+        [InlineData(10, 5)]
+        [InlineData(10, 6)]
+        [InlineData(10, 7)]
+        [InlineData(10, 8)]
+        [InlineData(10, 9)]
+        [InlineData(10, 10)]
+        [InlineData(10, 11)]
+        public async Task DisposeAllAsync_Respects_Requested_Concurrency(int count, int concurrency)
+        {
+            var disposableMocks = Enumerable.Range(1, count).Select(_ => new Mock<IAsyncDisposable>()).ToArray();
+
+            using var semaphore = new SemaphoreSlim(0, concurrency);
+            var flights = 0;
+
+            async ValueTask DisposeAsync(Task task)
+            {
+                // Release semaphore when # of call in flight equal concurrency.
+                if (concurrency == Interlocked.Increment(ref flights))
+                    semaphore.Release();
+
+                await task;
+            }
+
+            var tcsQueue = new Queue<TaskCompletionSource>();
+            foreach (var disposableMock in disposableMocks)
+            {
+                var tcs = new TaskCompletionSource();
+                tcsQueue.Enqueue(tcs);
+                disposableMock.Setup(x => x.DisposeAsync()).Returns(() => DisposeAsync(tcs.Task));
+            }
+
+            var task = disposableMocks.Select(m => m.Object).DisposeAllAsync(concurrency);
+
+            for (var remaining = count - concurrency; remaining > 0; remaining--)
+            {
+                // Wait until expected # of calls are in flight
+                Assert.True(await semaphore.WaitAsync(TimeSpan.FromSeconds(5)));
+                Assert.Equal(concurrency, flights);
+                // Decrement calls in flight because one will be completed.
+                flights--;
+                tcsQueue.Dequeue().SetResult();
+            }
+
+            Assert.Equal(Math.Min(concurrency, count), tcsQueue.Count);
+
+            // Complete all remaining tasks.
+            while (tcsQueue.Count > 0)
+                tcsQueue.Dequeue().SetResult();
+
+            await task;
+        }
+    }
+}

--- a/Tests/Unit/NetworkServer/ListExtensions.cs
+++ b/Tests/Unit/NetworkServer/ListExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.NetworkServer
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    internal static class ListExtensions
+    {
+        public static IReadOnlyCollection<T> WrapInReadOnlyCollection<T>(this IList<T> list) => new ReadOnlyCollection<T>(list);
+
+        internal sealed class ReadOnlyCollection<T> : IReadOnlyCollection<T>
+        {
+            private readonly IList<T> list;
+
+            public ReadOnlyCollection(IList<T> list) => this.list = list;
+            public int Count => this.list.Count;
+            public IEnumerator<T> GetEnumerator() => this.list.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)this.list).GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
# PR for issue #1564

## What is being addressed

Throttled disposal of clients & devices without using `Parallel.ForEachAsync` that's better-suited for CPU-bound operations.

## How is this addressed

Added an extension method for disposing a sequence `IAsyncDisposable` objects with a concurrency argument.
