### PR TITLE
Fix restart of the Basic Station Docker container

### DIFF
--- a/LoRaEngine/modules/LoRaBasicsStationModule/start_basicsstation.sh
+++ b/LoRaEngine/modules/LoRaBasicsStationModule/start_basicsstation.sh
@@ -13,9 +13,9 @@ if [[ -z "$STATION_PATH" ]]; then
 fi
 
 if [[ "$CORECELL" == true ]]; then
-    mv corecell.station.conf station.conf
+    cp corecell.station.conf station.conf
 else
-    mv sx1301.station.conf station.conf
+    cp sx1301.station.conf station.conf
 fi
 
 resetPin


### PR DESCRIPTION
# Fix restart of the Basic Station Docker container

## What is being addressed

When restarting the Basic Station module, it currently triggers the following issue:
![image](https://user-images.githubusercontent.com/8555833/173240727-c73f32f2-0f21-436d-8175-f25672110309.png)

The reason is that the startup script moves the file 'sx1301.station.conf'. When the container restarts, the startup script executes and fails as the file doesn't exist anymore at the source location.

## How is this addressed

We change the move command to a copy command; this resolves the issue [when deploying the branch](https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/2483975105) and manually restarting the container we observe the following:
![image](https://user-images.githubusercontent.com/8555833/173241338-7a92c4f8-91b1-43f7-84fc-dd99953f05cb.png)

