### PR TITLE
Rafactoring - Wrap TwinCollection into ITwinProperties interface

### DIFF
--- a/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/EdgeDeviceGetter.cs
@@ -9,8 +9,6 @@ namespace LoraKeysManagerFacade
     using System.Threading;
     using System.Threading.Tasks;
     using LoRaTools;
-    using LoRaTools.IoTHubImpl;
-    using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Logging;
 
     public class EdgeDeviceGetter : IEdgeDeviceGetter

--- a/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
+++ b/LoRaEngine/LoraKeysManagerFacade/SendCloudToDeviceMessage/SendCloudToDeviceMessage.cs
@@ -128,8 +128,8 @@ namespace LoraKeysManagerFacade
 
                 if (twin != null)
                 {
-                    var desiredReader = new TwinCollectionReader(twin.Properties.Desired, this.log);
-                    var reportedReader = new TwinCollectionReader(twin.Properties.Reported, this.log);
+                    var desiredReader = new TwinPropertiesReader(twin.Properties.Desired, this.log);
+                    var reportedReader = new TwinPropertiesReader(twin.Properties.Reported, this.log);
 
                     // the device must have a DevAddr
                     if (!desiredReader.TryRead(TwinPropertiesConstants.DevAddr, out DevAddr _) && !reportedReader.TryRead(TwinPropertiesConstants.DevAddr, out DevAddr _))

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Constants.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Constants.cs
@@ -13,6 +13,5 @@ namespace LoRaTools
 
         public const string NetworkTagName = "network";
         public const string NetworkId = "quickstartnetwork";
-
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IDeviceRegistryManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IDeviceRegistryManager.cs
@@ -12,6 +12,7 @@ namespace LoRaTools
     {
         Task<IDeviceTwin> GetTwinAsync(string deviceId, CancellationToken? cancellationToken = null);
         Task<ILoRaDeviceTwin> GetLoRaDeviceTwinAsync(string deviceId, CancellationToken? cancellationToken = null);
+        Task<IStationTwin> GetStationTwinAsync(StationEui stationEui, CancellationToken? cancellationToken = null);
         Task<string> GetDevicePrimaryKeyAsync(string deviceId);
         Task<IDeviceTwin> UpdateTwinAsync(string deviceId, string moduleId, IDeviceTwin deviceTwin, string eTag, CancellationToken cancellationToken);
         Task<bool> AddDeviceAsync(IDeviceTwin twin);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IStationTwin.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IStationTwin.cs
@@ -3,14 +3,8 @@
 
 namespace LoRaTools
 {
-    using Microsoft.Azure.Devices.Shared;
-
-    public interface IDeviceTwin
+    public interface IStationTwin : IDeviceTwin
     {
-        string DeviceId { get; }
-
-        string ETag { get; }
-
-        TwinProperties Properties { get; }
+        string NetworkId { get; }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/ITwinProperties.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/ITwinProperties.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaTools
+{
+    using System;
+    using Microsoft.Azure.Devices.Shared;
+
+    public interface ITwinProperties
+    {
+        long Version { get; }
+
+        dynamic this[string propertyName] { get; set; }
+
+        bool ContainsKey(string propertyName);
+
+        DateTime GetLastUpdated();
+
+        Metadata GetMetadata();
+
+        bool TryGetValue(string propertyName, out object item);
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/ITwinPropertiesContainer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/ITwinPropertiesContainer.cs
@@ -3,12 +3,10 @@
 
 namespace LoRaTools
 {
-    public interface IDeviceTwin
+    public interface ITwinPropertiesContainer
     {
-        string DeviceId { get; }
+        public ITwinProperties Desired { get; }
 
-        string ETag { get; }
-
-        ITwinPropertiesContainer Properties { get; }
+        public ITwinProperties Reported { get; }
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubDeviceTwin.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubDeviceTwin.cs
@@ -10,13 +10,12 @@ namespace LoRaTools.IoTHubImpl
     {
         internal Twin TwinInstance { get; }
 
-        public TwinProperties Properties => this.TwinInstance.Properties;
+        public ITwinPropertiesContainer Properties { get; }
 
         public IoTHubDeviceTwin(Twin twin)
         {
-            ArgumentNullException.ThrowIfNull(twin, nameof(twin));
-
             this.TwinInstance = twin;
+            this.Properties = new IoTHubTwinPropertiesContainer(twin);
         }
 
         public string ETag => this.TwinInstance.ETag;

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubDeviceTwin.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubDeviceTwin.cs
@@ -4,7 +4,6 @@
 namespace LoRaTools.IoTHubImpl
 {
     using System;
-    using LoRaTools.Utils;
     using Microsoft.Azure.Devices.Shared;
 
     public class IoTHubDeviceTwin : IDeviceTwin
@@ -13,10 +12,10 @@ namespace LoRaTools.IoTHubImpl
 
         public TwinProperties Properties => this.TwinInstance.Properties;
 
-        public TwinCollection Tags => this.TwinInstance.Tags;
-
         public IoTHubDeviceTwin(Twin twin)
         {
+            ArgumentNullException.ThrowIfNull(twin, nameof(twin));
+
             this.TwinInstance = twin;
         }
 

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubLoRaDeviceTwin.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubLoRaDeviceTwin.cs
@@ -13,15 +13,15 @@ namespace LoRaTools.IoTHubImpl
         }
 
         public string GetGatewayID()
-            => TwinInstance.Properties.Desired.TryRead<string>(TwinPropertiesConstants.GatewayID, null, out var someGatewayId)
+            => this.Properties.Desired.TryRead<string>(TwinPropertiesConstants.GatewayID, null, out var someGatewayId)
              ? someGatewayId
              : string.Empty;
 
         public string GetNwkSKey()
         {
-            return TwinInstance.Properties.Desired.TryRead(TwinPropertiesConstants.NwkSKey, null, out string nwkSKey)
+            return this.Properties.Desired.TryRead(TwinPropertiesConstants.NwkSKey, null, out string nwkSKey)
                 ? nwkSKey
-                : TwinInstance.Properties.Reported.TryRead(TwinPropertiesConstants.NwkSKey, null, out nwkSKey)
+                : this.Properties.Reported.TryRead(TwinPropertiesConstants.NwkSKey, null, out nwkSKey)
                 ? nwkSKey
                 : null;
         }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubRegistryManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubRegistryManager.cs
@@ -83,6 +83,9 @@ namespace LoRaTools.IoTHubImpl
             return new IoTHubLoRaDeviceTwinPageResult(q);
         }
 
+        public async Task<IStationTwin> GetStationTwinAsync(StationEui stationEui, CancellationToken? cancellationToken = null)
+             => new IoTHubStationTwin(await this.instance.GetTwinAsync(stationEui.ToString(), cancellationToken ?? CancellationToken.None));
+
         public IRegistryPageResult<ILoRaDeviceTwin> GetLastUpdatedLoRaDevices(DateTime lastUpdateDateTime)
         {
             var formattedDateTime = lastUpdateDateTime.ToString(Constants.RoundTripDateTimeStringFormat, CultureInfo.InvariantCulture);

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubStationTwin.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubStationTwin.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaTools.IoTHubImpl
+{
+    using LoRaTools.Utils;
+    using Microsoft.Azure.Devices.Shared;
+
+    public class IoTHubStationTwin : IoTHubDeviceTwin, IStationTwin
+    {
+        public string NetworkId => base.TwinInstance.Tags.ReadRequired<string>(Constants.NetworkTagName);
+
+        public IoTHubStationTwin(Twin twinInstance)
+            : base(twinInstance)
+        {
+
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubTwinProperties.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubTwinProperties.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaTools.IoTHubImpl
+{
+    using System;
+    using Microsoft.Azure.Devices.Shared;
+
+    public class IoTHubTwinProperties : ITwinProperties
+    {
+        private readonly TwinCollection twinCollection;
+
+        public long Version => this.twinCollection.Version;
+
+        public dynamic this[string propertyName] { get => this.twinCollection[propertyName]; set => this.twinCollection[propertyName] = value; }
+
+        public IoTHubTwinProperties(TwinCollection twinCollection)
+        {
+            this.twinCollection = twinCollection;
+        }
+
+        public DateTime GetLastUpdated() =>
+            this.twinCollection.GetLastUpdated();
+
+        public Metadata GetMetadata() => this.twinCollection.GetMetadata();
+
+        public bool ContainsKey(string propertyName)
+            => this.twinCollection.Contains(propertyName);
+
+        public bool TryGetValue(string propertyName, out object item)
+        {
+            item = null;
+
+            if (!this.twinCollection.Contains(propertyName))
+                return false;
+
+            item = this.twinCollection[propertyName];
+
+            return true;
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubTwinPropertiesContainer.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubTwinPropertiesContainer.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaTools.IoTHubImpl
+{
+    using Microsoft.Azure.Devices.Shared;
+
+    public class IoTHubTwinPropertiesContainer : ITwinPropertiesContainer
+    {
+        public ITwinProperties Desired { get; }
+
+        public ITwinProperties Reported { get; }
+
+        public IoTHubTwinPropertiesContainer(Twin twin)
+        {
+            this.Desired = new IoTHubTwinProperties(twin?.Properties?.Desired ?? new TwinCollection());
+            this.Reported = new IoTHubTwinProperties(twin?.Properties?.Reported ?? new TwinCollection());
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinCollectionExtensions.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinCollectionExtensions.cs
@@ -7,23 +7,12 @@ namespace LoRaTools.Utils
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using System.Globalization;
     using System.Text.Json;
-    using LoRaWan;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Logging;
 
     public static class TwinCollectionExtensions
     {
-        private static readonly Type StationEuiType = typeof(StationEui);
-        private static readonly Type DevNonceType = typeof(DevNonce);
-        private static readonly Type DevAddrType = typeof(DevAddr);
-        private static readonly Type AppSessionKeyType = typeof(AppSessionKey);
-        private static readonly Type AppKeyType = typeof(AppKey);
-        private static readonly Type NetworkSessionKeyType = typeof(NetworkSessionKey);
-        private static readonly Type JoinEuiType = typeof(JoinEui);
-        private static readonly Type NetIdType = typeof(NetId);
-
         public static T? SafeRead<T>(this TwinCollection twinCollection, string property, T? defaultValue = default, ILogger? logger = null)
             => twinCollection.TryRead<T>(property, logger, out var someT) ? someT : defaultValue;
 
@@ -44,58 +33,7 @@ namespace LoRaTools.Utils
             // cast to object to avoid dynamic code to be generated
             var some = (object)twinCollection[property];
 
-            // quick path for values that can be directly converted
-            if (some is Newtonsoft.Json.Linq.JValue someJValue)
-            {
-                if (someJValue.Value is T someT)
-                {
-                    value = someT;
-                    return true;
-                }
-            }
-
-            try
-            {
-                var t = typeof(T);
-                var tPrime = Nullable.GetUnderlyingType(t) ?? t;
-
-                // For 100% case coverage we should handle the case where type T is nullable and the token is null.
-                // Since this is not possible in IoT hub, we do not handle the null cases exhaustively.
-
-                if (tPrime == StationEuiType)
-                    value = (T)(object)StationEui.Parse(some.ToString());
-                else if (tPrime == DevNonceType)
-                    value = (T)(object)new DevNonce(Convert.ToUInt16(some, CultureInfo.InvariantCulture));
-                else if (tPrime == DevAddrType)
-                    value = (T)(object)DevAddr.Parse(some.ToString());
-                else if (tPrime == AppSessionKeyType)
-                    value = (T)(object)AppSessionKey.Parse(some.ToString());
-                else if (tPrime == AppKeyType)
-                    value = (T)(object)AppKey.Parse(some.ToString());
-                else if (tPrime == NetworkSessionKeyType)
-                    value = (T)(object)NetworkSessionKey.Parse(some.ToString());
-                else if (tPrime == JoinEuiType)
-                    value = (T)(object)JoinEui.Parse(some.ToString());
-                else if (tPrime == NetIdType)
-                    value = (T)(object)NetId.Parse(some.ToString());
-                else
-                    value = (T)Convert.ChangeType(some, t, CultureInfo.InvariantCulture);
-                if (t.IsEnum && !t.IsEnumDefined(value))
-                {
-                    LogParsingError(logger, property, some);
-                    return false;
-                }
-            }
-            catch (Exception ex) when (ex is ArgumentException
-                                          or InvalidCastException
-                                          or FormatException
-                                          or OverflowException
-                                          or Newtonsoft.Json.JsonSerializationException)
-            {
-                LogParsingError(logger, property, some, ex);
-                return false;
-            }
-            return true;
+            return TwinPropertyParser.TryParse<T>(property, some, logger, out value);
         }
 
         public static bool TryReadJsonBlock(this TwinCollection twinCollection, string property, [NotNullWhen(true)] out string? json)
@@ -126,8 +64,5 @@ namespace LoRaTools.Utils
             }
             return value != null;
         }
-
-        private static void LogParsingError(ILogger? logger, string property, object? value, Exception? ex = default)
-            => logger?.LogError(ex, "Failed to parse twin '{TwinProperty}'. The value stored is '{TwinValue}'", property, value);
     }
 }

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinPropertiesExtensions.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinPropertiesExtensions.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaTools.Utils
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.Extensions.Logging;
+
+    public static class TwinPropertiesExtensions
+    {
+        public static T? SafeRead<T>(this ITwinProperties twinCollection, string property, T? defaultValue = default, ILogger? logger = null)
+            => twinCollection.TryRead<T>(property, logger, out var someT) ? someT : defaultValue;
+
+        public static bool TryRead<T>(this ITwinProperties twinCollection, string property, ILogger? logger, [NotNullWhen(true)] out T? value)
+        {
+            _ = twinCollection ?? throw new ArgumentNullException(nameof(twinCollection));
+
+            value = default;
+
+            if (!twinCollection.TryGetValue(property, out var some))
+                return false;
+
+            return TwinPropertyParser.TryParse<T>(property, some, logger, out value);
+        }
+
+        public static bool TryReadJsonBlock(this ITwinProperties twinCollection, string property, [NotNullWhen(true)] out string? json)
+        {
+            _ = twinCollection ?? throw new ArgumentNullException(nameof(twinCollection));
+            json = null;
+
+            if (!twinCollection.TryGetValue(property, out var some))
+                return false;
+
+            json = some.ToString();
+            return json != null;
+        }
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinPropertiesReader.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinPropertiesReader.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaTools.Utils
+{
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.Extensions.Logging;
+
+    public sealed class TwinPropertiesReader
+    {
+        private readonly ITwinProperties twinCollection;
+        private readonly ILogger logger;
+
+        public TwinPropertiesReader(ITwinProperties twinCollection, ILogger logger)
+        {
+            this.twinCollection = twinCollection;
+            this.logger = logger;
+        }
+
+        public T? SafeRead<T>(string property, T? defaultValue = default)
+            => this.twinCollection.SafeRead(property, defaultValue, this.logger);
+
+        public bool TryRead<T>(string property, [NotNullWhen(true)] out T? value)
+            => this.twinCollection.TryRead(property, this.logger, out value);
+    }
+}

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinPropertyParser.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/Utils/TwinPropertyParser.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace LoRaTools.Utils
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
+    using LoRaWan;
+    using Microsoft.Extensions.Logging;
+
+    internal static class TwinPropertyParser
+    {
+        private static readonly Type StationEuiType = typeof(StationEui);
+        private static readonly Type DevNonceType = typeof(DevNonce);
+        private static readonly Type DevAddrType = typeof(DevAddr);
+        private static readonly Type AppSessionKeyType = typeof(AppSessionKey);
+        private static readonly Type AppKeyType = typeof(AppKey);
+        private static readonly Type NetworkSessionKeyType = typeof(NetworkSessionKey);
+        private static readonly Type JoinEuiType = typeof(JoinEui);
+        private static readonly Type NetIdType = typeof(NetId);
+
+        public static bool TryParse<T>(string property, object some, ILogger? logger, [NotNullWhen(true)] out T? value)
+        {
+            try
+            {
+                if (!Parse(some, out value))
+                {
+                    LogParsingError(logger, property, value);
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex) when (ex is ArgumentException
+                              or InvalidCastException
+                              or FormatException
+                              or OverflowException
+                              or Newtonsoft.Json.JsonSerializationException)
+            {
+                LogParsingError(logger, property, some);
+                value = default;
+
+                return false;
+            }
+        }
+
+        public static bool Parse<T>(object some, [NotNullWhen(true)] out T? value)
+        {
+            // quick path for values that can be directly converted
+            if (some is Newtonsoft.Json.Linq.JValue someJValue && someJValue.Value is T someT)
+            {
+                value = someT;
+                return true;
+            }
+
+            var t = typeof(T);
+
+            var tPrime = Nullable.GetUnderlyingType(t) ?? t;
+
+            // For 100% case coverage we should handle the case where type T is nullable and the token is null.
+            // Since this is not possible in IoT hub, we do not handle the null cases exhaustively.
+
+            if (tPrime == StationEuiType)
+                value = (T)(object)StationEui.Parse(some.ToString());
+            else if (tPrime == DevNonceType)
+                value = (T)(object)new DevNonce(Convert.ToUInt16(some, CultureInfo.InvariantCulture));
+            else if (tPrime == DevAddrType)
+                value = (T)(object)DevAddr.Parse(some.ToString());
+            else if (tPrime == AppSessionKeyType)
+                value = (T)(object)AppSessionKey.Parse(some.ToString());
+            else if (tPrime == AppKeyType)
+                value = (T)(object)AppKey.Parse(some.ToString());
+            else if (tPrime == NetworkSessionKeyType)
+                value = (T)(object)NetworkSessionKey.Parse(some.ToString());
+            else if (tPrime == JoinEuiType)
+                value = (T)(object)JoinEui.Parse(some.ToString());
+            else if (tPrime == NetIdType)
+                value = (T)(object)NetId.Parse(some.ToString());
+            else
+                value = (T)Convert.ChangeType(some, t, CultureInfo.InvariantCulture);
+
+            return !t.IsEnum || t.IsEnumDefined(value);
+        }
+
+        private static void LogParsingError(ILogger? logger, string property, object? value, Exception? ex = default)
+            => logger?.LogError(ex, "Failed to parse twin '{TwinProperty}'. The value stored is '{TwinValue}'", property, value);
+    }
+}

--- a/Tests/Common/IntegrationTestFixtureBase.Asserts.cs
+++ b/Tests/Common/IntegrationTestFixtureBase.Asserts.cs
@@ -207,9 +207,10 @@ namespace LoRaWan.Tests.Common
                 await Task.Delay(DelayForJoinTwinStore);
 
                 var twins = await GetTwinAsync(devEUI.ToString());
-                if (twins.Properties.Reported.Contains(DevAddrProperty))
+
+                if (twins.Properties.Reported.TryGetValue(DevAddrProperty, out var item))
                 {
-                    reported = devAddr.Equals(twins.Properties.Reported[DevAddrProperty].Value as string, StringComparison.OrdinalIgnoreCase);
+                    reported = devAddr.Equals(item as string, StringComparison.OrdinalIgnoreCase);
                 }
             }
 

--- a/Tests/Common/IntegrationTestFixtureBase.cs
+++ b/Tests/Common/IntegrationTestFixtureBase.cs
@@ -336,7 +336,7 @@ namespace LoRaWan.Tests.Common
             if (getDeviceResult == null)
                 throw new InvalidOperationException("Concentrator should exist in IoT Hub");
             var deviceTwin = await registryManager.GetTwinAsync(stationDeviceId);
-            var cupsJson = ((object)deviceTwin.Properties.Desired[BasicsStationConfigurationService.CupsPropertyName]).ToString();
+            var cupsJson = (string)(deviceTwin.Properties.Desired[BasicsStationConfigurationService.CupsPropertyName]).ToString();
             var newCupsInfo = JsonConvert.DeserializeObject<CupsTwinInfo>(cupsJson) with
             {
                 TcCredCrc = crc,
@@ -355,7 +355,7 @@ namespace LoRaWan.Tests.Common
             if (getDeviceResult == null)
                 throw new InvalidOperationException("Concentrator should exist in IoT Hub");
             var deviceTwin = await registryManager.GetTwinAsync(stationDeviceId);
-            var cupsJson = ((object)deviceTwin.Properties.Desired[BasicsStationConfigurationService.CupsPropertyName]).ToString();
+            var cupsJson = (string)(deviceTwin.Properties.Desired[BasicsStationConfigurationService.CupsPropertyName]).ToString();
             var newCupsInfo = JsonConvert.DeserializeObject<CupsTwinInfo>(cupsJson) with
             {
                 FwKeyChecksum = crc,
@@ -396,11 +396,11 @@ namespace LoRaWan.Tests.Common
                 {
                     // compare device twin and make changes if needed
                     var deviceTwin = await registryManager.GetTwinAsync(testDevice.DeviceID);
-                    var twinCollectionReader = new TwinCollectionReader(deviceTwin.Properties.Desired, NullLogger.Instance);
+                    var twinCollectionReader = new TwinPropertiesReader(deviceTwin.Properties.Desired, NullLogger.Instance);
                     var desiredProperties = testDevice.GetDesiredProperties();
                     foreach (var kv in desiredProperties)
                     {
-                        if (kv.Key == BasicsStationConfigurationService.RouterConfigPropertyName && deviceTwin.Properties.Desired.Contains(kv.Key))
+                        if (kv.Key == BasicsStationConfigurationService.RouterConfigPropertyName && deviceTwin.Properties.Desired.ContainsKey(kv.Key))
                         {
                             // The router config property cannot be updated automatically. If it is present, we assume that it is correct.
                             continue;
@@ -409,7 +409,7 @@ namespace LoRaWan.Tests.Common
                         if (twinCollectionReader.SafeRead<string>(kv.Key) != kv.Value.ToString())
                         {
                             var existingValue = string.Empty;
-                            if (deviceTwin.Properties.Desired.Contains(kv.Key))
+                            if (deviceTwin.Properties.Desired.ContainsKey(kv.Key))
                             {
                                 existingValue = deviceTwin.Properties.Desired[kv.Key].ToString();
                             }

--- a/Tests/E2E/CupsTests.cs
+++ b/Tests/E2E/CupsTests.cs
@@ -120,7 +120,7 @@ namespace LoRaWan.Tests.E2E
                 Assert.True(updfLog.Found);
 
                 var twin = await TestFixture.GetTwinAsync(stationEui.ToString());
-                var twinReader = new TwinCollectionReader(twin.Properties.Reported, null);
+                var twinReader = new TwinPropertiesReader(twin.Properties.Reported, null);
                 Assert.True(twinReader.TryRead<string>(TwinProperty.Package, out var reportedPackage)
                             && string.Equals(fwPackage, reportedPackage, StringComparison.OrdinalIgnoreCase));
             }

--- a/Tests/E2E/OTAAJoinTest.cs
+++ b/Tests/E2E/OTAAJoinTest.cs
@@ -61,14 +61,14 @@ namespace LoRaWan.Tests.E2E
             Assert.NotNull(twinAfterJoin.Properties.Reported);
             try
             {
-                Assert.True(twinAfterJoin.Properties.Reported.Contains("FCntUp"), "Property FCntUp does not exist");
-                Assert.True(twinAfterJoin.Properties.Reported.Contains("FCntDown"), "Property FCntDown does not exist");
-                Assert.True(twinAfterJoin.Properties.Reported.Contains("NetId"), "Property NetId does not exist");
-                Assert.True(twinAfterJoin.Properties.Reported.Contains("DevAddr"), "Property DevAddr does not exist");
-                Assert.True(twinAfterJoin.Properties.Reported.Contains("DevNonce"), "Property DevNonce does not exist");
-                Assert.True(twinAfterJoin.Properties.Reported.Contains("NwkSKey"), "Property NwkSKey does not exist");
-                Assert.True(twinAfterJoin.Properties.Reported.Contains("AppSKey"), "Property AppSKey does not exist");
-                Assert.True(twinAfterJoin.Properties.Reported.Contains("DevEUI"), "Property DevEUI does not exist");
+                Assert.True(twinAfterJoin.Properties.Reported.ContainsKey("FCntUp"), "Property FCntUp does not exist");
+                Assert.True(twinAfterJoin.Properties.Reported.ContainsKey("FCntDown"), "Property FCntDown does not exist");
+                Assert.True(twinAfterJoin.Properties.Reported.ContainsKey("NetId"), "Property NetId does not exist");
+                Assert.True(twinAfterJoin.Properties.Reported.ContainsKey("DevAddr"), "Property DevAddr does not exist");
+                Assert.True(twinAfterJoin.Properties.Reported.ContainsKey("DevNonce"), "Property DevNonce does not exist");
+                Assert.True(twinAfterJoin.Properties.Reported.ContainsKey("NwkSKey"), "Property NwkSKey does not exist");
+                Assert.True(twinAfterJoin.Properties.Reported.ContainsKey("AppSKey"), "Property AppSKey does not exist");
+                Assert.True(twinAfterJoin.Properties.Reported.ContainsKey("DevEUI"), "Property DevEUI does not exist");
                 var devAddrBefore = (string)twinBeforeJoin.Properties.Reported["DevAddr"];
                 var devAddrAfter = (string)twinAfterJoin.Properties.Reported["DevAddr"];
                 var actualReportedDevEUI = (string)twinAfterJoin.Properties.Reported["DevEUI"];

--- a/Tests/Integration/LnsDiscoveryIntegrationTests.cs
+++ b/Tests/Integration/LnsDiscoveryIntegrationTests.cs
@@ -201,8 +201,8 @@ namespace LoRaWan.Tests.Integration
         {
             this.subject
                 .RegistryManagerMock?
-                .Setup(rm => rm.GetTwinAsync(stationEui.ToString(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new IoTHubDeviceTwin(new Twin { Tags = new TwinCollection(@$"{{""network"":""{networkId}""}}") }));
+                .Setup(rm => rm.GetStationTwinAsync(stationEui, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new IoTHubStationTwin(new Twin { Tags = new TwinCollection(@$"{{""network"":""{networkId}""}}") }));
         }
 
         private void SetupIotHubQueryResponse(string networkId, IList<string> hostAddresses)

--- a/Tests/Unit/IoTHubImpl/FakeIoTHubDeviceTwinTests.cs
+++ b/Tests/Unit/IoTHubImpl/FakeIoTHubDeviceTwinTests.cs
@@ -5,17 +5,14 @@ namespace LoRaWan.Tests.Unit.IoTHubImpl
 {
     using System;
     using global::LoRaTools;
-    using Microsoft.Azure.Devices.Shared;
 
     internal sealed class FakeIoTHubDeviceTwinTests : IDeviceTwin
     {
         public string ETag => throw new NotImplementedException();
 
-        public TwinProperties Properties => throw new NotImplementedException();
-
-        public TwinCollection Tags => throw new NotImplementedException();
-
         public string DeviceId => throw new NotImplementedException();
+
+        public ITwinPropertiesContainer Properties => throw new NotImplementedException();
 
         public string GetGatewayID()
         {

--- a/Tests/Unit/IoTHubImpl/IoTHubRegistryManagerTests.cs
+++ b/Tests/Unit/IoTHubImpl/IoTHubRegistryManagerTests.cs
@@ -157,6 +157,32 @@ namespace LoRaWan.Tests.Unit.IoTHubImpl
         }
 
         [Fact]
+        public async Task GetStationTwinAsync()
+        {
+            var stationEui = new StationEui(01234);
+
+            // Arrange
+            using (var manager = CreateManager())
+            {
+                var twin = new Twin(stationEui.ToString());
+
+                this.mockRegistryManager.Setup(c => c.GetTwinAsync(
+                        It.Is<string>(x => x == stationEui.ToString()),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(twin);
+
+                // Act
+                var result = await manager.GetStationTwinAsync(stationEui);
+
+                // Assert
+                Assert.Equal(twin, result.ToIoTHubDeviceTwin());
+            }
+
+            this.mockRepository.VerifyAll();
+        }
+
+
+        [Fact]
         public async Task UpdateTwinAsync2()
         {
             // Arrange

--- a/Tests/Unit/IoTHubImpl/IoTHubTwinPropertiesTests.cs
+++ b/Tests/Unit/IoTHubImpl/IoTHubTwinPropertiesTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace LoRaWan.Tests.Unit.IoTHubImpl
+{
+    using System;
+    using global::LoRaTools.IoTHubImpl;
+    using Microsoft.Azure.Devices.Shared;
+    using Moq;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using Xunit;
+
+    public class IoTHubTwinPropertiesTests
+    {
+        [Fact]
+        public void VersionAccessorTest()
+        {
+            // Arrange
+            var mockCollection = new TwinCollection(/*lang=json,strict*/ "{\"$version\":123}");
+
+            var instance = new IoTHubTwinProperties(mockCollection);
+
+            // Act
+            var result = instance.Version;
+
+            // Asset
+            Assert.Equal(123, result);
+        }
+
+        [Fact]
+        public void GetLastUpdatedTest()
+        {
+            // Arrange
+            var expected = DateTime.Now;
+            var mockCollection = new TwinCollection(JObject.Parse(/*lang=json,strict*/ "{\"$version\":123}"),
+                                                    JObject.Parse(/*lang=json,strict*/ $"{{\"$lastUpdated\":\"{expected:o}\",\"$lastUpdatedVersion\":123}}"));
+
+            var instance = new IoTHubTwinProperties(mockCollection);
+
+            // Act
+            var result = instance.GetLastUpdated();
+
+            // Asset
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void GetMetadataTest()
+        {
+            // Arrange
+            var expected = DateTime.Now;
+            var mockCollection = new TwinCollection(JObject.Parse(/*lang=json,strict*/ "{\"$version\":123}"),
+                                                    JObject.Parse(/*lang=json,strict*/ $"{{\"$lastUpdated\":\"{expected:o}\",\"$lastUpdatedVersion\":123}}"));
+
+            var instance = new IoTHubTwinProperties(mockCollection);
+
+            // Act
+            var result = instance.GetMetadata();
+
+            // Asset
+            Assert.Equal(123, result.LastUpdatedVersion);
+            Assert.Equal(expected, result.LastUpdated);
+        }
+
+        [Theory]
+        [InlineData(/*lang=json,strict*/ "{\"searchProperty\": \"aaa\"}", true)]
+        [InlineData(/*lang=json,strict*/ "{\"other\": \"aaa\"}", false)]
+        public void ContainsKeyTest(string json, bool expected)
+        {
+            // Arrange
+            var mockCollection = new TwinCollection(json);
+
+            var instance = new IoTHubTwinProperties(mockCollection);
+
+            // Act
+            var result = instance.ContainsKey("searchProperty");
+
+            // Asset
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Tests/Unit/LoraKeysManagerFacade/SendCloudToDeviceMessageTest.cs
+++ b/Tests/Unit/LoraKeysManagerFacade/SendCloudToDeviceMessageTest.cs
@@ -6,6 +6,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq.Expressions;
     using System.Net;
     using System.Text;
     using System.Threading;
@@ -13,6 +14,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
     using global::LoraKeysManagerFacade;
     using global::LoRaTools;
     using global::LoRaTools.CommonAPI;
+    using global::LoRaTools.IoTHubImpl;
     using LoRaWan.Tests.Common;
     using LoRaWan.Tests.Unit.IoTHubImpl;
     using Microsoft.AspNetCore.Http;
@@ -23,6 +25,7 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
     using Xunit;
 
     public class SendCloudToDeviceMessageTest
@@ -226,8 +229,10 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var devEui = new DevEui(123456789);
 
             var mockDeviceTwin = new Mock<ILoRaDeviceTwin>();
+            var mockTwinProperties = SetupMockTwinProperties();
+
             mockDeviceTwin.SetupGet(c => c.Properties)
-                           .Returns(new TwinProperties());
+                           .Returns(mockTwinProperties.Object);
 
             var query = new Mock<IRegistryPageResult<ILoRaDeviceTwin>>(MockBehavior.Strict);
             query.Setup(x => x.HasMoreResults).Returns(true);
@@ -318,12 +323,12 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
 
             var mockDeviceTwin = new Mock<ILoRaDeviceTwin>();
 
+            var mockTwinProperties = SetupMockTwinProperties(
+                desired: $"{{\"DevAddr\": \"03010101\", \"ClassType\": \"C\"}}",
+                reported: $"{{\"PreferredGatewayID\": \"gateway1\" }}");
+
             mockDeviceTwin.SetupGet(c => c.Properties)
-                .Returns(new TwinProperties()
-                {
-                    Desired = new TwinCollection($"{{\"DevAddr\": \"03010101\", \"ClassType\": \"C\"}}"),
-                    Reported = new TwinCollection($"{{\"PreferredGatewayID\": \"gateway1\" }}"),
-                });
+                .Returns(mockTwinProperties.Object);
 
             var query = new Mock<IRegistryPageResult<ILoRaDeviceTwin>>(MockBehavior.Strict);
             query.Setup(x => x.HasMoreResults).Returns(true);
@@ -387,12 +392,10 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
 
             var mockDeviceTwin = new Mock<ILoRaDeviceTwin>();
 
+            var mockTwinProperties = SetupMockTwinProperties(desired: $"{{\"DevAddr\": \"{new DevAddr(100)}\", \"ClassType\": \"C\", \"GatewayID\":\"mygateway\"}}");
+
             mockDeviceTwin.SetupGet(c => c.Properties)
-                .Returns(new TwinProperties()
-                {
-                    Desired = new TwinCollection($"{{\"DevAddr\": \"{new DevAddr(100)}\", \"ClassType\": \"C\", \"GatewayID\":\"mygateway\"}}"),
-                    Reported = new TwinCollection(),
-                });
+                .Returns(mockTwinProperties.Object);
 
             var query = new Mock<IRegistryPageResult<ILoRaDeviceTwin>>(MockBehavior.Strict);
             query.Setup(x => x.HasMoreResults).Returns(true);
@@ -451,12 +454,10 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             var devAddr = new DevAddr(03010101);
             var mockDeviceTwin = new Mock<ILoRaDeviceTwin>();
 
+            var mockTwinProperties = SetupMockTwinProperties(desired: $"{{\"DevAddr\": \"{devAddr}\", \"ClassType\": \"C\"}}");
+
             mockDeviceTwin.SetupGet(c => c.Properties)
-                .Returns(new TwinProperties()
-                {
-                    Desired = new TwinCollection($"{{\"DevAddr\": \"{devAddr}\", \"ClassType\": \"C\"}}"),
-                    Reported = new TwinCollection(),
-                });
+                .Returns(mockTwinProperties.Object);
 
             var query = new Mock<IRegistryPageResult<ILoRaDeviceTwin>>(MockBehavior.Strict);
             query.Setup(x => x.HasMoreResults).Returns(true);
@@ -492,11 +493,10 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
 
             var mockDeviceTwin = new Mock<ILoRaDeviceTwin>();
 
+            var mockTwinProperties = SetupMockTwinProperties(desired: $"{{\"DevAddr\": \"03010101\"}}");
+
             mockDeviceTwin.SetupGet(c => c.Properties)
-                .Returns(new TwinProperties()
-                {
-                    Desired = new TwinCollection($"{{\"DevAddr\": \"03010101\"}}"),
-                });
+                .Returns(mockTwinProperties.Object);
 
             var query = new Mock<IRegistryPageResult<ILoRaDeviceTwin>>(MockBehavior.Strict);
             query.Setup(x => x.HasMoreResults).Returns(true);
@@ -547,11 +547,10 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
 
             var mockDeviceTwin = new Mock<ILoRaDeviceTwin>();
 
+            var mockTwinProperties = SetupMockTwinProperties(desired: $"{{\"DevAddr\": \"03010101\"}}");
+
             mockDeviceTwin.SetupGet(c => c.Properties)
-                .Returns(new TwinProperties()
-                {
-                    Desired = new TwinCollection($"{{\"DevAddr\": \"03010101\"}}"),
-                });
+                .Returns(mockTwinProperties.Object);
 
             var query = new Mock<IRegistryPageResult<ILoRaDeviceTwin>>(MockBehavior.Strict);
             query.Setup(x => x.HasMoreResults).Returns(true);
@@ -581,6 +580,49 @@ namespace LoRaWan.Tests.Unit.LoraKeysManagerFacade
             this.serviceClient.VerifyAll();
             this.registryManager.VerifyAll();
             query.VerifyAll();
+        }
+
+        private static Mock<ITwinPropertiesContainer> SetupMockTwinProperties(string desired = "{}", string reported = "{}")
+        {
+            ArgumentNullException.ThrowIfNull(desired, nameof(desired));
+            ArgumentNullException.ThrowIfNull(reported, nameof(reported));
+
+            var mockDesiredProperties = SetupMockTwinProperties(desired);
+            var mockReportedProperties = SetupMockTwinProperties(reported);
+
+            var mockTwinProperties = new Mock<ITwinPropertiesContainer>();
+
+            mockTwinProperties.SetupGet(c => c.Desired)
+                .Returns(mockDesiredProperties.Object);
+
+            mockTwinProperties.SetupGet(c => c.Reported)
+                .Returns(mockReportedProperties.Object);
+
+            return mockTwinProperties;
+        }
+
+        private static Mock<ITwinProperties> SetupMockTwinProperties(string properties)
+        {
+            var mockProperties = new Mock<ITwinProperties>();
+
+            var propertiesObject = JObject.Parse(properties);
+
+            mockProperties.Setup(c => c[It.IsAny<string>()])
+                            .Returns((string propertyName) => propertiesObject[propertyName]);
+
+            mockProperties.Setup(c => c.ContainsKey(It.IsAny<string>()))
+                .Returns((string c) => propertiesObject.ContainsKey(c));
+
+            _ = mockProperties.Setup(c => c.TryGetValue(It.IsAny<string>(), out It.Ref<object>.IsAny))
+                .Returns((string parameterName, out object outval) =>
+                {
+                    var tryGetValueResult = propertiesObject.TryGetValue(parameterName, out var token);
+                    outval = token;
+
+                    return tryGetValueResult;
+                });
+
+            return mockProperties;
         }
     }
 }

--- a/Tests/Unit/NetworkServer/LoRaDeviceTest.cs
+++ b/Tests/Unit/NetworkServer/LoRaDeviceTest.cs
@@ -828,7 +828,7 @@ namespace LoRaWan.Tests.Unit.NetworkServer
 
             private class LoRaDeviceTest : LoRaDevice
             {
-                private readonly ILogger<TwinCollectionReader> logger = NullLogger<TwinCollectionReader>.Instance;
+                private readonly ILogger<TwinPropertiesReader> logger = NullLogger<TwinPropertiesReader>.Instance;
 
                 public LoRaDeviceTest(ILoRaDeviceClient deviceClient)
 #pragma warning disable CA2000 // Dispose objects before losing scope - ownership is transferred

--- a/Tests/Unit/NetworkServerDiscovery/TagBasedLnsDiscoveryTests.cs
+++ b/Tests/Unit/NetworkServerDiscovery/TagBasedLnsDiscoveryTests.cs
@@ -84,7 +84,7 @@ namespace LoRaWan.Tests.Unit.NetworkServerDiscovery
         public async Task ResolveLnsAsync_Throws_If_Network_Is_Empty()
         {
             SetupLbsTwinResponse(StationEui, string.Empty);
-            _ = await Assert.ThrowsAsync<InvalidOperationException>(() => this.subject.ResolveLnsAsync(StationEui, CancellationToken.None));
+            _ = await Assert.ThrowsAsync<LoRaProcessingException>(() => this.subject.ResolveLnsAsync(StationEui, CancellationToken.None));
         }
 
         [Fact]
@@ -198,14 +198,14 @@ namespace LoRaWan.Tests.Unit.NetworkServerDiscovery
             _ = await this.subject.ResolveLnsAsync(StationEui, CancellationToken.None);
 
             // assert
-            this.registryManagerMock.Verify(rm => rm.GetTwinAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            this.registryManagerMock.Verify(rm => rm.GetStationTwinAsync(It.IsAny<StationEui>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         private void SetupLbsTwinResponse(StationEui stationEui, string networkId)
         {
             this.registryManagerMock
-                .Setup(rm => rm.GetTwinAsync(stationEui.ToString(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new IoTHubDeviceTwin(new Twin { Tags = new TwinCollection(@$"{{""network"":""{networkId}""}}") }));
+                .Setup(rm => rm.GetStationTwinAsync(stationEui, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new IoTHubStationTwin(new Twin { Tags = new TwinCollection(@$"{{""network"":""{networkId}""}}") }));
         }
 
         private void SetupIotHubQueryResponse(string networkId, IList<string?> hostAddresses)


### PR DESCRIPTION
# PR for wrapping TwinCollection to ITwinProperties interface

## What is being addressed

<!-- Describe the current behavior you are modifying -->

The objective is to decouple the IDevice interface from the ``Microsoft.Azure.Devices`` namespace. This introduce the ITwinProperties that gives access to properties from the twin as usual.

## How is this addressed

<!--
- Describe the changes made, and if appropriate, why they are addressed this way
- Note any pending work (with links to the issues that will address them)
-->

- [ ] Introduce the ITwinProperties interface
- [ ] Add TwinProperties extensions methods
- [ ] Adapt unit tests 
