### PR TITLE
Add Redis Connection String to LNS Configuration and StackExchange.Redis NuGet Package

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -80,7 +80,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         .AddHttpClient()
                         .AddApiClient(NetworkServerConfiguration, ApiVersion.LatestVersion)
                         .AddSingleton(NetworkServerConfiguration)
-                        .AddSingleton<ILnsRemoteCall, LnsRemoteCall>()
+                        .AddSingleton<ILnsRemoteCallHandler, LnsRemoteCallHandler>()
                         .AddSingleton<ILoRaDeviceFrameCounterUpdateStrategyProvider, LoRaDeviceFrameCounterUpdateStrategyProvider>()
                         .AddSingleton<IDeduplicationStrategyFactory, DeduplicationStrategyFactory>()
                         .AddSingleton<ILoRaADRStrategyProvider, LoRaADRStrategyProvider>()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -14,6 +14,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
     using LoRaTools.CommonAPI;
     using LoRaTools.NetworkServerDiscovery;
     using LoRaWan;
+    using LoRaWan.NetworkServer;
     using LoRaWan.NetworkServer.ADR;
     using LoRaWan.NetworkServer.BasicsStation.ModuleConnection;
     using LoRaWan.NetworkServer.BasicsStation.Processors;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
 {
     using LoRaTools.Utils;
+    using LoRaWan.NetworkServer;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Azure.Devices.Shared;
@@ -11,7 +12,6 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
     using System;
     using System.Configuration;
     using System.Diagnostics.Metrics;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -20,7 +20,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
         private const string LnsVersionPropertyName = "LnsVersion";
         private readonly NetworkServerConfiguration networkServerConfiguration;
         private readonly LoRaDeviceAPIServiceBase loRaDeviceAPIService;
-        private readonly ILnsRemoteCall lnsRemoteCall;
+        private readonly ILnsRemoteCallHandler lnsRemoteCallHandler;
         private readonly ILogger<ModuleConnectionHost> logger;
         private readonly Counter<int> unhandledExceptionCount;
         private ILoraModuleClient loRaModuleClient;
@@ -30,13 +30,13 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
             NetworkServerConfiguration networkServerConfiguration,
             ILoRaModuleClientFactory loRaModuleClientFactory,
             LoRaDeviceAPIServiceBase loRaDeviceAPIService,
-            ILnsRemoteCall lnsRemoteCall,
+            ILnsRemoteCallHandler lnsRemoteCallHandler,
             ILogger<ModuleConnectionHost> logger,
             Meter meter)
         {
             this.networkServerConfiguration = networkServerConfiguration ?? throw new ArgumentNullException(nameof(networkServerConfiguration));
             this.loRaDeviceAPIService = loRaDeviceAPIService ?? throw new ArgumentNullException(nameof(loRaDeviceAPIService));
-            this.lnsRemoteCall = lnsRemoteCall ?? throw new ArgumentNullException(nameof(lnsRemoteCall));
+            this.lnsRemoteCallHandler = lnsRemoteCallHandler ?? throw new ArgumentNullException(nameof(lnsRemoteCallHandler));
             this.loRaModuleClientFactory = loRaModuleClientFactory ?? throw new ArgumentNullException(nameof(loRaModuleClientFactory));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.unhandledExceptionCount = (meter ?? throw new ArgumentNullException(nameof(meter))).CreateCounter<int>(MetricRegistry.UnhandledExceptions);
@@ -91,31 +91,33 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
                 using var cts = methodRequest.ResponseTimeout is { } someResponseTimeout ? new CancellationTokenSource(someResponseTimeout) : null;
                 var token = cts?.Token ?? CancellationToken.None;
 
+                // Mapping via the constants for backwards compatibility.
+                LnsRemoteCall lnsRemoteCall;
                 if (string.Equals(Constants.CloudToDeviceClearCache, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    return AsMethodResponse(await this.lnsRemoteCall.ClearCacheAsync());
+                    lnsRemoteCall = new LnsRemoteCall(RemoteCallKind.ClearCache, null);
                 }
                 else if (string.Equals(Constants.CloudToDeviceCloseConnection, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    return AsMethodResponse(await this.lnsRemoteCall.CloseConnectionAsync(methodRequest.DataAsJson, token));
+                    lnsRemoteCall = new LnsRemoteCall(RemoteCallKind.CloseConnection, methodRequest.DataAsJson);
                 }
                 else if (string.Equals(Constants.CloudToDeviceDecoderElementName, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    return AsMethodResponse(await this.lnsRemoteCall.SendCloudToDeviceMessageAsync(methodRequest.DataAsJson, token));
+                    lnsRemoteCall = new LnsRemoteCall(RemoteCallKind.CloudToDeviceMessage, methodRequest.DataAsJson);
+                }
+                else
+                {
+                    throw new LoRaProcessingException($"Unknown direct method called: {methodRequest.Name}");
                 }
 
-                this.logger.LogError($"Unknown direct method called: {methodRequest.Name}");
-
-                return AsMethodResponse(HttpStatusCode.BadRequest);
+                var statusCode = await lnsRemoteCallHandler.ExecuteAsync(lnsRemoteCall, token);
+                return new MethodResponse((int)statusCode);
             }
             catch (Exception ex) when (ExceptionFilterUtility.False(() => this.logger.LogError(ex, $"An exception occurred on a direct method call: {ex}"),
                                                                     () => this.unhandledExceptionCount.Add(1)))
             {
                 throw;
             }
-
-            static MethodResponse AsMethodResponse(HttpStatusCode httpStatusCode) =>
-                new MethodResponse((int)httpStatusCode);
         }
 
         /// <summary>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCall.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCall.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaWan.NetworkServer
+{
+    internal sealed record LnsRemoteCall(RemoteCallKind Kind, string? JsonData);
+
+    internal enum RemoteCallKind
+    {
+        CloudToDeviceMessage,
+        ClearCache,
+        CloseConnection
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCallListener.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCallListener.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaWan.NetworkServer
+{
+    using System;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+    using StackExchange.Redis;
+
+    internal interface ILnsRemoteCallListener
+    {
+        void Subscribe(string lns, Func<LnsRemoteCall, Task> function);
+    }
+
+    internal sealed class RedisRemoteCallListener : ILnsRemoteCallListener
+    {
+        private readonly ConnectionMultiplexer redis;
+
+        public RedisRemoteCallListener(ConnectionMultiplexer redis)
+        {
+            this.redis = redis;
+        }
+
+        public void Subscribe(string lns, Func<LnsRemoteCall, Task> function)
+        {
+            this.redis.GetSubscriber().Subscribe(lns).OnMessage(value =>
+                function(JsonSerializer.Deserialize<LnsRemoteCall>(value.Message)));
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCallListener.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCallListener.cs
@@ -27,7 +27,7 @@ namespace LoRaWan.NetworkServer
         public void Subscribe(string lns, Func<LnsRemoteCall, Task> function)
         {
             this.redis.GetSubscriber().Subscribe(lns).OnMessage(value =>
-                function(JsonSerializer.Deserialize<LnsRemoteCall>(value.Message)));
+                function(JsonSerializer.Deserialize<LnsRemoteCall>(value.Message) ?? throw new ArgumentException("Input LnsRemoteCall json was not parsed as valid one.")));
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaWan.NetworkServer.csproj
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LoRaWan.NetworkServer.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.5" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="$(PrometheusNetVersion)" />
+    <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeRedisVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -131,6 +131,11 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         public string LnsVersion { get; private set; }
 
+        /// <summary>
+        /// Gets the connection string of Redis server for Pub/Sub functionality in Cloud only deployments.
+        /// </summary>
+        public string RedisConnectionString { get; private set; }
+
         /// Specifies the pool size for upstream AMQP connection
         /// </summary>
         public uint IotHubConnectionPoolSize { get; internal set; } = 1;
@@ -190,6 +195,10 @@ namespace LoRaWan.NetworkServer
                                               && size < AmqpConnectionPoolSettings.AbsoluteMaxPoolSize
                                               ? size
                                               : throw new NotSupportedException($"'IOTHUB_CONNECTION_POOL_SIZE' needs to be between 1 and {AmqpConnectionPoolSettings.AbsoluteMaxPoolSize}.");
+
+            config.RedisConnectionString = envVars.GetEnvVar("REDIS_CONNECTION_STRING", string.Empty);
+            if (!config.RunningAsIoTEdgeModule && string.IsNullOrEmpty(config.RedisConnectionString))
+                throw new InvalidOperationException($"'REDIS_CONNECTION_STRING' can't be empty if running network server as part of a cloud only deployment.");
 
             return config;
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -198,7 +198,7 @@ namespace LoRaWan.NetworkServer
 
             config.RedisConnectionString = envVars.GetEnvVar("REDIS_CONNECTION_STRING", string.Empty);
             if (!config.RunningAsIoTEdgeModule && string.IsNullOrEmpty(config.RedisConnectionString))
-                throw new InvalidOperationException($"'REDIS_CONNECTION_STRING' can't be empty if running network server as part of a cloud only deployment.");
+                throw new InvalidOperationException("'REDIS_CONNECTION_STRING' can't be empty if running network server as part of a cloud only deployment.");
 
             return config;
         }

--- a/Tests/Integration/RedisFixture.cs
+++ b/Tests/Integration/RedisFixture.cs
@@ -27,11 +27,10 @@ namespace LoRaWan.Tests.Integration
         private const int RedisPort = 6001;
         private static readonly string TestContainerName = ContainerName + RedisPort;
 
-        private ConnectionMultiplexer redis;
-
         private string containerId;
 
         public IDatabase Database { get; set; }
+        public ConnectionMultiplexer Redis { get; set; }
 
         private async Task StartRedisContainer()
         {
@@ -127,8 +126,8 @@ namespace LoRaWan.Tests.Integration
             var redisConnectionString = $"localhost:{RedisPort}";
             try
             {
-                this.redis = await ConnectionMultiplexer.ConnectAsync(redisConnectionString);
-                Database = this.redis.GetDatabase();
+                this.Redis = await ConnectionMultiplexer.ConnectAsync(redisConnectionString);
+                Database = this.Redis.GetDatabase();
             }
             catch (Exception ex)
             {
@@ -157,8 +156,8 @@ namespace LoRaWan.Tests.Integration
                 }
             }
 
-            this.redis?.Dispose();
-            this.redis = null;
+            this.Redis?.Dispose();
+            this.Redis = null;
         }
     }
 }

--- a/Tests/Integration/RedisRemoteCallListenerTests.cs
+++ b/Tests/Integration/RedisRemoteCallListenerTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Integration
+{
+    using System;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+    using LoRaWan.NetworkServer;
+    using Moq;
+    using StackExchange.Redis;
+    using Xunit;
+
+    [Collection(RedisFixture.CollectionName)]
+    public sealed class RedisRemoteCallListenerTests : IClassFixture<RedisFixture>
+    {
+        private readonly ConnectionMultiplexer redis;
+        private readonly RedisRemoteCallListener subject;
+
+        public RedisRemoteCallListenerTests(RedisFixture redisFixture)
+        {
+            this.redis = redisFixture.Redis;
+            this.subject = new RedisRemoteCallListener(this.redis);
+        }
+
+        [Fact]
+        public async Task Subscribe_Receives_Message()
+        {
+            // arrange
+            var lnsName = "some-lns";
+            var remoteCall = new LnsRemoteCall(RemoteCallKind.CloudToDeviceMessage, "somejsondata");
+            var function = new Mock<Func<LnsRemoteCall, Task>>();
+
+            // act
+            this.subject.Subscribe(lnsName, function.Object);
+            await PublishAsync(lnsName, remoteCall);
+
+            // assert
+            function.Verify(a => a.Invoke(remoteCall), Times.Once);
+        }
+
+        [Fact]
+        public async Task Subscribe_On_Different_Channel_Does_Not_Receive_Message()
+        {
+            // arrange
+            var function = new Mock<Func<LnsRemoteCall, Task>>();
+
+            // act
+            this.subject.Subscribe("lns-1", function.Object);
+            await PublishAsync("lns-2", new LnsRemoteCall(RemoteCallKind.CloudToDeviceMessage, null));
+
+            // assert
+            function.Verify(a => a.Invoke(It.IsAny<LnsRemoteCall>()), Times.Never);
+        }
+
+        private async Task PublishAsync(string channel, LnsRemoteCall lnsRemoteCall)
+        {
+            await this.redis.GetSubscriber().PublishAsync(channel, JsonSerializer.Serialize(lnsRemoteCall));
+        }
+    }
+}

--- a/Tests/Simulation/SimulatedLoadTests.cs
+++ b/Tests/Simulation/SimulatedLoadTests.cs
@@ -22,7 +22,6 @@ namespace LoRaWan.Tests.Simulation
     using static MoreLinq.Extensions.RepeatExtension;
     using static MoreLinq.Extensions.IndexExtension;
     using static MoreLinq.Extensions.TransposeExtension;
-    using LoRaWan.NetworkServer.BasicsStation;
 
     [Trait("Category", "SkipWhenLiveUnitTesting")]
     public sealed class SimulatedLoadTests : IntegrationTestBaseSim, IAsyncLifetime
@@ -101,7 +100,7 @@ namespace LoRaWan.Tests.Simulation
 
             await Task.Delay(messagesToSendEachLNS * IntervalBetweenMessages);
             _ = await TestFixture.AssertNetworkServerModuleLogExistsAsync(
-                x => !x.Contains(LnsRemoteCall.ClosedConnectionLog, StringComparison.Ordinal),
+                x => !x.Contains(LnsRemoteCallHandler.ClosedConnectionLog, StringComparison.Ordinal),
                 new SearchLogOptions("No connection switch should be logged") { TreatAsError = true });
 
             // act: change basics station that the device is listened from and therefore the gateway it uses as well
@@ -111,8 +110,8 @@ namespace LoRaWan.Tests.Simulation
             // assert
             var expectedLnsToDropConnection = Configuration.LnsEndpointsForSimulator.First().Key;
             _ = await TestFixture.AssertNetworkServerModuleLogExistsAsync(
-                x => x.Contains(LnsRemoteCall.ClosedConnectionLog, StringComparison.Ordinal) && x.Contains(expectedLnsToDropConnection, StringComparison.Ordinal),
-                new SearchLogOptions($"{LnsRemoteCall.ClosedConnectionLog} and {expectedLnsToDropConnection}") { TreatAsError = true });
+                x => x.Contains(LnsRemoteCallHandler.ClosedConnectionLog, StringComparison.Ordinal) && x.Contains(expectedLnsToDropConnection, StringComparison.Ordinal),
+                new SearchLogOptions($"{LnsRemoteCallHandler.ClosedConnectionLog} and {expectedLnsToDropConnection}") { TreatAsError = true });
             await AssertIotHubMessageCountAsync(simulatedDevice, messagesToSendEachLNS * 2);
         }
 

--- a/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
+++ b/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
@@ -35,7 +35,12 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
         [InlineData(false, true)]
         public void ModuleConnectionHostIsInjectedOrNot(bool cloud_deployment, bool enable_gateway)
         {
-            var envVariables = new[] { ("CLOUD_DEPLOYMENT", cloud_deployment.ToString()), ("ENABLE_GATEWAY", enable_gateway.ToString()) };
+            var envVariables = new[]
+            {
+                ("CLOUD_DEPLOYMENT", cloud_deployment.ToString()),
+                ("ENABLE_GATEWAY", enable_gateway.ToString()),
+                ("REDIS_CONNECTION_STRING", "someString")
+            };
 
             try
             {

--- a/Tests/Unit/NetworkServer/ConfigurationTest.cs
+++ b/Tests/Unit/NetworkServer/ConfigurationTest.cs
@@ -38,6 +38,40 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             }
         }
 
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void Should_Throw_On_Invalid_Cloud_Configuration_When_Redis_Connection_String_Not_Set(bool shouldSetRedisString, bool isCloudDeployment)
+        {
+            // arrange
+            var cloudDeploymentKey = "CLOUD_DEPLOYMENT";
+            var key = "REDIS_CONNECTION_STRING";
+            var value = "someValue";
+            var lnsConfigurationCreation = () => NetworkServerConfiguration.CreateFromEnvironmentVariables();
+
+            if (isCloudDeployment)
+                Environment.SetEnvironmentVariable(cloudDeploymentKey, true.ToString());
+
+            if (shouldSetRedisString)
+                Environment.SetEnvironmentVariable(key, value);
+
+            // act and assert
+            if (isCloudDeployment && !shouldSetRedisString)
+            {
+                _ = Assert.Throws<InvalidOperationException>(lnsConfigurationCreation);
+            }
+            else
+            {
+                _ = lnsConfigurationCreation();
+            }
+
+            Environment.SetEnvironmentVariable(key, string.Empty);
+            Environment.SetEnvironmentVariable(cloudDeploymentKey, string.Empty);
+        }
+
+
         public static TheoryData<string, DevAddr[]> AllowedDevAddressesInput =>
             TheoryDataFactory.From(("0228B1B1;", new[] { new DevAddr(0x0228b1b1) }),
                                    ("0228B1B1;0228B1B2", new DevAddr[] { new DevAddr(0x0228b1b1), new DevAddr(0x0228b1b2) }),

--- a/Tests/Unit/NetworkServer/ConfigurationTest.cs
+++ b/Tests/Unit/NetworkServer/ConfigurationTest.cs
@@ -5,10 +5,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 {
     using System;
     using LoRaWan.NetworkServer;
-    using LoRaWan.NetworkServer.BasicsStation;
     using LoRaWan.Tests.Common;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
     using Xunit;
 
     public class ConfigurationTest
@@ -52,7 +49,10 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var lnsConfigurationCreation = () => NetworkServerConfiguration.CreateFromEnvironmentVariables();
 
             if (isCloudDeployment)
+            {
                 Environment.SetEnvironmentVariable(cloudDeploymentKey, true.ToString());
+                Environment.SetEnvironmentVariable("ENABLE_GATEWAY", false.ToString());
+            }
 
             if (shouldSetRedisString)
                 Environment.SetEnvironmentVariable(key, value);
@@ -69,6 +69,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             Environment.SetEnvironmentVariable(key, string.Empty);
             Environment.SetEnvironmentVariable(cloudDeploymentKey, string.Empty);
+            Environment.SetEnvironmentVariable("ENABLE_GATEWAY", string.Empty);
         }
 
 
@@ -76,18 +77,22 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             TheoryDataFactory.From(("0228B1B1;", new[] { new DevAddr(0x0228b1b1) }),
                                    ("0228B1B1;0228B1B2", new DevAddr[] { new DevAddr(0x0228b1b1), new DevAddr(0x0228b1b2) }),
                                    ("ads;0228B1B2;", new DevAddr[] { new DevAddr(0x0228b1b2) }));
+
         [Theory]
         [CombinatorialData]
         public void EnableGatewayTrue_IoTModuleFalse_IsNotSupported(bool cloud_deployment, bool enable_gateway)
         {
-            var envVariables = new[] { ("CLOUD_DEPLOYMENT", cloud_deployment.ToString()), ("ENABLE_GATEWAY", enable_gateway.ToString()) };
+            var envVariables = new[]
+            {
+                ("CLOUD_DEPLOYMENT", cloud_deployment.ToString()),
+                ("ENABLE_GATEWAY", enable_gateway.ToString()),
+                ("REDIS_CONNECTION_STRING", "someString")
+            };
 
             try
             {
                 foreach (var (key, value) in envVariables)
                     Environment.SetEnvironmentVariable(key, value);
-
-
 
                 if (cloud_deployment && enable_gateway)
                 {

--- a/Tests/Unit/NetworkServer/LnsRemoteCallTests.cs
+++ b/Tests/Unit/NetworkServer/LnsRemoteCallTests.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaWan.Tests.Unit.NetworkServer
+{
+    using System.Text.Json;
+    using LoRaWan.NetworkServer;
+    using Xunit;
+
+    public sealed class LnsRemoteCallTests
+    {
+        [Fact]
+        public void Serialization_And_Deserialization_Preserves_Information()
+        {
+            // arrange
+            var subject = new LnsRemoteCall(RemoteCallKind.CloudToDeviceMessage, "somepayload");
+
+            // act
+            var result = JsonSerializer.Deserialize<LnsRemoteCall>(JsonSerializer.Serialize(subject));
+
+            // assert
+            Assert.Equal(subject, result);
+        }
+    }
+}


### PR DESCRIPTION
# PR for issue #1635 

## What is being addressed

- [x] Redis Connection String is injected via "REDIS_CONNECTION_STRING" environment variable and properly parsed from the NetworkServerConfiguration class
- [x] Redis connection string can be empty or null for Edge based deployments
- [x] Redis connection string is required for Cloud based deployments and an exception must be thrown if not there
- [x] StackExchange.Redis NuGet package is imported in LoRaWan.NetworkServer project
- [x] Adding a unit test for checking if exception is being thrown correctly