### PR TITLE
Add troubleshooting doc about reset pin with spi enabled.

### DIFF
--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -12,13 +12,11 @@ ral_config failed with status 0x08
 Closing connection to muxs - error in s2e_onMsg
 ```
 
-It could be because SPI is enabled on the reset pin, then the reset pin cannot be used.
-You can disable SPI on this pin and enable it on another pin to fix the issue. For that, you need to add a dtoverlay
-entry to your `/boot/config.txt`file.  
+It could be that your reset pin is already used. To fix the problem, you can give the functionality of your reset pin to another pin.
+For that, you need to add a dtoverlay entry to your `/boot/config.txt`file.  
 
 Example:
-Your reset pin is 7. spi0 is enabled on this pin. You can change the default pins for Chip Select 1 to the GPIO pin 25
-by adding this line to the `/boot/config.txt` file:
+Let's say your reset pin is 7. We can see in this [documentation](https://pinout.xyz/pinout/spi) that by default, GPIO 7 is the `Chip select 1` pin for SPI0. With [dtoverlay](https://docs.kernel.org/devicetree/overlay-notes.html), you can change the chip select 1 pin to be GPIO 25 by adding this line to the `/boot/config.txt` file:
 
 `dtoverlay=spi0-cs,cs1_pin=25`
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -1,0 +1,25 @@
+# Troubleshooting
+
+## Failed to load fw
+
+If you see the following logs in your basic station:
+
+```text
+[load_firmware:219] Failed to load fw 1
+[lgw_start:841] Version of calibration firmware not expected, actual:0 expected:2
+Concentrator start failed: lgw_start
+ral_config failed with status 0x08
+Closing connection to muxs - error in s2e_onMsg
+```
+
+It could be because SPI is enabled on the reset pin, then the reset pin cannot be used.
+You can disable SPI on this pin and enable it on another pin to fix the issue. For that, you need to add a dtoverlay
+entry to your `/boot/config.txt`file.  
+
+Example:
+Your reset pin is 7. spi0 is enabled on this pin. You can change the default pins for Chip Select 1 to the GPIO pin 25
+by adding this line to the `/boot/config.txt` file:
+
+`dtoverlay=spi0-cs,cs1_pin=25`
+
+We choose 25 here but you should choose a free pin.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
     - user-guide/documentation.md
     - user-guide/observability.md
     - user-guide/lns-discovery.md
+    - user-guide/troubleshooting.md
     - 'Basic Station configuration':
       - user-guide/pkt-fwd-to-station.md
       - user-guide/station-device-provisioning.md


### PR DESCRIPTION
# PR for issue #1927 

## What is being addressed

Document issue encountered:
- Reset pin was already in used because it was the `SPI0 CE1` pin by default.

## How is this addressed
Documented how to fix the issue.
