### PR TITLE
docs: adapting to application insights instrumentationkey/connstring changes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,14 @@
 title: Release Notes
 ---
 
+## v2.2.0
+
+### New features
+
+### Breaking Changes
+
+- [#1794](https://github.com/Azure/iotedge-lorawan-starterkit/pull/1794): Application Insights is now requiring a connection string instead of instrumentation key. Make sure that, when updating to this version, the `APPLICATIONINSIGHTS_CONNECTION_STRING` is set instead of obsolete `APPINSIGHTS_INSTRUMENTATIONKEY`. More information on how to [migrate from Application Insights instrumentation keys to connection strings](https://docs.microsoft.com/en-us/azure/azure-monitor/app/migrate-from-instrumentation-keys-to-connection-strings) on the official Azure documentation.
+
 ## v2.1.0
 
 ### New Features

--- a/docs/user-guide/lns-configuration.md
+++ b/docs/user-guide/lns-configuration.md
@@ -32,7 +32,7 @@ as environment variables for manual configuration of the
 | CLIENT_CERTIFICATE_MODE     | Specifies the client certificate mode with which the server should be run              | No (defaults to `NoCertificate`)    |
 | LNS_VERSION                 | Version of the LNS                                                                     | No                                  |
 | IOTHUB_CONNECTION_POOL_SIZE | AMQP Connection Pool Size for communication to IoT Edge Hub / IoT Hub (depending on `ENABLE_GATEWAY`). Increasing this value to higher number will improve scalability; for more information see [Scalability](./scalability.md) | No (defaults to 1) |
-| APPINSIGHTS_INSTRUMENTATIONKEY | Instrumentation key for forwarding metrics to Application Insights                  | No                                  |
+| APPLICATIONINSIGHTS_CONNECTION_STRING | Connection string for forwarding metrics to Application Insights                  | No                                  |
 
 The following settings can be configured via desired properties of the Network
 Server module twin in IoT Hub:

--- a/docs/user-guide/lns-discovery.md
+++ b/docs/user-guide/lns-discovery.md
@@ -55,7 +55,7 @@ You can configure the following behavior of the LNS discovery service.
 | Environment variable | Description | Deployment type |
 | ---                  | ---         | ---             |
 | `Logging__LogLevel__Default` | Configures the default log level. For more fine-grained configuration of the console log level, refer to [Logging in .NET Core and ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-6.0#set-log-level-by-command-line-environment-variables-and-other-configuration) | All |
-| `APPINSIGHTS_INSTRUMENTATIONKEY` | Sends telemetry data to Application Insights | All |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | Useful for sending telemetry data to Application Insights | All |
 | `Logging__ApplicationInsights__LogLevel__<Default|..>` | Configures the Application Insights log levels | All |
 | `ASPNETCORE_URLS` | Configures on which URLs the service is listening. Multiple URLs should be separated by a `;` | All |
 | `IotHubHostName` | Host name of the Iot Hub. Only used if you connect to IoT Hub using managed identities. | App Service |

--- a/docs/user-guide/observability.md
+++ b/docs/user-guide/observability.md
@@ -11,13 +11,13 @@ Even if you decide to not use Azure Monitor, you can always access metrics in [P
 If you decide to use Azure Monitor, you will need to create an Application Insights instance and a Log Analytics workspace in your Azure subscription. Follow the steps in the [Dev Guide](devguide.md) to learn how to deploy the engine components. To enable observability using Azure Monitor, ensure that the following settings in your `.env` file (also described in the Dev Guide) are used for the IoT Edge deployment:
 
 ```{bash}
-APPINSIGHTS_INSTRUMENTATIONKEY={appinsights_key}
+APPLICATIONINSIGHTS_CONNECTION_STRING={application_insights_connection_string}
 IOT_HUB_RESOURCE_ID=/subscriptions/{subscription_id}/resourceGroups/{resource_group}/providers/Microsoft.Devices/IotHubs/{iot_hub_name}
 LOG_ANALYTICS_WORKSPACE_ID={log_analytics_workspace_id}
 LOG_ANALYTICS_SHARED_KEY={log_analytics_shared_key}
 ```
 
-Generate a deployment manifest from [`deployment_observability.layered.template.json`](https://github.com/Azure/iotedge-lorawan-starterkit/blob/dev/LoRaEngine/deployment_observability.layered.template.json) and deploy it to the edge devices for which you want to apply the observability. The template will set up the [metrics collector module](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-collect-and-transport-metrics?view=iotedge-2020-11&tabs=iothub#metrics-collector-module) on the edge and connect it with your Log Analytics instance. The gateway will connect directly to your Application Insights instance, if you make sure to set the `APPINSIGHTS_INSTRUMENTATIONKEY` before deploying the `deployment.template.lbs.json` solution. The Application Insights log level will always be the same as the console log level.
+Generate a deployment manifest from [`deployment_observability.layered.template.json`](https://github.com/Azure/iotedge-lorawan-starterkit/blob/dev/LoRaEngine/deployment_observability.layered.template.json) and deploy it to the edge devices for which you want to apply the observability. The template will set up the [metrics collector module](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-collect-and-transport-metrics?view=iotedge-2020-11&tabs=iothub#metrics-collector-module) on the edge and connect it with your Log Analytics instance. The gateway will connect directly to your Application Insights instance, if you make sure to set the `APPLICATIONINSIGHTS_CONNECTION_STRING` before deploying the `deployment.template.lbs.json` solution. The Application Insights log level will always be the same as the console log level.
 
 ## Integrating with the Elastic stack
 


### PR DESCRIPTION
## What is being addressed

The documentation has been updated to reflect the changes from Instrumentation Key to Connection String in Application Insights.

Release notes for upcoming v2.2.0 have been added with this first breaking change

