### PR TITLE
feat: Introduce dependabot for github actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    # Maintain dependencies for universal decoder
+  # Maintain dependencies for universal decoder
   - package-ecosystem: "npm"
     directory: "/Samples/UniversalDecoder"
     schedule:
+      interval: "daily"
+  # Maintain dependencies for github actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
       interval: "daily"


### PR DESCRIPTION
# PR for issue #1744 

## What is being addressed

GitHub Actions requires updates to their version. Instead of manually keeping track of changes, we can use dependabot for understanding what needs an update