### PR TITLE
Implement IoT Hub Station twin

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Constants.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Constants.cs
@@ -13,6 +13,5 @@ namespace LoRaTools
 
         public const string NetworkTagName = "network";
         public const string NetworkId = "quickstartnetwork";
-
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IDeviceRegistryManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IDeviceRegistryManager.cs
@@ -12,6 +12,7 @@ namespace LoRaTools
     {
         Task<IDeviceTwin> GetTwinAsync(string deviceId, CancellationToken? cancellationToken = null);
         Task<ILoRaDeviceTwin> GetLoRaDeviceTwinAsync(string deviceId, CancellationToken? cancellationToken = null);
+        Task<IStationTwin> GetStationTwinAsync(StationEui stationEui, CancellationToken? cancellationToken = null);
         Task<string> GetDevicePrimaryKeyAsync(string deviceId);
         Task<IDeviceTwin> UpdateTwinAsync(string deviceId, string moduleId, IDeviceTwin deviceTwin, string eTag, CancellationToken cancellationToken);
         Task<bool> AddDeviceAsync(IDeviceTwin twin);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IStationTwin.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IStationTwin.cs
@@ -3,14 +3,8 @@
 
 namespace LoRaTools
 {
-    using Microsoft.Azure.Devices.Shared;
-
-    public interface IDeviceTwin
+    public interface IStationTwin : IDeviceTwin
     {
-        string DeviceId { get; }
-
-        string ETag { get; }
-
-        TwinProperties Properties { get; }
+        string NetworkId { get; }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubDeviceTwin.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubDeviceTwin.cs
@@ -12,10 +12,10 @@ namespace LoRaTools.IoTHubImpl
 
         public TwinProperties Properties => this.TwinInstance.Properties;
 
-        public TwinCollection Tags => this.TwinInstance.Tags;
-
         public IoTHubDeviceTwin(Twin twin)
         {
+            ArgumentNullException.ThrowIfNull(twin, nameof(twin));
+
             this.TwinInstance = twin;
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubRegistryManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubRegistryManager.cs
@@ -83,6 +83,9 @@ namespace LoRaTools.IoTHubImpl
             return new IoTHubLoRaDeviceTwinPageResult(q);
         }
 
+        public async Task<IStationTwin> GetStationTwinAsync(StationEui stationEui, CancellationToken? cancellationToken = null)
+             => new IoTHubStationTwin(await this.instance.GetTwinAsync(stationEui.ToString(), cancellationToken ?? CancellationToken.None));
+
         public IRegistryPageResult<ILoRaDeviceTwin> GetLastUpdatedLoRaDevices(DateTime lastUpdateDateTime)
         {
             var formattedDateTime = lastUpdateDateTime.ToString(Constants.RoundTripDateTimeStringFormat, CultureInfo.InvariantCulture);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubStationTwin.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubStationTwin.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaTools.IoTHubImpl
+{
+    using LoRaTools.Utils;
+    using Microsoft.Azure.Devices.Shared;
+
+    public class IoTHubStationTwin : IoTHubDeviceTwin, IStationTwin
+    {
+        public string NetworkId => base.TwinInstance.Tags.ReadRequired<string>(Constants.NetworkTagName);
+
+        public IoTHubStationTwin(Twin twinInstance)
+            : base(twinInstance)
+        {
+
+        }
+    }
+}

--- a/Tests/Integration/LnsDiscoveryIntegrationTests.cs
+++ b/Tests/Integration/LnsDiscoveryIntegrationTests.cs
@@ -200,8 +200,8 @@ namespace LoRaWan.Tests.Integration
         {
             this.subject
                 .RegistryManagerMock?
-                .Setup(rm => rm.GetTwinAsync(stationEui.ToString(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new IoTHubDeviceTwin(new Twin { Tags = new TwinCollection(@$"{{""network"":""{networkId}""}}") }));
+                .Setup(rm => rm.GetStationTwinAsync(stationEui, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new IoTHubStationTwin(new Twin { Tags = new TwinCollection(@$"{{""network"":""{networkId}""}}") }));
         }
 
         private void SetupIotHubQueryResponse(string networkId, IList<string> hostAddresses)

--- a/Tests/Unit/NetworkServerDiscovery/TagBasedLnsDiscoveryTests.cs
+++ b/Tests/Unit/NetworkServerDiscovery/TagBasedLnsDiscoveryTests.cs
@@ -83,7 +83,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerDiscovery
         public async Task ResolveLnsAsync_Throws_If_Network_Is_Empty()
         {
             SetupLbsTwinResponse(StationEui, string.Empty);
-            _ = await Assert.ThrowsAsync<InvalidOperationException>(() => this.subject.ResolveLnsAsync(StationEui, CancellationToken.None));
+            _ = await Assert.ThrowsAsync<LoRaProcessingException>(() => this.subject.ResolveLnsAsync(StationEui, CancellationToken.None));
         }
 
         [Fact]
@@ -197,14 +197,14 @@ namespace LoRaWan.Tests.Unit.NetworkServerDiscovery
             _ = await this.subject.ResolveLnsAsync(StationEui, CancellationToken.None);
 
             // assert
-            this.registryManagerMock.Verify(rm => rm.GetTwinAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            this.registryManagerMock.Verify(rm => rm.GetStationTwinAsync(It.IsAny<StationEui>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         private void SetupLbsTwinResponse(StationEui stationEui, string networkId)
         {
             this.registryManagerMock
-                .Setup(rm => rm.GetTwinAsync(stationEui.ToString(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new IoTHubDeviceTwin(new Twin { Tags = new TwinCollection(@$"{{""network"":""{networkId}""}}") }));
+                .Setup(rm => rm.GetStationTwinAsync(stationEui, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new IoTHubStationTwin(new Twin { Tags = new TwinCollection(@$"{{""network"":""{networkId}""}}") }));
         }
 
         private void SetupIotHubQueryResponse(string networkId, IList<string?> hostAddresses)


### PR DESCRIPTION
# PR for implementing Station twin in IoT Hub implementation

## What is being addressed

<!-- Describe the current behavior you are modifying -->

Implementing the station twin, helps me to decouple LoRa management facade from the IoT Hub device twin.

## How is this addressed

- Create the IStationTwin interface
- Implement new method in Registry manager to retrieve station by its StationEui
- Adapt unit test
