### PR TITLE
OCW2022 Decouple LoRaWAN Starter Kit from IoTEdge

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -79,7 +79,6 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         .AddHttpClient()
                         .AddApiClient(NetworkServerConfiguration, ApiVersion.LatestVersion)
                         .AddSingleton(NetworkServerConfiguration)
-                        .AddSingleton<ModuleConnectionHost>()
                         .AddSingleton<ILnsRemoteCall, LnsRemoteCall>()
                         .AddSingleton<ILoRaDeviceFrameCounterUpdateStrategyProvider, LoRaDeviceFrameCounterUpdateStrategyProvider>()
                         .AddSingleton<IDeduplicationStrategyFactory, DeduplicationStrategyFactory>()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -79,7 +79,6 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         .AddHttpClient()
                         .AddApiClient(NetworkServerConfiguration, ApiVersion.LatestVersion)
                         .AddSingleton(NetworkServerConfiguration)
-                        .AddSingleton<ModuleConnectionHost>()
                         .AddSingleton<ILoRaDeviceFrameCounterUpdateStrategyProvider, LoRaDeviceFrameCounterUpdateStrategyProvider>()
                         .AddSingleton<IDeduplicationStrategyFactory, DeduplicationStrategyFactory>()
                         .AddSingleton<ILoRaADRStrategyProvider, LoRaADRStrategyProvider>()
@@ -124,6 +123,10 @@ namespace LoRaWan.NetworkServer.BasicsStation
 
             if (NetworkServerConfiguration.ClientCertificateMode is not ClientCertificateMode.NoCertificate)
                 _ = services.AddSingleton<IClientCertificateValidatorService, ClientCertificateValidatorService>();
+            if (NetworkServerConfiguration.RunningAsIoTEdgeModule)
+            {
+                _ = services.AddSingleton<ModuleConnectionHost>();
+            }
         }
 
 #pragma warning disable CA1822 // Mark members as static

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -138,7 +138,7 @@ namespace LoRaWan.NetworkServer
         /// <summary>
         /// Specifies the Processing Delay in Milliseconds
         /// </summary>
-        public int ProcessingDelayInMilliseconds { get; set; }
+        public int ProcessingDelayInMilliseconds { get; set; } = Constants.DefaultProcessingDelayInMilliseconds;
 
         // Creates a new instance of NetworkServerConfiguration by reading values from environment variables
         public static NetworkServerConfiguration CreateFromEnvironmentVariables()
@@ -147,7 +147,7 @@ namespace LoRaWan.NetworkServer
 
             // Create case insensitive dictionary from environment variables
             var envVars = new CaseInsensitiveEnvironmentVariables(Environment.GetEnvironmentVariables());
-            config.ProcessingDelayInMilliseconds = envVars.GetEnvVar("PROCESSING_DELAY_IN_MS", Constants.DefaultProcessingDelayInMilliseconds);
+            config.ProcessingDelayInMilliseconds = envVars.GetEnvVar("PROCESSING_DELAY_IN_MS", config.ProcessingDelayInMilliseconds);
             config.RunningAsIoTEdgeModule = !envVars.GetEnvVar("CLOUD_DEPLOYMENT", false);
             config.IoTHubHostName = envVars.GetEnvVar("IOTEDGE_IOTHUBHOSTNAME", string.Empty);
             config.GatewayHostName = envVars.GetEnvVar("IOTEDGE_GATEWAYHOSTNAME", string.Empty);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -135,7 +135,10 @@ namespace LoRaWan.NetworkServer
         /// </summary>
         public uint IotHubConnectionPoolSize { get; internal set; } = 1;
 
-        public int ProcessingDelayInMilliseconds { get; set; } = Constants.DefaultProcessingDelayInMilliseconds;
+        /// <summary>
+        /// Specifies the Processing Delay in Milliseconds
+        /// </summary>
+        public int ProcessingDelayInMilliseconds { get; set; }
 
         // Creates a new instance of NetworkServerConfiguration by reading values from environment variables
         public static NetworkServerConfiguration CreateFromEnvironmentVariables()
@@ -144,7 +147,7 @@ namespace LoRaWan.NetworkServer
 
             // Create case insensitive dictionary from environment variables
             var envVars = new CaseInsensitiveEnvironmentVariables(Environment.GetEnvironmentVariables());
-
+            config.ProcessingDelayInMilliseconds = envVars.GetEnvVar("PROCESSING_DELAY_IN_MS", Constants.DefaultProcessingDelayInMilliseconds);
             config.RunningAsIoTEdgeModule = !envVars.GetEnvVar("CLOUD_DEPLOYMENT", false);
             config.IoTHubHostName = envVars.GetEnvVar("IOTEDGE_IOTHUBHOSTNAME", string.Empty);
             config.GatewayHostName = envVars.GetEnvVar("IOTEDGE_GATEWAYHOSTNAME", string.Empty);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -151,11 +151,11 @@ namespace LoRaWan.NetworkServer
             config.RunningAsIoTEdgeModule = !envVars.GetEnvVar("CLOUD_DEPLOYMENT", false);
             config.IoTHubHostName = envVars.GetEnvVar("IOTEDGE_IOTHUBHOSTNAME", string.Empty);
             config.GatewayHostName = envVars.GetEnvVar("IOTEDGE_GATEWAYHOSTNAME", string.Empty);
-            config.EnableGateway = envVars.GetEnvVar("ENABLE_GATEWAY", config.EnableGateway) is bool enable_gateway
-                                   && !config.RunningAsIoTEdgeModule
-                                   && enable_gateway
-                                   ? throw new NotSupportedException("ENABLE_GATEWAY cannot be true if RunningAsIoTEdgeModule is false.")
-                                   : enable_gateway;
+            config.EnableGateway = envVars.GetEnvVar("ENABLE_GATEWAY", true);
+            if (!config.RunningAsIoTEdgeModule && config.EnableGateway)
+            {
+                throw new NotSupportedException("ENABLE_GATEWAY cannot be true if RunningAsIoTEdgeModule is false.");
+            }
             config.GatewayID = envVars.GetEnvVar("IOTEDGE_DEVICEID", string.Empty);
             config.HttpsProxy = envVars.GetEnvVar("HTTPS_PROXY", string.Empty);
             config.Rx2DataRate = envVars.GetEnvVar("RX2_DATR", -1) is var datrNum && (DataRateIndex)datrNum is var datr && Enum.IsDefined(datr) ? datr : null;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -145,7 +145,7 @@ namespace LoRaWan.NetworkServer
             // Create case insensitive dictionary from environment variables
             var envVars = new CaseInsensitiveEnvironmentVariables(Environment.GetEnvironmentVariables());
 
-            config.RunningAsIoTEdgeModule = !string.IsNullOrEmpty(envVars.GetEnvVar("IOTEDGE_APIVERSION", string.Empty));
+            config.RunningAsIoTEdgeModule = !envVars.GetEnvVar("CLOUD_DEPLOYMENT", false);
             config.IoTHubHostName = envVars.GetEnvVar("IOTEDGE_IOTHUBHOSTNAME", string.Empty);
             config.GatewayHostName = envVars.GetEnvVar("IOTEDGE_GATEWAYHOSTNAME", string.Empty);
             config.EnableGateway = envVars.GetEnvVar("ENABLE_GATEWAY", config.EnableGateway);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -148,7 +148,11 @@ namespace LoRaWan.NetworkServer
             config.RunningAsIoTEdgeModule = !envVars.GetEnvVar("CLOUD_DEPLOYMENT", false);
             config.IoTHubHostName = envVars.GetEnvVar("IOTEDGE_IOTHUBHOSTNAME", string.Empty);
             config.GatewayHostName = envVars.GetEnvVar("IOTEDGE_GATEWAYHOSTNAME", string.Empty);
-            config.EnableGateway = envVars.GetEnvVar("ENABLE_GATEWAY", config.EnableGateway);
+            config.EnableGateway = envVars.GetEnvVar("ENABLE_GATEWAY", config.EnableGateway) is bool enable_gateway
+                                   && !config.RunningAsIoTEdgeModule
+                                   && enable_gateway
+                                   ? throw new NotSupportedException("ENABLE_GATEWAY cannot be true if RunningAsIoTEdgeModule is false.")
+                                   : enable_gateway;
             config.GatewayID = envVars.GetEnvVar("IOTEDGE_DEVICEID", string.Empty);
             config.HttpsProxy = envVars.GetEnvVar("HTTPS_PROXY", string.Empty);
             config.Rx2DataRate = envVars.GetEnvVar("RX2_DATR", -1) is var datrNum && (DataRateIndex)datrNum is var datr && Enum.IsDefined(datr) ? datr : null;

--- a/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
+++ b/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
 {
     using System;
+    using LoRaWan.NetworkServer;
     using LoRaWan.NetworkServer.BasicsStation;
     using LoRaWan.NetworkServer.BasicsStation.ModuleConnection;
     using Microsoft.Extensions.Configuration;

--- a/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
+++ b/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
@@ -60,5 +60,33 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
                 Assert.NotNull(result);
             }
         }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void EnableGatewayTrue_IoTModuleFalse_IsNotSupported(bool cloud_deployment, bool enable_gateway)
+        {
+            // arrange
+            Environment.SetEnvironmentVariable("CLOUD_DEPLOYMENT", cloud_deployment.ToString());
+            Environment.SetEnvironmentVariable("ENABLE_GATEWAY", enable_gateway.ToString());
+            var services = new ServiceCollection();
+            var config = new ConfigurationBuilder().Build();
+
+            // act + assert
+            if (cloud_deployment && enable_gateway)
+            {
+                Assert.Throws<NotSupportedException>(() => {
+                    var startup = new BasicsStationNetworkServerStartup(config);
+                });
+            }
+            else
+            {
+                var startup = new BasicsStationNetworkServerStartup(config);
+                startup.ConfigureServices(services);
+            }
+
+        }
     }
 }

--- a/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
+++ b/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
@@ -4,7 +4,6 @@
 namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
 {
     using System;
-    using LoRaWan.NetworkServer;
     using LoRaWan.NetworkServer.BasicsStation;
     using LoRaWan.NetworkServer.BasicsStation.ModuleConnection;
     using Microsoft.Extensions.Configuration;
@@ -32,62 +31,46 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ModuleConnectionHostIsInjectedOrNot(bool cloud_deployment)
-        {
-            // arrange
-            Environment.SetEnvironmentVariable("CLOUD_DEPLOYMENT", cloud_deployment.ToString());
-            var services = new ServiceCollection();
-            var config = new ConfigurationBuilder().Build();
-
-            // act + assert
-            var startup = new BasicsStationNetworkServerStartup(config);
-            startup.ConfigureServices(services);
-
-            var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
-            {
-                ValidateOnBuild = true,
-                ValidateScopes = true
-            });
-
-            var result = serviceProvider.GetService<ModuleConnectionHost>();
-            if (cloud_deployment)
-            {
-                Assert.Null(result);
-            }
-            else
-            {
-                Assert.NotNull(result);
-            }
-        }
-
-        [Theory]
-        [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void EnableGatewayTrue_IoTModuleFalse_IsNotSupported(bool cloud_deployment, bool enable_gateway)
+        public void ModuleConnectionHostIsInjectedOrNot(bool cloud_deployment, bool enable_gateway)
         {
-            // arrange
-            Environment.SetEnvironmentVariable("CLOUD_DEPLOYMENT", cloud_deployment.ToString());
-            Environment.SetEnvironmentVariable("ENABLE_GATEWAY", enable_gateway.ToString());
-            var services = new ServiceCollection();
-            var config = new ConfigurationBuilder().Build();
+            var envVariables = new[] { ("CLOUD_DEPLOYMENT", cloud_deployment.ToString()), ("ENABLE_GATEWAY", enable_gateway.ToString()) };
 
-            // act + assert
-            if (cloud_deployment && enable_gateway)
+            try
             {
-                Assert.Throws<NotSupportedException>(() => {
-                    var startup = new BasicsStationNetworkServerStartup(config);
-                });
-            }
-            else
-            {
+                foreach (var (key, value) in envVariables)
+                    Environment.SetEnvironmentVariable(key, value);
+
+                var services = new ServiceCollection();
+                var config = new ConfigurationBuilder().Build();
+
+                // act + assert
                 var startup = new BasicsStationNetworkServerStartup(config);
                 startup.ConfigureServices(services);
-            }
 
+                var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
+                {
+                    ValidateOnBuild = true,
+                    ValidateScopes = true
+                });
+
+                var result = serviceProvider.GetService<ModuleConnectionHost>();
+                if (cloud_deployment)
+                {
+                    Assert.Null(result);
+                }
+                else
+                {
+                    Assert.NotNull(result);
+                }
+
+            }
+            finally
+            {
+                foreach (var (key, _) in envVariables)
+                    Environment.SetEnvironmentVariable(key, string.Empty);
+            }
         }
     }
 }

--- a/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
+++ b/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
@@ -3,7 +3,9 @@
 
 namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
 {
+    using System;
     using LoRaWan.NetworkServer.BasicsStation;
+    using LoRaWan.NetworkServer.BasicsStation.ModuleConnection;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Xunit;
@@ -26,6 +28,37 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
                 ValidateOnBuild = true,
                 ValidateScopes = true
             });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ModuleConnectionHostIsInjectedOrNot(bool cloud_deployment)
+        {
+            // arrange
+            Environment.SetEnvironmentVariable("CLOUD_DEPLOYMENT", cloud_deployment.ToString());
+            var services = new ServiceCollection();
+            var config = new ConfigurationBuilder().Build();
+
+            // act + assert
+            var startup = new BasicsStationNetworkServerStartup(config);
+            startup.ConfigureServices(services);
+
+            var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
+            {
+                ValidateOnBuild = true,
+                ValidateScopes = true
+            });
+
+            var result = serviceProvider.GetService<ModuleConnectionHost>();
+            if (cloud_deployment)
+            {
+                Assert.Null(result);
+            }
+            else
+            {
+                Assert.NotNull(result);
+            }
         }
     }
 }

--- a/Tests/Unit/NetworkServer/ConfigurationTest.cs
+++ b/Tests/Unit/NetworkServer/ConfigurationTest.cs
@@ -5,7 +5,10 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 {
     using System;
     using LoRaWan.NetworkServer;
+    using LoRaWan.NetworkServer.BasicsStation;
     using LoRaWan.Tests.Common;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
     using Xunit;
 
     public class ConfigurationTest
@@ -39,6 +42,37 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             TheoryDataFactory.From(("0228B1B1;", new[] { new DevAddr(0x0228b1b1) }),
                                    ("0228B1B1;0228B1B2", new DevAddr[] { new DevAddr(0x0228b1b1), new DevAddr(0x0228b1b2) }),
                                    ("ads;0228B1B2;", new DevAddr[] { new DevAddr(0x0228b1b2) }));
+        [Theory]
+        [CombinatorialData]
+        public void EnableGatewayTrue_IoTModuleFalse_IsNotSupported(bool cloud_deployment, bool enable_gateway)
+        {
+            var envVariables = new[] { ("CLOUD_DEPLOYMENT", cloud_deployment.ToString()), ("ENABLE_GATEWAY", enable_gateway.ToString()) };
+
+            try
+            {
+                foreach (var (key, value) in envVariables)
+                    Environment.SetEnvironmentVariable(key, value);
+
+
+
+                if (cloud_deployment && enable_gateway)
+                {
+                    Assert.Throws<NotSupportedException>(() => {
+                        var networkServerConfiguration = NetworkServerConfiguration.CreateFromEnvironmentVariables();
+                    });
+                }
+                else
+                {
+                    var networkServerConfiguration = NetworkServerConfiguration.CreateFromEnvironmentVariables();
+                }
+            }
+            finally
+            {
+                foreach (var (key, _) in envVariables)
+                    Environment.SetEnvironmentVariable(key, string.Empty);
+            }
+        }
+
         [Theory]
         [InlineData("500")]
         [InlineData("x")]

--- a/Tests/Unit/NetworkServer/ConfigurationTest.cs
+++ b/Tests/Unit/NetworkServer/ConfigurationTest.cs
@@ -39,5 +39,31 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             TheoryDataFactory.From(("0228B1B1;", new[] { new DevAddr(0x0228b1b1) }),
                                    ("0228B1B1;0228B1B2", new DevAddr[] { new DevAddr(0x0228b1b1), new DevAddr(0x0228b1b2) }),
                                    ("ads;0228B1B2;", new DevAddr[] { new DevAddr(0x0228b1b2) }));
+        [Theory]
+        [InlineData("500")]
+        [InlineData("x")]
+        public void ProcessingDelayIsConfigurable(string processing_delay)
+        {
+            var envVariables = new[] { ("PROCESSING_DELAY_IN_MS", processing_delay) };
+
+            try
+            {
+                foreach (var (key, value) in envVariables)
+                    Environment.SetEnvironmentVariable(key, value);
+
+                var networkServerConfiguration = NetworkServerConfiguration.CreateFromEnvironmentVariables();
+
+                if (!int.TryParse(processing_delay, out var int_processing_delay))
+                {
+                    int_processing_delay = Constants.DefaultProcessingDelayInMilliseconds;
+                }
+                Assert.Equal(int_processing_delay, networkServerConfiguration.ProcessingDelayInMilliseconds);
+            }
+            finally
+            {
+                foreach (var (key, _) in envVariables)
+                    Environment.SetEnvironmentVariable(key, string.Empty);
+            }
+        }
     }
 }

--- a/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
+++ b/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
@@ -34,7 +34,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
         public ModuleConnectionHostTest()
         {
-            this.networkServerConfiguration = new NetworkServerConfiguration();
+            this.networkServerConfiguration = NetworkServerConfiguration.CreateFromEnvironmentVariables();
             this.loRaModuleClient.Setup(x => x.DisposeAsync());
             this.loRaModuleClientFactory.Setup(x => x.CreateAsync()).ReturnsAsync(loRaModuleClient.Object);
             this.lnsRemoteCall = new Mock<ILnsRemoteCall>();


### PR DESCRIPTION
# PR for issues #1627 #1628 #1629 

## What is being addressed

- Introduce CLOUD_DEPLOYMENT environment variable
- When not running as Edge module, ENABLE_GATEWAY can't be set to true
- Make ProcessingDelayInMilliseconds configurable from environment variables

## How is this addressed

- Added and modified environment variables with accompanying unit tests.
