### PR TITLE
Don't use rx1droffset during join accept

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoRaWan.NetworkServer/JoinRequestMessageHandler.cs
@@ -267,7 +267,8 @@ namespace LoRaWan.NetworkServer
                 var joinAcceptBytes = loRaPayloadJoinAccept.Serialize(appKey);
 
                 var rx1 = windowToUse is not ReceiveWindow2
-                        ? new ReceiveWindow(loraRegion.GetDownstreamDataRate(request.RadioMetadata.DataRate, loRaDevice.ReportedRX1DROffset), freq)
+                        // For join accept messages the RX1DROffsetvalue is ignored as the join accept message carry the settings to the device.
+                        ? new ReceiveWindow(loraRegion.GetDownstreamDataRate(request.RadioMetadata.DataRate), freq)
                         : (ReceiveWindow?)null;
 
                 var rx2 = new ReceiveWindow(loraRegion.GetDownstreamRX2DataRate(this.configuration.Rx2DataRate, null, deviceJoinInfo, this.logger),

--- a/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
+++ b/Tests/Unit/NetworkServer/MessageProcessorJoinTest.cs
@@ -639,16 +639,16 @@ namespace LoRaWan.Tests.Unit.NetworkServer
         [Theory]
         // Base dr is 2
         // In case the offset is invalid, we rollback to offset 0. for europe that means = to upstream
-        [InlineData(0, DR2)]
-        [InlineData(1, DR1)]
-        [InlineData(2, DR0)]
-        [InlineData(3, DR0)]
-        [InlineData(4, DR0)]
-        [InlineData(6, DR2)]
-        [InlineData(12, DR2)]
-        [InlineData(-2, DR2)]
-        public async Task When_Getting_RX1_Offset_From_Twin_Returns_JoinAccept_With_Correct_Settings_And_Behaves_Correctly(int rx1offset, DataRateIndex expectedDR)
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(6)]
+        [InlineData(-2)]
+        public async Task When_Getting_RX1_Offset_From_Twin_Returns_JoinAccept_With_Correct_Settings_And_Behaves_Correctly(int rx1offset)
         {
+            var expectedDR = DR2;
             var deviceGatewayID = ServerGatewayID;
             var simulatedDevice = new SimulatedDevice(TestDeviceInfo.CreateOTAADevice(1, gatewayID: deviceGatewayID));
             var joinRequest = simulatedDevice.CreateJoinRequest();


### PR DESCRIPTION
# PR for issue #1727 

## What is being addressed

Don't use rx1droffset for the join accept message.

## How is this addressed

As the Join accept message carries the settings for the end device, it is impossible that the setting is applied during the join procedure as the end device can't know about it.