### PR TITLE
 Exclude greenme from universal decoder

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,7 +40,7 @@
       <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>6.0.1</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
       <MicrosoftExtensionsConfigurationJsonVersion>6.0.0</MicrosoftExtensionsConfigurationJsonVersion>
       <SystemIOPortsVersion>6.0.0</SystemIOPortsVersion>
-      <XUnitRunnerVisualStudio>2.4.3</XUnitRunnerVisualStudio>
+      <XUnitRunnerVisualStudio>2.4.5</XUnitRunnerVisualStudio>
       <CoverletMSBuild>3.1.2</CoverletMSBuild>
       <MicrosoftExtensionsLogging>6.0.0</MicrosoftExtensionsLogging>
       <MicrosoftExtensionsLoggingConfiguration>6.0.0</MicrosoftExtensionsLoggingConfiguration>

--- a/Samples/UniversalDecoder/tools/copy-codecs.js
+++ b/Samples/UniversalDecoder/tools/copy-codecs.js
@@ -11,12 +11,12 @@ const srcDir = args[0] || './node_modules/lorawan-devices/vendor';
 const dstDir = args[1] || './codecs';
 const indexFilePath = path.join(dstDir, 'index.js');
 // cube.js is ignored as esprima doesn't support class parsing https://github.com/jquery/esprima/issues/1971
-const ignoreList = ["greenme/cube.js"];
 const index = glob.sync(`**/*`,
   {
     cwd: srcDir,
     nodir: true,
     ignore: [
+      "greenme/cube.js",
       '**/*.jpg',
       '**/*.png',
       '**/*.svg',
@@ -28,7 +28,7 @@ const index = glob.sync(`**/*`,
     console.log(`Copying ${srcPath} to ${dstPath}`);
     fse.copySync(srcPath, dstPath);
 
-    if (f.endsWith(".js") && !ignoreList.includes(f)) {
+    if (f.endsWith(".js")) {
       // Sniff a top-level declaration for a function named "decodeUplink"
       // and include the decoder if only one is found.
       const tree = esprima.parseScript(fs.readFileSync(srcPath).toString());

--- a/Samples/UniversalDecoder/tools/copy-codecs.js
+++ b/Samples/UniversalDecoder/tools/copy-codecs.js
@@ -10,7 +10,8 @@ var args = process.argv.slice(2);
 const srcDir = args[0] || './node_modules/lorawan-devices/vendor';
 const dstDir = args[1] || './codecs';
 const indexFilePath = path.join(dstDir, 'index.js');
-
+// cube.js is ignored as esprima doesn't support class parsing https://github.com/jquery/esprima/issues/1971
+const ignoreList = ["greenme/cube.js"];
 const index = glob.sync(`**/*`,
   {
     cwd: srcDir,
@@ -27,7 +28,7 @@ const index = glob.sync(`**/*`,
     console.log(`Copying ${srcPath} to ${dstPath}`);
     fse.copySync(srcPath, dstPath);
 
-    if (f.endsWith(".js")) {
+    if (f.endsWith(".js" && ignoreList.includes(f))) {
       // Sniff a top-level declaration for a function named "decodeUplink"
       // and include the decoder if only one is found.
       const tree = esprima.parseScript(fs.readFileSync(srcPath).toString());

--- a/Samples/UniversalDecoder/tools/copy-codecs.js
+++ b/Samples/UniversalDecoder/tools/copy-codecs.js
@@ -28,7 +28,7 @@ const index = glob.sync(`**/*`,
     console.log(`Copying ${srcPath} to ${dstPath}`);
     fse.copySync(srcPath, dstPath);
 
-    if (f.endsWith(".js" && ignoreList.includes(f))) {
+    if (f.endsWith(".js") && !ignoreList.includes(f)) {
       // Sniff a top-level declaration for a function named "decodeUplink"
       // and include the decoder if only one is found.
       const tree = esprima.parseScript(fs.readFileSync(srcPath).toString());


### PR DESCRIPTION
Currently the Universal decode CI is broken because of a new decoder from greenme that makes usage of Node classes. We are using the [Esprima ](https://esprima.org/) library to ensure that the node script from the decoder is valid javascript and it seems [esprima doesn't support classes as of now](https://github.com/jquery/esprima/issues/1971).

The proposal is to add an exclusion list to skip the file using unsupported attributes for now. The list might be revisited in the future. The current fix was tested locally and seems to fix the issue