### PR TITLE
Adding EdgeDeviceGetter and unit tests

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
@@ -74,8 +74,10 @@ namespace LoraKeysManagerFacade
             return isEdgeDevice;
         }
 
+        private static string RedisLnsDeviceCacheKey(string lnsId) => $"lnsInstance-{lnsId}";
+
         private bool MarkDeviceAsNonEdge(string lnsId)
-            => this.cacheStore.ObjectSet(lnsId,
+            => this.cacheStore.ObjectSet(RedisLnsDeviceCacheKey(lnsId),
                                          new DeviceKind(isEdge: false),
                                          TimeSpan.FromDays(1),
                                          onlyIfNotExists: true);
@@ -86,7 +88,7 @@ namespace LoraKeysManagerFacade
             var twins = await GetEdgeDevicesAsync(cancellationToken);
             foreach (var t in twins)
             {
-                _ = this.cacheStore.ObjectSet(t.DeviceId,
+                _ = this.cacheStore.ObjectSet(RedisLnsDeviceCacheKey(t.DeviceId),
                                               new DeviceKind(isEdge: true),
                                               TimeSpan.FromDays(1),
                                               onlyIfNotExists: true);

--- a/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoraKeysManagerFacade
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using LoRaTools;
+    using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Logging;
+
+    internal class EdgeDeviceGetter
+    {
+        private readonly IDeviceRegistryManager registryManager;
+        private readonly ILoRaDeviceCacheStore cacheStore;
+        private readonly ILogger<EdgeDeviceGetter> logger;
+
+        public EdgeDeviceGetter(IDeviceRegistryManager registryManager,
+                                ILoRaDeviceCacheStore cacheStore,
+                                ILogger<EdgeDeviceGetter> logger)
+        {
+            this.registryManager = registryManager;
+            this.cacheStore = cacheStore;
+            this.logger = logger;
+        }
+
+        private async Task<List<Twin>> GetEdgeDevicesAsync()
+        {
+            this.logger.LogDebug("Getting Azure IoT Edge devices");
+            var q = this.registryManager.CreateQuery("SELECT * FROM devices where capabilities.iotEdge = true");
+            var twins = new List<Twin>();
+            do
+            {
+                twins.AddRange(await q.GetNextAsTwinAsync());
+            } while (q.HasMoreResults);
+            return twins;
+        }
+
+        internal async Task<bool> IsEdgeDeviceAsync(string lnsId)
+        {
+            var isEdgeDevice = false;
+            var findInCache = () => this.cacheStore.GetObject<DeviceKind>(lnsId);
+            if (findInCache() is null)
+            {
+                await RefreshEdgeDevicesCacheAsync();
+                isEdgeDevice = findInCache() is { IsEdge: true };
+                if (!isEdgeDevice)
+                    _ = MarkDeviceAsNonEdge(lnsId);
+            }
+            return isEdgeDevice;
+        }
+
+        internal bool MarkDeviceAsNonEdge(string lnsId)
+            => this.cacheStore.ObjectSet(lnsId, new DeviceKind(false), TimeSpan.FromDays(1), true);
+
+        private async Task RefreshEdgeDevicesCacheAsync()
+        {
+            this.logger.LogDebug("Refreshing Azure IoT Edge devices cache");
+            var twins = await GetEdgeDevicesAsync();
+            foreach (var t in twins)
+            {
+                _ = this.cacheStore.ObjectSet(t.DeviceId,
+                                              new DeviceKind(true),
+                                              TimeSpan.FromDays(1),
+                                              true);
+            }
+        }
+    }
+
+    internal class DeviceKind
+    {
+        public bool IsEdge { get; set; }
+        public DeviceKind(bool isEdge)
+        {
+            IsEdge = isEdge;
+        }
+    }
+}

--- a/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
@@ -49,7 +49,7 @@ namespace LoraKeysManagerFacade
             {
                 if (await this.cacheStore.LockTakeAsync(keyLock, owner, TimeSpan.FromSeconds(10)))
                 {
-                    var findInCache = () => this.cacheStore.GetObject<DeviceKind>(lnsId);
+                    var findInCache = () => this.cacheStore.GetObject<DeviceKind>(RedisLnsDeviceCacheKey(lnsId));
                     if (findInCache() is null)
                     {
                         await RefreshEdgeDevicesCacheAsync(cancellationToken);

--- a/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
@@ -51,8 +51,11 @@ namespace LoraKeysManagerFacade
             return isEdgeDevice;
         }
 
-        internal bool MarkDeviceAsNonEdge(string lnsId)
-            => this.cacheStore.ObjectSet(lnsId, new DeviceKind(false), TimeSpan.FromDays(1), true);
+        private bool MarkDeviceAsNonEdge(string lnsId)
+            => this.cacheStore.ObjectSet(lnsId,
+                                         new DeviceKind(isEdge: false),
+                                         TimeSpan.FromDays(1),
+                                         onlyIfNotExists: true);
 
         private async Task RefreshEdgeDevicesCacheAsync()
         {
@@ -61,16 +64,16 @@ namespace LoraKeysManagerFacade
             foreach (var t in twins)
             {
                 _ = this.cacheStore.ObjectSet(t.DeviceId,
-                                              new DeviceKind(true),
+                                              new DeviceKind(isEdge: true),
                                               TimeSpan.FromDays(1),
-                                              true);
+                                              onlyIfNotExists: true);
             }
         }
     }
 
     internal class DeviceKind
     {
-        public bool IsEdge { get; set; }
+        public bool IsEdge { get; private set; }
         public DeviceKind(bool isEdge)
         {
             IsEdge = isEdge;

--- a/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
@@ -60,6 +60,7 @@ namespace LoraKeysManagerFacade
                                                                               sp.GetRequiredService<ILogger<LoRaADRServerManager>>()))
                 .AddSingleton<CreateEdgeDevice>()
                 .AddSingleton<DeviceGetter>()
+                .AddSingleton<EdgeDeviceGetter>()
                 .AddSingleton<FCntCacheCheck>()
                 .AddSingleton<FunctionBundlerFunction>()
                 .AddSingleton<IFunctionBundlerExecutionItem, NextFCntDownExecutionItem>()

--- a/Tests/Unit/LoraKeysManagerFacade/EdgeDeviceGetterTests.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/EdgeDeviceGetterTests.cs
@@ -23,7 +23,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
         public async Task IsEdgeDeviceAsync_Returns_Proper_Answer(string lnsId, bool isEdge)
         {
             var edgeDeviceGetter = new EdgeDeviceGetter(InitRegistryManager(), new LoRaInMemoryDeviceStore(), NullLogger<EdgeDeviceGetter>.Instance);
-            Assert.Equal(isEdge, await edgeDeviceGetter.IsEdgeDeviceAsync(lnsId));
+            Assert.Equal(isEdge, await edgeDeviceGetter.IsEdgeDeviceAsync(lnsId, default));
         }
 
         private static IDeviceRegistryManager InitRegistryManager()

--- a/Tests/Unit/LoraKeysManagerFacade/EdgeDeviceGetterTests.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/EdgeDeviceGetterTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using global::LoraKeysManagerFacade;
+    using global::LoRaTools;
+    using Microsoft.Azure.Devices;
+    using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Moq;
+    using Xunit;
+
+    public class EdgeDeviceGetterTests
+    {
+        private const string EdgeDevice1 = "edgeDevice1";
+
+        [Theory]
+        [InlineData(EdgeDevice1, true)]
+        [InlineData("another", false)]
+        public async Task IsEdgeDeviceAsync_Returns_Proper_Answer(string lnsId, bool isEdge)
+        {
+            var edgeDeviceGetter = new EdgeDeviceGetter(InitRegistryManager(), new LoRaInMemoryDeviceStore(), NullLogger<EdgeDeviceGetter>.Instance);
+            Assert.Equal(isEdge, await edgeDeviceGetter.IsEdgeDeviceAsync(lnsId));
+        }
+
+        private static IDeviceRegistryManager InitRegistryManager()
+        {
+            var mockQuery = new Mock<IQuery>();
+            var mockRegistryManager = new Mock<IDeviceRegistryManager>();
+
+            var twins = new List<Twin>()
+            {
+                new Twin(EdgeDevice1) { Capabilities = new DeviceCapabilities() { IotEdge = true }},
+            };
+
+            mockQuery.Setup(x => x.GetNextAsTwinAsync())
+                .ReturnsAsync(twins);
+
+            mockRegistryManager
+                .Setup(x => x.CreateQuery(It.IsAny<string>()))
+                .Returns(mockQuery.Object);
+
+            return mockRegistryManager.Object;
+        }
+    }
+}


### PR DESCRIPTION
# PR for issue #1694

## What is being addressed

This PR is adding functionality to get all the IoT Edge devices in Azure Function to discriminate whether to use Direct Methods or Pub/Sub Functionality (#1633, #1634)