### PR TITLE
Add full ci label for .net dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   # Maintain dependencies the LoRa Engine
   - package-ecosystem: "nuget"
     directory: "/"
+    labels:
+      - "fullci"
     schedule:
       interval: "daily"
     # Maintain dependencies for universal decoder


### PR DESCRIPTION
Currently each time dependabot raise a .net PR we need to manually configure the CI to execute as full and add the correct label, losing a bit of time each time. With this change dependabot will always create PRs with the fullci label