### PR TITLE
Add IDeviceTwin interface + IoT Hub Device Twin wrapper on it

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/CreateEdgeDevice.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/CreateEdgeDevice.cs
@@ -11,6 +11,7 @@ namespace LoraKeysManagerFacade
     using System.Text;
     using System.Threading.Tasks;
     using LoRaTools;
+    using LoRaTools.IoTHubImpl;
     using LoRaWan;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Azure.Devices;
@@ -146,7 +147,7 @@ namespace LoraKeysManagerFacade
                 twin.Tags[NetworkTagName] = NetworkId;
                 var remoteTwin = await this.registryManager.GetTwinAsync(deviceName);
 
-                _ = await this.registryManager.UpdateTwinAsync(deviceName, "LoRaWanNetworkSrvModule", twin, remoteTwin.ETag);
+                _ = await this.registryManager.UpdateTwinAsync(deviceName, "LoRaWanNetworkSrvModule", new IoTHubDeviceTwin(twin), remoteTwin.ETag);
 
                 // Deploy concentrator
                 using var httpClient = this.httpClientFactory.CreateClient();
@@ -176,14 +177,14 @@ namespace LoraKeysManagerFacade
                     var otaaEndTwin = new Twin();
                     otaaEndTwin.Properties.Desired = new TwinCollection(@"{AppEUI:'BE7A0000000014E2',AppKey:'8AFE71A145B253E49C3031AD068277A1',GatewayID:'',SensorDecoder:'DecoderValueSensor'}");
                     var otaaRemoteTwin = _ = await this.registryManager.GetTwinAsync(OtaaDeviceId);
-                    _ = await this.registryManager.UpdateTwinAsync(OtaaDeviceId, otaaEndTwin, otaaRemoteTwin.ETag);
+                    _ = await this.registryManager.UpdateTwinAsync(OtaaDeviceId, new IoTHubDeviceTwin(otaaEndTwin), otaaRemoteTwin.ETag);
 
                     var abpDevice = new Device(AbpDeviceId);
                     _ = await this.registryManager.AddDeviceAsync(abpDevice);
                     var abpTwin = new Twin();
                     abpTwin.Properties.Desired = new TwinCollection(@"{AppSKey:'2B7E151628AED2A6ABF7158809CF4F3C',NwkSKey:'3B7E151628AED2A6ABF7158809CF4F3C',GatewayID:'',DevAddr:'0228B1B1',SensorDecoder:'DecoderValueSensor'}");
                     var abpRemoteTwin = await this.registryManager.GetTwinAsync(AbpDeviceId);
-                    _ = await this.registryManager.UpdateTwinAsync(AbpDeviceId, abpTwin, abpRemoteTwin.ETag);
+                    _ = await this.registryManager.UpdateTwinAsync(AbpDeviceId, new IoTHubDeviceTwin(abpTwin), abpRemoteTwin.ETag);
                 }
             }
 #pragma warning disable CA1031 // Do not catch general exception types. This will go away when we implement #242

--- a/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
@@ -9,6 +9,7 @@ namespace LoraKeysManagerFacade
     using LoraKeysManagerFacade.FunctionBundler;
     using LoRaTools;
     using LoRaTools.ADR;
+    using LoRaTools.IoTHubImpl;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Functions.Extensions.DependencyInjection;
     using Microsoft.Extensions.Azure;

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDevAddrCache.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDevAddrCache.cs
@@ -236,27 +236,7 @@ namespace LoraKeysManagerFacade
                     if (!twin.Properties.Desired.TryRead(TwinPropertiesConstants.DevAddr, this.logger, out DevAddr devAddr) &&
                         !twin.Properties.Reported.TryRead(TwinPropertiesConstants.DevAddr, this.logger, out devAddr))
                     {
-                        if (!twin.Properties.Desired.TryRead(TwinPropertiesConstants.DevAddr, this.logger, out DevAddr devAddr) &&
-                            !twin.Properties.Reported.TryRead(TwinPropertiesConstants.DevAddr, this.logger, out devAddr))
-                        {
-                            continue;
-                        }
-
-                        devAddrCacheInfos.Add(new DevAddrCacheInfo()
-                        {
-                            DevAddr = devAddr,
-                            DevEUI = DevEui.Parse(twin.DeviceId),
-                            GatewayId = twin.GetGatewayID(),
-                            NwkSKey = twin.GetNwkSKey(),
-                            LastUpdatedTwins = twin.Properties.Desired.GetLastUpdated()
-                        });
-
-                        if (!isFullReload
-                            && twin.Properties.Desired.GetMetadata() is { LastUpdated: { } desiredUpdateTime }
-                            && twin.Properties.Reported.GetMetadata() is { LastUpdated: { } reportedUpdateTime })
-                        {
-                            lastDeltaUpdateFromCacheTicks = Math.Max(lastDeltaUpdateFromCacheTicks.Value, Math.Max(desiredUpdateTime.Ticks, reportedUpdateTime.Ticks));
-                        }
+                        continue;
                     }
 
                     devAddrCacheInfos.Add(new DevAddrCacheInfo()
@@ -267,6 +247,13 @@ namespace LoraKeysManagerFacade
                         NwkSKey = twin.GetNwkSKey(),
                         LastUpdatedTwins = twin.Properties.Desired.GetLastUpdated()
                     });
+
+                    if (!isFullReload
+                        && twin.Properties.Desired.GetMetadata() is { LastUpdated: { } desiredUpdateTime }
+                        && twin.Properties.Reported.GetMetadata() is { LastUpdated: { } reportedUpdateTime })
+                    {
+                        lastDeltaUpdateFromCacheTicks = Math.Max(lastDeltaUpdateFromCacheTicks.Value, Math.Max(desiredUpdateTime.Ticks, reportedUpdateTime.Ticks));
+                    }
                 }
             }
 

--- a/LoRaEngine/LoraKeysManagerFacade/LoRaDevAddrCache.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoRaDevAddrCache.cs
@@ -235,8 +235,8 @@ namespace LoraKeysManagerFacade
                 {
                     if (twin.DeviceId != null)
                     {
-                        if (!twin.Properties.Desired.TryRead(LoraKeysManagerFacadeConstants.TwinProperty_DevAddr, this.logger, out DevAddr devAddr) &&
-                            !twin.Properties.Reported.TryRead(LoraKeysManagerFacadeConstants.TwinProperty_DevAddr, this.logger, out devAddr))
+                        if (!twin.Properties.Desired.TryRead(TwinPropertiesConstants.DevAddr, this.logger, out DevAddr devAddr) &&
+                            !twin.Properties.Reported.TryRead(TwinPropertiesConstants.DevAddr, this.logger, out devAddr))
                         {
                             continue;
                         }

--- a/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacadeConstants.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/LoraKeysManagerFacadeConstants.cs
@@ -5,11 +5,6 @@ namespace LoraKeysManagerFacade
 {
     internal static class LoraKeysManagerFacadeConstants
     {
-        internal const string TwinProperty_GatewayID = "GatewayID";
-        internal const string TwinProperty_ClassType = "ClassType";
-        internal const string TwinProperty_PreferredGatewayID = "PreferredGatewayID";
-        internal const string TwinProperty_DevAddr = "DevAddr";
-        internal const string TwinProperty_NwkSKey = "NwkSKey";
         internal const string NetworkServerModuleId = "LoRaWanNetworkSrvModule";
         internal const string ClearCacheMethodName = "clearcache";
         internal const string CloudToDeviceMessageMethodName = "cloudtodevicemessage";

--- a/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
@@ -133,15 +133,15 @@ namespace LoraKeysManagerFacade
                     var reportedReader = new TwinCollectionReader(twin.Properties.Reported, this.log);
 
                     // the device must have a DevAddr
-                    if (!desiredReader.TryRead(LoraKeysManagerFacadeConstants.TwinProperty_DevAddr, out DevAddr _) && !reportedReader.TryRead(LoraKeysManagerFacadeConstants.TwinProperty_DevAddr, out DevAddr _))
+                    if (!desiredReader.TryRead(TwinPropertiesConstants.DevAddr, out DevAddr _) && !reportedReader.TryRead(TwinPropertiesConstants.DevAddr, out DevAddr _))
                     {
                         return new BadRequestObjectResult("Device DevAddr is unknown. Ensure the device has been correctly setup as a LoRa device and that it has connected to network at least once.");
                     }
 
-                    if (desiredReader.TryRead(LoraKeysManagerFacadeConstants.TwinProperty_ClassType, out string deviceClass) && string.Equals("c", deviceClass, StringComparison.OrdinalIgnoreCase))
+                    if (desiredReader.TryRead(TwinPropertiesConstants.ClassType, out string deviceClass) && string.Equals("c", deviceClass, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((reportedReader.TryRead(LoraKeysManagerFacadeConstants.TwinProperty_PreferredGatewayID, out string gatewayID)
-                            || desiredReader.TryRead(LoraKeysManagerFacadeConstants.TwinProperty_GatewayID, out gatewayID))
+                        if ((reportedReader.TryRead(TwinPropertiesConstants.PreferredGatewayID, out string gatewayID)
+                            || desiredReader.TryRead(TwinPropertiesConstants.GatewayID, out gatewayID))
                             && !string.IsNullOrEmpty(gatewayID))
                         {
                             // add it to cache (if it does not exist)

--- a/LoRaEngine/LoraKeysManagerFacade/TwinExtensions.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/TwinExtensions.cs
@@ -3,20 +3,21 @@
 
 namespace LoraKeysManagerFacade
 {
+    using LoRaTools;
     using LoRaTools.Utils;
     using Microsoft.Azure.Devices.Shared;
 
     internal static class TwinExtensions
     {
         internal static string GetGatewayID(this Twin twin)
-            => twin.Properties.Desired.TryRead<string>(LoraKeysManagerFacadeConstants.TwinProperty_GatewayID, null, out var someGatewayId)
+            => twin.Properties.Desired.TryRead<string>(TwinPropertiesConstants.GatewayID, null, out var someGatewayId)
              ? someGatewayId
              : string.Empty;
 
         internal static string GetNwkSKey(this Twin twin)
-            => twin.Properties.Desired.TryRead(LoraKeysManagerFacadeConstants.TwinProperty_NwkSKey, null, out string nwkSKey)
+            => twin.Properties.Desired.TryRead(TwinPropertiesConstants.NwkSKey, null, out string nwkSKey)
              ? nwkSKey
-             : twin.Properties.Reported.TryRead(LoraKeysManagerFacadeConstants.TwinProperty_NwkSKey, null, out nwkSKey)
+             : twin.Properties.Reported.TryRead(TwinPropertiesConstants.NwkSKey, null, out nwkSKey)
                 ? nwkSKey
                 : null;
     }

--- a/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/TagBasedLnsDiscovery.cs
+++ b/LoRaEngine/modules/LoRaWan.NetworkServerDiscovery/TagBasedLnsDiscovery.cs
@@ -8,6 +8,7 @@ namespace LoRaWan.NetworkServerDiscovery
     using System.Threading.Tasks;
     using Azure.Identity;
     using LoRaTools;
+    using LoRaTools.IoTHubImpl;
     using LoRaTools.NetworkServerDiscovery;
     using LoRaTools.Utils;
     using LoRaWan;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IDeviceRegistryManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IDeviceRegistryManager.cs
@@ -6,24 +6,23 @@ namespace LoRaTools
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices;
-    using Microsoft.Azure.Devices.Shared;
 
     public interface IDeviceRegistryManager
     {
-        Task<Twin> GetTwinAsync(string deviceId, CancellationToken cancellationToken);
+        Task<IDeviceTwin> GetTwinAsync(string deviceId, CancellationToken cancellationToken);
         Task<Device> GetDeviceAsync(string deviceId);
-        Task<Twin> UpdateTwinAsync(string deviceId, string moduleId, Twin deviceTwin, string eTag, CancellationToken cancellationToken);
-        Task<Twin> UpdateTwinAsync(string deviceId, string moduleId, Twin deviceTwin, string eTag);
-        Task<Twin> UpdateTwinAsync(string deviceId, Twin twin, string eTag, CancellationToken cancellationToken);
-        Task<BulkRegistryOperationResult> AddDeviceWithTwinAsync(Device device, Twin twin);
+        Task<IDeviceTwin> UpdateTwinAsync(string deviceId, string moduleId, IDeviceTwin deviceTwin, string eTag, CancellationToken cancellationToken);
+        Task<IDeviceTwin> UpdateTwinAsync(string deviceId, string moduleId, IDeviceTwin deviceTwin, string eTag);
+        Task<IDeviceTwin> UpdateTwinAsync(string deviceId, IDeviceTwin twin, string eTag, CancellationToken cancellationToken);
+        Task<BulkRegistryOperationResult> AddDeviceWithTwinAsync(Device device, IDeviceTwin twin);
         IQuery CreateQuery(string query);
         IQuery CreateQuery(string query, int? pageSize);
         Task<Device> AddDeviceAsync(Device edgeGatewayDevice);
         Task<Module> AddModuleAsync(Module moduleToAdd);
         Task ApplyConfigurationContentOnDeviceAsync(string deviceName, ConfigurationContent deviceConfigurationContent);
-        Task<Twin> GetTwinAsync(string deviceName);
+        Task<IDeviceTwin> GetTwinAsync(string deviceName);
         Task<Configuration> AddConfigurationAsync(Configuration configuration);
-        Task<Twin> UpdateTwinAsync(string deviceName, Twin twin, string eTag);
+        Task<IDeviceTwin> UpdateTwinAsync(string deviceName, IDeviceTwin twin, string eTag);
         Task RemoveDeviceAsync(string deviceId);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IDeviceTwin.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IDeviceTwin.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaTools
+{
+    using Microsoft.Azure.Devices.Shared;
+
+    public interface IDeviceTwin
+    {
+        string ETag { get; }
+
+        TwinProperties Properties { get; }
+
+        TwinCollection Tags { get; }
+
+        string GetGatewayID();
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/DeviceTwinExtensions.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/DeviceTwinExtensions.cs
@@ -12,12 +12,10 @@ namespace LoRaTools.IoTHubImpl
         {
             ArgumentNullException.ThrowIfNull(twin, nameof(twin));
 
-            if (twin is not IoTHubDeviceTwin)
+            if (twin is not IoTHubDeviceTwin iotHubDeviceTwin)
             {
                 throw new ArgumentException($"Cannot convert {twin.GetType().Name} to IoTHubDeviceTwin instance.");
             }
-
-            var iotHubDeviceTwin = twin as IoTHubDeviceTwin;
 
             return iotHubDeviceTwin.TwinInstance;
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/DeviceTwinExtensions.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/DeviceTwinExtensions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaTools.IoTHubImpl
+{
+    using System;
+    using Microsoft.Azure.Devices.Shared;
+
+    internal static class DeviceTwinExtensions
+    {
+        internal static Twin ToIoTHubDeviceTwin(this IDeviceTwin twin)
+        {
+            ArgumentNullException.ThrowIfNull(twin, nameof(twin));
+
+            if (twin is not IoTHubDeviceTwin)
+            {
+                throw new ArgumentException($"Cannot convert {twin.GetType().Name} to IoTHubDeviceTwin instance.");
+            }
+
+            var iotHubDeviceTwin = twin as IoTHubDeviceTwin;
+
+            return iotHubDeviceTwin.TwinInstance;
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubDeviceTwin.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubDeviceTwin.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaTools.IoTHubImpl
+{
+    using System;
+    using LoRaTools.Utils;
+    using Microsoft.Azure.Devices.Shared;
+
+    public class IoTHubDeviceTwin : IDeviceTwin
+    {
+        internal Twin TwinInstance { get; }
+
+        public TwinProperties Properties => this.TwinInstance.Properties;
+
+        public TwinCollection Tags => this.TwinInstance.Tags;
+
+        public IoTHubDeviceTwin(Twin twin)
+        {
+            this.TwinInstance = twin;
+        }
+
+        public string GetGatewayID()
+            => TwinInstance.Properties.Desired.TryRead<string>(TwinPropertiesConstants.GatewayID, null, out var someGatewayId)
+             ? someGatewayId
+             : string.Empty;
+
+        public string ETag => this.TwinInstance.ETag;
+
+        public override bool Equals(object obj)
+        {
+            ArgumentNullException.ThrowIfNull(obj, nameof(obj));
+
+            if (obj is not IoTHubDeviceTwin)
+            {
+                return false;
+            }
+
+            return (obj as IoTHubDeviceTwin)?.TwinInstance == this.TwinInstance;
+        }
+
+        public override int GetHashCode()
+        {
+            return TwinInstance.GetHashCode();
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubRegistryManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubRegistryManager.cs
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace LoRaTools
+namespace LoRaTools.IoTHubImpl
 {
     using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices;
-    using Microsoft.Azure.Devices.Shared;
 
     public sealed class IoTHubRegistryManager : IDeviceRegistryManager, IDisposable
     {
@@ -29,7 +28,7 @@ namespace LoRaTools
 
         public Task<Device> AddDeviceAsync(Device edgeGatewayDevice) => this.instance.AddDeviceAsync(edgeGatewayDevice);
 
-        public Task<BulkRegistryOperationResult> AddDeviceWithTwinAsync(Device device, Twin twin) => this.instance.AddDeviceWithTwinAsync(device, twin);
+        public Task<BulkRegistryOperationResult> AddDeviceWithTwinAsync(Device device, IDeviceTwin twin) => this.instance.AddDeviceWithTwinAsync(device, twin.ToIoTHubDeviceTwin());
 
         public Task<Module> AddModuleAsync(Module moduleToAdd) => this.instance.AddModuleAsync(moduleToAdd);
 
@@ -44,22 +43,22 @@ namespace LoRaTools
 
         public Task<Device> GetDeviceAsync(string deviceId) => this.instance.GetDeviceAsync(deviceId);
 
-        public Task<Twin> GetTwinAsync(string deviceId, CancellationToken cancellationToken)
-            => this.instance.GetTwinAsync(deviceId, cancellationToken);
+        public async Task<IDeviceTwin> GetTwinAsync(string deviceId, CancellationToken cancellationToken)
+            => new IoTHubDeviceTwin(await this.instance.GetTwinAsync(deviceId, cancellationToken));
 
-        public Task<Twin> GetTwinAsync(string deviceName) => this.instance.GetTwinAsync(deviceName);
+        public async Task<IDeviceTwin> GetTwinAsync(string deviceName) => new IoTHubDeviceTwin(await this.instance.GetTwinAsync(deviceName));
 
-        public Task<Twin> UpdateTwinAsync(string deviceId, string moduleId, Twin deviceTwin, string eTag)
-            => this.instance.UpdateTwinAsync(deviceId, moduleId, deviceTwin, eTag);
+        public async Task<IDeviceTwin> UpdateTwinAsync(string deviceId, string moduleId, IDeviceTwin deviceTwin, string eTag)
+            => new IoTHubDeviceTwin(await this.instance.UpdateTwinAsync(deviceId, moduleId, deviceTwin.ToIoTHubDeviceTwin(), eTag));
 
-        public Task<Twin> UpdateTwinAsync(string deviceId, Twin twin, string eTag, CancellationToken cancellationToken)
-            => this.instance.UpdateTwinAsync(deviceId, twin, eTag, cancellationToken);
+        public async Task<IDeviceTwin> UpdateTwinAsync(string deviceId, IDeviceTwin twin, string eTag, CancellationToken cancellationToken)
+            => new IoTHubDeviceTwin(await this.instance.UpdateTwinAsync(deviceId, twin.ToIoTHubDeviceTwin(), eTag, cancellationToken));
 
-        public Task<Twin> UpdateTwinAsync(string deviceName, Twin twin, string eTag)
-            => this.instance.UpdateTwinAsync(deviceName, twin, eTag);
+        public async Task<IDeviceTwin> UpdateTwinAsync(string deviceName, IDeviceTwin twin, string eTag)
+            => new IoTHubDeviceTwin(await this.instance.UpdateTwinAsync(deviceName, twin.ToIoTHubDeviceTwin(), eTag));
 
-        public Task<Twin> UpdateTwinAsync(string deviceId, string moduleId, Twin deviceTwin, string eTag, CancellationToken cancellationToken)
-            => this.instance.UpdateTwinAsync(deviceId, moduleId, deviceTwin, eTag, cancellationToken);
+        public async Task<IDeviceTwin> UpdateTwinAsync(string deviceId, string moduleId, IDeviceTwin deviceTwin, string eTag, CancellationToken cancellationToken)
+            => new IoTHubDeviceTwin(await this.instance.UpdateTwinAsync(deviceId, moduleId, deviceTwin.ToIoTHubDeviceTwin(), eTag, cancellationToken));
 
         public Task RemoveDeviceAsync(string deviceId)
             => this.instance.RemoveDeviceAsync(deviceId);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/TwinPropertiesConstants.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/TwinPropertiesConstants.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaTools
+{
+    public static class TwinPropertiesConstants
+    {
+        public const string GatewayID = "GatewayID";
+        public const string ClassType = "ClassType";
+        public const string PreferredGatewayID = "PreferredGatewayID";
+        public const string DevAddr = "DevAddr";
+        public const string NwkSKey = "NwkSKey";
+    }
+}

--- a/Tests/Common/IntegrationTestFixtureBase.cs
+++ b/Tests/Common/IntegrationTestFixtureBase.cs
@@ -11,6 +11,7 @@ namespace LoRaWan.Tests.Common
     using System.Threading.Tasks;
     using LoRaTools;
     using LoRaTools.CommonAPI;
+    using LoRaTools.IoTHubImpl;
     using LoRaTools.Utils;
     using LoRaWan.NetworkServer.BasicsStation;
     using Microsoft.Azure.Devices;
@@ -119,7 +120,7 @@ namespace LoRaWan.Tests.Common
             return this.registryManager ??= IoTHubRegistryManager.CreateWithProvider(() => RegistryManager.CreateFromConnectionString(Configuration.IoTHubConnectionString));
         }
 
-        public async Task<Twin> GetTwinAsync(string deviceId)
+        public async Task<IDeviceTwin> GetTwinAsync(string deviceId)
         {
             return await GetRegistryManager().GetTwinAsync(deviceId);
         }
@@ -386,7 +387,7 @@ namespace LoRaWan.Tests.Common
                     twin.Properties.Desired = new TwinCollection(JsonConvert.SerializeObject(testDevice.GetDesiredProperties()));
 
                     TestLogger.Log($"Creating device {testDevice.DeviceID}");
-                    await registryManager.AddDeviceWithTwinAsync(device, twin);
+                    await registryManager.AddDeviceWithTwinAsync(device, new IoTHubDeviceTwin(twin));
                 }
                 else
                 {
@@ -414,7 +415,7 @@ namespace LoRaWan.Tests.Common
 
                             var patch = new Twin();
                             patch.Properties.Desired = new TwinCollection(JsonConvert.SerializeObject(desiredProperties));
-                            await registryManager.UpdateTwinAsync(testDevice.DeviceID, patch, deviceTwin.ETag);
+                            await registryManager.UpdateTwinAsync(testDevice.DeviceID, new IoTHubDeviceTwin(patch), deviceTwin.ETag);
                             TestLogger.Log($"Update twin for device {testDevice.DeviceID}");
                             break;
                         }

--- a/Tests/E2E/LnsDiscoveryTests.cs
+++ b/Tests/E2E/LnsDiscoveryTests.cs
@@ -17,6 +17,7 @@ namespace LoRaWan.Tests.E2E
     using System.Threading;
     using System.Threading.Tasks;
     using LoRaTools;
+    using LoRaTools.IoTHubImpl;
     using LoRaWan.Tests.Common;
     using Microsoft.AspNetCore.Mvc.Testing;
     using Microsoft.AspNetCore.TestHost;
@@ -77,10 +78,10 @@ namespace LoRaWan.Tests.E2E
             {
                 await this.registryManager.AddDeviceAsync(new Device(lns.DeviceId));
                 await this.registryManager.AddModuleAsync(new Module(lns.DeviceId, LnsModuleName));
-                var twin = new Twin(new TwinProperties { Desired = new TwinCollection(JsonSerializer.Serialize(new { hostAddress = lns.HostAddress })) })
+                var twin = new IoTHubDeviceTwin(new Twin(new TwinProperties { Desired = new TwinCollection(JsonSerializer.Serialize(new { hostAddress = lns.HostAddress })) })
                 {
                     Tags = GetNetworkTags(lns.NetworkId)
-                };
+                });
                 await this.registryManager.UpdateTwinAsync(lns.DeviceId, LnsModuleName, twin, "*", CancellationToken.None);
             }
 
@@ -88,7 +89,7 @@ namespace LoRaWan.Tests.E2E
             {
                 var deviceId = station.StationEui.ToString();
                 await this.registryManager.AddDeviceAsync(new Device(deviceId));
-                await this.registryManager.UpdateTwinAsync(deviceId, new Twin { Tags = GetNetworkTags(station.NetworkId) }, "*", CancellationToken.None);
+                await this.registryManager.UpdateTwinAsync(deviceId, new IoTHubDeviceTwin(new Twin { Tags = GetNetworkTags(station.NetworkId) }), "*", CancellationToken.None);
             }
 
             var waitTime = TimeSpan.FromSeconds(60);

--- a/Tests/Integration/DevAddrCacheTest.cs
+++ b/Tests/Integration/DevAddrCacheTest.cs
@@ -90,7 +90,7 @@ namespace LoRaWan.Tests.Integration
                             DeviceId = devaddrItem.DevEUI.Value.ToString(),
                             Properties = new TwinProperties()
                             {
-                                Desired = new TwinCollection($"{{\"{LoraKeysManagerFacadeConstants.TwinProperty_DevAddr}\": \"{devaddrItem.DevAddr}\", \"{LoraKeysManagerFacadeConstants.TwinProperty_GatewayID}\": \"{devaddrItem.GatewayId}\"}}", $"{{\"$lastUpdated\": \"{devaddrItem.LastUpdatedTwins.ToString(LoraKeysManagerFacadeConstants.RoundTripDateTimeStringFormat)}\"}}"),
+                                Desired = new TwinCollection($"{{\"{TwinPropertiesConstants.DevAddr}\": \"{devaddrItem.DevAddr}\", \"{TwinPropertiesConstants.GatewayID}\": \"{devaddrItem.GatewayId}\"}}", $"{{\"$lastUpdated\": \"{devaddrItem.LastUpdatedTwins.ToString(LoraKeysManagerFacadeConstants.RoundTripDateTimeStringFormat)}\"}}"),
                                 Reported = new TwinCollection($"{{}}", $"{{\"$lastUpdated\": \"0001-01-01T00:00:00Z\"}}"),
                             }
                         };

--- a/Tests/Integration/DevAddrCacheTest.cs
+++ b/Tests/Integration/DevAddrCacheTest.cs
@@ -90,12 +90,8 @@ namespace LoRaWan.Tests.Integration
                             DeviceId = devaddrItem.DevEUI.Value.ToString(),
                             Properties = new TwinProperties()
                             {
-<<<<<<< HEAD
                                 Desired = new TwinCollection($"{{\"{LoraKeysManagerFacadeConstants.TwinProperty_DevAddr}\": \"{devaddrItem.DevAddr}\", \"{LoraKeysManagerFacadeConstants.TwinProperty_GatewayID}\": \"{devaddrItem.GatewayId}\"}}", $"{{\"$lastUpdated\": \"{devaddrItem.LastUpdatedTwins.ToString(LoraKeysManagerFacadeConstants.RoundTripDateTimeStringFormat)}\"}}"),
                                 Reported = new TwinCollection($"{{}}", $"{{\"$lastUpdated\": \"0001-01-01T00:00:00Z\"}}"),
-=======
-                                Desired = new TwinCollection($"{{\"{TwinPropertiesConstants.DevAddr}\": \"{devaddrItem.DevAddr}\", \"{TwinPropertiesConstants.GatewayID}\": \"{devaddrItem.GatewayId}\"}}", $"{{\"$lastUpdated\": \"{devaddrItem.LastUpdatedTwins.ToString(LoraKeysManagerFacadeConstants.RoundTripDateTimeStringFormat)}\"}}"),
->>>>>>> Add IDeviceTwin interface + IoT Hub Device Twin wrapper on it
                             }
                         };
 

--- a/Tests/Integration/DevAddrCacheTest.cs
+++ b/Tests/Integration/DevAddrCacheTest.cs
@@ -12,6 +12,7 @@ namespace LoRaWan.Tests.Integration
     using System.Threading.Tasks;
     using LoraKeysManagerFacade;
     using LoRaTools;
+    using LoRaTools.IoTHubImpl;
     using LoRaWan.Tests.Common;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Shared;
@@ -55,7 +56,7 @@ namespace LoRaWan.Tests.Integration
 
             mockRegistryManager
                 .Setup(x => x.GetTwinAsync(It.IsNotNull<string>()))
-                .ReturnsAsync((string deviceId) => new Twin(deviceId));
+                .ReturnsAsync((string deviceId) => new IoTHubDeviceTwin(new Twin(deviceId)));
 
             var numberOfDevices = deviceIds.Count;
 
@@ -89,8 +90,12 @@ namespace LoRaWan.Tests.Integration
                             DeviceId = devaddrItem.DevEUI.Value.ToString(),
                             Properties = new TwinProperties()
                             {
+<<<<<<< HEAD
                                 Desired = new TwinCollection($"{{\"{LoraKeysManagerFacadeConstants.TwinProperty_DevAddr}\": \"{devaddrItem.DevAddr}\", \"{LoraKeysManagerFacadeConstants.TwinProperty_GatewayID}\": \"{devaddrItem.GatewayId}\"}}", $"{{\"$lastUpdated\": \"{devaddrItem.LastUpdatedTwins.ToString(LoraKeysManagerFacadeConstants.RoundTripDateTimeStringFormat)}\"}}"),
                                 Reported = new TwinCollection($"{{}}", $"{{\"$lastUpdated\": \"0001-01-01T00:00:00Z\"}}"),
+=======
+                                Desired = new TwinCollection($"{{\"{TwinPropertiesConstants.DevAddr}\": \"{devaddrItem.DevAddr}\", \"{TwinPropertiesConstants.GatewayID}\": \"{devaddrItem.GatewayId}\"}}", $"{{\"$lastUpdated\": \"{devaddrItem.LastUpdatedTwins.ToString(LoraKeysManagerFacadeConstants.RoundTripDateTimeStringFormat)}\"}}"),
+>>>>>>> Add IDeviceTwin interface + IoT Hub Device Twin wrapper on it
                             }
                         };
 

--- a/Tests/Integration/LnsDiscoveryIntegrationTests.cs
+++ b/Tests/Integration/LnsDiscoveryIntegrationTests.cs
@@ -16,6 +16,7 @@ namespace LoRaWan.Tests.Integration
     using System.Threading;
     using System.Threading.Tasks;
     using LoRaTools;
+    using LoRaTools.IoTHubImpl;
     using LoRaTools.NetworkServerDiscovery;
     using LoRaWan.NetworkServerDiscovery;
     using LoRaWan.Tests.Common;
@@ -201,7 +202,7 @@ namespace LoRaWan.Tests.Integration
             this.subject
                 .RegistryManagerMock?
                 .Setup(rm => rm.GetTwinAsync(stationEui.ToString(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Twin { Tags = new TwinCollection(@$"{{""network"":""{networkId}""}}") });
+                .ReturnsAsync(new IoTHubDeviceTwin(new Twin { Tags = new TwinCollection(@$"{{""network"":""{networkId}""}}") }));
         }
 
         private void SetupIotHubQueryResponse(string networkId, IList<string> hostAddresses)

--- a/Tests/Unit/IoTHubImpl/DeviceTwinExtensionsTests.cs
+++ b/Tests/Unit/IoTHubImpl/DeviceTwinExtensionsTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.IoTHubImpl
+{
+    using System;
+    using global::LoRaTools;
+    using global::LoRaTools.IoTHubImpl;
+    using Microsoft.Azure.Devices.Shared;
+    using Xunit;
+
+    public class DeviceTwinExtensionsTests
+    {
+        [Fact]
+        public void ToIoTHubDeviceTwinShouldReturnTwinInstance()
+        {
+            // Arrange
+            var twin = new Twin();
+
+            var deviceTwin = new IoTHubDeviceTwin(twin);
+
+            // Act
+            var result = deviceTwin.ToIoTHubDeviceTwin();
+
+            // Assert
+            Assert.Equal(twin, result);
+        }
+
+        [Fact]
+        public void WhenDeviceTwinIsNullShouldThrowArgumentNullException()
+        {
+            // Arrange
+            IoTHubDeviceTwin deviceTwin = null;
+
+            // Act
+            Assert.Throws<ArgumentNullException>(() => deviceTwin.ToIoTHubDeviceTwin());
+        }
+
+        [Fact]
+        public void WhenDeviceTwinIsNotIoTHubDeviceTwinShouldThrowArgumentException()
+        {
+            // Arrange
+            IDeviceTwin deviceTwin = new FakeIoTHubDeviceTwin();
+
+            // Act
+            Assert.Throws<ArgumentException>(() => deviceTwin.ToIoTHubDeviceTwin());
+        }
+    }
+}

--- a/Tests/Unit/IoTHubImpl/FakeIoTHubDeviceTwin.cs
+++ b/Tests/Unit/IoTHubImpl/FakeIoTHubDeviceTwin.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.IoTHubImpl
+{
+    using System;
+    using global::LoRaTools;
+    using Microsoft.Azure.Devices.Shared;
+
+    internal sealed class FakeIoTHubDeviceTwin : IDeviceTwin
+    {
+        public string ETag => throw new NotImplementedException();
+
+        public TwinProperties Properties => throw new NotImplementedException();
+
+        public TwinCollection Tags => throw new NotImplementedException();
+
+        public string GetGatewayID()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Tests/Unit/IoTHubImpl/IoTHubDeviceTwinTests.cs
+++ b/Tests/Unit/IoTHubImpl/IoTHubDeviceTwinTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.IoTHubImpl
+{
+    using global::LoRaTools;
+    using global::LoRaTools.IoTHubImpl;
+    using Microsoft.Azure.Devices.Shared;
+    using Moq;
+    using Xunit;
+
+    public class IoTHubDeviceTwinTests
+    {
+        private readonly MockRepository mockRepository;
+
+        public IoTHubDeviceTwinTests()
+        {
+            this.mockRepository = new MockRepository(MockBehavior.Strict);
+        }
+
+        [Fact]
+        public void GetGatewayID()
+        {
+            // Arrange
+            const string gatewayId = "mygatewayid";
+            var twinCollection = new TwinCollection();
+            twinCollection[TwinPropertiesConstants.GatewayID] = gatewayId;
+
+            var twin = new Twin();
+            twin.Properties.Desired = twinCollection;
+
+            var ioTHubDeviceTwin = new IoTHubDeviceTwin(twin);
+
+            // Act
+            var result = ioTHubDeviceTwin.GetGatewayID();
+
+            // Assert
+            Assert.Equal(gatewayId, result);
+            this.mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void GetGatewayIDShouldReturnEmptyStringIfGatewayIdNotPresentInTwin()
+        {
+            // Arrange
+            var twinCollection = new TwinCollection();
+
+            var twin = new Twin();
+            twin.Properties.Desired = twinCollection;
+
+            var ioTHubDeviceTwin = new IoTHubDeviceTwin(twin);
+
+            // Act
+            var result = ioTHubDeviceTwin.GetGatewayID();
+
+            // Assert
+            Assert.True(string.IsNullOrEmpty(result));
+            this.mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void EqualsShouldReturnFalseIfTwinInstancesAreNotEquals()
+        {
+            // Arrange
+            var twin1 = new Twin("device1");
+            var device1 = new IoTHubDeviceTwin(twin1);
+
+            var twin2 = new Twin("device2");
+            var device2 = new IoTHubDeviceTwin(twin2);
+
+            // Act
+            var result = device1.Equals(device2);
+
+            // Assert
+            Assert.False(result);
+            this.mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void EqualsShouldReturnTrueIfTwinInstancesAreEquals()
+        {
+            // Arrange
+            var twin = new Twin("device1");
+            var device1 = new IoTHubDeviceTwin(twin);
+            var device2 = new IoTHubDeviceTwin(twin);
+
+            // Act
+            var result = device1.Equals(device2);
+
+            // Assert
+            Assert.True(result);
+            this.mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void WhenSecondIsNotIoTHubDeviceTwinEqualsShouldReturnFalse()
+        {
+            // Arrange
+            var twin = new Twin("device1");
+            var device1 = new IoTHubDeviceTwin(twin);
+            IDeviceTwin device2 = new FakeIoTHubDeviceTwin();
+
+            // Act
+            var result = device1.Equals(device2);
+
+            // Assert
+            Assert.False(result);
+            this.mockRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void GetHashCodeShouldRetuenTheTwinInstancesHashCode()
+        {
+            // Arrange
+            var twin = new Twin();
+            var ioTHubDeviceTwin = new IoTHubDeviceTwin(twin);
+
+            // Act
+            var result = ioTHubDeviceTwin.GetHashCode();
+
+            // Assert
+            Assert.Equal(twin.GetHashCode(), result);
+            this.mockRepository.VerifyAll();
+        }
+    }
+}

--- a/Tests/Unit/IoTHubImpl/IoTHubRegistryManagerTests.cs
+++ b/Tests/Unit/IoTHubImpl/IoTHubRegistryManagerTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace LoRaWan.Tests.Unit
+namespace LoRaWan.Tests.Unit.IoTHubImpl
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -34,7 +34,7 @@ namespace LoRaWan.Tests.Unit
         public async Task AddConfigurationAsync()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var configuration = new Configuration("testConfiguration");
 
@@ -55,7 +55,7 @@ namespace LoRaWan.Tests.Unit
         public async Task AddDeviceAsync()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var edgeGatewayDevice = new Device("deviceid");
 
@@ -76,7 +76,7 @@ namespace LoRaWan.Tests.Unit
         public async Task AddDeviceWithTwinAsync()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var device = new Device("deviceid");
                 var twin = new IoTHubDeviceTwin(new Twin("deviceid"));
@@ -104,7 +104,7 @@ namespace LoRaWan.Tests.Unit
         public async Task AddModuleAsync()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var moduleToAdd = new Module();
 
@@ -126,7 +126,7 @@ namespace LoRaWan.Tests.Unit
         public async Task ApplyConfigurationContentOnDeviceAsync()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var deviceName = "deviceid";
                 var deviceConfigurationContent = new ConfigurationContent();
@@ -148,7 +148,7 @@ namespace LoRaWan.Tests.Unit
         public void CreateQuery()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var query = "new query";
                 var mockQuery = this.mockRepository.Create<IQuery>();
@@ -171,7 +171,7 @@ namespace LoRaWan.Tests.Unit
         public void CreateQuery_WithPageSize()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var pageSize = 10;
                 var query = "new query";
@@ -196,7 +196,7 @@ namespace LoRaWan.Tests.Unit
         public async Task GetDeviceAsync()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var deviceId = "deviceid";
                 var device = new Device(deviceId);
@@ -219,7 +219,7 @@ namespace LoRaWan.Tests.Unit
         public async Task GetTwinAsync_With_CancellationToken()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var deviceId = "deviceid";
                 var cancellationToken = CancellationToken.None;
@@ -244,7 +244,7 @@ namespace LoRaWan.Tests.Unit
         public async Task GetTwinAsync()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var deviceId = "deviceid";
                 var twin = new Twin(deviceId);
@@ -267,7 +267,7 @@ namespace LoRaWan.Tests.Unit
         public async Task UpdateTwinAsync_With_Module()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var deviceId = "deviceid";
                 var moduleId = "moduleid";
@@ -295,7 +295,7 @@ namespace LoRaWan.Tests.Unit
         public async Task UpdateTwinAsync_With_CancellationToken()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var deviceId = "deviceid";
                 var deviceTwin = new IoTHubDeviceTwin(new Twin());
@@ -323,10 +323,10 @@ namespace LoRaWan.Tests.Unit
         public async Task UpdateTwinAsync2()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var deviceId = "deviceid";
-                var deviceTwin =  new IoTHubDeviceTwin(new Twin());
+                var deviceTwin = new IoTHubDeviceTwin(new Twin());
                 var eTag = "eTag";
 
                 this.mockRegistryManager.Setup(c => c.UpdateTwinAsync(
@@ -349,7 +349,7 @@ namespace LoRaWan.Tests.Unit
         public async Task UpdateTwinAsync_With_Module_And_CancellationToken()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var deviceId = "deviceid";
                 var moduleId = "moduleid";
@@ -384,7 +384,7 @@ namespace LoRaWan.Tests.Unit
         public async Task RemoveDeviceAsync()
         {
             // Arrange
-            using (var manager = this.CreateManager())
+            using (var manager = CreateManager())
             {
                 var deviceId = "deviceid";
 

--- a/Tests/Unit/IoTHubRegistryManagerTests.cs
+++ b/Tests/Unit/IoTHubRegistryManagerTests.cs
@@ -5,7 +5,7 @@ namespace LoRaWan.Tests.Unit
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using global::LoRaTools;
+    using global::LoRaTools.IoTHubImpl;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Shared;
     using Moq;
@@ -79,11 +79,11 @@ namespace LoRaWan.Tests.Unit
             using (var manager = this.CreateManager())
             {
                 var device = new Device("deviceid");
-                var twin = new Twin("deviceid");
+                var twin = new IoTHubDeviceTwin(new Twin("deviceid"));
 
                 this.mockRegistryManager.Setup(c => c.AddDeviceWithTwinAsync(
                         It.Is<Device>(x => x == device),
-                        It.Is<Twin>(x => x == twin)))
+                        It.Is<Twin>(x => x == twin.TwinInstance)))
                     .ReturnsAsync(new BulkRegistryOperationResult
                     {
                         IsSuccessful = true
@@ -234,7 +234,7 @@ namespace LoRaWan.Tests.Unit
                 var result = await manager.GetTwinAsync(deviceId, cancellationToken);
 
                 // Assert
-                Assert.Equal(twin, result);
+                Assert.Equal(twin, result.ToIoTHubDeviceTwin());
             }
 
             this.mockRepository.VerifyAll();
@@ -257,7 +257,7 @@ namespace LoRaWan.Tests.Unit
                 var result = await manager.GetTwinAsync(deviceId);
 
                 // Assert
-                Assert.Equal(twin, result);
+                Assert.Equal(twin, result.ToIoTHubDeviceTwin());
             }
 
             this.mockRepository.VerifyAll();
@@ -271,15 +271,15 @@ namespace LoRaWan.Tests.Unit
             {
                 var deviceId = "deviceid";
                 var moduleId = "moduleid";
-                var deviceTwin = new Twin();
+                var deviceTwin = new IoTHubDeviceTwin(new Twin());
                 var eTag = "eTag";
 
                 this.mockRegistryManager.Setup(c => c.UpdateTwinAsync(
                         It.Is<string>(x => x == deviceId),
                         It.Is<string>(x => x == moduleId),
-                        It.Is<Twin>(x => x == deviceTwin),
+                        It.Is<Twin>(x => x == deviceTwin.TwinInstance),
                         It.Is<string>(x => x == eTag)))
-                    .ReturnsAsync(deviceTwin);
+                    .ReturnsAsync(deviceTwin.TwinInstance);
 
                 // Act
                 var result = await manager.UpdateTwinAsync(deviceId, moduleId, deviceTwin, eTag);
@@ -298,16 +298,16 @@ namespace LoRaWan.Tests.Unit
             using (var manager = this.CreateManager())
             {
                 var deviceId = "deviceid";
-                var deviceTwin = new Twin();
+                var deviceTwin = new IoTHubDeviceTwin(new Twin());
                 var eTag = "eTag";
                 var cancellationToken = CancellationToken.None;
 
                 this.mockRegistryManager.Setup(c => c.UpdateTwinAsync(
                         It.Is<string>(x => x == deviceId),
-                        It.Is<Twin>(x => x == deviceTwin),
+                        It.Is<Twin>(x => x == deviceTwin.TwinInstance),
                         It.Is<string>(x => x == eTag),
                         It.Is<CancellationToken>(x => x == cancellationToken)))
-                    .ReturnsAsync(deviceTwin);
+                    .ReturnsAsync(deviceTwin.TwinInstance);
 
                 // Act
                 var result = await manager.UpdateTwinAsync(deviceId, deviceTwin, eTag, cancellationToken);
@@ -326,14 +326,14 @@ namespace LoRaWan.Tests.Unit
             using (var manager = this.CreateManager())
             {
                 var deviceId = "deviceid";
-                var deviceTwin = new Twin();
+                var deviceTwin =  new IoTHubDeviceTwin(new Twin());
                 var eTag = "eTag";
 
                 this.mockRegistryManager.Setup(c => c.UpdateTwinAsync(
                         It.Is<string>(x => x == deviceId),
-                        It.Is<Twin>(x => x == deviceTwin),
+                        It.Is<Twin>(x => x == deviceTwin.TwinInstance),
                         It.Is<string>(x => x == eTag)))
-                    .ReturnsAsync(deviceTwin);
+                    .ReturnsAsync(deviceTwin.TwinInstance);
 
                 // Act
                 var result = await manager.UpdateTwinAsync(deviceId, deviceTwin, eTag);
@@ -353,17 +353,17 @@ namespace LoRaWan.Tests.Unit
             {
                 var deviceId = "deviceid";
                 var moduleId = "moduleid";
-                var deviceTwin = new Twin();
+                var deviceTwin = new IoTHubDeviceTwin(new Twin());
                 var eTag = "eTag";
                 var cancellationToken = CancellationToken.None;
 
                 this.mockRegistryManager.Setup(c => c.UpdateTwinAsync(
                         It.Is<string>(x => x == deviceId),
                         It.Is<string>(x => x == moduleId),
-                        It.Is<Twin>(x => x == deviceTwin),
+                        It.Is<Twin>(x => x == deviceTwin.TwinInstance),
                         It.Is<string>(x => x == eTag),
                         It.Is<CancellationToken>(x => x == cancellationToken)))
-                    .ReturnsAsync(deviceTwin);
+                    .ReturnsAsync(deviceTwin.TwinInstance);
 
                 // Act
                 var result = await manager.UpdateTwinAsync(

--- a/Tests/Unit/LoraKeysManagerFacade/ConcentratorCredentialTests.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/ConcentratorCredentialTests.cs
@@ -14,6 +14,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
     using global::LoraKeysManagerFacade;
     using global::LoRaTools;
     using global::LoRaTools.CommonAPI;
+    using global::LoRaTools.IoTHubImpl;
     using LoRaWan.Tests.Common;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
@@ -133,7 +134,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var twin = new Twin();
             twin.Properties.Desired = new TwinCollection(JsonUtil.Strictify(@"{'key': 'value'}"));
             this.registryManager.Setup(m => m.GetTwinAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                                .ReturnsAsync(twin);
+                                .ReturnsAsync(new IoTHubDeviceTwin(twin));
 
             var actual = await this.concentratorCredential.RunFetchConcentratorCredentials(httpRequest.Object, CancellationToken.None);
 
@@ -177,7 +178,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             return httpRequest;
         }
 
-        private static Twin SetupDeviceTwin()
+        private static IDeviceTwin SetupDeviceTwin()
         {
             var twin = new Twin();
             twin.Properties.Desired = new TwinCollection(JsonUtil.Strictify(@"{'cups': {
@@ -189,7 +190,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
                 'tcCredentialUrl': 'https://storage.blob.core.windows.net/container/blob'
             }}"));
 
-            return twin;
+            return new IoTHubDeviceTwin(twin);
         }
     }
 }

--- a/Tests/Unit/LoraKeysManagerFacade/ConcentratorFirmwareFunctionTests.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/ConcentratorFirmwareFunctionTests.cs
@@ -14,6 +14,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
     using Azure.Storage.Blobs.Models;
     using global::LoraKeysManagerFacade;
     using global::LoRaTools;
+    using global::LoRaTools.IoTHubImpl;
     using LoRaWan.Tests.Common;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
@@ -75,7 +76,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
                 'fwSignature': '123'
             }}"));
             this.registryManager.Setup(m => m.GetTwinAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                                .Returns(Task.FromResult(twin));
+                                .Returns(Task.FromResult<IDeviceTwin>(new IoTHubDeviceTwin(twin)));
 
             var blobBytes = Encoding.UTF8.GetBytes(BlobContent);
             using var blobContentStream = new MemoryStream(blobBytes);
@@ -115,7 +116,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
                 'fwSignature': '123'
             }}"));
             this.registryManager.Setup(m => m.GetTwinAsync("AnotherTwin", It.IsAny<CancellationToken>()))
-                                .Returns(Task.FromResult(twin));
+                                .Returns(Task.FromResult<IDeviceTwin>(new IoTHubDeviceTwin(twin)));
 
             var result = await this.concentratorFirmware.RunFetchConcentratorFirmware(httpRequest.Object, CancellationToken.None);
 
@@ -150,7 +151,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var twin = new Twin();
             twin.Properties.Desired = new TwinCollection(JsonUtil.Strictify(@"{'a': 'b'}"));
             this.registryManager.Setup(m => m.GetTwinAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                                .Returns(Task.FromResult(twin));
+                                .Returns(Task.FromResult<IDeviceTwin>(new IoTHubDeviceTwin(twin)));
 
             var actual = await this.concentratorFirmware.RunFetchConcentratorFirmware(httpRequest.Object, CancellationToken.None);
 
@@ -176,7 +177,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
                 'fwSignature': '123'
             }}"));
             this.registryManager.Setup(m => m.GetTwinAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                                .Returns(Task.FromResult(twin));
+                                .Returns(Task.FromResult<IDeviceTwin>(new IoTHubDeviceTwin(twin)));
 
             var actual = await this.concentratorFirmware.RunFetchConcentratorFirmware(httpRequest.Object, CancellationToken.None);
 
@@ -203,7 +204,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
                 'fwSignature': '123'
             }}"));
             this.registryManager.Setup(m => m.GetTwinAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                                .Returns(Task.FromResult(twin));
+                                .Returns(Task.FromResult<IDeviceTwin>(new IoTHubDeviceTwin(twin)));
 
             this.blobClient.Setup(m => m.DownloadStreamingAsync(It.IsAny<HttpRange>(),
                                                                 It.IsAny<BlobRequestConditions>(),

--- a/Tests/Unit/LoraKeysManagerFacade/DeviceGetterTest.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/DeviceGetterTest.cs
@@ -7,6 +7,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
     using System.Text;
     using global::LoraKeysManagerFacade;
     using global::LoRaTools;
+    using global::LoRaTools.IoTHubImpl;
     using LoRaWan.Tests.Common;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Shared;
@@ -41,7 +42,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
 
             mockRegistryManager
                 .Setup(x => x.GetTwinAsync(It.Is(devEui.ToString(), StringComparer.Ordinal)))
-                .ReturnsAsync((string deviceId) => new Twin(deviceId));
+                .ReturnsAsync((string deviceId) => new IoTHubDeviceTwin(new Twin(deviceId)));
 
             return mockRegistryManager.Object;
         }

--- a/Tests/Unit/NetworkServerDiscovery/TagBasedLnsDiscoveryTests.cs
+++ b/Tests/Unit/NetworkServerDiscovery/TagBasedLnsDiscoveryTests.cs
@@ -12,6 +12,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerDiscovery
     using System.Threading;
     using System.Threading.Tasks;
     using global::LoRaTools;
+    using global::LoRaTools.IoTHubImpl;
     using LoRaWan.NetworkServerDiscovery;
     using LoRaWan.Tests.Common;
     using Microsoft.Azure.Devices;
@@ -204,7 +205,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerDiscovery
         {
             this.registryManagerMock
                 .Setup(rm => rm.GetTwinAsync(stationEui.ToString(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Twin { Tags = new TwinCollection(@$"{{""network"":""{networkId}""}}") });
+                .ReturnsAsync(new IoTHubDeviceTwin(new Twin { Tags = new TwinCollection(@$"{{""network"":""{networkId}""}}") }));
         }
 
         private void SetupIotHubQueryResponse(string networkId, IList<string?> hostAddresses)


### PR DESCRIPTION
# PR for Wrapping IoT Hub 

## What is being addressed

<!-- Describe the current behavior you are modifying -->
The objective is to wrap the IoT Hub implementation to bring after the IoT Central feature.

## How is this addressed

<!--
- Describe the changes made, and if appropriate, why they are addressed this way
- Note any pending work (with links to the issues that will address them)
-->

- Adding the ``IoTHubDeviceTwin`` class that inherit from IDeviceTwin, and wraps the IoT Hub Device twin
- Change method signatures to ``IDeviceRegistryManager`` to use this interface
- Refactors the code and unit tests
