### PR TITLE
Fix CI conditions

### DIFF
--- a/.github/workflows/e2e-ci.yaml
+++ b/.github/workflows/e2e-ci.yaml
@@ -92,7 +92,7 @@ jobs:
 
   power_on_azure_vm:
     name: Power ON EFLOW
-    if: always()
+    if: always() && needs.env_var.outputs.StopFullCi != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -109,7 +109,7 @@ jobs:
 
   reset_redis_cache:
     name: Reset the Redis Cache
-    if: always()
+    if: always() && needs.env_var.outputs.StopFullCi != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Flush the database


### PR DESCRIPTION
# PR to avoid CI triggering unneeded events

## What is being addressed

Currently any trigger of the E2E CI is going to reset the redis and turn on EFLOW VM. We want to avoid this therefore I add conditions to avoid such operation if they are not deemed necessary

