### PR TITLE
Use logging scope in discovery service

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApplicationInsightsTracing.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/ApplicationInsightsTracing.cs
@@ -6,6 +6,7 @@
 namespace LoRaWan.NetworkServer
 {
     using System;
+    using LoRaTools;
     using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.DataContracts;
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ClientCertificateValidatorService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ClientCertificateValidatorService.cs
@@ -12,7 +12,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
-    using LoRaWan.NetworkServer.Logger;
+    using LoRaTools;
     using Microsoft.Extensions.Logging;
 
     internal sealed class ClientCertificateValidatorService : IClientCertificateValidatorService

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
@@ -3,8 +3,8 @@
 
 namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
 {
+    using LoRaTools;
     using LoRaTools.Utils;
-    using LoRaWan.NetworkServer.Logger;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Azure.Devices.Shared;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/Processors/LnsProtocolMessageProcessor.cs
@@ -17,7 +17,6 @@ namespace LoRaWan.NetworkServer.BasicsStation.Processors
     using LoRaTools.LoRaMessage;
     using LoRaTools.NetworkServerDiscovery;
     using LoRaWan.NetworkServer.BasicsStation.JsonHandlers;
-    using LoRaWan.NetworkServer.Logger;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Routing;
     using Microsoft.Extensions.Logging;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/DeviceLoaderSynchronizer.cs
@@ -7,7 +7,7 @@ namespace LoRaWan.NetworkServer
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using LoRaWan.NetworkServer.Logger;
+    using LoRaTools;
     using Microsoft.Extensions.Logging;
 
     /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -14,7 +14,6 @@ namespace LoRaWan.NetworkServer
     using LoRaTools.LoRaPhysical;
     using LoRaTools.Regions;
     using LoRaTools.Utils;
-    using LoRaWan.NetworkServer.Logger;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
     using static LoRaWan.ReceiveWindowNumber;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDevice.cs
@@ -8,10 +8,10 @@ namespace LoRaWan.NetworkServer
     using System.Diagnostics.Metrics;
     using System.Threading;
     using System.Threading.Tasks;
+    using LoRaTools;
     using LoRaTools.LoRaMessage;
     using LoRaTools.Regions;
     using LoRaTools.Utils;
-    using LoRaWan.NetworkServer.Logger;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Azure.Devices.Shared;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaDeviceClientConnectionManager.cs
@@ -7,9 +7,7 @@ namespace LoRaWan.NetworkServer
 {
     using System;
     using System.Collections.Concurrent;
-    using LoRaWan.NetworkServer.Logger;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
@@ -18,6 +16,7 @@ namespace LoRaWan.NetworkServer
     using Microsoft.Extensions.Caching.Memory;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
+    using LoRaTools;
 
     /// <summary>
     /// Manages <see cref="ILoRaDeviceClient"/> connections for <see cref="LoRaDevice"/>.

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Logger/IotHubLogger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Logger/IotHubLogger.cs
@@ -9,6 +9,7 @@ namespace LoRaWan.NetworkServer.Logger
     using System.Collections.Concurrent;
     using System.Text;
     using System.Threading.Tasks;
+    using LoRaTools;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Logger/LoRaConsoleLogger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Logger/LoRaConsoleLogger.cs
@@ -6,6 +6,7 @@ namespace LoRaWan.NetworkServer.Logger
 {
     using System;
     using System.Collections.Concurrent;
+    using LoRaTools;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Logging;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Logger/LoggerHelper.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Logger/LoggerHelper.cs
@@ -7,6 +7,7 @@ namespace LoRaWan.NetworkServer.Logger
 {
     using System;
     using System.Collections.Generic;
+    using LoRaTools;
     using Microsoft.Extensions.Logging;
 
     internal static class LoggerHelper

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Logger/TcpLogger.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/Logger/TcpLogger.cs
@@ -18,6 +18,7 @@ namespace LoRaWan.NetworkServer.Logger
     using System.Threading;
     using System.Threading.Channels;
     using System.Threading.Tasks;
+    using LoRaTools;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Logging;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/MessageDispatcher.cs
@@ -6,8 +6,8 @@ namespace LoRaWan.NetworkServer
     using System;
     using System.Diagnostics.Metrics;
     using System.Threading.Tasks;
+    using LoRaTools;
     using LoRaTools.LoRaMessage;
-    using LoRaWan.NetworkServer.Logger;
     using Microsoft.Extensions.Logging;
 
     /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/ILoggerExtensions.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/ILoggerExtensions.cs
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace LoRaWan.NetworkServer.Logger
+namespace LoRaTools
 {
     using System;
     using System.Collections.Generic;
+    using LoRaWan;
     using Microsoft.Extensions.Logging;
 
     public static class ILoggerExtensions

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/NetworkServerDiscovery/DiscoveryService.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/NetworkServerDiscovery/DiscoveryService.cs
@@ -55,6 +55,8 @@ namespace LoRaTools.NetworkServerDiscovery
                 {
                     var json = message.Current;
                     var stationEui = QueryReader.Read(json);
+
+                    using var scope = this.logger.BeginEuiScope(stationEui);
                     this.logger.LogInformation("Received discovery request from: {StationEui}", stationEui);
 
                     try

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/NoopDisposable.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/NoopDisposable.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace LoRaWan.NetworkServer
+#nullable enable
+
+namespace LoRaTools
 {
     using System;
 

--- a/Tests/Common/TestOutputLogger.cs
+++ b/Tests/Common/TestOutputLogger.cs
@@ -7,7 +7,7 @@ namespace LoRaWan.Tests.Common
 {
     using System;
     using System.Collections.Concurrent;
-    using LoRaWan.NetworkServer;
+    using LoRaTools;
     using Microsoft.Extensions.Logging;
     using Xunit.Abstractions;
 

--- a/Tests/Unit/NetworkServer/LnsProtocolMessageProcessorTests.cs
+++ b/Tests/Unit/NetworkServer/LnsProtocolMessageProcessorTests.cs
@@ -23,7 +23,6 @@ namespace LoRaWan.Tests.Unit.NetworkServer
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
-    using Org.BouncyCastle.Asn1.IsisMtt.X509;
     using Xunit;
 
     public class LnsProtocolMessageProcessorTests

--- a/Tests/Unit/NetworkServer/Logger/IoTHubLoggerTests.cs
+++ b/Tests/Unit/NetworkServer/Logger/IoTHubLoggerTests.cs
@@ -8,6 +8,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer.Logger
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using global::LoRaTools;
     using LoRaWan.NetworkServer;
     using LoRaWan.NetworkServer.Logger;
     using LoRaWan.Tests.Common;

--- a/Tests/Unit/NetworkServer/Logger/LoRaConsoleLoggerTests.cs
+++ b/Tests/Unit/NetworkServer/Logger/LoRaConsoleLoggerTests.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.Tests.Unit.NetworkServer.Logger
 {
     using System;
+    using global::LoRaTools;
     using LoRaWan;
     using LoRaWan.NetworkServer.Logger;
     using Microsoft.Extensions.Logging;

--- a/Tests/Unit/NetworkServer/Logger/LoggerConfigurationMonitorTests.cs
+++ b/Tests/Unit/NetworkServer/Logger/LoggerConfigurationMonitorTests.cs
@@ -6,7 +6,7 @@
 namespace LoRaWan.Tests.Unit.NetworkServer.Logger
 {
     using System;
-    using LoRaWan.NetworkServer;
+    using global::LoRaTools;
     using LoRaWan.NetworkServer.Logger;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;


### PR DESCRIPTION
## What is being addressed

We use logging scopes for the station EUI as soon as it's known in the discovery service. This will improve observability, as the station EUI will be available as a custom dimension in Application Insights.

