### PR TITLE
fix: e2e-ci pipeline

### DIFF
--- a/.github/workflows/e2e-ci.yaml
+++ b/.github/workflows/e2e-ci.yaml
@@ -213,7 +213,7 @@ jobs:
     # This image is very costly to rebuild and we rebuild it only when something change in the folders since last commit.
     - name: Build Docker LoRaWanBasicsStation images
       run: |
-        git diff --quiet HEAD HEAD~1 -- modules/LoRaBasicsStationModule/ || docker buildx bake --push LoraBasicsStationarm32v7
+        git diff --quiet HEAD HEAD~1 -- modules/LoRaBasicsStationModule/ || docker buildx bake --push LoraBasicsStationarm32v7 --set *.args.SOURCE_CONTAINER_REGISTRY_ADDRESS=${{ env.CONTAINER_REGISTRY_ADDRESS }}
       working-directory: LoRaEngine
       env:
         CONTAINER_REGISTRY_ADDRESS: ${{ env.CONTAINER_REGISTRY_ADDRESS }}


### PR DESCRIPTION
# PR for issue #1764

Fixes the e2e CI pipeline to also include the ARG overwrite for building the LBS image

