### PR TITLE
Reset the redis cache

### DIFF
--- a/.github/workflows/e2e-ci.yaml
+++ b/.github/workflows/e2e-ci.yaml
@@ -107,6 +107,19 @@ jobs:
           AZURE_SP_SECRET: ${{ secrets.AZURE_SP_SECRET }}
           AZURE_TENANTID: ${{ secrets.AZURE_TENANTID }}
 
+  reset_redis_cache:
+    name: Reset the Redis Cache
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Flush the database
+        shell: bash
+        run: |
+          wget https://github.com/IBM-Cloud/redli/releases/download/v0.5.2/redli_0.5.2_linux_amd64.tar.gz
+          tar xzf redli_0.5.2_linux_amd64.tar.gz
+          chmod +x redli
+          ./redli --tls -h ${{ secrets.REDIS_HOSTNAME }}.redis.cache.windows.net -p 6380 -a ${{ secrets.REDIS_PASSWORD }} FLUSHALL
+
   # Build and deploy Facade Azure Function
   deploy_facade_function:
     environment:
@@ -625,7 +638,7 @@ jobs:
       - e2e_tests_job
     steps:
       - uses: actions/checkout@v2
-
+      - sudo shutdown -h now
       - name: Power OFF Azure VM
         uses: ./.github/actions/power-azure-vm
         with:

--- a/.github/workflows/e2e-ci.yaml
+++ b/.github/workflows/e2e-ci.yaml
@@ -638,7 +638,6 @@ jobs:
       - e2e_tests_job
     steps:
       - uses: actions/checkout@v2
-      - sudo shutdown -h now
       - name: Power OFF Azure VM
         uses: ./.github/actions/power-azure-vm
         with:


### PR DESCRIPTION
# PR for issue #1269 

## What is being addressed

To ensure consistent CI E2E runs, we want to flush the Redis cache to ensure all changes are run against an empty cache.

## How is this addressed

* Added two new secrets to the CI to connect to the Redis
* A new stage at the CI start use [redli](https://github.com/IBM-Cloud/redli) to issue commands to the Redis cache. Usage of Redli was preferred to redis-cli as it handles much better SSL. Usage of redis-cli would either have [resulted in a more complex setup or opening non-ssl ports](https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-how-to-redis-cli-tool#enable-access-for-redis-cliexe).
