### PR TITLE
Handling alternative paths for direct method invocations from Azure Function

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
@@ -11,7 +11,7 @@ namespace LoraKeysManagerFacade
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Logging;
 
-    internal class EdgeDeviceGetter
+    internal class EdgeDeviceGetter : IEdgeDeviceGetter
     {
         private readonly IDeviceRegistryManager registryManager;
         private readonly ILoRaDeviceCacheStore cacheStore;

--- a/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
@@ -11,7 +11,7 @@ namespace LoraKeysManagerFacade
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Logging;
 
-    internal class EdgeDeviceGetter : IEdgeDeviceGetter
+    public class EdgeDeviceGetter : IEdgeDeviceGetter
     {
         private readonly IDeviceRegistryManager registryManager;
         private readonly ILoRaDeviceCacheStore cacheStore;
@@ -41,7 +41,7 @@ namespace LoraKeysManagerFacade
             return twins;
         }
 
-        internal async Task<bool> IsEdgeDeviceAsync(string lnsId, CancellationToken cancellationToken)
+        public async Task<bool> IsEdgeDeviceAsync(string lnsId, CancellationToken cancellationToken)
         {
             const string keyLock = $"{nameof(EdgeDeviceGetter)}-lock";
             const string owner = nameof(EdgeDeviceGetter);

--- a/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FacadeStartup.cs
@@ -61,7 +61,7 @@ namespace LoraKeysManagerFacade
                 .AddSingleton<CreateEdgeDevice>()
                 .AddSingleton<IChannelPublisher>(sp => new RedisChannelPublisher(redis, sp.GetRequiredService<ILogger<RedisChannelPublisher>>()))
                 .AddSingleton<DeviceGetter>()
-                .AddSingleton<EdgeDeviceGetter>()
+                .AddSingleton<IEdgeDeviceGetter, EdgeDeviceGetter>()
                 .AddSingleton<FCntCacheCheck>()
                 .AddSingleton<FunctionBundlerFunction>()
                 .AddSingleton<IFunctionBundlerExecutionItem, NextFCntDownExecutionItem>()

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/DeduplicationExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/DeduplicationExecutionItem.cs
@@ -4,7 +4,9 @@
 namespace LoraKeysManagerFacade.FunctionBundler
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
+    using LoRaTools;
     using LoRaTools.CommonAPI;
     using LoRaWan;
     using Microsoft.ApplicationInsights;
@@ -21,16 +23,21 @@ namespace LoraKeysManagerFacade.FunctionBundler
 
         private readonly ILoRaDeviceCacheStore cacheStore;
         private readonly IServiceClient serviceClient;
+        private readonly IEdgeDeviceGetter edgeDeviceGetter;
+        private readonly IChannelPublisher channelPublisher;
         private readonly Microsoft.ApplicationInsights.Metric connectionOwnershipChangedMetric;
 
         public DeduplicationExecutionItem(
             ILoRaDeviceCacheStore cacheStore,
             IServiceClient serviceClient,
+            IEdgeDeviceGetter edgeDeviceGetter,
+            IChannelPublisher channelPublisher,
             TelemetryConfiguration telemetryConfiguration)
         {
             this.cacheStore = cacheStore;
             this.serviceClient = serviceClient;
-
+            this.edgeDeviceGetter = edgeDeviceGetter;
+            this.channelPublisher = channelPublisher;
             var telemetryClient = new TelemetryClient(telemetryConfiguration);
             var metricIdentifier = new MetricIdentifier(LoraKeysManagerFacadeConstants.MetricNamespace, ConnectionOwnershipChangeMetricName);
             this.connectionOwnershipChangedMetric = telemetryClient.GetMetric(metricIdentifier);
@@ -59,6 +66,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
 
         internal async Task<DuplicateMsgResult> GetDuplicateMessageResultAsync(DevEui devEUI, string gatewayId, uint clientFCntUp, uint clientFCntDown, ILogger logger = null)
         {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             var isDuplicate = true;
             var processedDevice = gatewayId;
 
@@ -105,16 +113,26 @@ namespace LoraKeysManagerFacade.FunctionBundler
                                 };
 
                                 var method = new CloudToDeviceMethod(LoraKeysManagerFacadeConstants.CloudToDeviceCloseConnection, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
-                                _ = method.SetPayloadJson(JsonConvert.SerializeObject(loraC2DMessage));
+                                var jsonContents = JsonConvert.SerializeObject(loraC2DMessage);
+                                _ = method.SetPayloadJson(jsonContents);
 
                                 try
                                 {
-                                    var res = await this.serviceClient.InvokeDeviceMethodAsync(previousGateway, LoraKeysManagerFacadeConstants.NetworkServerModuleId, method);
-                                    logger?.LogDebug("Connection owner changed and direct method was called on previous gateway '{PreviousConnectionOwner}' to close connection; result is '{Status}'", previousGateway, res?.Status);
-
-                                    if (!HttpUtilities.IsSuccessStatusCode(res.Status))
+                                    if (await this.edgeDeviceGetter.IsEdgeDeviceAsync(previousGateway, cts.Token))
                                     {
-                                        logger?.LogError("Failed to invoke direct method on LNS '{PreviousConnectionOwner}' to close the connection for device '{DevEUI}'; status '{Status}'", previousGateway, devEUI, res?.Status);
+                                        var res = await this.serviceClient.InvokeDeviceMethodAsync(previousGateway, LoraKeysManagerFacadeConstants.NetworkServerModuleId, method);
+                                        logger?.LogDebug("Connection owner changed and direct method was called on previous gateway '{PreviousConnectionOwner}' to close connection; result is '{Status}'", previousGateway, res?.Status);
+
+                                        if (!HttpUtilities.IsSuccessStatusCode(res.Status))
+                                        {
+                                            logger?.LogError("Failed to invoke direct method on LNS '{PreviousConnectionOwner}' to close the connection for device '{DevEUI}'; status '{Status}'", previousGateway, devEUI, res?.Status);
+                                        }
+
+                                    }
+                                    else
+                                    {
+                                        await this.channelPublisher.PublishAsync(previousGateway, new LnsRemoteCall(RemoteCallKind.CloseConnection, jsonContents));
+                                        logger?.LogDebug("Connection owner changed and message was published to previous gateway '{PreviousConnectionOwner}' to close connection", previousGateway);
                                     }
                                 }
                                 catch (IotHubException ex)

--- a/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/DeduplicationExecutionItem.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/FunctionsBundler/DeduplicationExecutionItem.cs
@@ -27,6 +27,8 @@ namespace LoraKeysManagerFacade.FunctionBundler
         private readonly IChannelPublisher channelPublisher;
         private readonly Microsoft.ApplicationInsights.Metric connectionOwnershipChangedMetric;
 
+        private static readonly TimeSpan DuplicateMessageTimeout = TimeSpan.FromSeconds(30);
+
         public DeduplicationExecutionItem(
             ILoRaDeviceCacheStore cacheStore,
             IServiceClient serviceClient,
@@ -66,7 +68,7 @@ namespace LoraKeysManagerFacade.FunctionBundler
 
         internal async Task<DuplicateMsgResult> GetDuplicateMessageResultAsync(DevEui devEUI, string gatewayId, uint clientFCntUp, uint clientFCntDown, ILogger logger = null)
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cts = new CancellationTokenSource(DuplicateMessageTimeout);
             var isDuplicate = true;
             var processedDevice = gatewayId;
 

--- a/LoRaEngine/LoraKeysManagerFacade/IEdgeDeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/IEdgeDeviceGetter.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoraKeysManagerFacade
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal class IEdgeDeviceGetter
+    {
+        Task<bool> IsEdgeDeviceAsync(string lnsId, CancellationToken cancellationToken);
+    }
+}

--- a/LoRaEngine/LoraKeysManagerFacade/IEdgeDeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/IEdgeDeviceGetter.cs
@@ -6,8 +6,8 @@ namespace LoraKeysManagerFacade
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class IEdgeDeviceGetter
+    public interface IEdgeDeviceGetter
     {
-        Task<bool> IsEdgeDeviceAsync(string lnsId, CancellationToken cancellationToken);
+        public Task<bool> IsEdgeDeviceAsync(string lnsId, CancellationToken cancellationToken);
     }
 }

--- a/LoRaEngine/LoraKeysManagerFacade/IEdgeDeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/IEdgeDeviceGetter.cs
@@ -6,7 +6,7 @@ namespace LoraKeysManagerFacade
     using System.Threading;
     using System.Threading.Tasks;
 
-    internal class IEdgeDeviceGetter
+    public class IEdgeDeviceGetter
     {
         Task<bool> IsEdgeDeviceAsync(string lnsId, CancellationToken cancellationToken);
     }

--- a/LoRaEngine/LoraKeysManagerFacade/IEdgeDeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/IEdgeDeviceGetter.cs
@@ -8,6 +8,6 @@ namespace LoraKeysManagerFacade
 
     public interface IEdgeDeviceGetter
     {
-        public Task<bool> IsEdgeDeviceAsync(string lnsId, CancellationToken cancellationToken);
+        Task<bool> IsEdgeDeviceAsync(string lnsId, CancellationToken cancellationToken);
     }
 }

--- a/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
@@ -8,6 +8,7 @@ namespace LoraKeysManagerFacade
     using System.Linq;
     using System.Net;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using LoRaTools;
     using LoRaTools.CommonAPI;
@@ -33,20 +34,30 @@ namespace LoraKeysManagerFacade
         private readonly ILoRaDeviceCacheStore cacheStore;
         private readonly IDeviceRegistryManager registryManager;
         private readonly IServiceClient serviceClient;
+        private readonly IEdgeDeviceGetter edgeDeviceGetter;
+        private readonly IChannelPublisher channelPublisher;
         private readonly ILogger log;
 
-        public SendCloudToDeviceMessage(ILoRaDeviceCacheStore cacheStore, IDeviceRegistryManager registryManager, IServiceClient serviceClient, ILogger<SendCloudToDeviceMessage> log)
+        public SendCloudToDeviceMessage(ILoRaDeviceCacheStore cacheStore,
+                                        IDeviceRegistryManager registryManager,
+                                        IServiceClient serviceClient,
+                                        IEdgeDeviceGetter edgeDeviceGetter,
+                                        IChannelPublisher channelPublisher,
+                                        ILogger<SendCloudToDeviceMessage> log)
         {
             this.cacheStore = cacheStore;
             this.registryManager = registryManager;
             this.serviceClient = serviceClient;
+            this.edgeDeviceGetter = edgeDeviceGetter;
+            this.channelPublisher = channelPublisher;
             this.log = log;
         }
 
         [FunctionName("SendCloudToDeviceMessage")]
         public async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "cloudtodevicemessage/{devEUI}")] HttpRequest req,
-            string devEUI)
+            string devEUI,
+            CancellationToken cancellationToken)
         {
             DevEui parsedDevEui;
 
@@ -78,10 +89,10 @@ namespace LoraKeysManagerFacade
             var c2dMessage = JsonConvert.DeserializeObject<LoRaCloudToDeviceMessage>(requestBody);
             c2dMessage.DevEUI = parsedDevEui;
 
-            return await SendCloudToDeviceMessageImplementationAsync(parsedDevEui, c2dMessage);
+            return await SendCloudToDeviceMessageImplementationAsync(parsedDevEui, c2dMessage, cancellationToken);
         }
 
-        public async Task<IActionResult> SendCloudToDeviceMessageImplementationAsync(DevEui devEUI, LoRaCloudToDeviceMessage c2dMessage)
+        public async Task<IActionResult> SendCloudToDeviceMessageImplementationAsync(DevEui devEUI, LoRaCloudToDeviceMessage c2dMessage, CancellationToken cancellationToken)
         {
             if (c2dMessage == null)
             {
@@ -96,7 +107,7 @@ namespace LoraKeysManagerFacade
             var cachedPreferredGateway = LoRaDevicePreferredGateway.LoadFromCache(this.cacheStore, devEUI);
             if (cachedPreferredGateway != null && !string.IsNullOrEmpty(cachedPreferredGateway.GatewayID))
             {
-                return await SendMessageViaDirectMethodAsync(cachedPreferredGateway.GatewayID, devEUI, c2dMessage);
+                return await SendMessageViaDirectMethodOrPubSubAsync(cachedPreferredGateway.GatewayID, devEUI, c2dMessage, cancellationToken);
             }
 
             var queryText = $"SELECT * FROM devices WHERE deviceId = '{devEUI}'";
@@ -137,7 +148,7 @@ namespace LoraKeysManagerFacade
                             var preferredGateway = new LoRaDevicePreferredGateway(gatewayID, 0);
                             _ = LoRaDevicePreferredGateway.SaveToCache(this.cacheStore, devEUI, preferredGateway, onlyIfNotExists: true);
 
-                            return await SendMessageViaDirectMethodAsync(gatewayID, devEUI, c2dMessage);
+                            return await SendMessageViaDirectMethodOrPubSubAsync(gatewayID, devEUI, c2dMessage, cancellationToken);
                         }
 
                         // class c device that did not send a single upstream message
@@ -189,21 +200,44 @@ namespace LoraKeysManagerFacade
             }
         }
 
-        private async Task<IActionResult> SendMessageViaDirectMethodAsync(
+        private async Task<IActionResult> SendMessageViaDirectMethodOrPubSubAsync(
             string preferredGatewayID,
             DevEui devEUI,
-            LoRaCloudToDeviceMessage c2dMessage)
+            LoRaCloudToDeviceMessage c2dMessage,
+            CancellationToken cancellationToken)
         {
             try
             {
                 var method = new CloudToDeviceMethod(LoraKeysManagerFacadeConstants.CloudToDeviceMessageMethodName, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
-                _ = method.SetPayloadJson(JsonConvert.SerializeObject(c2dMessage));
-                // class c devices are always listening - we want to publish message to redis queue here 
-                // call IChannelPublisher.PublishAsync
-                var res = await this.serviceClient.InvokeDeviceMethodAsync(preferredGatewayID, LoraKeysManagerFacadeConstants.NetworkServerModuleId, method);
-                if (HttpUtilities.IsSuccessStatusCode(res.Status))
+                var jsonContent = JsonConvert.SerializeObject(c2dMessage);
+                _ = method.SetPayloadJson(jsonContent);
+
+                if (await edgeDeviceGetter.IsEdgeDeviceAsync(preferredGatewayID, cancellationToken))
                 {
-                    this.log.LogInformation("Direct method call to {gatewayID} and {devEUI} succeeded with {statusCode}", preferredGatewayID, devEUI, res.Status);
+                    var res = await this.serviceClient.InvokeDeviceMethodAsync(preferredGatewayID, LoraKeysManagerFacadeConstants.NetworkServerModuleId, method);
+                    if (HttpUtilities.IsSuccessStatusCode(res.Status))
+                    {
+                        this.log.LogInformation("Direct method call to {gatewayID} and {devEUI} succeeded with {statusCode}", preferredGatewayID, devEUI, res.Status);
+
+                        return new OkObjectResult(new SendCloudToDeviceMessageResult()
+                        {
+                            DevEui = devEUI,
+                            MessageID = c2dMessage.MessageId,
+                            ClassType = "C",
+                        });
+                    }
+
+                    this.log.LogError("Direct method call to {gatewayID} failed with {statusCode}. Response: {response}", preferredGatewayID, res.Status, res.GetPayloadAsJson());
+
+                    return new ObjectResult(res.GetPayloadAsJson())
+                    {
+                        StatusCode = res.Status,
+                    };
+                }
+                else
+                {
+                    await this.channelPublisher.PublishAsync(preferredGatewayID, new LnsRemoteCall(RemoteCallKind.CloudToDeviceMessage, jsonContent));
+                    this.log.LogInformation("C2D message to {gatewayID} and {devEUI} published to Redis queue", preferredGatewayID, devEUI);
 
                     return new OkObjectResult(new SendCloudToDeviceMessageResult()
                     {
@@ -212,13 +246,6 @@ namespace LoraKeysManagerFacade
                         ClassType = "C",
                     });
                 }
-
-                this.log.LogError("Direct method call to {gatewayID} failed with {statusCode}. Response: {response}", preferredGatewayID, res.Status, res.GetPayloadAsJson());
-
-                return new ObjectResult(res.GetPayloadAsJson())
-                {
-                    StatusCode = res.Status,
-                };
             }
             catch (JsonSerializationException ex)
             {

--- a/Tests/Integration/DeduplicationWithRedisIntegrationTests.cs
+++ b/Tests/Integration/DeduplicationWithRedisIntegrationTests.cs
@@ -6,9 +6,11 @@
 namespace LoRaWan.Tests.Integration
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using LoraKeysManagerFacade;
     using LoraKeysManagerFacade.FunctionBundler;
+    using LoRaTools;
     using LoRaWan.Tests.Common;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.Azure.Devices;
@@ -24,6 +26,8 @@ namespace LoRaWan.Tests.Integration
         private readonly ILoRaDeviceCacheStore cache;
         private readonly Mock<IServiceClient> serviceClientMock;
         private readonly TelemetryConfiguration telemetryConfiguration;
+        private readonly Mock<IEdgeDeviceGetter> edgeDeviceGetter;
+        private readonly Mock<IChannelPublisher> channelPublisher;
         private readonly DeduplicationExecutionItem deduplicationExecutionItem;
 
         public DeduplicationTestWithRedis(RedisFixture redis)
@@ -33,7 +37,13 @@ namespace LoRaWan.Tests.Integration
             this.cache = new LoRaDeviceCacheRedisStore(redis.Database);
             this.serviceClientMock = new Mock<IServiceClient>();
             this.telemetryConfiguration = new TelemetryConfiguration();
-            this.deduplicationExecutionItem = new DeduplicationExecutionItem(this.cache, this.serviceClientMock.Object, this.telemetryConfiguration);
+            this.edgeDeviceGetter = new Mock<IEdgeDeviceGetter>();
+            this.channelPublisher = new Mock<IChannelPublisher>();
+            this.deduplicationExecutionItem = new DeduplicationExecutionItem(this.cache,
+                                                                             this.serviceClientMock.Object,
+                                                                             this.edgeDeviceGetter.Object,
+                                                                             this.channelPublisher.Object,
+                                                                             this.telemetryConfiguration);
         }
 
         [Theory]
@@ -41,8 +51,9 @@ namespace LoRaWan.Tests.Integration
         [InlineData("gateway1", 1, "gateway1", 2)]
         [InlineData("gateway1", 1, "gateway2", 1)]
         [InlineData("gateway1", 1, "gateway2", 2)]
-        public async Task When_Called_Multiple_Times_With_Same_Device_Should_Detect_Duplicates(string gateway1, uint fcnt1, string gateway2, uint fcnt2)
+        public async Task When_Called_Multiple_Times_With_Same_Device_Should_Detect_Duplicates_Direct_Method(string gateway1, uint fcnt1, string gateway2, uint fcnt2)
         {
+            this.edgeDeviceGetter.Setup(m => m.IsEdgeDeviceAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
             this.serviceClientMock.Setup(
                 x => x.InvokeDeviceMethodAsync(It.IsAny<string>(), LoraKeysManagerFacadeConstants.NetworkServerModuleId, It.IsAny<CloudToDeviceMethod>()))
                 .ReturnsAsync(new CloudToDeviceMethodResult() { Status = 200 });
@@ -85,6 +96,56 @@ namespace LoRaWan.Tests.Integration
                 this.serviceClientMock.Verify(x => x.InvokeDeviceMethodAsync(gateway1, LoraKeysManagerFacadeConstants.NetworkServerModuleId,
                     It.Is<CloudToDeviceMethod>(m => m.MethodName == LoraKeysManagerFacadeConstants.CloudToDeviceCloseConnection
                     && m.GetPayloadAsJson().Contains(devEUI.ToString()))));
+            }
+        }
+
+        [Theory]
+        [InlineData("gateway1", 1, "gateway1", 1)]
+        [InlineData("gateway1", 1, "gateway1", 2)]
+        [InlineData("gateway1", 1, "gateway2", 1)]
+        [InlineData("gateway1", 1, "gateway2", 2)]
+        public async Task When_Called_Multiple_Times_With_Same_Device_Should_Detect_Duplicates_Pub_Sub(string gateway1, uint fcnt1, string gateway2, uint fcnt2)
+        {
+            this.edgeDeviceGetter.Setup(m => m.IsEdgeDeviceAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+            var devEUI = TestEui.GenerateDevEui();
+
+            var req1 = new FunctionBundlerRequest() { GatewayId = gateway1, ClientFCntUp = fcnt1, ClientFCntDown = fcnt1 };
+            var pipeline1 = new FunctionBundlerPipelineExecuter(new IFunctionBundlerExecutionItem[] { this.deduplicationExecutionItem }, devEUI, req1);
+            var res1 = await this.deduplicationExecutionItem.ExecuteAsync(pipeline1);
+
+            Assert.Equal(FunctionBundlerExecutionState.Continue, res1);
+            Assert.NotNull(pipeline1.Result.DeduplicationResult);
+            Assert.False(pipeline1.Result.DeduplicationResult.IsDuplicate);
+
+            var req2 = new FunctionBundlerRequest() { GatewayId = gateway2, ClientFCntUp = fcnt2, ClientFCntDown = fcnt2 };
+            var pipeline2 = new FunctionBundlerPipelineExecuter(new IFunctionBundlerExecutionItem[] { this.deduplicationExecutionItem }, devEUI, req2);
+            var res2 = await this.deduplicationExecutionItem.ExecuteAsync(pipeline2);
+
+            Assert.NotNull(pipeline2.Result.DeduplicationResult);
+
+            // same gateway -> no duplicate
+            if (gateway1 == gateway2)
+            {
+                Assert.Equal(FunctionBundlerExecutionState.Continue, res2);
+                Assert.False(pipeline2.Result.DeduplicationResult.IsDuplicate);
+            }
+            // different gateway, the same fcnt -> duplicate
+            else if (fcnt1 == fcnt2)
+            {
+                Assert.Equal(FunctionBundlerExecutionState.Abort, res2);
+                Assert.True(pipeline2.Result.DeduplicationResult.IsDuplicate);
+            }
+            // different gateway, higher fcnt -> no duplicate
+            else
+            {
+                Assert.Equal(FunctionBundlerExecutionState.Continue, res2);
+                Assert.False(pipeline2.Result.DeduplicationResult.IsDuplicate);
+
+                // gateway1 should be notified that it needs to drop connection for the device
+                this.channelPublisher.Verify(x => x.PublishAsync(It.IsAny<string>(), It.IsAny<LnsRemoteCall>()));
+
+                this.serviceClientMock.VerifyNoOtherCalls();
             }
         }
 

--- a/Tests/Integration/DeduplicationWithRedisIntegrationTests.cs
+++ b/Tests/Integration/DeduplicationWithRedisIntegrationTests.cs
@@ -105,7 +105,7 @@ namespace LoRaWan.Tests.Integration
                 }
                 else
                 {
-                    this.channelPublisher.Verify(x => x.PublishAsync(It.IsAny<string>(), It.IsAny<LnsRemoteCall>()));
+                    this.channelPublisher.Verify(x => x.PublishAsync(gateway1, It.Is<LnsRemoteCall>(c => c.Kind == RemoteCallKind.CloseConnection)));
                     this.serviceClientMock.VerifyNoOtherCalls();
                 }
             }

--- a/Tests/Unit/LoRaTools/ApiVersionTest.cs
+++ b/Tests/Unit/LoRaTools/ApiVersionTest.cs
@@ -32,7 +32,7 @@ namespace LoRaWan.Tests.Unit.LoRaTools.CommonAPI
                 (req) => new DeviceGetter(null, null, NullLogger<DeviceGetter>.Instance).GetDevice(req),
                 (req) => Task.Run(() => new FCntCacheCheck(null, NullLogger<FCntCacheCheck>.Instance).NextFCntDownInvoke(req)),
                 (req) => Task.Run(() => new FunctionBundlerFunction(Array.Empty<IFunctionBundlerExecutionItem>(), NullLogger<FunctionBundlerFunction>.Instance).FunctionBundler(req, string.Empty)),
-                (req) => new SendCloudToDeviceMessage(null, null, null, null).Run(req, string.Empty)
+                (req) => new SendCloudToDeviceMessage(null, null, null, null, null, null).Run(req, string.Empty, default)
             };
 
             foreach (var apiCall in apiCalls)

--- a/Tests/Unit/LoraKeysManagerFacade/FunctionBundlerTest.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/FunctionBundlerTest.cs
@@ -58,7 +58,11 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade.FunctionBundler
             this.telemetryConfiguration = new TelemetryConfiguration();
             var items = new IFunctionBundlerExecutionItem[]
             {
-                new DeduplicationExecutionItem(cacheStore, Mock.Of<IServiceClient>(), this.telemetryConfiguration),
+                new DeduplicationExecutionItem(cacheStore,
+                                               Mock.Of<IServiceClient>(),
+                                               Mock.Of<IEdgeDeviceGetter>(),
+                                               Mock.Of<IChannelPublisher>(),
+                                               this.telemetryConfiguration),
                 this.adrExecutionItem,
                 new NextFCntDownExecutionItem(new FCntCacheCheck(cacheStore, NullLogger<FCntCacheCheck>.Instance)),
                 new PreferredGatewayExecutionItem(cacheStore, new NullLogger<PreferredGatewayExecutionItem>(), null),
@@ -339,7 +343,11 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade.FunctionBundler
 
             var items = new IFunctionBundlerExecutionItem[]
             {
-                new DeduplicationExecutionItem(cacheStore, Mock.Of<IServiceClient>(), this.telemetryConfiguration),
+                new DeduplicationExecutionItem(cacheStore,
+                                               Mock.Of<IServiceClient>(),
+                                               Mock.Of<IEdgeDeviceGetter>(),
+                                               Mock.Of<IChannelPublisher>(),
+                                               this.telemetryConfiguration),
                 new ADRExecutionItem(this.adrManager),
                 new NextFCntDownExecutionItem(new FCntCacheCheck(cacheStore, NullLogger<FCntCacheCheck>.Instance)),
                 new PreferredGatewayExecutionItem(cacheStore, new NullLogger<PreferredGatewayExecutionItem>(), null),

--- a/Tests/Unit/LoraKeysManagerFacade/MessageDeduplicationTests.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/MessageDeduplicationTests.cs
@@ -4,6 +4,7 @@
 namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade.FunctionBundler
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using global::LoraKeysManagerFacade;
     using global::LoraKeysManagerFacade.FunctionBundler;
@@ -19,13 +20,21 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade.FunctionBundler
         private readonly DeduplicationExecutionItem deduplicationExecutionItem;
         private readonly Mock<IServiceClient> serviceClientMock;
         private readonly TelemetryConfiguration telemetryConfiguration;
+        private readonly Mock<IEdgeDeviceGetter> edgeDeviceGetter;
 
         public MessageDeduplicationTests()
         {
             this.serviceClientMock = new Mock<IServiceClient>();
 
             this.telemetryConfiguration = new TelemetryConfiguration();
-            this.deduplicationExecutionItem = new DeduplicationExecutionItem(new LoRaInMemoryDeviceStore(), this.serviceClientMock.Object, this.telemetryConfiguration);
+            this.edgeDeviceGetter = new Mock<IEdgeDeviceGetter>();
+            this.edgeDeviceGetter.Setup(m => m.IsEdgeDeviceAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+            this.deduplicationExecutionItem = new DeduplicationExecutionItem(new LoRaInMemoryDeviceStore(),
+                                                                             this.serviceClientMock.Object,
+                                                                             this.edgeDeviceGetter.Object,
+                                                                             Mock.Of<IChannelPublisher>(),
+                                                                             this.telemetryConfiguration);
         }
 
         [Fact]


### PR DESCRIPTION
# PR for issue #1633 #1634 

## What is being addressed

- [x] GetDuplicateMessageResultAsync in DeduplicationExecutionItem is handling the CloudToDeviceCloseConnection for cloud based devices
- [x] The message published on the IChannelPublisher has to be published on the channel named as GatewayId (i.e. previousGateway variable)
- [x] The value of the published message should be the json serialization of the already existing LoRaCloudToDeviceMessage
- [x] The new path is covered by at least one unit test in MessageDeduplicationTests
- [x] SendCloudToDeviceMessage is handling the scenario covered by SendMessageViaDirectMethodAsync for cloud based devices
- [x] The message published on the IChannelPublisher has to be published on the channel named as the GatewayId (i.e. preferredGatewayID variable)
- [x] The value of the published message should be the json serialization of the already existing LoRaCloudToDeviceMessage
- [x] The new path is covered by at least one unit test in SendCloudToDeviceMessageTest