### PR TITLE
Providing alternatives to IOTEDGE_* environment variables

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -155,11 +155,7 @@ namespace LoRaWan.NetworkServer
             config.ProcessingDelayInMilliseconds = envVars.GetEnvVar("PROCESSING_DELAY_IN_MS", config.ProcessingDelayInMilliseconds);
             config.RunningAsIoTEdgeModule = !envVars.GetEnvVar("CLOUD_DEPLOYMENT", false);
 
-            var iotHubHostName = envVars.GetEnvVar("IOTEDGE_IOTHUBHOSTNAME", string.Empty);
-            if (string.IsNullOrEmpty(iotHubHostName))
-            {
-                iotHubHostName = envVars.GetEnvVar("IOTHUBHOSTNAME", string.Empty);
-            }
+            var iotHubHostName = envVars.GetEnvVar("IOTEDGE_IOTHUBHOSTNAME", envVars.GetEnvVar("IOTHUBHOSTNAME", string.Empty));
             config.IoTHubHostName = !string.IsNullOrEmpty(iotHubHostName) ? iotHubHostName : throw new InvalidOperationException("Either 'IOTEDGE_IOTHUBHOSTNAME' or 'IOTHUBHOSTNAME' environment variable should be populated");
 
             config.GatewayHostName = envVars.GetEnvVar("IOTEDGE_GATEWAYHOSTNAME", string.Empty);
@@ -169,11 +165,7 @@ namespace LoRaWan.NetworkServer
                 throw new NotSupportedException("ENABLE_GATEWAY cannot be true if RunningAsIoTEdgeModule is false.");
             }
 
-            var gatewayId = envVars.GetEnvVar("IOTEDGE_DEVICEID", string.Empty);
-            if (string.IsNullOrEmpty(gatewayId))
-            {
-                gatewayId = envVars.GetEnvVar("HOSTNAME", string.Empty);
-            }
+            var gatewayId = envVars.GetEnvVar("IOTEDGE_DEVICEID", envVars.GetEnvVar("HOSTNAME", string.Empty));
             config.GatewayID = !string.IsNullOrEmpty(gatewayId) ? gatewayId : throw new InvalidOperationException("Either 'IOTEDGE_DEVICEID' or 'HOSTNAME' environment variable should be populated");
 
             config.HttpsProxy = envVars.GetEnvVar("HTTPS_PROXY", string.Empty);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/NetworkServerConfiguration.cs
@@ -154,14 +154,28 @@ namespace LoRaWan.NetworkServer
             var envVars = new CaseInsensitiveEnvironmentVariables(Environment.GetEnvironmentVariables());
             config.ProcessingDelayInMilliseconds = envVars.GetEnvVar("PROCESSING_DELAY_IN_MS", config.ProcessingDelayInMilliseconds);
             config.RunningAsIoTEdgeModule = !envVars.GetEnvVar("CLOUD_DEPLOYMENT", false);
-            config.IoTHubHostName = envVars.GetEnvVar("IOTEDGE_IOTHUBHOSTNAME", string.Empty);
+
+            var iotHubHostName = envVars.GetEnvVar("IOTEDGE_IOTHUBHOSTNAME", string.Empty);
+            if (string.IsNullOrEmpty(iotHubHostName))
+            {
+                iotHubHostName = envVars.GetEnvVar("IOTHUBHOSTNAME", string.Empty);
+            }
+            config.IoTHubHostName = !string.IsNullOrEmpty(iotHubHostName) ? iotHubHostName : throw new InvalidOperationException("Either 'IOTEDGE_IOTHUBHOSTNAME' or 'IOTHUBHOSTNAME' environment variable should be populated");
+
             config.GatewayHostName = envVars.GetEnvVar("IOTEDGE_GATEWAYHOSTNAME", string.Empty);
             config.EnableGateway = envVars.GetEnvVar("ENABLE_GATEWAY", true);
             if (!config.RunningAsIoTEdgeModule && config.EnableGateway)
             {
                 throw new NotSupportedException("ENABLE_GATEWAY cannot be true if RunningAsIoTEdgeModule is false.");
             }
-            config.GatewayID = envVars.GetEnvVar("IOTEDGE_DEVICEID", string.Empty);
+
+            var gatewayId = envVars.GetEnvVar("IOTEDGE_DEVICEID", string.Empty);
+            if (string.IsNullOrEmpty(gatewayId))
+            {
+                gatewayId = envVars.GetEnvVar("HOSTNAME", string.Empty);
+            }
+            config.GatewayID = !string.IsNullOrEmpty(gatewayId) ? gatewayId : throw new InvalidOperationException("Either 'IOTEDGE_DEVICEID' or 'HOSTNAME' environment variable should be populated");
+
             config.HttpsProxy = envVars.GetEnvVar("HTTPS_PROXY", string.Empty);
             config.Rx2DataRate = envVars.GetEnvVar("RX2_DATR", -1) is var datrNum && (DataRateIndex)datrNum is var datr && Enum.IsDefined(datr) ? datr : null;
             config.Rx2Frequency = envVars.GetEnvVar("RX2_FREQ") is { } someFreq ? Hertz.Mega(someFreq) : null;

--- a/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
+++ b/Tests/Unit/NetworkServer/BasicsStation/BasicsStationNetworkServerStartupTests.cs
@@ -18,16 +18,33 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
             // arrange
             var services = new ServiceCollection();
             var config = new ConfigurationBuilder().Build();
-
-            // act + assert
-            var startup = new BasicsStationNetworkServerStartup(config);
-            startup.ConfigureServices(services);
-
-            services.BuildServiceProvider(new ServiceProviderOptions
+            var envVariables = new[]
             {
-                ValidateOnBuild = true,
-                ValidateScopes = true
-            });
+                ("HOSTNAME", "test"),
+                ("IOTHUBHOSTNAME", "test")
+            };
+
+            try
+            {
+                foreach (var (key, value) in envVariables)
+                    Environment.SetEnvironmentVariable(key, value);
+
+                // act + assert
+                var startup = new BasicsStationNetworkServerStartup(config);
+                startup.ConfigureServices(services);
+
+                services.BuildServiceProvider(new ServiceProviderOptions
+                {
+                    ValidateOnBuild = true,
+                    ValidateScopes = true
+                });
+
+            }
+            finally
+            {
+                foreach (var (key, _) in envVariables)
+                    Environment.SetEnvironmentVariable(key, string.Empty);
+            }
         }
 
         [Theory]
@@ -39,7 +56,9 @@ namespace LoRaWan.Tests.Unit.NetworkServer.BasicsStation
             {
                 ("CLOUD_DEPLOYMENT", cloud_deployment.ToString()),
                 ("ENABLE_GATEWAY", enable_gateway.ToString()),
-                ("REDIS_CONNECTION_STRING", "someString")
+                ("REDIS_CONNECTION_STRING", "someString"),
+                ("HOSTNAME", "test"),
+                ("IOTHUBHOSTNAME", "test")
             };
 
             try

--- a/Tests/Unit/NetworkServer/ConfigurationTest.cs
+++ b/Tests/Unit/NetworkServer/ConfigurationTest.cs
@@ -14,7 +14,13 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [MemberData(nameof(AllowedDevAddressesInput))]
         public void Should_Setup_Allowed_Dev_Addresses_Correctly(string inputAllowedDevAddrValues, DevAddr[] expectedAllowedDevAddrValues)
         {
-            var envVariables = new[] { ("AllowedDevAddresses", inputAllowedDevAddrValues), ("FACADE_SERVER_URL", "https://aka.ms") };
+            var envVariables = new[]
+            {
+                ("AllowedDevAddresses", inputAllowedDevAddrValues),
+                ("FACADE_SERVER_URL", "https://aka.ms"),
+                ("HOSTNAME", "test"),
+                ("IOTHUBHOSTNAME", "test")
+            };
 
             try
             {
@@ -47,6 +53,9 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             var key = "REDIS_CONNECTION_STRING";
             var value = "someValue";
             var lnsConfigurationCreation = () => NetworkServerConfiguration.CreateFromEnvironmentVariables();
+
+            Environment.SetEnvironmentVariable("HOSTNAME", "test");
+            Environment.SetEnvironmentVariable("IOTHUBHOSTNAME", "test");
 
             if (isCloudDeployment)
             {
@@ -86,7 +95,9 @@ namespace LoRaWan.Tests.Unit.NetworkServer
             {
                 ("CLOUD_DEPLOYMENT", cloud_deployment.ToString()),
                 ("ENABLE_GATEWAY", enable_gateway.ToString()),
-                ("REDIS_CONNECTION_STRING", "someString")
+                ("REDIS_CONNECTION_STRING", "someString"),
+                ("HOSTNAME", "test"),
+                ("IOTHUBHOSTNAME", "test")
             };
 
             try
@@ -117,7 +128,11 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [InlineData("x")]
         public void ProcessingDelayIsConfigurable(string processing_delay)
         {
-            var envVariables = new[] { ("PROCESSING_DELAY_IN_MS", processing_delay) };
+            var envVariables = new[]
+            {
+                ("PROCESSING_DELAY_IN_MS", processing_delay),
+                ("HOSTNAME", "test")
+            };
 
             try
             {

--- a/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
+++ b/Tests/Unit/NetworkServer/ModuleConnectionHostTest.cs
@@ -33,7 +33,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
         public ModuleConnectionHostTest()
         {
-            this.networkServerConfiguration = NetworkServerConfiguration.CreateFromEnvironmentVariables();
+            this.networkServerConfiguration = new NetworkServerConfiguration();
             this.loRaModuleClient.Setup(x => x.DisposeAsync());
             this.loRaModuleClientFactory.Setup(x => x.CreateAsync()).ReturnsAsync(loRaModuleClient.Object);
             this.lnsRemoteCall = new Mock<ILnsRemoteCallHandler>();


### PR DESCRIPTION
# PR for issue #1703 

## What is being addressed

As per #1703 
- [x] An alternative 'HOSTNAME' environment variable should be parsed instead of 'IOTEDGE_DEVICEID'
- [x] An alternative 'IOTHUBHOSTNAME' environment variable should be parsed instead of 'IOTEDGE_IOTHUBHOSTNAME'
- [x] Unit tests are provided