### PR TITLE
disable docker detector for a few files.

### DIFF
--- a/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.amd64
+++ b/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.amd64
@@ -1,5 +1,6 @@
 #This docker builds a container for the LoRa Basics station on amd64 architecture
 
+# DisableDockerDetector "Users should have the possibility to build the docker image locally. The CI build will use the docker image from our internal registry. See ./.github/workflows/ci.yml for more information."
 ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=docker.io
 FROM $SOURCE_CONTAINER_REGISTRY_ADDRESS/amd64/debian:buster as build
 RUN apt-get update

--- a/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.arm32v7
@@ -1,5 +1,6 @@
 #This docker builds a container for the LoRa Basics station on arm32 architecture
 
+# DisableDockerDetector "Users should have the possibility to build the docker image locally. The CI build will use the docker image from our internal registry. See ./.github/workflows/ci.yml for more information."
 ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=docker.io
 FROM $SOURCE_CONTAINER_REGISTRY_ADDRESS/amd64/debian:buster as build
 RUN apt-get update \

--- a/Samples/UniversalDecoder/Dockerfile.amd64
+++ b/Samples/UniversalDecoder/Dockerfile.amd64
@@ -1,3 +1,5 @@
+
+# DisableDockerDetector "Users should have the possibility to build the docker image locally. The CI build will use the docker image from our internal registry. See ./.github/workflows/ci.yml for more information."
 ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=docker.io
 FROM $SOURCE_CONTAINER_REGISTRY_ADDRESS/amd64/node:14-alpine
 

--- a/Samples/UniversalDecoder/Dockerfile.arm32v7
+++ b/Samples/UniversalDecoder/Dockerfile.arm32v7
@@ -1,3 +1,4 @@
+# DisableDockerDetector "Users should have the possibility to build the docker image locally. The CI build will use the docker image from our internal registry. See ./.github/workflows/ci.yml for more information."
 ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=docker.io
 FROM $SOURCE_CONTAINER_REGISTRY_ADDRESS/arm32v7/node:14-slim
 

--- a/Samples/UniversalDecoder/Dockerfile.arm64v8
+++ b/Samples/UniversalDecoder/Dockerfile.arm64v8
@@ -1,3 +1,4 @@
+# DisableDockerDetector "Users should have the possibility to build the docker image locally. The CI build will use the docker image from our internal registry. See ./.github/workflows/ci.yml for more information."
 ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=docker.io
 FROM $SOURCE_CONTAINER_REGISTRY_ADDRESS/arm64v8/node:14-slim
 


### PR DESCRIPTION
# PR for issue #1764

Ignore component governance for LBS and Universal Decoder docker files until we clarify the correct behavior with CG
