### PR TITLE
Add extensions to get logs from mocked loggers

### DIFF
--- a/Tests/Common/LoggerMockExtensions.cs
+++ b/Tests/Common/LoggerMockExtensions.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaWan.Tests.Common
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+
+    public sealed record LoggerLogInvocation(LogLevel LogLevel, EventId EventId, Exception? Exception, string Message);
+
+    public static class LoggerMockExtensions
+    {
+        private static readonly MethodInfo? LogMethodInfo = typeof(ILogger).GetMethod(nameof(ILogger.Log));
+
+        public static IEnumerable<LoggerLogInvocation> GetLogInvocations(this Mock<ILogger> mock)
+        {
+            ArgumentNullException.ThrowIfNull(mock, nameof(mock));
+            return mock.Invocations.GetLoggerLogInvocations();
+        }
+
+        public static IEnumerable<LoggerLogInvocation> GetLogInvocations<T>(this Mock<ILogger<T>> mock)
+        {
+            ArgumentNullException.ThrowIfNull(mock, nameof(mock));
+            return mock.Invocations.GetLoggerLogInvocations();
+        }
+
+        public static IEnumerable<LoggerLogInvocation> GetLoggerLogInvocations(this IInvocationList invocations)
+        {
+            ArgumentNullException.ThrowIfNull(invocations, nameof(invocations));
+
+            return from i in invocations
+                   where i.Method.IsGenericMethod && i.Method.GetGenericMethodDefinition() == LogMethodInfo
+                   select i.Arguments into args
+                   select new LoggerLogInvocation((LogLevel)args[0],
+                                            (EventId)args[1],
+                                            (Exception?)args[3],
+                                            (string)((Delegate)args[4]).DynamicInvoke(args[2], args[3])!);
+        }
+    }
+}

--- a/Tests/Common/LoggerMockExtensions.cs
+++ b/Tests/Common/LoggerMockExtensions.cs
@@ -38,9 +38,9 @@ namespace LoRaWan.Tests.Common
                    where i.Method.IsGenericMethod && i.Method.GetGenericMethodDefinition() == LogMethodInfo
                    select i.Arguments into args
                    select new LoggerLogInvocation((LogLevel)args[0],
-                                            (EventId)args[1],
-                                            (Exception?)args[3],
-                                            (string)((Delegate)args[4]).DynamicInvoke(args[2], args[3])!);
+                                                  (EventId)args[1],
+                                                  (Exception?)args[3],
+                                                  (string)((Delegate)args[4]).DynamicInvoke(args[2], args[3])!);
         }
     }
 }

--- a/Tests/Common/LoggerMockExtensions.cs
+++ b/Tests/Common/LoggerMockExtensions.cs
@@ -20,19 +20,19 @@ namespace LoRaWan.Tests.Common
 
         public static IEnumerable<LoggerLogInvocation> GetLogInvocations(this Mock<ILogger> mock)
         {
-            ArgumentNullException.ThrowIfNull(mock, nameof(mock));
+            ArgumentNullException.ThrowIfNull(mock);
             return mock.Invocations.GetLoggerLogInvocations();
         }
 
         public static IEnumerable<LoggerLogInvocation> GetLogInvocations<T>(this Mock<ILogger<T>> mock)
         {
-            ArgumentNullException.ThrowIfNull(mock, nameof(mock));
+            ArgumentNullException.ThrowIfNull(mock);
             return mock.Invocations.GetLoggerLogInvocations();
         }
 
         public static IEnumerable<LoggerLogInvocation> GetLoggerLogInvocations(this IInvocationList invocations)
         {
-            ArgumentNullException.ThrowIfNull(invocations, nameof(invocations));
+            ArgumentNullException.ThrowIfNull(invocations);
 
             return from i in invocations
                    where i.Method.IsGenericMethod && i.Method.GetGenericMethodDefinition() == LogMethodInfo

--- a/Tests/Unit/NetworkServer/BasicsStation/ClientCertificateValidatorServiceTests.cs
+++ b/Tests/Unit/NetworkServer/BasicsStation/ClientCertificateValidatorServiceTests.cs
@@ -11,6 +11,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
     using System.Security.Cryptography.X509Certificates;
     using System.Threading;
     using System.Threading.Tasks;
+    using Common;
     using LoRaWan.NetworkServer.BasicsStation;
     using Microsoft.Extensions.Logging;
     using Moq;
@@ -96,7 +97,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
                 var result = await this.clientCertValidatorSvc.ValidateAsync(cert, chain, System.Net.Security.SslPolicyErrors.None, default);
 
                 Assert.False(result);
-                Assert.Contains(this.logger.Invocations, i => i.Arguments.Any(a => a.ToString()!.Contains(InvalidStationEui, StringComparison.OrdinalIgnoreCase)));
+                Assert.Contains(this.logger.GetLogInvocations(), args => args.Message.Contains(InvalidStationEui, StringComparison.OrdinalIgnoreCase));
             }
             finally
             {

--- a/Tests/Unit/NetworkServer/CupsProtocolMessageProcessorTests.cs
+++ b/Tests/Unit/NetworkServer/CupsProtocolMessageProcessorTests.cs
@@ -117,7 +117,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             // assert
             Assert.Equal((int)HttpStatusCode.BadRequest, httpContext.Object.Response.StatusCode);
-            Assert.Contains(this.logger.Invocations, i => i.Arguments.Any(a => a.GetType() == exceptionType));
+            Assert.Contains(this.logger.GetLogInvocations(), args => args.Exception is { } exception && exception.GetType() == exceptionType);
         }
 
         [Fact]


### PR DESCRIPTION
## What is being addressed

Different and duplicated ways of extracting logs from mocked loggers.

## How is this addressed

Consolidated into a single way by adding extension methods that allow extracting strong-typed invocations of [`ILogger.Log<>`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.ilogger.log?view=dotnet-plat-ext-6.0#microsoft-extensions-logging-ilogger-log-1(microsoft-extensions-logging-loglevel-microsoft-extensions-logging-eventid-0-system-exception-system-func((-0-system-exception-system-string)))) given an instance of a mocked logger. The invocation arguments can then be used in regular assertions.
