### PR TITLE
fix: Universal decoder pipeline uses esprima-next

### DIFF
--- a/Samples/UniversalDecoder/package-lock.json
+++ b/Samples/UniversalDecoder/package-lock.json
@@ -875,6 +875,14 @@
             "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "dev": true
         },
+        "abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "requires": {
+                "event-target-shim": "^5.0.0"
+            }
+        },
         "accepts": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -925,73 +933,6 @@
             "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
-            }
-        },
-        "args": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
-            "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
-            "requires": {
-                "camelcase": "5.0.0",
-                "chalk": "2.4.2",
-                "leven": "2.1.0",
-                "mri": "1.1.4"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "camelcase": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-                    "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
-                },
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
-                },
-                "leven": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-                    "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA=="
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
             }
         },
         "array-flatten": {
@@ -1256,9 +1197,9 @@
             "dev": true
         },
         "colorette": {
-            "version": "2.0.17",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.17.tgz",
-            "integrity": "sha512-hJo+3Bkn0NCHybn9Tu35fIeoOKGOk5OCC32y4Hz2It+qlCO2Q3DeQ1hRn/tDDMQKRYUEzqsl7jbF6dYKjlE60g=="
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -1470,17 +1411,29 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
         },
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "esprima-next": {
+            "version": "5.8.3",
+            "resolved": "https://registry.npmjs.org/esprima-next/-/esprima-next-5.8.3.tgz",
+            "integrity": "sha512-ND7DiWoiLxc6kwhB9Xt3YzewG2FPk09FxwWICCSu/nBj4gyRuEhkOToiO0KAnE0pUW73gH2R+IJNVtF97VBdjw=="
         },
         "etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+        },
+        "event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
         },
         "execa": {
             "version": "5.1.1",
@@ -1572,9 +1525,9 @@
             }
         },
         "express-validator": {
-            "version": "6.14.1",
-            "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.14.1.tgz",
-            "integrity": "sha512-4w7gn/jPW1a+r833xBqpu4pL7XiiScDwlbBIMtiqUEt/MVNqR94HOHyKLcCtnqCnEPiqrX1Mqt9l/SVN/iqeLA==",
+            "version": "6.14.2",
+            "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.14.2.tgz",
+            "integrity": "sha512-8XfAUrQ6Y7dIIuy9KcUPCfG/uCbvREctrxf5EeeME+ulanJ4iiW71lWmm9r4YcKKYOCBMan0WpVg7FtHu4Z4Wg==",
             "requires": {
                 "lodash": "^4.17.21",
                 "validator": "^13.7.0"
@@ -1811,6 +1764,15 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
             "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+        },
+        "help-me": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.0.1.tgz",
+            "integrity": "sha512-PLv01Z+OhEPKj2QPYB4kjoCUkopYNPUK3EROlaPIf5bib752fZ+VCvGDAoA+FXo/OwCyLEA4D2e0mX8+Zhcplw==",
+            "requires": {
+                "glob": "^8.0.0",
+                "readable-stream": "^3.6.0"
+            }
         },
         "hexoid": {
             "version": "1.0.0",
@@ -2578,12 +2540,12 @@
         "media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
         },
         "merge-descriptors": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+            "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
         },
         "merge-stream": {
             "version": "2.0.0",
@@ -2639,15 +2601,15 @@
                 "brace-expansion": "^1.1.7"
             }
         },
-        "mri": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
-            "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
+        "minimist": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -2790,7 +2752,7 @@
         "path-to-regexp": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+            "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
         },
         "picocolors": {
             "version": "1.0.0",
@@ -2805,32 +2767,49 @@
             "dev": true
         },
         "pino": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/pino/-/pino-8.0.0.tgz",
-            "integrity": "sha512-EvZh9ZUoLGkrhqhoF9UBxw2/ZiAhXHUKlGrI4WUT/wLu0sfu8Wr3NJaZ6lxcy/S51W0PMSon5KE7ujPAhc/G6g==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-8.1.0.tgz",
+            "integrity": "sha512-53jlxs+02UNTtF1XwVWfa0dHipBiM5GK73XhkHn8M2hUl9y3L94dNwB8BwQhpd5WdHjBkyJiO7v0LRt4SGgsPg==",
             "requires": {
                 "atomic-sleep": "^1.0.0",
-                "fast-redact": "^3.0.0",
-                "on-exit-leak-free": "^1.0.0",
-                "pino-abstract-transport": "v0.5.0",
+                "fast-redact": "^3.1.1",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "v1.0.0",
                 "pino-std-serializers": "^5.0.0",
                 "process-warning": "^2.0.0",
                 "quick-format-unescaped": "^4.0.3",
                 "real-require": "^0.1.0",
-                "safe-stable-stringify": "^2.1.0",
+                "safe-stable-stringify": "^2.3.1",
                 "sonic-boom": "^3.0.0",
                 "thread-stream": "^1.0.0"
             },
             "dependencies": {
                 "on-exit-leak-free": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+                    "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+                },
+                "pino-abstract-transport": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-1.0.0.tgz",
-                    "integrity": "sha512-Ve8ubhrXRdnuCJ5bQSQpP3uaV43K1PMcOfSRC1pqHgRZommXCgsXwh08jVC5NpjwScE23BPDwDvVg4cov3mwjw=="
+                    "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+                    "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+                    "requires": {
+                        "readable-stream": "^4.0.0",
+                        "split2": "^4.0.0"
+                    }
                 },
                 "pino-std-serializers": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-5.3.0.tgz",
-                    "integrity": "sha512-Jm6EfiTTWUMxiyi07RUPpD9KLntgqc4P9lriWZG5TpabeJYxG/zkI5aUdTpUdgfS1mj3YD+0n3BINbQTz9r0Ig=="
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-5.6.0.tgz",
+                    "integrity": "sha512-VdUXCw8gO+xhir7sFuoYSjTnzB+TMDGxhAC/ph3YS3sdHnXNdsK0wMtADNUltfeGkn2KDxEM21fnjF3RwXyC8A=="
+                },
+                "readable-stream": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.0.0.tgz",
+                    "integrity": "sha512-Mf7ilWBP6AV3tF3MjtBrHMH3roso7wIrpgzCwt9ybvqiJQVWIEBMnp/W+S//yvYSsUUi2cJIwD7q7m57l0AqZw==",
+                    "requires": {
+                        "abort-controller": "^3.0.0"
+                    }
                 },
                 "sonic-boom": {
                     "version": "3.0.0",
@@ -2896,23 +2875,56 @@
             }
         },
         "pino-pretty": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-8.0.0.tgz",
-            "integrity": "sha512-6Zn+2HBc8ZXEJb1XYZfY0Kh0jVBeKxmu077BzE0wzJZzQwNffmdQbIH7bNe0WPLjLApnVTx8TvvR8UNUcgE4nA==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-8.1.0.tgz",
+            "integrity": "sha512-oKfI8qKXR2a3haHs/X8iB6QSnWLqoOGAjwxIAXem4+XOGIGNw7IKpozId1uE7j89Rj46HIfWnGbAgmQmr8+yRw==",
             "requires": {
-                "args": "5.0.1",
                 "colorette": "^2.0.7",
                 "dateformat": "^4.6.3",
                 "fast-copy": "^2.1.1",
-                "fast-safe-stringify": "^2.0.7",
+                "fast-safe-stringify": "^2.1.1",
+                "help-me": "^4.0.1",
                 "joycon": "^3.1.1",
-                "on-exit-leak-free": "^0.2.0",
-                "pino-abstract-transport": "^0.5.0",
+                "minimist": "^1.2.6",
+                "on-exit-leak-free": "^1.0.0",
+                "pino-abstract-transport": "^1.0.0",
                 "pump": "^3.0.0",
-                "readable-stream": "^3.6.0",
+                "readable-stream": "^4.0.0",
                 "secure-json-parse": "^2.4.0",
-                "sonic-boom": "^2.2.0",
+                "sonic-boom": "^3.0.0",
                 "strip-json-comments": "^3.1.1"
+            },
+            "dependencies": {
+                "on-exit-leak-free": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-1.0.0.tgz",
+                    "integrity": "sha512-Ve8ubhrXRdnuCJ5bQSQpP3uaV43K1PMcOfSRC1pqHgRZommXCgsXwh08jVC5NpjwScE23BPDwDvVg4cov3mwjw=="
+                },
+                "pino-abstract-transport": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+                    "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+                    "requires": {
+                        "readable-stream": "^4.0.0",
+                        "split2": "^4.0.0"
+                    }
+                },
+                "readable-stream": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.0.0.tgz",
+                    "integrity": "sha512-Mf7ilWBP6AV3tF3MjtBrHMH3roso7wIrpgzCwt9ybvqiJQVWIEBMnp/W+S//yvYSsUUi2cJIwD7q7m57l0AqZw==",
+                    "requires": {
+                        "abort-controller": "^3.0.0"
+                    }
+                },
+                "sonic-boom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.0.0.tgz",
+                    "integrity": "sha512-p5DiZOZHbJ2ZO5MADczp5qrfOd3W5Vr2vHxfCpe7G4AzPwVOweIjbfgku8wSQUuk+Y5Yuo8W7JqRe6XKmKistg==",
+                    "requires": {
+                        "atomic-sleep": "^1.0.0"
+                    }
+                }
             }
         },
         "pino-std-serializers": {
@@ -3544,7 +3556,7 @@
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
         },
         "util-deprecate": {
             "version": "1.0.2",
@@ -3554,7 +3566,7 @@
         "utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+            "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
         },
         "v8-to-istanbul": {
             "version": "9.0.0",
@@ -3575,7 +3587,7 @@
         "vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
         },
         "walker": {
             "version": "1.0.8",

--- a/Samples/UniversalDecoder/package.json
+++ b/Samples/UniversalDecoder/package.json
@@ -13,7 +13,7 @@
         "codecs": "rm -fR node_modules/lorawan-devices codecs/* && git clone --depth 1 https://github.com/TheThingsNetwork/lorawan-devices.git node_modules/lorawan-devices && node tools/copy-codecs.js"
     },
     "dependencies": {
-        "esprima": "^4.0.1",
+        "esprima-next": "^5.8.3",
         "express": "^4.18.1",
         "express-pino-logger": "^7.0.0",
         "express-validator": "^6.14.1",

--- a/Samples/UniversalDecoder/tools/copy-codecs.js
+++ b/Samples/UniversalDecoder/tools/copy-codecs.js
@@ -4,19 +4,17 @@ const glob = require('glob');
 const fs = require('fs');
 const fse = require('fs-extra');
 const path = require('path');
-const esprima = require('esprima');
+const esprima = require('esprima-next');
 
 var args = process.argv.slice(2);
 const srcDir = args[0] || './node_modules/lorawan-devices/vendor';
 const dstDir = args[1] || './codecs';
 const indexFilePath = path.join(dstDir, 'index.js');
-// cube.js is ignored as esprima doesn't support class parsing https://github.com/jquery/esprima/issues/1971
 const index = glob.sync(`**/*`,
   {
     cwd: srcDir,
     nodir: true,
     ignore: [
-      "greenme/cube.js",
       '**/*.jpg',
       '**/*.png',
       '**/*.svg',


### PR DESCRIPTION
# PR for issue #1742 

## What is being addressed

The universal decoder pipeline is again failing because of missing esprima support for class parsing.

## How is this addressed

Instead of ignoring some specific files (#1680), this PR is introducing esprima-next to be used as an alternative to legacy esprima