### PR TITLE
fix: Small bump for mkdocs version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs==1.2.3
+mkdocs==1.2.4
 mkdocs-material==8.1.3
 pymdown-extensions==9.1
 markdown==3.3.6


### PR DESCRIPTION
Upgrading mkdocs for compatibility with jinja2 new version (see [here](https://github.com/mkdocs/mkdocs/releases/tag/1.2.4))