### PR TITLE
Fix CI Install Step

### DIFF
--- a/.github/actions/iotedgedev/entrypoint.sh
+++ b/.github/actions/iotedgedev/entrypoint.sh
@@ -2,8 +2,8 @@
 
 # This file generate an IoT Edge deployment file using token replacement to replace secrets with environment variables
 # then the file proceed to remove the previous deployment and replace it with the current one
+sudo -E az extension add --name azure-iot
 sudo -E iotedgedev genconfig -f $2/$1 -P $3  --fail-on-validation-error
-sudo az extension add --name azure-iot
 sudo -E az iot edge deployment delete --login "$IOTHUB_CONNECTION_STRING" --deployment-id "$IOT_EDGE_DEPLOYMENT_ID"
 sudo -E az iot edge deployment create --login "$IOTHUB_CONNECTION_STRING" --content "config/${1//'.template'}" --deployment-id "$IOT_EDGE_DEPLOYMENT_ID" --target-condition "deviceId='$DEVICE_ID'"
 


### PR DESCRIPTION
## What is being addressed

The E2E CI currently [fails](https://github.com/Azure/iotedge-lorawan-starterkit/runs/6087248496?check_suite_focus=true) because of missing dependencies.

## How is this addressed

Adding a command with -E to install missing dependencies seems to [fix the issue](https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/2216221423)

