### PR TITLE
Redis subscriber implementation

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -81,7 +81,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         .AddApiClient(NetworkServerConfiguration, ApiVersion.LatestVersion)
                         .AddSingleton(NetworkServerConfiguration)
                         .AddSingleton<ModuleConnectionHost>()
-                        .AddSingleton<ILnsRemoteHandler, LnsRemoteCallHandler>()
+                        .AddSingleton<ILnsRemoteCallHandler, LnsRemoteCallHandler>()
                         .AddSingleton<ILoRaDeviceFrameCounterUpdateStrategyProvider, LoRaDeviceFrameCounterUpdateStrategyProvider>()
                         .AddSingleton<IDeduplicationStrategyFactory, DeduplicationStrategyFactory>()
                         .AddSingleton<ILoRaADRStrategyProvider, LoRaADRStrategyProvider>()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/BasicsStationNetworkServerStartup.cs
@@ -14,6 +14,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
     using LoRaTools.CommonAPI;
     using LoRaTools.NetworkServerDiscovery;
     using LoRaWan;
+    using LoRaWan.NetworkServer;
     using LoRaWan.NetworkServer.ADR;
     using LoRaWan.NetworkServer.BasicsStation.ModuleConnection;
     using LoRaWan.NetworkServer.BasicsStation.Processors;
@@ -80,7 +81,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
                         .AddApiClient(NetworkServerConfiguration, ApiVersion.LatestVersion)
                         .AddSingleton(NetworkServerConfiguration)
                         .AddSingleton<ModuleConnectionHost>()
-                        .AddSingleton<ILnsRemoteCall, LnsRemoteCall>()
+                        .AddSingleton<ILnsRemoteHandler, LnsRemoteCallHandler>()
                         .AddSingleton<ILoRaDeviceFrameCounterUpdateStrategyProvider, LoRaDeviceFrameCounterUpdateStrategyProvider>()
                         .AddSingleton<IDeduplicationStrategyFactory, DeduplicationStrategyFactory>()
                         .AddSingleton<ILoRaADRStrategyProvider, LoRaADRStrategyProvider>()

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
@@ -20,7 +20,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
         private const string LnsVersionPropertyName = "LnsVersion";
         private readonly NetworkServerConfiguration networkServerConfiguration;
         private readonly LoRaDeviceAPIServiceBase loRaDeviceAPIService;
-        private readonly ILnsRemoteHandler lnsRemoteCaller;
+        private readonly ILnsRemoteHandler lnsRemoteHandler;
         private readonly ILogger<ModuleConnectionHost> logger;
         private readonly Counter<int> unhandledExceptionCount;
         private ILoraModuleClient loRaModuleClient;
@@ -30,13 +30,13 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
             NetworkServerConfiguration networkServerConfiguration,
             ILoRaModuleClientFactory loRaModuleClientFactory,
             LoRaDeviceAPIServiceBase loRaDeviceAPIService,
-            ILnsRemoteHandler lnsRemoteCaller,
+            ILnsRemoteHandler lnsRemoteHandler,
             ILogger<ModuleConnectionHost> logger,
             Meter meter)
         {
             this.networkServerConfiguration = networkServerConfiguration ?? throw new ArgumentNullException(nameof(networkServerConfiguration));
             this.loRaDeviceAPIService = loRaDeviceAPIService ?? throw new ArgumentNullException(nameof(loRaDeviceAPIService));
-            this.lnsRemoteCaller = lnsRemoteCaller ?? throw new ArgumentNullException(nameof(lnsRemoteCaller));
+            this.lnsRemoteHandler = lnsRemoteHandler ?? throw new ArgumentNullException(nameof(lnsRemoteHandler));
             this.loRaModuleClientFactory = loRaModuleClientFactory ?? throw new ArgumentNullException(nameof(loRaModuleClientFactory));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.unhandledExceptionCount = (meter ?? throw new ArgumentNullException(nameof(meter))).CreateCounter<int>(MetricRegistry.UnhandledExceptions);
@@ -110,7 +110,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
                     throw new LoRaProcessingException($"Unknown direct method called: {methodRequest.Name}");
                 }
 
-                var statusCode = await lnsRemoteCaller.ExecuteAsync(lnsRemoteCall, token);
+                var statusCode = await lnsRemoteHandler.ExecuteAsync(lnsRemoteCall, token);
                 return new MethodResponse((int)statusCode);
             }
             catch (Exception ex) when (ExceptionFilterUtility.False(() => this.logger.LogError(ex, $"An exception occurred on a direct method call: {ex}"),

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/BasicsStation/ModuleConnection/ModuleConnectionHost.cs
@@ -20,7 +20,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
         private const string LnsVersionPropertyName = "LnsVersion";
         private readonly NetworkServerConfiguration networkServerConfiguration;
         private readonly LoRaDeviceAPIServiceBase loRaDeviceAPIService;
-        private readonly ILnsRemoteHandler lnsRemoteHandler;
+        private readonly ILnsRemoteCallHandler lnsRemoteCallHandler;
         private readonly ILogger<ModuleConnectionHost> logger;
         private readonly Counter<int> unhandledExceptionCount;
         private ILoraModuleClient loRaModuleClient;
@@ -30,13 +30,13 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
             NetworkServerConfiguration networkServerConfiguration,
             ILoRaModuleClientFactory loRaModuleClientFactory,
             LoRaDeviceAPIServiceBase loRaDeviceAPIService,
-            ILnsRemoteHandler lnsRemoteHandler,
+            ILnsRemoteCallHandler lnsRemoteCallHandler,
             ILogger<ModuleConnectionHost> logger,
             Meter meter)
         {
             this.networkServerConfiguration = networkServerConfiguration ?? throw new ArgumentNullException(nameof(networkServerConfiguration));
             this.loRaDeviceAPIService = loRaDeviceAPIService ?? throw new ArgumentNullException(nameof(loRaDeviceAPIService));
-            this.lnsRemoteHandler = lnsRemoteHandler ?? throw new ArgumentNullException(nameof(lnsRemoteHandler));
+            this.lnsRemoteCallHandler = lnsRemoteCallHandler ?? throw new ArgumentNullException(nameof(lnsRemoteCallHandler));
             this.loRaModuleClientFactory = loRaModuleClientFactory ?? throw new ArgumentNullException(nameof(loRaModuleClientFactory));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.unhandledExceptionCount = (meter ?? throw new ArgumentNullException(nameof(meter))).CreateCounter<int>(MetricRegistry.UnhandledExceptions);
@@ -110,7 +110,7 @@ namespace LoRaWan.NetworkServer.BasicsStation.ModuleConnection
                     throw new LoRaProcessingException($"Unknown direct method called: {methodRequest.Name}");
                 }
 
-                var statusCode = await lnsRemoteHandler.ExecuteAsync(lnsRemoteCall, token);
+                var statusCode = await lnsRemoteCallHandler.ExecuteAsync(lnsRemoteCall, token);
                 return new MethodResponse((int)statusCode);
             }
             catch (Exception ex) when (ExceptionFilterUtility.False(() => this.logger.LogError(ex, $"An exception occurred on a direct method call: {ex}"),

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCall.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCall.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaWan.NetworkServer
+{
+    internal sealed record LnsRemoteCall(RemoteCallKind Kind, string? JsonData);
+
+    internal enum RemoteCallKind
+    {
+        CloudToDeviceMessage,
+        ClearCache,
+        CloseConnection
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCallHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCallHandler.cs
@@ -11,12 +11,12 @@ namespace LoRaWan.NetworkServer
     using LoRaTools;
     using Microsoft.Extensions.Logging;
 
-    internal interface ILnsRemoteHandler
+    internal interface ILnsRemoteCallHandler
     {
         Task<HttpStatusCode> ExecuteAsync(LnsRemoteCall lnsRemoteCall, CancellationToken cancellationToken);
     }
 
-    internal sealed class LnsRemoteCallHandler : ILnsRemoteHandler
+    internal sealed class LnsRemoteCallHandler : ILnsRemoteCallHandler
     {
         internal const string ClosedConnectionLog = "Device connection was closed ";
         private static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCallListener.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCallListener.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 namespace LoRaWan.NetworkServer
 {
     using System;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCallListener.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCallListener.cs
@@ -4,12 +4,13 @@
 namespace LoRaWan.NetworkServer
 {
     using System;
+    using System.Text.Json;
     using System.Threading.Tasks;
     using StackExchange.Redis;
 
     internal interface ILnsRemoteCallListener
     {
-        void Subscribe(string lns, Func<string, Task> function);
+        void Subscribe(string lns, Func<LnsRemoteCall, Task> function);
     }
 
     internal sealed class RedisRemoteCallListener : ILnsRemoteCallListener
@@ -21,9 +22,10 @@ namespace LoRaWan.NetworkServer
             this.redis = redis;
         }
 
-        public void Subscribe(string lns, Func<string, Task> function)
+        public void Subscribe(string lns, Func<LnsRemoteCall, Task> function)
         {
-            this.redis.GetSubscriber().Subscribe(lns).OnMessage(value => function(value.Message));
+            this.redis.GetSubscriber().Subscribe(lns).OnMessage(value =>
+                function(JsonSerializer.Deserialize<LnsRemoteCall>(value.Message)));
         }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCallListener.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCallListener.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.NetworkServer
+{
+    using System;
+    using System.Threading.Tasks;
+    using StackExchange.Redis;
+
+    internal interface ILnsRemoteCallListener
+    {
+        void Subscribe(string lns, Func<string, Task> function);
+    }
+
+    internal sealed class RedisRemoteCallListener : ILnsRemoteCallListener
+    {
+        private readonly ConnectionMultiplexer redis;
+
+        public RedisRemoteCallListener(ConnectionMultiplexer redis)
+        {
+            this.redis = redis;
+        }
+
+        public void Subscribe(string lns, Func<string, Task> function)
+        {
+            this.redis.GetSubscriber().Subscribe(lns).OnMessage(value => function(value.Message));
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCaller.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/LnsRemoteCaller.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace LoRaWan.NetworkServer.BasicsStation
+namespace LoRaWan.NetworkServer
 {
     using System.Diagnostics.Metrics;
     using System.Net;
@@ -11,14 +11,12 @@ namespace LoRaWan.NetworkServer.BasicsStation
     using LoRaTools;
     using Microsoft.Extensions.Logging;
 
-    internal interface ILnsRemoteCall
+    internal interface ILnsRemoteHandler
     {
-        Task<HttpStatusCode> ClearCacheAsync();
-        Task<HttpStatusCode> CloseConnectionAsync(string json, CancellationToken cancellationToken);
-        Task<HttpStatusCode> SendCloudToDeviceMessageAsync(string json, CancellationToken cancellationToken);
+        Task<HttpStatusCode> ExecuteAsync(LnsRemoteCall lnsRemoteCall, CancellationToken cancellationToken);
     }
 
-    internal sealed class LnsRemoteCall : ILnsRemoteCall
+    internal sealed class LnsRemoteCallHandler : ILnsRemoteHandler
     {
         internal const string ClosedConnectionLog = "Device connection was closed ";
         private static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
@@ -26,14 +24,14 @@ namespace LoRaWan.NetworkServer.BasicsStation
         private readonly NetworkServerConfiguration networkServerConfiguration;
         private readonly IClassCDeviceMessageSender classCDeviceMessageSender;
         private readonly ILoRaDeviceRegistry loRaDeviceRegistry;
-        private readonly ILogger<LnsRemoteCall> logger;
+        private readonly ILogger<LnsRemoteCallHandler> logger;
         private readonly Counter<int> forceClosedConnections;
 
-        public LnsRemoteCall(NetworkServerConfiguration networkServerConfiguration,
-                            IClassCDeviceMessageSender classCDeviceMessageSender,
-                            ILoRaDeviceRegistry loRaDeviceRegistry,
-                            ILogger<LnsRemoteCall> logger,
-                            Meter meter)
+        public LnsRemoteCallHandler(NetworkServerConfiguration networkServerConfiguration,
+                                    IClassCDeviceMessageSender classCDeviceMessageSender,
+                                    ILoRaDeviceRegistry loRaDeviceRegistry,
+                                    ILogger<LnsRemoteCallHandler> logger,
+                                    Meter meter)
         {
             this.networkServerConfiguration = networkServerConfiguration;
             this.classCDeviceMessageSender = classCDeviceMessageSender;
@@ -42,7 +40,18 @@ namespace LoRaWan.NetworkServer.BasicsStation
             this.forceClosedConnections = meter.CreateCounter<int>(MetricRegistry.ForceClosedClientConnections);
         }
 
-        public async Task<HttpStatusCode> SendCloudToDeviceMessageAsync(string json, CancellationToken cancellationToken)
+        public Task<HttpStatusCode> ExecuteAsync(LnsRemoteCall lnsRemoteCall, CancellationToken cancellationToken)
+        {
+            return lnsRemoteCall.Kind switch
+            {
+                RemoteCallKind.CloudToDeviceMessage => SendCloudToDeviceMessageAsync(lnsRemoteCall.JsonData, cancellationToken),
+                RemoteCallKind.ClearCache => ClearCacheAsync(),
+                RemoteCallKind.CloseConnection => CloseConnectionAsync(lnsRemoteCall.JsonData, cancellationToken),
+                _ => throw new System.NotImplementedException(),
+            };
+        }
+
+        private async Task<HttpStatusCode> SendCloudToDeviceMessageAsync(string json, CancellationToken cancellationToken)
         {
             if (!string.IsNullOrEmpty(json))
             {
@@ -62,15 +71,13 @@ namespace LoRaWan.NetworkServer.BasicsStation
                 this.logger.LogDebug($"received cloud to device message from direct method: {json}");
 
                 if (await this.classCDeviceMessageSender.SendAsync(c2d, cancellationToken))
-                {
                     return HttpStatusCode.OK;
-                }
             }
 
             return HttpStatusCode.BadRequest;
         }
 
-        public async Task<HttpStatusCode> CloseConnectionAsync(string json, CancellationToken cancellationToken)
+        private async Task<HttpStatusCode> CloseConnectionAsync(string json, CancellationToken cancellationToken)
         {
             ReceivedLoRaCloudToDeviceMessage c2d;
 
@@ -114,7 +121,7 @@ namespace LoRaWan.NetworkServer.BasicsStation
             return HttpStatusCode.OK;
         }
 
-        public async Task<HttpStatusCode> ClearCacheAsync()
+        private async Task<HttpStatusCode> ClearCacheAsync()
         {
             await this.loRaDeviceRegistry.ResetDeviceCacheAsync();
             return HttpStatusCode.OK;

--- a/Tests/Integration/RedisFixture.cs
+++ b/Tests/Integration/RedisFixture.cs
@@ -27,11 +27,10 @@ namespace LoRaWan.Tests.Integration
         private const int RedisPort = 6001;
         private static readonly string TestContainerName = ContainerName + RedisPort;
 
-        private ConnectionMultiplexer redis;
-
         private string containerId;
 
         public IDatabase Database { get; set; }
+        public ConnectionMultiplexer Redis { get; set; }
 
         private async Task StartRedisContainer()
         {
@@ -127,8 +126,8 @@ namespace LoRaWan.Tests.Integration
             var redisConnectionString = $"localhost:{RedisPort}";
             try
             {
-                this.redis = await ConnectionMultiplexer.ConnectAsync(redisConnectionString);
-                Database = this.redis.GetDatabase();
+                this.Redis = await ConnectionMultiplexer.ConnectAsync(redisConnectionString);
+                Database = this.Redis.GetDatabase();
             }
             catch (Exception ex)
             {
@@ -157,8 +156,8 @@ namespace LoRaWan.Tests.Integration
                 }
             }
 
-            this.redis?.Dispose();
-            this.redis = null;
+            this.Redis?.Dispose();
+            this.Redis = null;
         }
     }
 }

--- a/Tests/Integration/RedisRemoteCallListenerTests.cs
+++ b/Tests/Integration/RedisRemoteCallListenerTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Integration
+{
+    using System;
+    using System.Threading.Tasks;
+    using LoRaWan.NetworkServer;
+    using Moq;
+    using StackExchange.Redis;
+    using Xunit;
+
+    [Collection(RedisFixture.CollectionName)]
+    public sealed class RedisRemoteCallListenerTests : IClassFixture<RedisFixture>
+    {
+        private readonly ConnectionMultiplexer redis;
+        private readonly RedisRemoteCallListener subject;
+
+        public RedisRemoteCallListenerTests(RedisFixture redisFixture)
+        {
+            this.redis = redisFixture.Redis;
+            this.subject = new RedisRemoteCallListener(this.redis);
+        }
+
+        [Fact]
+        public async Task Subscribe_Rceives_Message()
+        {
+            // arrange
+            var lnsName = "some-lns";
+            var message = "somemessage";
+            var function = new Mock<Func<string, Task>>();
+
+            // act
+            this.subject.Subscribe(lnsName, function.Object);
+            await PublishAsync(lnsName, message);
+
+            // assert
+            function.Verify(a => a.Invoke(message), Times.Once);
+        }
+
+        [Fact]
+        public async Task Subscribe_On_Different_Channel_Does_Not_Receive_Message()
+        {
+            // arrange
+            var function = new Mock<Func<string, Task>>();
+
+            // act
+            this.subject.Subscribe("lns-1", function.Object);
+            await PublishAsync("lns-2", string.Empty);
+
+            // assert
+            function.Verify(a => a.Invoke(It.IsAny<string>()), Times.Never);
+        }
+
+        private async Task PublishAsync(string channel, string message)
+        {
+            await this.redis.GetSubscriber().PublishAsync(channel, message);
+        }
+    }
+}

--- a/Tests/Integration/RedisRemoteCallListenerTests.cs
+++ b/Tests/Integration/RedisRemoteCallListenerTests.cs
@@ -24,7 +24,7 @@ namespace LoRaWan.Tests.Integration
         }
 
         [Fact]
-        public async Task Subscribe_Rceives_Message()
+        public async Task Subscribe_Receives_Message()
         {
             // arrange
             var lnsName = "some-lns";

--- a/Tests/Simulation/SimulatedLoadTests.cs
+++ b/Tests/Simulation/SimulatedLoadTests.cs
@@ -22,7 +22,6 @@ namespace LoRaWan.Tests.Simulation
     using static MoreLinq.Extensions.RepeatExtension;
     using static MoreLinq.Extensions.IndexExtension;
     using static MoreLinq.Extensions.TransposeExtension;
-    using LoRaWan.NetworkServer.BasicsStation;
 
     [Trait("Category", "SkipWhenLiveUnitTesting")]
     public sealed class SimulatedLoadTests : IntegrationTestBaseSim, IAsyncLifetime
@@ -101,7 +100,7 @@ namespace LoRaWan.Tests.Simulation
 
             await Task.Delay(messagesToSendEachLNS * IntervalBetweenMessages);
             _ = await TestFixture.AssertNetworkServerModuleLogExistsAsync(
-                x => !x.Contains(LnsRemoteCall.ClosedConnectionLog, StringComparison.Ordinal),
+                x => !x.Contains(LnsRemoteCallHandler.ClosedConnectionLog, StringComparison.Ordinal),
                 new SearchLogOptions("No connection switch should be logged") { TreatAsError = true });
 
             // act: change basics station that the device is listened from and therefore the gateway it uses as well
@@ -111,8 +110,8 @@ namespace LoRaWan.Tests.Simulation
             // assert
             var expectedLnsToDropConnection = Configuration.LnsEndpointsForSimulator.First().Key;
             _ = await TestFixture.AssertNetworkServerModuleLogExistsAsync(
-                x => x.Contains(LnsRemoteCall.ClosedConnectionLog, StringComparison.Ordinal) && x.Contains(expectedLnsToDropConnection, StringComparison.Ordinal),
-                new SearchLogOptions($"{LnsRemoteCall.ClosedConnectionLog} and {expectedLnsToDropConnection}") { TreatAsError = true });
+                x => x.Contains(LnsRemoteCallHandler.ClosedConnectionLog, StringComparison.Ordinal) && x.Contains(expectedLnsToDropConnection, StringComparison.Ordinal),
+                new SearchLogOptions($"{LnsRemoteCallHandler.ClosedConnectionLog} and {expectedLnsToDropConnection}") { TreatAsError = true });
             await AssertIotHubMessageCountAsync(simulatedDevice, messagesToSendEachLNS * 2);
         }
 

--- a/Tests/Unit/NetworkServer/LnsRemoteCallTests.cs
+++ b/Tests/Unit/NetworkServer/LnsRemoteCallTests.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaWan.Tests.Unit.NetworkServer
+{
+    using System.Text.Json;
+    using LoRaWan.NetworkServer;
+    using Xunit;
+
+    public sealed class LnsRemoteCallTests
+    {
+        [Fact]
+        public void Serialization_And_Deserialization_Preserves_Information()
+        {
+            // arrange
+            var subject = new LnsRemoteCall(RemoteCallKind.CloudToDeviceMessage, "somepayload");
+
+            // act
+            var result = JsonSerializer.Deserialize<LnsRemoteCall>(JsonSerializer.Serialize(subject));
+
+            // assert
+            Assert.Equal(subject, result);
+        }
+    }
+}

--- a/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
+++ b/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
@@ -28,7 +28,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         private readonly Mock<ILoraModuleClient> loRaModuleClient = new();
         private readonly LoRaDeviceAPIServiceBase loRaDeviceApiServiceBase = Mock.Of<LoRaDeviceAPIServiceBase>();
         private readonly Faker faker = new Faker();
-        private readonly Mock<ILnsRemoteHandler> lnsRemoteCall;
+        private readonly Mock<ILnsRemoteCallHandler> lnsRemoteCall;
         private readonly ModuleConnectionHost subject;
 
         public ModuleConnectionHostTest()
@@ -36,7 +36,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             this.networkServerConfiguration = new NetworkServerConfiguration();
             this.loRaModuleClient.Setup(x => x.DisposeAsync());
             this.loRaModuleClientFactory.Setup(x => x.CreateAsync()).ReturnsAsync(loRaModuleClient.Object);
-            this.lnsRemoteCall = new Mock<ILnsRemoteHandler>();
+            this.lnsRemoteCall = new Mock<ILnsRemoteCallHandler>();
             this.subject = new ModuleConnectionHost(this.networkServerConfiguration,
                                                     this.loRaModuleClientFactory.Object,
                                                     this.loRaDeviceApiServiceBase,
@@ -57,7 +57,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, this.loRaModuleClientFactory.Object, null, this.lnsRemoteCall.Object, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance));
             Assert.Equal("loRaDeviceAPIService", ex.ParamName);
             ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, this.loRaModuleClientFactory.Object, this.loRaDeviceApiServiceBase, null, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance));
-            Assert.Equal("lnsRemoteHandler", ex.ParamName);
+            Assert.Equal("lnsRemoteCallHandler", ex.ParamName);
         }
 
         [Fact]

--- a/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
+++ b/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
@@ -5,7 +5,6 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 {
     using Bogus;
     using LoRaWan.NetworkServer;
-    using LoRaWan.NetworkServer.BasicsStation;
     using LoRaWan.NetworkServer.BasicsStation.ModuleConnection;
     using LoRaWan.Tests.Common;
     using Microsoft.Azure.Devices.Client;
@@ -29,7 +28,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         private readonly Mock<ILoraModuleClient> loRaModuleClient = new();
         private readonly LoRaDeviceAPIServiceBase loRaDeviceApiServiceBase = Mock.Of<LoRaDeviceAPIServiceBase>();
         private readonly Faker faker = new Faker();
-        private readonly Mock<ILnsRemoteCall> lnsRemoteCall;
+        private readonly Mock<ILnsRemoteHandler> lnsRemoteCall;
         private readonly ModuleConnectionHost subject;
 
         public ModuleConnectionHostTest()
@@ -37,7 +36,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             this.networkServerConfiguration = new NetworkServerConfiguration();
             this.loRaModuleClient.Setup(x => x.DisposeAsync());
             this.loRaModuleClientFactory.Setup(x => x.CreateAsync()).ReturnsAsync(loRaModuleClient.Object);
-            this.lnsRemoteCall = new Mock<ILnsRemoteCall>();
+            this.lnsRemoteCall = new Mock<ILnsRemoteHandler>();
             this.subject = new ModuleConnectionHost(this.networkServerConfiguration,
                                                     this.loRaModuleClientFactory.Object,
                                                     this.loRaDeviceApiServiceBase,
@@ -58,7 +57,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, this.loRaModuleClientFactory.Object, null, this.lnsRemoteCall.Object, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance));
             Assert.Equal("loRaDeviceAPIService", ex.ParamName);
             ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, this.loRaModuleClientFactory.Object, this.loRaDeviceApiServiceBase, null, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance));
-            Assert.Equal("lnsRemoteCall", ex.ParamName);
+            Assert.Equal("lnsRemoteCaller", ex.ParamName);
         }
 
         [Fact]
@@ -231,7 +230,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         public async Task OnDirectMethodCall_Should_Invoke_ClearCache()
         {
             await this.subject.OnDirectMethodCalled(new MethodRequest(Constants.CloudToDeviceClearCache), null);
-            this.lnsRemoteCall.Verify(l => l.ClearCacheAsync(), Times.Once);
+            this.lnsRemoteCall.Verify(l => l.ExecuteAsync(new LnsRemoteCall(RemoteCallKind.ClearCache, null), CancellationToken.None), Times.Once);
         }
 
         [Fact]
@@ -245,7 +244,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             await this.subject.OnDirectMethodCalled(methodRequest, null);
 
             // assert
-            this.lnsRemoteCall.Verify(l => l.CloseConnectionAsync(json, CancellationToken.None), Times.Once);
+            this.lnsRemoteCall.Verify(l => l.ExecuteAsync(new LnsRemoteCall(RemoteCallKind.CloseConnection, json), CancellationToken.None), Times.Once);
         }
 
         [Fact]
@@ -259,7 +258,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var result = await this.subject.OnDirectMethodCalled(methodRequest, null);
 
             // assert
-            this.lnsRemoteCall.Verify(l => l.SendCloudToDeviceMessageAsync(json, CancellationToken.None), Times.Once);
+            this.lnsRemoteCall.Verify(l => l.ExecuteAsync(new LnsRemoteCall(RemoteCallKind.CloudToDeviceMessage, json), CancellationToken.None), Times.Once);
         }
 
         [Fact]

--- a/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
+++ b/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
@@ -57,7 +57,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, this.loRaModuleClientFactory.Object, null, this.lnsRemoteCall.Object, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance));
             Assert.Equal("loRaDeviceAPIService", ex.ParamName);
             ex = Assert.Throws<ArgumentNullException>(() => new ModuleConnectionHost(networkServerConfiguration, this.loRaModuleClientFactory.Object, this.loRaDeviceApiServiceBase, null, NullLogger<ModuleConnectionHost>.Instance, TestMeter.Instance));
-            Assert.Equal("lnsRemoteCaller", ex.ParamName);
+            Assert.Equal("lnsRemoteHandler", ex.ParamName);
         }
 
         [Fact]


### PR DESCRIPTION
# PR for issue #1636

## What is being addressed

With this PR we introduce a component that can subscribe to `LnsRemoteCall`s published on a Redis pub/sub channel.

## How this is handled

We introduce a shared class that represents a remote call, which can be transferred across the wire. In the future, there will be two paths to handle these `LnsRemoteCall`s - via direct methods or via a Redis channel subscription. We use a single channel per LNS for this PR, as Redis does not have a limit on pub/sub channels and this allows us to not need filter logic on the LNS side.