### PR TITLE
fix: Adjust mismatch of Basic Station tags in CI

### DIFF
--- a/.github/actions/deployedge/action.yml
+++ b/.github/actions/deployedge/action.yml
@@ -43,7 +43,8 @@ runs:
   - run: |
       $LBS_IMAGE_TAG=$(az acr repository show-tags --username ${{ env.CONTAINER_REGISTRY_USERNAME }} --password "${{ env.CONTAINER_REGISTRY_PASSWORD }}" --name ${{ env.CONTAINER_REGISTRY_ADDRESS }} --repository lorabasicsstation --orderby time_desc -o json | ConvertFrom-Json)[0]
       echo $LBS_IMAGE_TAG
-      $LBS_IMAGE_TAG=$LBS_IMAGE_TAG.replace("-${{ inputs.architecture }}",'')
+      $LBS_IMAGE_TAG=$LBS_IMAGE_TAG.replace("-arm32v7",'')
+      $LBS_IMAGE_TAG=$LBS_IMAGE_TAG.replace("-arm64v8",'')
       echo $LBS_IMAGE_TAG
       echo "::set-env name=LBS_VERSION::$LBS_IMAGE_TAG"
     shell: pwsh


### PR DESCRIPTION
# PR for issue #1790

## What is being addressed

deployedge github actions is checking for arm32v7 and arm64v8 tags in the registry (not only arm32v7)

## Validation

[Full CI Run](https://github.com/Azure/iotedge-lorawan-starterkit/runs/7384664049)


