### PR TITLE
Use logging scopes in Facade wherever possible

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/ConcentratorCredentialsFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ConcentratorCredentialsFunction.cs
@@ -11,6 +11,7 @@ namespace LoraKeysManagerFacade
     using System.Threading.Tasks;
     using Azure.Storage.Blobs;
     using Azure.Storage.Blobs.Models;
+    using LoRaTools;
     using LoRaTools.CommonAPI;
     using LoRaTools.Utils;
     using LoRaWan;
@@ -69,6 +70,8 @@ namespace LoraKeysManagerFacade
                 this.logger.LogError("StationEui missing in request or invalid");
                 return new BadRequestObjectResult("StationEui missing in request or invalid");
             }
+
+            using var stationScope = this.logger.BeginEuiScope(stationEui);
 
             var credentialTypeQueryString = req.Query["CredentialType"];
             if (StringValues.IsNullOrEmpty(credentialTypeQueryString))

--- a/LoRaEngine/LoraKeysManagerFacade/ConcentratorFirmwareFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ConcentratorFirmwareFunction.cs
@@ -93,9 +93,8 @@ namespace LoraKeysManagerFacade
                         StatusCode = (int)HttpStatusCode.InternalServerError,
                     };
                 }
-                catch (RequestFailedException ex)
+                catch (RequestFailedException ex) when (ExceptionFilterUtility.True(() => this.logger.LogError(ex, "Failed to download firmware from storage.")))
                 {
-                    this.logger.LogError(ex, "Failed to download firmware from storage.");
                     return new ObjectResult("Failed to download firmware")
                     {
                         StatusCode = (int)HttpStatusCode.InternalServerError

--- a/LoRaEngine/LoraKeysManagerFacade/ConcentratorFirmwareFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/ConcentratorFirmwareFunction.cs
@@ -11,6 +11,7 @@ namespace LoraKeysManagerFacade
     using System.Threading.Tasks;
     using Azure;
     using Azure.Storage.Blobs;
+    using LoRaTools;
     using LoRaTools.Utils;
     using LoRaWan;
     using Microsoft.AspNetCore.Http;
@@ -67,6 +68,8 @@ namespace LoraKeysManagerFacade
                 this.logger.LogError("StationEui missing in request or invalid");
                 return new BadRequestObjectResult("StationEui missing in request or invalid");
             }
+
+            using var stationScope = this.logger.BeginEuiScope(stationEui);
 
             var twin = await this.registryManager.GetTwinAsync(stationEui.ToString("N", CultureInfo.InvariantCulture), cancellationToken);
             if (twin != null)

--- a/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/DeviceGetter.cs
@@ -85,9 +85,8 @@ namespace LoraKeysManagerFacade
             {
                 return new BadRequestObjectResult("UsedDevNonce");
             }
-            catch (JoinRefusedException ex)
+            catch (JoinRefusedException ex) when (ExceptionFilterUtility.True(() => this.logger.LogDebug("Join refused: {msg}", ex.Message)))
             {
-                this.logger.LogDebug("Join refused: {msg}", ex.Message);
                 return new BadRequestObjectResult("JoinRefused: " + ex.Message);
             }
             catch (ArgumentException ex)

--- a/LoRaEngine/LoraKeysManagerFacade/FCntCacheCheck.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FCntCacheCheck.cs
@@ -27,8 +27,7 @@ namespace LoraKeysManagerFacade
 
         [FunctionName("NextFCntDown")]
         public async Task<IActionResult> NextFCntDownInvoke(
-            [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req,
-            ILogger log)
+            [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req)
         {
             if (req is null) throw new ArgumentNullException(nameof(req));
 
@@ -72,7 +71,7 @@ namespace LoraKeysManagerFacade
                             // and continued processing
                             if (deviceInfo.FCntUp > 1)
                             {
-                                log.LogDebug("Resetting cache for device {devEUI}. FCntUp: {fcntup}", devEui, deviceInfo.FCntUp);
+                                this.logger.LogDebug("Resetting cache for device {devEUI}. FCntUp: {fcntup}", devEui, deviceInfo.FCntUp);
                                 deviceCache.ClearCache();
                             }
                         }

--- a/LoRaEngine/LoraKeysManagerFacade/FCntCacheCheck.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FCntCacheCheck.cs
@@ -5,6 +5,7 @@ namespace LoraKeysManagerFacade
 {
     using System;
     using System.Threading.Tasks;
+    using LoRaTools;
     using LoRaWan;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
@@ -16,10 +17,12 @@ namespace LoraKeysManagerFacade
     public class FCntCacheCheck
     {
         private readonly ILoRaDeviceCacheStore deviceCache;
+        private readonly ILogger<FCntCacheCheck> logger;
 
-        public FCntCacheCheck(ILoRaDeviceCacheStore deviceCache)
+        public FCntCacheCheck(ILoRaDeviceCacheStore deviceCache, ILogger<FCntCacheCheck> logger)
         {
             this.deviceCache = deviceCache;
+            this.logger = logger;
         }
 
         [FunctionName("NextFCntDown")]
@@ -48,6 +51,8 @@ namespace LoraKeysManagerFacade
             {
                 return new BadRequestObjectResult("Dev EUI is invalid.");
             }
+
+            using var deviceScope = this.logger.BeginDeviceScope(devEui);
 
             if (!uint.TryParse(fCntUp, out var clientFCntUp))
             {

--- a/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
@@ -58,6 +58,7 @@ namespace LoraKeysManagerFacade
                 .AddSingleton<ILoRaADRManager>(sp => new LoRaADRServerManager(new LoRaADRRedisStore(redisCache, sp.GetRequiredService<ILogger<LoRaADRRedisStore>>()),
                                                                               new LoRaADRStrategyProvider(sp.GetRequiredService<ILoggerFactory>()),
                                                                               deviceCacheStore,
+                                                                              sp.GetRequiredService<ILoggerFactory>(),
                                                                               sp.GetRequiredService<ILogger<LoRaADRServerManager>>()))
                 .AddSingleton<CreateEdgeDevice>()
                 .AddSingleton<DeviceGetter>()

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerFunction.cs
@@ -5,6 +5,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
 {
     using System.Linq;
     using System.Threading.Tasks;
+    using LoRaTools;
     using LoRaWan;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
@@ -16,11 +17,13 @@ namespace LoraKeysManagerFacade.FunctionBundler
     public class FunctionBundlerFunction
     {
         private readonly IFunctionBundlerExecutionItem[] executionItems;
+        private readonly ILogger<FunctionBundlerFunction> logger;
 
         public FunctionBundlerFunction(
-            IFunctionBundlerExecutionItem[] items)
+            IFunctionBundlerExecutionItem[] items, ILogger<FunctionBundlerFunction> logger)
         {
             this.executionItems = items.OrderBy(x => x.Priority).ToArray();
+            this.logger = logger;
         }
 
         [FunctionName("FunctionBundler")]
@@ -42,6 +45,8 @@ namespace LoraKeysManagerFacade.FunctionBundler
             {
                 return new BadRequestObjectResult("Dev EUI is invalid.");
             }
+
+            using var deviceScope = this.logger.BeginDeviceScope(parsedDevEui);
 
             var requestBody = await req.ReadAsStringAsync();
             if (string.IsNullOrEmpty(requestBody))

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerFunction.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/FunctionBundlerFunction.cs
@@ -29,7 +29,6 @@ namespace LoraKeysManagerFacade.FunctionBundler
         [FunctionName("FunctionBundler")]
         public async Task<IActionResult> FunctionBundler(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "FunctionBundler/{devEUI}")] HttpRequest req,
-            ILogger logger,
             string devEUI)
         {
             try
@@ -55,14 +54,14 @@ namespace LoraKeysManagerFacade.FunctionBundler
             }
 
             var functionBundlerRequest = JsonConvert.DeserializeObject<FunctionBundlerRequest>(requestBody);
-            var result = await HandleFunctionBundlerInvoke(parsedDevEui, functionBundlerRequest, logger);
+            var result = await HandleFunctionBundlerInvoke(parsedDevEui, functionBundlerRequest);
 
             return new OkObjectResult(result);
         }
 
-        public async Task<FunctionBundlerResult> HandleFunctionBundlerInvoke(DevEui devEUI, FunctionBundlerRequest request, ILogger logger = null)
+        public async Task<FunctionBundlerResult> HandleFunctionBundlerInvoke(DevEui devEUI, FunctionBundlerRequest request)
         {
-            var pipeline = new FunctionBundlerPipelineExecuter(this.executionItems, devEUI, request, logger);
+            var pipeline = new FunctionBundlerPipelineExecuter(this.executionItems, devEUI, request, this.logger);
             return await pipeline.Execute();
         }
     }

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaADRFunction/LoRaADRServerManager.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaADRFunction/LoRaADRServerManager.cs
@@ -11,16 +11,22 @@ namespace LoraKeysManagerFacade
     public class LoRaADRServerManager : LoRaADRManagerBase
     {
         private readonly ILoRaDeviceCacheStore deviceCacheStore;
+        private readonly ILoggerFactory loggerFactory;
 
-        public LoRaADRServerManager(ILoRaADRStore store, ILoRaADRStrategyProvider strategyProvider, ILoRaDeviceCacheStore deviceCacheStore, ILogger<LoRaADRServerManager> logger)
+        public LoRaADRServerManager(ILoRaADRStore store,
+                                    ILoRaADRStrategyProvider strategyProvider,
+                                    ILoRaDeviceCacheStore deviceCacheStore,
+                                    ILoggerFactory loggerFactory,
+                                    ILogger<LoRaADRServerManager> logger)
             : base(store, strategyProvider, logger)
         {
             this.deviceCacheStore = deviceCacheStore;
+            this.loggerFactory = loggerFactory;
         }
 
         public override async Task<uint> NextFCntDown(DevEui devEUI, string gatewayId, uint clientFCntUp, uint clientFCntDown)
         {
-            var fcntCheck = new FCntCacheCheck(this.deviceCacheStore);
+            var fcntCheck = new FCntCacheCheck(this.deviceCacheStore, this.loggerFactory.CreateLogger<FCntCacheCheck>());
             return await fcntCheck.GetNextFCntDownAsync(devEUI, gatewayId, clientFCntUp, clientFCntDown);
         }
     }

--- a/LoRaEngine/LoraKeysManagerFacade/SearchDeviceByDevEUI.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SearchDeviceByDevEUI.cs
@@ -26,7 +26,7 @@ namespace LoraKeysManagerFacade
         }
 
         [FunctionName(nameof(GetDeviceByDevEUI))]
-        public async Task<IActionResult> GetDeviceByDevEUI([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req, ILogger log)
+        public async Task<IActionResult> GetDeviceByDevEUI([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req)
         {
             if (req is null) throw new ArgumentNullException(nameof(req));
 
@@ -36,14 +36,14 @@ namespace LoraKeysManagerFacade
             }
             catch (IncompatibleVersionException ex)
             {
-                log.LogError(ex, "Invalid version");
+                this.logger.LogError(ex, "Invalid version");
                 return new BadRequestObjectResult(ex.Message);
             }
 
-            return await RunGetDeviceByDevEUI(req, log);
+            return await RunGetDeviceByDevEUI(req);
         }
 
-        private async Task<IActionResult> RunGetDeviceByDevEUI(HttpRequest req, ILogger log)
+        private async Task<IActionResult> RunGetDeviceByDevEUI(HttpRequest req)
         {
             string devEui = req.Query["DevEUI"];
             if (!DevEui.TryParse(devEui, out var parsedDevEui))
@@ -56,7 +56,7 @@ namespace LoraKeysManagerFacade
             var device = await this.registryManager.GetDeviceAsync(parsedDevEui.ToString());
             if (device != null)
             {
-                log.LogDebug($"Search for {devEui} found 1 device");
+                this.logger.LogDebug($"Search for {devEui} found 1 device");
                 return new OkObjectResult(new
                 {
                     DevEUI = devEui,
@@ -65,7 +65,7 @@ namespace LoraKeysManagerFacade
             }
             else
             {
-                log.LogInformation($"Search for {devEui} found 0 devices");
+                this.logger.LogInformation($"Search for {devEui} found 0 devices");
                 return new NotFoundResult();
             }
         }

--- a/LoRaEngine/LoraKeysManagerFacade/SearchDeviceByDevEUI.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SearchDeviceByDevEUI.cs
@@ -5,6 +5,7 @@ namespace LoraKeysManagerFacade
 {
     using System;
     using System.Threading.Tasks;
+    using LoRaTools;
     using LoRaWan;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
@@ -16,10 +17,12 @@ namespace LoraKeysManagerFacade
     public class SearchDeviceByDevEUI
     {
         private readonly RegistryManager registryManager;
+        private readonly ILogger<SearchDeviceByDevEUI> logger;
 
-        public SearchDeviceByDevEUI(RegistryManager registryManager)
+        public SearchDeviceByDevEUI(RegistryManager registryManager, ILogger<SearchDeviceByDevEUI> logger)
         {
             this.registryManager = registryManager;
+            this.logger = logger;
         }
 
         [FunctionName(nameof(GetDeviceByDevEUI))]
@@ -47,6 +50,8 @@ namespace LoraKeysManagerFacade
             {
                 return new BadRequestObjectResult("DevEUI missing or invalid.");
             }
+
+            using var deviceScope = this.logger.BeginDeviceScope(parsedDevEui);
 
             var device = await this.registryManager.GetDeviceAsync(parsedDevEui.ToString());
             if (device != null)

--- a/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
@@ -9,6 +9,7 @@ namespace LoraKeysManagerFacade
     using System.Net;
     using System.Text;
     using System.Threading.Tasks;
+    using LoRaTools;
     using LoRaTools.CommonAPI;
     using LoRaTools.Utils;
     using LoRaWan;
@@ -65,6 +66,8 @@ namespace LoraKeysManagerFacade
             {
                 return new BadRequestObjectResult(ex.Message);
             }
+
+            using var deviceScope = this.log.BeginDeviceScope(parsedDevEui);
 
             var requestBody = await req.ReadAsStringAsync();
             if (string.IsNullOrEmpty(requestBody))

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/ILoggerExtensions.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/ILoggerExtensions.cs
@@ -19,8 +19,8 @@ namespace LoRaTools
             ? logger?.BeginScope(new Dictionary<string, object> { [DevEUIKey] = someDevEui.ToString() })
             : NoopDisposable.Instance;
 
-        public static IDisposable BeginDeviceAddressScope(this ILogger logger, DevAddr devAddr) =>
-            logger?.BeginDeviceAddressScope(devAddr.ToString());
+        public static IDisposable BeginDeviceAddressScope(this ILogger logger, DevAddr? devAddr) =>
+            devAddr is { } someDevAddr ? logger?.BeginDeviceAddressScope(someDevAddr.ToString()) : NoopDisposable.Instance;
 
         public static IDisposable BeginDeviceAddressScope(this ILogger logger, string deviceAddress) =>
             logger?.BeginScope(new Dictionary<string, object> { [DeviceAddressKey] = deviceAddress });

--- a/Tests/Unit/LoRaTools/ApiVersionTest.cs
+++ b/Tests/Unit/LoRaTools/ApiVersionTest.cs
@@ -29,9 +29,9 @@ namespace LoRaWan.Tests.Unit.LoRaTools.CommonAPI
             var dummyExecContext = new ExecutionContext();
             var apiCalls = new Func<HttpRequest, Task<IActionResult>>[]
             {
-                (req) => new DeviceGetter(null, null).GetDevice(req, NullLogger.Instance),
-                (req) => Task.Run(() => new FCntCacheCheck(null).NextFCntDownInvoke(req, NullLogger.Instance)),
-                (req) => Task.Run(() => new FunctionBundlerFunction(Array.Empty<IFunctionBundlerExecutionItem>()).FunctionBundler(req, NullLogger.Instance, string.Empty)),
+                (req) => new DeviceGetter(null, null, NullLogger<DeviceGetter>.Instance).GetDevice(req, NullLogger.Instance),
+                (req) => Task.Run(() => new FCntCacheCheck(null, NullLogger<FCntCacheCheck>.Instance).NextFCntDownInvoke(req, NullLogger.Instance)),
+                (req) => Task.Run(() => new FunctionBundlerFunction(Array.Empty<IFunctionBundlerExecutionItem>(), NullLogger<FunctionBundlerFunction>.Instance).FunctionBundler(req, NullLogger.Instance, string.Empty)),
                 (req) => new SendCloudToDeviceMessage(null, null, null, null).Run(req, string.Empty)
             };
 

--- a/Tests/Unit/LoRaTools/ApiVersionTest.cs
+++ b/Tests/Unit/LoRaTools/ApiVersionTest.cs
@@ -29,9 +29,9 @@ namespace LoRaWan.Tests.Unit.LoRaTools.CommonAPI
             var dummyExecContext = new ExecutionContext();
             var apiCalls = new Func<HttpRequest, Task<IActionResult>>[]
             {
-                (req) => new DeviceGetter(null, null, NullLogger<DeviceGetter>.Instance).GetDevice(req, NullLogger.Instance),
-                (req) => Task.Run(() => new FCntCacheCheck(null, NullLogger<FCntCacheCheck>.Instance).NextFCntDownInvoke(req, NullLogger.Instance)),
-                (req) => Task.Run(() => new FunctionBundlerFunction(Array.Empty<IFunctionBundlerExecutionItem>(), NullLogger<FunctionBundlerFunction>.Instance).FunctionBundler(req, NullLogger.Instance, string.Empty)),
+                (req) => new DeviceGetter(null, null, NullLogger<DeviceGetter>.Instance).GetDevice(req),
+                (req) => Task.Run(() => new FCntCacheCheck(null, NullLogger<FCntCacheCheck>.Instance).NextFCntDownInvoke(req)),
+                (req) => Task.Run(() => new FunctionBundlerFunction(Array.Empty<IFunctionBundlerExecutionItem>(), NullLogger<FunctionBundlerFunction>.Instance).FunctionBundler(req, string.Empty)),
                 (req) => new SendCloudToDeviceMessage(null, null, null, null).Run(req, string.Empty)
             };
 

--- a/Tests/Unit/LoRaTools/LoggerExtensionsTests.cs
+++ b/Tests/Unit/LoRaTools/LoggerExtensionsTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaWan.Tests.Unit.LoRaTools
+{
+    using System;
+    using System.Collections.Generic;
+    using global::LoRaTools;
+    using LoRaWan.Tests.Common;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Xunit;
+
+    public sealed class LoggerExtensionsTests
+    {
+        private readonly List<Dictionary<string, object>> actualScopes = new();
+        private readonly ILogger logger;
+
+        public LoggerExtensionsTests()
+        {
+            var loggerMock = new Mock<ILogger>();
+            this.logger = loggerMock.Object;
+            loggerMock.Setup(l => l.BeginScope(It.IsAny<Dictionary<string, object>>()))
+                      .Callback((Dictionary<string, object> scope) => this.actualScopes.Add(scope));
+        }
+
+        public static TheoryData<DevAddr?, string?> BeginDeviceAddressScope_TheoryData() => TheoryDataFactory.From(new (DevAddr?, string?)[]
+        {
+            (new DevAddr(1), "00000001"),
+            (null, null)
+        });
+
+        [Theory]
+        [MemberData(nameof(BeginDeviceAddressScope_TheoryData))]
+        public void BeginDeviceAddressScope_Success(DevAddr? devAddr, string? expectedScopeValue) =>
+            AssertBeginScope(logger => logger.BeginDeviceAddressScope(devAddr), expectedScopeValue, "DevAddr");
+
+        public static TheoryData<DevEui?, string?> BeginDeviceScope_TheoryData() => TheoryDataFactory.From(new (DevEui?, string?)[]
+        {
+            (new DevEui(1), "0000000000000001"),
+            (null, null)
+        });
+
+        [Theory]
+        [MemberData(nameof(BeginDeviceScope_TheoryData))]
+        public void BeginDeviceScope_Success(DevEui? devEui, string? expectedScopeValue) =>
+            AssertBeginScope(logger => logger.BeginDeviceScope(devEui), expectedScopeValue, "DevEUI");
+
+        private void AssertBeginScope(Func<ILogger, IDisposable> act, string? expectedScopeValue, string expectedKey)
+        {
+            using (var scope = act(this.logger)) { /* noop */ }
+
+            if (expectedScopeValue is object someExpectedScopeValue)
+            {
+                var actualScopeDictionary = Assert.Single(this.actualScopes);
+                var actualScope = Assert.Single(actualScopeDictionary);
+                Assert.Equal(KeyValuePair.Create(expectedKey, someExpectedScopeValue), actualScope);
+            }
+            else
+            {
+                Assert.Empty(this.actualScopes);
+            }
+        }
+
+        [Fact]
+        public void BeginEuiScope_Success() =>
+            AssertBeginScope(logger => logger.BeginEuiScope(new StationEui(1)), "0000000000000001", "StationEUI");
+    }
+}

--- a/Tests/Unit/LoraKeysManagerFacade/ADRFunctionTest.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/ADRFunctionTest.cs
@@ -45,7 +45,11 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade.FunctionBundler
                 .Returns(adrStrategy.Object);
 
             this.adrStore = new LoRaADRInMemoryStore();
-            this.adrManager = new LoRaADRServerManager(this.adrStore, strategyProvider.Object, new LoRaInMemoryDeviceStore(), NullLogger<LoRaADRServerManager>.Instance);
+            this.adrManager = new LoRaADRServerManager(this.adrStore,
+                                                       strategyProvider.Object,
+                                                       new LoRaInMemoryDeviceStore(),
+                                                       NullLoggerFactory.Instance,
+                                                       NullLogger<LoRaADRServerManager>.Instance);
             this.adrExecutionItem = new ADRExecutionItem(this.adrManager);
         }
 

--- a/Tests/Unit/LoraKeysManagerFacade/ApiValidationTest.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/ApiValidationTest.cs
@@ -29,9 +29,9 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var dummyExecContext = new ExecutionContext();
             var apiCalls = new Func<HttpRequest, Task<IActionResult>>[]
             {
-                (req) => Task.Run(() => new FCntCacheCheck(null, NullLogger<FCntCacheCheck>.Instance).NextFCntDownInvoke(req, NullLogger.Instance)),
-                (req) => Task.Run(() => new FunctionBundlerFunction(Array.Empty<IFunctionBundlerExecutionItem>(), NullLogger<FunctionBundlerFunction>.Instance).FunctionBundler(req, NullLogger.Instance, string.Empty)),
-                (req) => new DeviceGetter(null, null, NullLogger<DeviceGetter>.Instance).GetDevice(req, NullLogger.Instance)
+                (req) => Task.Run(() => new FCntCacheCheck(null, NullLogger<FCntCacheCheck>.Instance).NextFCntDownInvoke(req)),
+                (req) => Task.Run(() => new FunctionBundlerFunction(Array.Empty<IFunctionBundlerExecutionItem>(), NullLogger<FunctionBundlerFunction>.Instance).FunctionBundler(req, string.Empty)),
+                (req) => new DeviceGetter(null, null, NullLogger<DeviceGetter>.Instance).GetDevice(req)
             };
 
             foreach (var apiCall in apiCalls)

--- a/Tests/Unit/LoraKeysManagerFacade/ApiValidationTest.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/ApiValidationTest.cs
@@ -29,9 +29,9 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var dummyExecContext = new ExecutionContext();
             var apiCalls = new Func<HttpRequest, Task<IActionResult>>[]
             {
-                (req) => Task.Run(() => new FCntCacheCheck(null).NextFCntDownInvoke(req, NullLogger.Instance)),
-                (req) => Task.Run(() => new FunctionBundlerFunction(Array.Empty<IFunctionBundlerExecutionItem>()).FunctionBundler(req, NullLogger.Instance, string.Empty)),
-                (req) => new DeviceGetter(null, null).GetDevice(req, NullLogger.Instance)
+                (req) => Task.Run(() => new FCntCacheCheck(null, NullLogger<FCntCacheCheck>.Instance).NextFCntDownInvoke(req, NullLogger.Instance)),
+                (req) => Task.Run(() => new FunctionBundlerFunction(Array.Empty<IFunctionBundlerExecutionItem>(), NullLogger<FunctionBundlerFunction>.Instance).FunctionBundler(req, NullLogger.Instance, string.Empty)),
+                (req) => new DeviceGetter(null, null, NullLogger<DeviceGetter>.Instance).GetDevice(req, NullLogger.Instance)
             };
 
             foreach (var apiCall in apiCalls)

--- a/Tests/Unit/LoraKeysManagerFacade/DeviceGetterTest.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/DeviceGetterTest.cs
@@ -9,6 +9,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
     using LoRaWan.Tests.Common;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
     using Xunit;
 
@@ -22,7 +23,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var devEui = TestEui.GenerateDevEui();
             var gatewayId = NewUniqueEUI64();
 
-            var deviceGetter = new DeviceGetter(InitRegistryManager(devEui), new LoRaInMemoryDeviceStore());
+            var deviceGetter = new DeviceGetter(InitRegistryManager(devEui), new LoRaInMemoryDeviceStore(), NullLogger<DeviceGetter>.Instance);
             var items = await deviceGetter.GetDeviceList(devEui, gatewayId, new DevNonce(0xABCD), null);
 
             Assert.Single(items);

--- a/Tests/Unit/LoraKeysManagerFacade/FCntCacheCheckTest.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/FCntCacheCheckTest.cs
@@ -5,6 +5,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
 {
     using global::LoraKeysManagerFacade;
     using LoRaWan.Tests.Common;
+    using Microsoft.Extensions.Logging.Abstractions;
     using System.Threading.Tasks;
     using Xunit;
 
@@ -14,7 +15,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
 
         public FCntCacheCheckTest()
         {
-            this.fcntCheck = new FCntCacheCheck(new LoRaInMemoryDeviceStore());
+            this.fcntCheck = new FCntCacheCheck(new LoRaInMemoryDeviceStore(), NullLogger<FCntCacheCheck>.Instance);
         }
 
         [Fact]

--- a/Tests/Unit/LoraKeysManagerFacade/FunctionBundlerTest.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/FunctionBundlerTest.cs
@@ -50,18 +50,18 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade.FunctionBundler
             // .Returns(new LoRaADRStandardStrategy());
             var cacheStore = new LoRaInMemoryDeviceStore();
             this.adrStore = new LoRaADRInMemoryStore();
-            this.adrManager = new LoRaADRServerManager(this.adrStore, strategyProvider.Object, cacheStore, NullLogger<LoRaADRServerManager>.Instance);
+            this.adrManager = new LoRaADRServerManager(this.adrStore, strategyProvider.Object, cacheStore, NullLoggerFactory.Instance, NullLogger<LoRaADRServerManager>.Instance);
             this.adrExecutionItem = new ADRExecutionItem(this.adrManager);
 
             var items = new IFunctionBundlerExecutionItem[]
             {
                 new DeduplicationExecutionItem(cacheStore),
                 this.adrExecutionItem,
-                new NextFCntDownExecutionItem(new FCntCacheCheck(cacheStore)),
+                new NextFCntDownExecutionItem(new FCntCacheCheck(cacheStore, NullLogger<FCntCacheCheck>.Instance)),
                 new PreferredGatewayExecutionItem(cacheStore, new NullLogger<PreferredGatewayExecutionItem>(), null),
             };
 
-            this.functionBundler = new FunctionBundlerFunction(items);
+            this.functionBundler = new FunctionBundlerFunction(items, NullLogger<FunctionBundlerFunction>.Instance);
         }
 
         [Fact]
@@ -338,7 +338,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade.FunctionBundler
             {
                 new DeduplicationExecutionItem(cacheStore),
                 new ADRExecutionItem(this.adrManager),
-                new NextFCntDownExecutionItem(new FCntCacheCheck(cacheStore)),
+                new NextFCntDownExecutionItem(new FCntCacheCheck(cacheStore, NullLogger<FCntCacheCheck>.Instance)),
                 new PreferredGatewayExecutionItem(cacheStore, new NullLogger<PreferredGatewayExecutionItem>(), null),
             };
 

--- a/Tests/Unit/LoraKeysManagerFacade/SearchDeviceByDevEUITest.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/SearchDeviceByDevEUITest.cs
@@ -29,7 +29,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var ctx = new DefaultHttpContext();
             ctx.Request.QueryString = new QueryString($"?{ApiVersion.QueryStringParamName}={ApiVersion.Version_2019_02_12_Preview.Version}");
             var registryManager = new Mock<RegistryManager>(MockBehavior.Strict);
-            var searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
+            var searchDeviceByDevEUI = SetupSubject(registryManager.Object);
             var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request, NullLogger.Instance);
             Assert.IsType<BadRequestObjectResult>(result);
         }
@@ -40,7 +40,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var ctx = new DefaultHttpContext();
             ctx.Request.QueryString = new QueryString($"?devEUI=193123");
             var registryManager = new Mock<RegistryManager>(MockBehavior.Strict);
-            var searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
+            var searchDeviceByDevEUI = SetupSubject(registryManager.Object);
             var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request, NullLogger.Instance);
             Assert.IsType<BadRequestObjectResult>(result);
         }
@@ -53,7 +53,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var ctx = new DefaultHttpContext();
             ctx.Request.QueryString = new QueryString($"?devEUI=193123&{ApiVersion.QueryStringParamName}={version}");
             var registryManager = new Mock<RegistryManager>(MockBehavior.Strict);
-            var searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
+            var searchDeviceByDevEUI = SetupSubject(registryManager.Object);
             var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request, NullLogger.Instance);
             Assert.IsType<BadRequestObjectResult>(result);
         }
@@ -71,7 +71,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             registryManager.Setup(x => x.GetDeviceAsync(devEUI.ToString()))
                 .ReturnsAsync((Device)null);
 
-            var searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
+            var searchDeviceByDevEUI = SetupSubject(registryManager.Object);
 
             var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request, NullLogger.Instance);
             Assert.IsType<NotFoundResult>(result);
@@ -86,7 +86,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var devEui = new DevEui(13213123212131);
             var primaryKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(PrimaryKey));
             var (registryManager, request) = SetupIotHubQuery(devEui.ToString(), PrimaryKey);
-            var searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
+            var searchDeviceByDevEUI = SetupSubject(registryManager.Object);
 
             // act
             var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(request, NullLogger.Instance);
@@ -104,7 +104,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var devEui = SearchByDevEuiContract.Eui;
             var primaryKey = SearchByDevEuiContract.PrimaryKey;
             var (registryManager, request) = SetupIotHubQuery(devEui, primaryKey);
-            var searchDeviceByDevEUI = new SearchDeviceByDevEUI(registryManager.Object);
+            var searchDeviceByDevEUI = SetupSubject(registryManager.Object);
 
             // act
             var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(request, NullLogger.Instance);
@@ -131,5 +131,8 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
 
             return (registryManager, ctx.Request);
         }
+
+        private static SearchDeviceByDevEUI SetupSubject(RegistryManager registryManager) =>
+            new SearchDeviceByDevEUI(registryManager, NullLogger<SearchDeviceByDevEUI>.Instance);
     }
 }

--- a/Tests/Unit/LoraKeysManagerFacade/SearchDeviceByDevEUITest.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/SearchDeviceByDevEUITest.cs
@@ -30,7 +30,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             ctx.Request.QueryString = new QueryString($"?{ApiVersion.QueryStringParamName}={ApiVersion.Version_2019_02_12_Preview.Version}");
             var registryManager = new Mock<RegistryManager>(MockBehavior.Strict);
             var searchDeviceByDevEUI = SetupSubject(registryManager.Object);
-            var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request, NullLogger.Instance);
+            var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request);
             Assert.IsType<BadRequestObjectResult>(result);
         }
 
@@ -41,7 +41,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             ctx.Request.QueryString = new QueryString($"?devEUI=193123");
             var registryManager = new Mock<RegistryManager>(MockBehavior.Strict);
             var searchDeviceByDevEUI = SetupSubject(registryManager.Object);
-            var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request, NullLogger.Instance);
+            var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request);
             Assert.IsType<BadRequestObjectResult>(result);
         }
 
@@ -54,7 +54,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             ctx.Request.QueryString = new QueryString($"?devEUI=193123&{ApiVersion.QueryStringParamName}={version}");
             var registryManager = new Mock<RegistryManager>(MockBehavior.Strict);
             var searchDeviceByDevEUI = SetupSubject(registryManager.Object);
-            var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request, NullLogger.Instance);
+            var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request);
             Assert.IsType<BadRequestObjectResult>(result);
         }
 
@@ -73,7 +73,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
 
             var searchDeviceByDevEUI = SetupSubject(registryManager.Object);
 
-            var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request, NullLogger.Instance);
+            var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(ctx.Request);
             Assert.IsType<NotFoundResult>(result);
 
             registryManager.VerifyAll();
@@ -89,7 +89,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var searchDeviceByDevEUI = SetupSubject(registryManager.Object);
 
             // act
-            var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(request, NullLogger.Instance);
+            var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(request);
 
             // assert
             var okObjectResult = Assert.IsType<OkObjectResult>(result);
@@ -107,7 +107,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var searchDeviceByDevEUI = SetupSubject(registryManager.Object);
 
             // act
-            var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(request, NullLogger.Instance);
+            var result = await searchDeviceByDevEUI.GetDeviceByDevEUI(request);
 
             // assert
             var okObjectResult = Assert.IsType<OkObjectResult>(result);


### PR DESCRIPTION
# PR for issue #1584

## What is being addressed

We add logging scopes for Stations, DevAddr and Dev EUIs wherever possible in the Facade function
