### PR TITLE
feat: split module connection host

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/AssemblyInfo.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/AssemblyInfo.cs
@@ -5,3 +5,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("LoRaWan.Tests.Common")]
 [assembly: InternalsVisibleTo("LoRaWan.Tests.Unit")]
 [assembly: InternalsVisibleTo("LoRaWan.Tests.Integration")]
+[assembly: InternalsVisibleTo("LoRaWan.Tests.Simulation")]

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -80,7 +80,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         .AddApiClient(NetworkServerConfiguration, ApiVersion.LatestVersion)
                         .AddSingleton(NetworkServerConfiguration)
                         .AddSingleton<ModuleConnectionHost>()
-                        .AddSingleton<ILnsOperation, LnsOperation>()
+                        .AddSingleton<ILnsRemoteCall, LnsRemoteCall>()
                         .AddSingleton<ILoRaDeviceFrameCounterUpdateStrategyProvider, LoRaDeviceFrameCounterUpdateStrategyProvider>()
                         .AddSingleton<IDeduplicationStrategyFactory, DeduplicationStrategyFactory>()
                         .AddSingleton<ILoRaADRStrategyProvider, LoRaADRStrategyProvider>()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -80,6 +80,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         .AddApiClient(NetworkServerConfiguration, ApiVersion.LatestVersion)
                         .AddSingleton(NetworkServerConfiguration)
                         .AddSingleton<ModuleConnectionHost>()
+                        .AddSingleton<ILnsOperation, LnsOperation>()
                         .AddSingleton<ILoRaDeviceFrameCounterUpdateStrategyProvider, LoRaDeviceFrameCounterUpdateStrategyProvider>()
                         .AddSingleton<IDeduplicationStrategyFactory, DeduplicationStrategyFactory>()
                         .AddSingleton<ILoRaADRStrategyProvider, LoRaADRStrategyProvider>()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/LnsOperation.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/LnsOperation.cs
@@ -46,7 +46,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
         {
             if (!string.IsNullOrEmpty(json))
             {
-                ReceivedLoRaCloudToDeviceMessage c2d = null;
+                ReceivedLoRaCloudToDeviceMessage c2d;
 
                 try
                 {
@@ -54,7 +54,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                 }
                 catch (JsonException ex)
                 {
-                    this.logger.LogError($"Impossible to parse Json for c2d message for device {c2d?.DevEUI}, error: {ex}");
+                    this.logger.LogError(ex, $"Impossible to parse Json for c2d message, error: '{ex}'");
                     return HttpStatusCode.BadRequest;
                 }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/LnsOperation.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/LnsOperation.cs
@@ -11,14 +11,14 @@ namespace LoRaWan.NetworkServer.BasicsStation
     using LoRaTools;
     using Microsoft.Extensions.Logging;
 
-    internal interface ILnsOperation
+    internal interface ILnsRemoteCall
     {
         Task<HttpStatusCode> ClearCacheAsync();
         Task<HttpStatusCode> CloseConnectionAsync(string json, CancellationToken cancellationToken);
         Task<HttpStatusCode> SendCloudToDeviceMessageAsync(string json, CancellationToken cancellationToken);
     }
 
-    internal sealed class LnsOperation : ILnsOperation
+    internal sealed class LnsRemoteCall : ILnsRemoteCall
     {
         internal const string ClosedConnectionLog = "Device connection was closed ";
         private static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
@@ -26,13 +26,13 @@ namespace LoRaWan.NetworkServer.BasicsStation
         private readonly NetworkServerConfiguration networkServerConfiguration;
         private readonly IClassCDeviceMessageSender classCDeviceMessageSender;
         private readonly ILoRaDeviceRegistry loRaDeviceRegistry;
-        private readonly ILogger<LnsOperation> logger;
+        private readonly ILogger<LnsRemoteCall> logger;
         private readonly Counter<int> forceClosedConnections;
 
-        public LnsOperation(NetworkServerConfiguration networkServerConfiguration,
+        public LnsRemoteCall(NetworkServerConfiguration networkServerConfiguration,
                             IClassCDeviceMessageSender classCDeviceMessageSender,
                             ILoRaDeviceRegistry loRaDeviceRegistry,
-                            ILogger<LnsOperation> logger,
+                            ILogger<LnsRemoteCall> logger,
                             Meter meter)
         {
             this.networkServerConfiguration = networkServerConfiguration;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/LnsOperation.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/LnsOperation.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer.BasicsStation
+{
+    using System.Diagnostics.Metrics;
+    using System.Net;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using LoRaTools;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Extensions.Logging;
+
+    internal interface ILnsOperation
+    {
+        Task<HttpStatusCode> ClearCacheAsync();
+        Task<HttpStatusCode> CloseConnectionAsync(MethodRequest methodRequest);
+        Task<HttpStatusCode> SendCloudToDeviceMessageAsync(MethodRequest methodRequest);
+    }
+
+    internal sealed class LnsOperation : ILnsOperation
+    {
+        internal const string ClosedConnectionLog = "Device connection was closed ";
+
+        private readonly NetworkServerConfiguration networkServerConfiguration;
+        private readonly IClassCDeviceMessageSender classCDeviceMessageSender;
+        private readonly ILoRaDeviceRegistry loRaDeviceRegistry;
+        private readonly ILogger<LnsOperation> logger;
+        private readonly Counter<int> forceClosedConnections;
+
+        public LnsOperation(NetworkServerConfiguration networkServerConfiguration,
+                            IClassCDeviceMessageSender classCDeviceMessageSender,
+                            ILoRaDeviceRegistry loRaDeviceRegistry,
+                            ILogger<LnsOperation> logger,
+                            Meter meter)
+        {
+            this.networkServerConfiguration = networkServerConfiguration;
+            this.classCDeviceMessageSender = classCDeviceMessageSender;
+            this.loRaDeviceRegistry = loRaDeviceRegistry;
+            this.logger = logger;
+            this.forceClosedConnections = meter.CreateCounter<int>(MetricRegistry.ForceClosedClientConnections);
+        }
+
+        public async Task<HttpStatusCode> SendCloudToDeviceMessageAsync(MethodRequest methodRequest)
+        {
+            if (!string.IsNullOrEmpty(methodRequest.DataAsJson))
+            {
+                ReceivedLoRaCloudToDeviceMessage c2d = null;
+
+                try
+                {
+                    c2d = JsonSerializer.Deserialize<ReceivedLoRaCloudToDeviceMessage>(methodRequest.DataAsJson, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                }
+                catch (JsonException ex)
+                {
+                    this.logger.LogError($"Impossible to parse Json for c2d message for device {c2d?.DevEUI}, error: {ex}");
+                    return HttpStatusCode.BadRequest;
+                }
+
+                using var scope = this.logger.BeginDeviceScope(c2d.DevEUI);
+                this.logger.LogDebug($"received cloud to device message from direct method: {methodRequest.DataAsJson}");
+
+                using var cts = methodRequest.ResponseTimeout.HasValue ? new CancellationTokenSource(methodRequest.ResponseTimeout.Value) : null;
+
+                if (await this.classCDeviceMessageSender.SendAsync(c2d, cts?.Token ?? CancellationToken.None))
+                {
+                    return HttpStatusCode.OK;
+                }
+            }
+
+            return HttpStatusCode.BadRequest;
+        }
+
+        public async Task<HttpStatusCode> CloseConnectionAsync(MethodRequest methodRequest)
+        {
+            ReceivedLoRaCloudToDeviceMessage c2d = null;
+
+            try
+            {
+                c2d = methodRequest.DataAsJson is { } json ? JsonSerializer.Deserialize<ReceivedLoRaCloudToDeviceMessage>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) : null;
+            }
+            catch (JsonException ex)
+            {
+                this.logger.LogError(ex, "Unable to parse Json for direct method '{MethodName}' for device '{DevEui}', message id '{MessageId}'", methodRequest.Name, c2d?.DevEUI, c2d?.MessageId);
+                return HttpStatusCode.BadRequest;
+            }
+
+            if (c2d == null)
+            {
+                this.logger.LogError("Missing payload for direct method '{MethodName}'", methodRequest.Name);
+                return HttpStatusCode.BadRequest;
+            }
+
+            if (c2d.DevEUI == null)
+            {
+                this.logger.LogError("DevEUI missing, cannot identify device to close connection for; message Id '{MessageId}'", c2d.MessageId);
+                return HttpStatusCode.BadRequest;
+            }
+
+            using var scope = this.logger.BeginDeviceScope(c2d.DevEUI);
+
+            var loRaDevice = await this.loRaDeviceRegistry.GetDeviceByDevEUIAsync(c2d.DevEUI.Value);
+            if (loRaDevice == null)
+            {
+                this.logger.LogError("Could not retrieve LoRa device; message id '{MessageId}'", c2d.MessageId);
+                return HttpStatusCode.NotFound;
+            }
+
+            loRaDevice.IsConnectionOwner = false;
+            using var cts = methodRequest.ResponseTimeout is { } timeout ? new CancellationTokenSource(timeout) : null;
+            await loRaDevice.CloseConnectionAsync(cts?.Token ?? CancellationToken.None, force: true);
+
+            this.logger.LogInformation(ClosedConnectionLog + "from gateway with id '{GatewayId}', message id '{MessageId}'", this.networkServerConfiguration.GatewayID, c2d.MessageId);
+            this.forceClosedConnections.Add(1);
+
+            return HttpStatusCode.OK;
+        }
+
+        public async Task<HttpStatusCode> ClearCacheAsync()
+        {
+            await this.loRaDeviceRegistry.ResetDeviceCacheAsync();
+            return HttpStatusCode.OK;
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
@@ -20,7 +20,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
         private const string LnsVersionPropertyName = "LnsVersion";
         private readonly NetworkServerConfiguration networkServerConfiguration;
         private readonly LoRaDeviceAPIServiceBase loRaDeviceAPIService;
-        private readonly ILnsOperation lnsOperation;
+        private readonly ILnsRemoteCall lnsRemoteCall;
         private readonly ILogger<ModuleConnectionHost> logger;
         private readonly Counter<int> unhandledExceptionCount;
         private ILoraModuleClient loRaModuleClient;
@@ -30,13 +30,13 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
             NetworkServerConfiguration networkServerConfiguration,
             ILoRaModuleClientFactory loRaModuleClientFactory,
             LoRaDeviceAPIServiceBase loRaDeviceAPIService,
-            ILnsOperation lnsOperation,
+            ILnsRemoteCall lnsRemoteCall,
             ILogger<ModuleConnectionHost> logger,
             Meter meter)
         {
             this.networkServerConfiguration = networkServerConfiguration ?? throw new ArgumentNullException(nameof(networkServerConfiguration));
             this.loRaDeviceAPIService = loRaDeviceAPIService ?? throw new ArgumentNullException(nameof(loRaDeviceAPIService));
-            this.lnsOperation = lnsOperation ?? throw new ArgumentNullException(nameof(lnsOperation));
+            this.lnsRemoteCall = lnsRemoteCall ?? throw new ArgumentNullException(nameof(lnsRemoteCall));
             this.loRaModuleClientFactory = loRaModuleClientFactory ?? throw new ArgumentNullException(nameof(loRaModuleClientFactory));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.unhandledExceptionCount = (meter ?? throw new ArgumentNullException(nameof(meter))).CreateCounter<int>(MetricRegistry.UnhandledExceptions);
@@ -93,15 +93,15 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
 
                 if (string.Equals(Constants.CloudToDeviceClearCache, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    return AsMethodResponse(await this.lnsOperation.ClearCacheAsync());
+                    return AsMethodResponse(await this.lnsRemoteCall.ClearCacheAsync());
                 }
                 else if (string.Equals(Constants.CloudToDeviceCloseConnection, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    return AsMethodResponse(await this.lnsOperation.CloseConnectionAsync(methodRequest.DataAsJson, token));
+                    return AsMethodResponse(await this.lnsRemoteCall.CloseConnectionAsync(methodRequest.DataAsJson, token));
                 }
                 else if (string.Equals(Constants.CloudToDeviceDecoderElementName, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    return AsMethodResponse(await this.lnsOperation.SendCloudToDeviceMessageAsync(methodRequest.DataAsJson, token));
+                    return AsMethodResponse(await this.lnsRemoteCall.SendCloudToDeviceMessageAsync(methodRequest.DataAsJson, token));
                 }
 
                 this.logger.LogError($"Unknown direct method called: {methodRequest.Name}");

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
@@ -88,17 +88,20 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
 
             try
             {
+                using var cts = methodRequest.ResponseTimeout is { } someResponseTimeout ? new CancellationTokenSource(someResponseTimeout) : null;
+                var token = cts?.Token ?? CancellationToken.None;
+
                 if (string.Equals(Constants.CloudToDeviceClearCache, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
                 {
                     return AsMethodResponse(await this.lnsOperation.ClearCacheAsync());
                 }
                 else if (string.Equals(Constants.CloudToDeviceCloseConnection, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    return AsMethodResponse(await this.lnsOperation.CloseConnectionAsync(methodRequest));
+                    return AsMethodResponse(await this.lnsOperation.CloseConnectionAsync(methodRequest.DataAsJson, token));
                 }
                 else if (string.Equals(Constants.CloudToDeviceDecoderElementName, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    return AsMethodResponse(await this.lnsOperation.SendCloudToDeviceMessageAsync(methodRequest));
+                    return AsMethodResponse(await this.lnsOperation.SendCloudToDeviceMessageAsync(methodRequest.DataAsJson, token));
                 }
 
                 this.logger.LogError($"Unknown direct method called: {methodRequest.Name}");

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
@@ -3,7 +3,6 @@
 
 namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
 {
-    using LoRaTools;
     using LoRaTools.Utils;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Client.Exceptions;
@@ -13,42 +12,34 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
     using System.Configuration;
     using System.Diagnostics.Metrics;
     using System.Net;
-    using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
 
-    public sealed class ModuleConnectionHost : IAsyncDisposable
+    internal sealed class ModuleConnectionHost : IAsyncDisposable
     {
         private const string LnsVersionPropertyName = "LnsVersion";
         private readonly NetworkServerConfiguration networkServerConfiguration;
-        private readonly IClassCDeviceMessageSender classCMessageSender;
-        private readonly ILoRaDeviceRegistry loRaDeviceRegistry;
         private readonly LoRaDeviceAPIServiceBase loRaDeviceAPIService;
+        private readonly ILnsOperation lnsOperation;
         private readonly ILogger<ModuleConnectionHost> logger;
         private readonly Counter<int> unhandledExceptionCount;
-        private readonly Counter<int> forceClosedConnections;
         private ILoraModuleClient loRaModuleClient;
         private readonly ILoRaModuleClientFactory loRaModuleClientFactory;
 
-        public const string ClosedConnectionLog = "Device connection was closed ";
-
         public ModuleConnectionHost(
             NetworkServerConfiguration networkServerConfiguration,
-            IClassCDeviceMessageSender defaultClassCDevicesMessageSender,
             ILoRaModuleClientFactory loRaModuleClientFactory,
-            ILoRaDeviceRegistry loRaDeviceRegistry,
             LoRaDeviceAPIServiceBase loRaDeviceAPIService,
+            ILnsOperation lnsOperation,
             ILogger<ModuleConnectionHost> logger,
             Meter meter)
         {
             this.networkServerConfiguration = networkServerConfiguration ?? throw new ArgumentNullException(nameof(networkServerConfiguration));
-            this.classCMessageSender = defaultClassCDevicesMessageSender ?? throw new ArgumentNullException(nameof(defaultClassCDevicesMessageSender));
-            this.loRaDeviceRegistry = loRaDeviceRegistry ?? throw new ArgumentNullException(nameof(loRaDeviceRegistry));
             this.loRaDeviceAPIService = loRaDeviceAPIService ?? throw new ArgumentNullException(nameof(loRaDeviceAPIService));
+            this.lnsOperation = lnsOperation ?? throw new ArgumentNullException(nameof(lnsOperation));
             this.loRaModuleClientFactory = loRaModuleClientFactory ?? throw new ArgumentNullException(nameof(loRaModuleClientFactory));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.unhandledExceptionCount = (meter ?? throw new ArgumentNullException(nameof(meter))).CreateCounter<int>(MetricRegistry.UnhandledExceptions);
-            this.forceClosedConnections = meter.CreateCounter<int>(MetricRegistry.ForceClosedClientConnections);
         }
 
         public async Task CreateAsync(CancellationToken cancellationToken)
@@ -99,107 +90,29 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
             {
                 if (string.Equals(Constants.CloudToDeviceClearCache, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    return await ClearCacheAsync();
+                    return AsMethodResponse(await this.lnsOperation.ClearCacheAsync());
                 }
                 else if (string.Equals(Constants.CloudToDeviceCloseConnection, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    return await CloseConnectionAsync(methodRequest);
+                    return AsMethodResponse(await this.lnsOperation.CloseConnectionAsync(methodRequest));
                 }
                 else if (string.Equals(Constants.CloudToDeviceDecoderElementName, methodRequest.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    return await SendCloudToDeviceMessageAsync(methodRequest);
+                    return AsMethodResponse(await this.lnsOperation.SendCloudToDeviceMessageAsync(methodRequest));
                 }
 
                 this.logger.LogError($"Unknown direct method called: {methodRequest.Name}");
 
-                return new MethodResponse((int)HttpStatusCode.BadRequest);
+                return AsMethodResponse(HttpStatusCode.BadRequest);
             }
             catch (Exception ex) when (ExceptionFilterUtility.False(() => this.logger.LogError(ex, $"An exception occurred on a direct method call: {ex}"),
                                                                     () => this.unhandledExceptionCount.Add(1)))
             {
                 throw;
             }
-        }
 
-        private async Task<MethodResponse> SendCloudToDeviceMessageAsync(MethodRequest methodRequest)
-        {
-            if (!string.IsNullOrEmpty(methodRequest.DataAsJson))
-            {
-                ReceivedLoRaCloudToDeviceMessage c2d = null;
-
-                try
-                {
-                    c2d = JsonSerializer.Deserialize<ReceivedLoRaCloudToDeviceMessage>(methodRequest.DataAsJson, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                }
-                catch (JsonException ex)
-                {
-                    this.logger.LogError($"Impossible to parse Json for c2d message for device {c2d?.DevEUI}, error: {ex}");
-                    return new MethodResponse((int)HttpStatusCode.BadRequest);
-                }
-
-                using var scope = this.logger.BeginDeviceScope(c2d.DevEUI);
-                this.logger.LogDebug($"received cloud to device message from direct method: {methodRequest.DataAsJson}");
-
-                using var cts = methodRequest.ResponseTimeout.HasValue ? new CancellationTokenSource(methodRequest.ResponseTimeout.Value) : null;
-
-                if (await this.classCMessageSender.SendAsync(c2d, cts?.Token ?? CancellationToken.None))
-                {
-                    return new MethodResponse((int)HttpStatusCode.OK);
-                }
-            }
-
-            return new MethodResponse((int)HttpStatusCode.BadRequest);
-        }
-
-        private async Task<MethodResponse> ClearCacheAsync()
-        {
-            await this.loRaDeviceRegistry.ResetDeviceCacheAsync();
-            return new MethodResponse((int)HttpStatusCode.OK);
-        }
-
-        private async Task<MethodResponse> CloseConnectionAsync(MethodRequest methodRequest)
-        {
-            ReceivedLoRaCloudToDeviceMessage c2d = null;
-
-            try
-            {
-                c2d = methodRequest.DataAsJson is { } json ? JsonSerializer.Deserialize<ReceivedLoRaCloudToDeviceMessage>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) : null;
-            }
-            catch (JsonException ex)
-            {
-                this.logger.LogError(ex, "Unable to parse Json for direct method '{MethodName}' for device '{DevEui}', message id '{MessageId}'", methodRequest.Name, c2d?.DevEUI, c2d?.MessageId);
-                return new MethodResponse((int)HttpStatusCode.BadRequest);
-            }
-
-            if (c2d == null)
-            {
-                this.logger.LogError("Missing payload for direct method '{MethodName}'", methodRequest.Name);
-                return new MethodResponse((int)HttpStatusCode.BadRequest);
-            }
-
-            if (c2d.DevEUI == null)
-            {
-                this.logger.LogError("DevEUI missing, cannot identify device to close connection for; message Id '{MessageId}'", c2d.MessageId);
-                return new MethodResponse((int)HttpStatusCode.BadRequest);
-            }
-
-            using var scope = this.logger.BeginDeviceScope(c2d.DevEUI);
-
-            var loRaDevice = await this.loRaDeviceRegistry.GetDeviceByDevEUIAsync(c2d.DevEUI.Value);
-            if (loRaDevice == null)
-            {
-                this.logger.LogError("Could not retrieve LoRa device; message id '{MessageId}'", c2d.MessageId);
-                return new MethodResponse((int)HttpStatusCode.NotFound);
-            }
-
-            loRaDevice.IsConnectionOwner = false;
-            using var cts = methodRequest.ResponseTimeout is { } timeout ? new CancellationTokenSource(timeout) : null;
-            await loRaDevice.CloseConnectionAsync(cts?.Token ?? CancellationToken.None, force: true);
-
-            this.logger.LogInformation(ClosedConnectionLog + "from gateway with id '{GatewayId}', message id '{MessageId}'", this.networkServerConfiguration.GatewayID, c2d.MessageId);
-            this.forceClosedConnections.Add(1);
-
-            return new MethodResponse((int)HttpStatusCode.OK);
+            static MethodResponse AsMethodResponse(HttpStatusCode httpStatusCode) =>
+                new MethodResponse((int)httpStatusCode);
         }
 
         /// <summary>

--- a/Tests/Simulation/SimulatedLoadTests.cs
+++ b/Tests/Simulation/SimulatedLoadTests.cs
@@ -101,7 +101,7 @@ namespace LoRaWan.Tests.Simulation
 
             await Task.Delay(messagesToSendEachLNS * IntervalBetweenMessages);
             _ = await TestFixture.AssertNetworkServerModuleLogExistsAsync(
-                x => !x.Contains(LnsOperation.ClosedConnectionLog, StringComparison.Ordinal),
+                x => !x.Contains(LnsRemoteCall.ClosedConnectionLog, StringComparison.Ordinal),
                 new SearchLogOptions("No connection switch should be logged") { TreatAsError = true });
 
             // act: change basics station that the device is listened from and therefore the gateway it uses as well
@@ -111,8 +111,8 @@ namespace LoRaWan.Tests.Simulation
             // assert
             var expectedLnsToDropConnection = Configuration.LnsEndpointsForSimulator.First().Key;
             _ = await TestFixture.AssertNetworkServerModuleLogExistsAsync(
-                x => x.Contains(LnsOperation.ClosedConnectionLog, StringComparison.Ordinal) && x.Contains(expectedLnsToDropConnection, StringComparison.Ordinal),
-                new SearchLogOptions($"{LnsOperation.ClosedConnectionLog} and {expectedLnsToDropConnection}") { TreatAsError = true });
+                x => x.Contains(LnsRemoteCall.ClosedConnectionLog, StringComparison.Ordinal) && x.Contains(expectedLnsToDropConnection, StringComparison.Ordinal),
+                new SearchLogOptions($"{LnsRemoteCall.ClosedConnectionLog} and {expectedLnsToDropConnection}") { TreatAsError = true });
             await AssertIotHubMessageCountAsync(simulatedDevice, messagesToSendEachLNS * 2);
         }
 

--- a/Tests/Simulation/SimulatedLoadTests.cs
+++ b/Tests/Simulation/SimulatedLoadTests.cs
@@ -22,7 +22,7 @@ namespace LoRaWan.Tests.Simulation
     using static MoreLinq.Extensions.RepeatExtension;
     using static MoreLinq.Extensions.IndexExtension;
     using static MoreLinq.Extensions.TransposeExtension;
-    using LoRaWan.NetworkServer.BasicsStation.ModuleConnection;
+    using LoRaWan.NetworkServer.BasicsStation;
 
     [Trait("Category", "SkipWhenLiveUnitTesting")]
     public sealed class SimulatedLoadTests : IntegrationTestBaseSim, IAsyncLifetime
@@ -101,7 +101,7 @@ namespace LoRaWan.Tests.Simulation
 
             await Task.Delay(messagesToSendEachLNS * IntervalBetweenMessages);
             _ = await TestFixture.AssertNetworkServerModuleLogExistsAsync(
-                x => !x.Contains(ModuleConnectionHost.ClosedConnectionLog, StringComparison.Ordinal),
+                x => !x.Contains(LnsOperation.ClosedConnectionLog, StringComparison.Ordinal),
                 new SearchLogOptions("No connection switch should be logged") { TreatAsError = true });
 
             // act: change basics station that the device is listened from and therefore the gateway it uses as well
@@ -111,8 +111,8 @@ namespace LoRaWan.Tests.Simulation
             // assert
             var expectedLnsToDropConnection = Configuration.LnsEndpointsForSimulator.First().Key;
             _ = await TestFixture.AssertNetworkServerModuleLogExistsAsync(
-                x => x.Contains(ModuleConnectionHost.ClosedConnectionLog, StringComparison.Ordinal) && x.Contains(expectedLnsToDropConnection, StringComparison.Ordinal),
-                new SearchLogOptions($"{ModuleConnectionHost.ClosedConnectionLog} and {expectedLnsToDropConnection}") { TreatAsError = true });
+                x => x.Contains(LnsOperation.ClosedConnectionLog, StringComparison.Ordinal) && x.Contains(expectedLnsToDropConnection, StringComparison.Ordinal),
+                new SearchLogOptions($"{LnsOperation.ClosedConnectionLog} and {expectedLnsToDropConnection}") { TreatAsError = true });
             await AssertIotHubMessageCountAsync(simulatedDevice, messagesToSendEachLNS * 2);
         }
 

--- a/Tests/Unit/NetworkServer/LnsOperationTests.cs
+++ b/Tests/Unit/NetworkServer/LnsOperationTests.cs
@@ -16,22 +16,22 @@ namespace LoRaWan.Tests.Unit.NetworkServer
     using Moq;
     using Xunit;
 
-    public sealed class LnsOperationTests
+    public sealed class LnsRemoteCallTests
     {
         private readonly Faker faker = new();
         private readonly NetworkServerConfiguration networkServerConfiguration;
         private readonly Mock<IClassCDeviceMessageSender> classCMessageSender;
         private readonly Mock<ILoRaDeviceRegistry> loRaDeviceRegistry;
-        private readonly Mock<ILogger<LnsOperation>> logger;
-        private readonly LnsOperation subject;
+        private readonly Mock<ILogger<LnsRemoteCall>> logger;
+        private readonly LnsRemoteCall subject;
 
-        public LnsOperationTests()
+        public LnsRemoteCallTests()
         {
             this.networkServerConfiguration = new NetworkServerConfiguration();
             this.classCMessageSender = new Mock<IClassCDeviceMessageSender>();
             this.loRaDeviceRegistry = new Mock<ILoRaDeviceRegistry>();
-            this.logger = new Mock<ILogger<LnsOperation>>();
-            this.subject = new LnsOperation(this.networkServerConfiguration,
+            this.logger = new Mock<ILogger<LnsRemoteCall>>();
+            this.subject = new LnsRemoteCall(this.networkServerConfiguration,
                                             this.classCMessageSender.Object,
                                             this.loRaDeviceRegistry.Object,
                                             this.logger.Object,

--- a/Tests/Unit/NetworkServer/LnsOperationTests.cs
+++ b/Tests/Unit/NetworkServer/LnsOperationTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.NetworkServer
+{
+    using System;
+    using System.Net;
+    using System.Text;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Bogus;
+    using LoRaWan.NetworkServer;
+    using LoRaWan.NetworkServer.BasicsStation;
+    using LoRaWan.Tests.Common;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Xunit;
+
+    public sealed class LnsOperationTests
+    {
+        private readonly Faker faker = new();
+        private readonly NetworkServerConfiguration networkServerConfiguration;
+        private readonly Mock<IClassCDeviceMessageSender> classCMessageSender;
+        private readonly Mock<ILoRaDeviceRegistry> loRaDeviceRegistry;
+        private readonly Mock<ILogger<LnsOperation>> logger;
+        private readonly LnsOperation subject;
+
+        public LnsOperationTests()
+        {
+            this.networkServerConfiguration = new NetworkServerConfiguration();
+            this.classCMessageSender = new Mock<IClassCDeviceMessageSender>();
+            this.loRaDeviceRegistry = new Mock<ILoRaDeviceRegistry>();
+            this.logger = new Mock<ILogger<LnsOperation>>();
+            this.subject = new LnsOperation(this.networkServerConfiguration,
+                                            this.classCMessageSender.Object,
+                                            this.loRaDeviceRegistry.Object,
+                                            this.logger.Object,
+                                            TestMeter.Instance);
+        }
+
+
+        [Fact]
+        public async Task OnDirectMethodCall_DropConnection_Should_Work_As_Expected()
+        {
+            // arrange
+            var devEui = new DevEui(0);
+            var mockedDevice = new Mock<LoRaDevice>(null, devEui, null);
+            _ = this.loRaDeviceRegistry.Setup(x => x.GetDeviceByDevEUIAsync(devEui)).ReturnsAsync(mockedDevice.Object);
+            var c2d = JsonSerializer.Serialize(new
+            {
+                DevEui = devEui.ToString(),
+                Fport = 1,
+                MessageId = Guid.NewGuid(),
+            });
+
+            // act
+            _ = await this.subject.CloseConnectionAsync(new MethodRequest(Constants.CloudToDeviceCloseConnection, Encoding.UTF8.GetBytes(c2d)));
+
+            // assert
+            this.loRaDeviceRegistry.VerifyAll();
+            mockedDevice.Verify(x => x.CloseConnectionAsync(It.IsAny<CancellationToken>(), true), Times.Once);
+        }
+
+        [Fact]
+        public async Task ClearCache_When_Correct_Should_Work()
+        {
+            // arrange
+            this.loRaDeviceRegistry.Setup(x => x.ResetDeviceCacheAsync()).Returns(Task.CompletedTask);
+            this.networkServerConfiguration.IoTEdgeTimeout = 5;
+
+            // act
+            await this.subject.ClearCacheAsync();
+
+            // assert
+            this.loRaDeviceRegistry.VerifyAll();
+        }
+
+        public static TheoryData<string, string> DropConnectionInvalidMessages =>
+            TheoryDataFactory.From(
+                (string.Empty, "Missing payload"),
+                ("null", "Missing payload"),
+                (JsonSerializer.Serialize(new { DevEui = (string)null, Fport = 1 }), "DevEUI missing"),
+                (JsonSerializer.Serialize(new { DevEui = new DevEui(0).ToString(), Fport = 1, MessageId = 123 }), "Unable to parse Json"));
+
+        [Theory]
+        [MemberData(nameof(DropConnectionInvalidMessages))]
+        public async Task CloseConnectionAsync_Should_Return_Bad_Request_When_Invalid_Message(string json, string expectedLogPattern)
+        {
+            // act
+            var response = await this.subject.CloseConnectionAsync(new MethodRequest(Constants.CloudToDeviceCloseConnection, Encoding.UTF8.GetBytes(json)));
+
+            // assert
+            Assert.Equal(HttpStatusCode.BadRequest, response);
+            var log = Assert.Single(this.logger.GetLogInvocations());
+            Assert.Matches(expectedLogPattern, log.Message);
+            this.loRaDeviceRegistry.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task CloseConnectionAsync_Should_Return_NotFound_When_Device_Not_Found()
+        {
+            // arrange
+            var devEui = new DevEui(0);
+            var c2d = JsonSerializer.Serialize(new { DevEui = devEui.ToString(), Fport = 1 });
+
+            // act
+            var response = await this.subject.CloseConnectionAsync(new MethodRequest(Constants.CloudToDeviceCloseConnection, Encoding.UTF8.GetBytes(c2d)));
+
+            // assert
+            Assert.Equal(HttpStatusCode.NotFound, response);
+            this.loRaDeviceRegistry.Verify(x => x.GetDeviceByDevEUIAsync(devEui), Times.Once);
+            this.loRaDeviceRegistry.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task SendCloudToDeviceMessageAsync_When_Correct_Should_Work()
+        {
+            // arrange
+            this.classCMessageSender.Setup(x => x.SendAsync(It.IsAny<ReceivedLoRaCloudToDeviceMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            var c2d = "{\"test\":\"asd\"}";
+
+            // act
+            var response = await this.subject.SendCloudToDeviceMessageAsync(new MethodRequest(Constants.CloudToDeviceDecoderElementName, Encoding.UTF8.GetBytes(c2d), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5)));
+
+            // assert
+            Assert.Equal(HttpStatusCode.OK, response);
+        }
+
+        [Fact]
+        public async Task SendCloudToDeviceMessageAsync_When_Incorrect_Should_Return_NotFound()
+        {
+            // arrange
+            var c2d = "{\"test\":\"asd\"}";
+
+            // act
+            var response = await this.subject.SendCloudToDeviceMessageAsync(new MethodRequest(this.faker.Random.String2(8), Encoding.UTF8.GetBytes(c2d)));
+
+            // assert
+            Assert.Equal(HttpStatusCode.BadRequest, response);
+        }
+
+        [Fact]
+        public async Task SendCloudToDeviceMessageAsync_When_ClassC_Msg_Is_Null_Or_Empty_Should_Return_Not_Found()
+        {
+            this.classCMessageSender.Setup(x => x.SendAsync(It.IsAny<ReceivedLoRaCloudToDeviceMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+            var response = await this.subject.SendCloudToDeviceMessageAsync(new MethodRequest(Constants.CloudToDeviceDecoderElementName, null));
+            Assert.Equal(HttpStatusCode.BadRequest, response);
+
+            var response2 = await this.subject.SendCloudToDeviceMessageAsync(new MethodRequest(Constants.CloudToDeviceDecoderElementName, Array.Empty<byte>()));
+            Assert.Equal(HttpStatusCode.BadRequest, response2);
+        }
+
+        [Fact]
+        public async Task SendCloudToDeviceMessageAsync_When_ClassC_Msg_Is_Not_CorrectJson_Should_Return_Not_Found()
+        {
+            var response = await this.subject.SendCloudToDeviceMessageAsync(new MethodRequest(Constants.CloudToDeviceDecoderElementName, Encoding.UTF8.GetBytes(this.faker.Random.String2(10))));
+            Assert.Equal(HttpStatusCode.BadRequest, response);
+        }
+    }
+}

--- a/Tests/Unit/NetworkServer/LnsOperationTests.cs
+++ b/Tests/Unit/NetworkServer/LnsOperationTests.cs
@@ -78,7 +78,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         public static TheoryData<string, string> DropConnectionInvalidMessages =>
             TheoryDataFactory.From(
                 (string.Empty, "Unable to parse Json when attempting to close"),
-                ("null", "Unable to parse Json when attempting to close"),
+                ("null", "Missing payload when attempting to close the"),
                 (JsonSerializer.Serialize(new { DevEui = (string)null, Fport = 1 }), "DevEUI missing"),
                 (JsonSerializer.Serialize(new { DevEui = new DevEui(0).ToString(), Fport = 1, MessageId = 123 }), "Unable to parse Json"));
 

--- a/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
+++ b/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
@@ -15,7 +15,6 @@ namespace LoRaWan.Tests.Unit.NetworkServer
     using Moq;
     using System;
     using System.Configuration;
-    using System.Net;
     using System.Net.Http;
     using System.Text;
     using System.Text.Json;
@@ -239,26 +238,28 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         public async Task OnDirectMethodCall_Should_Invoke_DropConnection()
         {
             // arrange
-            var methodRequest = new MethodRequest(Constants.CloudToDeviceCloseConnection, Array.Empty<byte>());
+            var json = @"{""foo"":""bar""}";
+            var methodRequest = new MethodRequest(Constants.CloudToDeviceCloseConnection, Encoding.UTF8.GetBytes(json));
 
             // act
             await this.subject.OnDirectMethodCalled(methodRequest, null);
 
             // assert
-            this.lnsOperation.Verify(l => l.CloseConnectionAsync(methodRequest), Times.Once);
+            this.lnsOperation.Verify(l => l.CloseConnectionAsync(json, CancellationToken.None), Times.Once);
         }
 
         [Fact]
         public async Task OnDirectMethodCall_Should_Invoke_SendCloudToDeviceMessageAsync()
         {
             // arrange
-            var methodRequest = new MethodRequest(Constants.CloudToDeviceDecoderElementName, Array.Empty<byte>());
+            var json = @"{""foo"":""bar""}";
+            var methodRequest = new MethodRequest(Constants.CloudToDeviceDecoderElementName, Encoding.UTF8.GetBytes(json));
 
             // act
             var result = await this.subject.OnDirectMethodCalled(methodRequest, null);
 
             // assert
-            this.lnsOperation.Verify(l => l.SendCloudToDeviceMessageAsync(methodRequest), Times.Once);
+            this.lnsOperation.Verify(l => l.SendCloudToDeviceMessageAsync(json, CancellationToken.None), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
# PR for issue #1637

## What is being addressed

With this PR we extract logic for operations on a LNS, which is currently tightly coupled to the `ModuleClient` to a separate class. This change allows us to call that logic from either the Module Client connection or via another mechanism

## How is this addressed

The changes are mostly mechanical, tests are refactored a bit (reduced duplication) but no additional coverage is added.
