### PR TITLE
fix: use non-existing registry by default

### DIFF
--- a/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.amd64
+++ b/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.amd64
@@ -1,7 +1,7 @@
 #This docker builds a container for the LoRa Basics station on amd64 architecture
 
-# DisableDockerDetector "Users should have the possibility to build the docker image locally. The CI build will use the docker image from our internal registry. See ./.github/workflows/ci.yml for more information."
-ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=docker.io
+# NOTE: Use either docker.io or your own registry address to build the image
+ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=your-registry-address.azurecr.io
 FROM $SOURCE_CONTAINER_REGISTRY_ADDRESS/amd64/debian:buster as build
 RUN apt-get update
 RUN apt-get install -y git

--- a/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.arm32v7
+++ b/LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.arm32v7
@@ -1,7 +1,7 @@
 #This docker builds a container for the LoRa Basics station on arm32 architecture
 
-# DisableDockerDetector "Users should have the possibility to build the docker image locally. The CI build will use the docker image from our internal registry. See ./.github/workflows/ci.yml for more information."
-ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=docker.io
+# NOTE: Use either docker.io or your own registry address to build the image
+ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=your-registry-address.azurecr.io
 FROM $SOURCE_CONTAINER_REGISTRY_ADDRESS/amd64/debian:buster as build
 RUN apt-get update \
     && apt-get install -y git apt-utils build-essential gcc-arm-linux-gnueabihf

--- a/Samples/UniversalDecoder/Dockerfile.amd64
+++ b/Samples/UniversalDecoder/Dockerfile.amd64
@@ -1,6 +1,5 @@
-
-# DisableDockerDetector "Users should have the possibility to build the docker image locally. The CI build will use the docker image from our internal registry. See ./.github/workflows/ci.yml for more information."
-ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=docker.io
+# NOTE: Use either docker.io or your own registry address to build the image
+ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=your-registry-address.azurecr.io
 FROM $SOURCE_CONTAINER_REGISTRY_ADDRESS/amd64/node:14-alpine
 
 WORKDIR /app/

--- a/Samples/UniversalDecoder/Dockerfile.arm32v7
+++ b/Samples/UniversalDecoder/Dockerfile.arm32v7
@@ -1,5 +1,5 @@
-# DisableDockerDetector "Users should have the possibility to build the docker image locally. The CI build will use the docker image from our internal registry. See ./.github/workflows/ci.yml for more information."
-ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=docker.io
+# NOTE: Use either docker.io or your own registry address to build the image
+ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=your-registry-address.azurecr.io
 FROM $SOURCE_CONTAINER_REGISTRY_ADDRESS/arm32v7/node:14-slim
 
 WORKDIR /app/

--- a/Samples/UniversalDecoder/Dockerfile.arm64v8
+++ b/Samples/UniversalDecoder/Dockerfile.arm64v8
@@ -1,5 +1,5 @@
-# DisableDockerDetector "Users should have the possibility to build the docker image locally. The CI build will use the docker image from our internal registry. See ./.github/workflows/ci.yml for more information."
-ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=docker.io
+# NOTE: Use either docker.io or your own registry address to build the image
+ARG SOURCE_CONTAINER_REGISTRY_ADDRESS=your-registry-address.azurecr.io
 FROM $SOURCE_CONTAINER_REGISTRY_ADDRESS/arm64v8/node:14-slim
 
 WORKDIR /app/


### PR DESCRIPTION
# PR for issue #1764 

Set the default container registry to a non-existing source, and add a comment that it needs to be replaced.
The build of the images will fail locally, but the CI overwrites the ARG to use our internal source.
