### PR TITLE
Fix condition on load tests

### DIFF
--- a/.github/workflows/e2e-ci.yaml
+++ b/.github/workflows/e2e-ci.yaml
@@ -449,7 +449,7 @@ jobs:
     environment:
       name: CI_AZURE_ENVIRONMENT
       url: ${{ needs.env_var.outputs.CheckSuiteUrl }}
-    if: always() && (github.event_name == 'schedule' || github.event.inputs.RunLoadTests == 'true')
+    if: always() && (github.event_name == 'schedule' || github.event.inputs.RunLoadTests == 'true') && needs.deploy_arm_gw_iot_edge.result == 'success' && needs.deploy_eflow_gw_iot_edge.result == 'success' && needs.deploy_facade_function.result == 'success' && needs.env_var.outputs.StopFullCi != 'true'
     needs:
       - deploy_arm_gw_iot_edge
       - deploy_eflow_gw_iot_edge


### PR DESCRIPTION
# Fix condition on load tests

The current load tests execute always even when a function deployment or an iot edge deployment failed. This behavior leads the current CI pipeline to be busy for a long time blocking other runs.
e.g. https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/3019137201 -> cancellation was requested but CI don't stop
https://github.com/Azure/iotedge-lorawan-starterkit/runs/8245287953 -> executed even when deployment fails

The current PR aims at changing the condition to add a check whether 
* The Edge deployment succeeded
* The function deployment succeeded 
* Checking whether stopfullci is true

# How is this addressed

Changing the condition
