### PR TITLE
Build decoders list for static loading in Universal Decoder

### DIFF
--- a/Samples/UniversalDecoder/.gitignore
+++ b/Samples/UniversalDecoder/.gitignore
@@ -1,1 +1,0 @@
-decoders.js

--- a/Samples/UniversalDecoder/.gitignore
+++ b/Samples/UniversalDecoder/.gitignore
@@ -1,0 +1,1 @@
+decoders.js

--- a/Samples/UniversalDecoder/app.decoder.js
+++ b/Samples/UniversalDecoder/app.decoder.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const glob = require('glob');
 const {logger} = require('./app.logging');
 
 const decoders = (() => {

--- a/Samples/UniversalDecoder/app.decoder.js
+++ b/Samples/UniversalDecoder/app.decoder.js
@@ -4,7 +4,7 @@ const {logger} = require('./app.logging');
 
 const decoders = (() => {
     try {
-        return require('./decoders');
+        return require('./codecs');
     } catch (e) {
         if (e instanceof Error && e.code === 'MODULE_NOT_FOUND') {
             return {};

--- a/Samples/UniversalDecoder/app.decoder.js
+++ b/Samples/UniversalDecoder/app.decoder.js
@@ -1,11 +1,22 @@
 'use strict';
 
 const glob = require('glob');
-const path = require('path');
 const {logger} = require('./app.logging');
 
+const decoders = (() => {
+    try {
+        return require('./decoders');
+    } catch (e) {
+        if (e instanceof Error && e.code === 'MODULE_NOT_FOUND') {
+            return {};
+        } else {
+            throw e;
+        }
+    }
+})();
+
 function getAllDecoders() {
-    return glob.sync(`./codecs/**/*.js`).map(d => path.basename(d).split('.')[0]);
+    return Object.keys(decoders);
 }
 
 // gets decoder by name
@@ -16,16 +27,11 @@ function getDecoder(decoderName) {
             decodeUplink: (input) => { return { data: input.bytes.join('') } }
         }
     }
-
-    // search for codec in "codecs" directory
-    const files = glob.sync(`./codecs/**/${decoderName}.js`);
-    if (files.length === 0) {
+    const decoder = decoders[decoderName];
+    if (!decoder) {
         throw new Error(`No codec found: ${decoderName}`);
-    } else if (files.length > 1) {
-        throw new Error(`Multiple codecs found: ${JSON.stringify(files)}`);
     }
-
-    return require(files[0]);
+    return decoder;
 }
 
 function decode(decoderName, payload, fPort) {

--- a/Samples/UniversalDecoder/package-lock.json
+++ b/Samples/UniversalDecoder/package-lock.json
@@ -1574,8 +1574,7 @@
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "estraverse": {
             "version": "5.3.0",

--- a/Samples/UniversalDecoder/package.json
+++ b/Samples/UniversalDecoder/package.json
@@ -28,6 +28,9 @@
     },
     "jest": {
         "testEnvironment": "node",
+        "transformIgnorePatterns": [
+            "/codecs/"
+        ],
         "coveragePathIgnorePatterns": [
             "/node_modules/"
         ]

--- a/Samples/UniversalDecoder/package.json
+++ b/Samples/UniversalDecoder/package.json
@@ -13,6 +13,7 @@
         "codecs": "rm -fR node_modules/lorawan-devices codecs/* && git clone --depth 1 https://github.com/TheThingsNetwork/lorawan-devices.git node_modules/lorawan-devices && node tools/copy-codecs.js"
     },
     "dependencies": {
+        "esprima": "^4.0.1",
         "express": "^4.17.3",
         "express-pino-logger": "^7.0.0",
         "express-validator": "^6.14.0",

--- a/Samples/UniversalDecoder/tools/copy-codecs.js
+++ b/Samples/UniversalDecoder/tools/copy-codecs.js
@@ -3,12 +3,15 @@
 const glob = require('glob');
 const fs = require('fs');
 const fse = require('fs-extra');
+const path = require('path');
+const esprima = require('esprima');
 
 var args = process.argv.slice(2);
 const srcDir = args[0] || './node_modules/lorawan-devices/vendor';
 const dstDir = args[1] || './codecs';
+const indexFilePath = path.join(dstDir, '../decoders.js');
 
-glob.sync(`**/*`,
+const index = glob.sync(`**/*`,
   {
     cwd: srcDir,
     nodir: true,
@@ -25,9 +28,18 @@ glob.sync(`**/*`,
     fse.copySync(srcPath, dstPath);
 
     if (f.endsWith(".js")) {
-      fs.appendFile(dstPath, '\nmodule.exports={decodeUplink};', function (err) {
-        if (err) throw err;
-        console.log(`Patching ${dstPath}`);
-      });
+      const tree = esprima.parseScript(fs.readFileSync(srcPath).toString());
+      if (tree.body.find(n => n.type === 'FunctionDeclaration' && n.id.name === 'decodeUplink')) {
+        fs.appendFile(dstPath, '\nmodule.exports={decodeUplink};', function (err) {
+          if (err) throw err;
+          console.log(`Patching ${dstPath}`);
+        });
+        return dstPath;
+      }
     }
-});
+  })
+  .filter(f => f)
+  .map(f => [path.basename(f).split('.')[0], f]);
+
+fs.writeFileSync(indexFilePath,
+  `module.exports = {\n${index.map(([k, v]) => `${JSON.stringify(k)}: require(${JSON.stringify(v)})`).join(',\n  ')}\n};\n`);

--- a/Samples/UniversalDecoder/tools/copy-codecs.js
+++ b/Samples/UniversalDecoder/tools/copy-codecs.js
@@ -9,7 +9,7 @@ const esprima = require('esprima');
 var args = process.argv.slice(2);
 const srcDir = args[0] || './node_modules/lorawan-devices/vendor';
 const dstDir = args[1] || './codecs';
-const indexFilePath = path.join(dstDir, '../decoders.js');
+const indexFilePath = path.join(dstDir, 'index.js');
 
 const index = glob.sync(`**/*`,
   {
@@ -39,7 +39,7 @@ const index = glob.sync(`**/*`,
     }
   })
   .filter(f => f)
-  .map(f => [path.basename(f).split('.')[0], f]);
+  .map(f => [path.basename(f).split('.')[0], path.relative(dstDir, f).replace(/\\/g, '/')]);
 
 fs.writeFileSync(indexFilePath,
-  `module.exports = {\n${index.map(([k, v]) => `${JSON.stringify(k)}: require(${JSON.stringify(v)})`).join(',\n  ')}\n};\n`);
+  `module.exports = {\n${index.map(([k, v]) => `${JSON.stringify(k)}: require(${JSON.stringify('./' + v)})`).join(',\n  ')}\n};\n`);

--- a/Samples/UniversalDecoder/tools/copy-codecs.js
+++ b/Samples/UniversalDecoder/tools/copy-codecs.js
@@ -28,6 +28,8 @@ const index = glob.sync(`**/*`,
     fse.copySync(srcPath, dstPath);
 
     if (f.endsWith(".js")) {
+      // Sniff a top-level declaration for a function named "decodeUplink"
+      // and include the decoder if only one is found.
       const tree = esprima.parseScript(fs.readFileSync(srcPath).toString());
       if (tree.body.find(n => n.type === 'FunctionDeclaration' && n.id.name === 'decodeUplink')) {
         fs.appendFile(dstPath, '\nmodule.exports={decodeUplink};', function (err) {


### PR DESCRIPTION
# PR for issue #1612

## What is being addressed

The potential for the Universal Decoder to load and execute arbitrary JavaScript code disguised as a decoder.

## How is this addressed

Instead of globbing for JavaScript files, this PR updates `copy-codecs.js` to build a static list of decoder modules as it copies and patches them from the TTN repo. The static list goes into the `./codecs`/`./codecs/index.js` module and an example of its content would be:

```js
module.exports = {
  "klax": require("./alpha-omega-technology/klax.js"),
  "aqs": require("./aquascope/aqs.js"),
  "bvs": require("./aquascope/bvs.js"),
  "kfr": require("./aquascope/kfr.js"),
  "wwd": require("./aquascope/wwd.js"),
  /* ... */
  "a3": require("./uradmonitor/a3.js"),
  "industrial": require("./uradmonitor/industrial.js"),
  "mousetrap": require("./xignal/mousetrap.js")
};
```

The `decoders.js` module is now loaded statically at run-time via `require('./decoders')` _if it exists_. The `decoders.js` module is ignored for version control since it is dynamically maintained.

Note that some JavaScript never contained the expected `decodeUplink` function and therefore would have failed to load at run-time previously at the following patched line:

```js
module.exports={decodeUplink};
```

`copy-codecs.js` now sniffs top-level function declarations for `decodeUplink` and includes a decoder in the list only if such a declaration is found.

One performance downside is that all decoders are now loaded (which can take 2-3 seconds) even if a tiny subset is used/tested, but performance is not a concern since Universal Decoder is just sample code for illustrating how the decoders from the TTN repo could be used with this kit.

