### PR TITLE
Use region full name in device provisioning

### DIFF
--- a/TemplateBicep/README.md
+++ b/TemplateBicep/README.md
@@ -39,7 +39,7 @@ For device creation debugging, there are alternatives other than deploying the w
 Option 1: Run bash script locally
 
 ```plain
-FACADE_SERVER_URL="https://myapp.com/api" IOTHUB_CONNECTION_STRING="<iothub-connection-string>" LORA_CLI_URL="https://github.com/Azure/iotedge-lorawan-starterkit/releases/download/v2.2.0/lora-cli.linux-x64.tar.gz" EDGE_GATEWAY_NAME="<iotedge-device-name>" STATION_DEVICE_NAME="<concentrator-device-name>" DEPLOY_DEVICE=1 RESET_PIN=<concentrator-reset-pin> LORA_VERSION="<lora-starter-kit-release-version>" ./create_device.sh
+FACADE_SERVER_URL="https://myapp.com/api" IOTHUB_CONNECTION_STRING="<iothub-connection-string>" LORA_CLI_URL="https://github.com/Azure/iotedge-lorawan-starterkit/releases/download/v<current-version>/lora-cli.linux-x64.tar.gz" EDGE_GATEWAY_NAME="<iotedge-device-name>" STATION_DEVICE_NAME="<concentrator-device-name>" DEPLOY_DEVICE=1 RESET_PIN=<concentrator-reset-pin> LORA_VERSION="<lora-starter-kit-release-version>" ./create_device.sh
 ```
 
 Option 2: Run the device provisioning Bicep

--- a/TemplateBicep/create_device.sh
+++ b/TemplateBicep/create_device.sh
@@ -27,7 +27,7 @@ create_devices_with_lora_cli() {
 
 # Setting default values
 STATION_DEVICE_NAME=${STATION_DEVICE_NAME:-AA555A0000000101}
-REGION=${REGION:-eu}
+REGION=${REGION:-EU863}
 NETWORK=${NETWORK-quickstartnetwork}
 LNS_HOST_ADDRESS=${LNS_HOST_ADDRESS-ws://mylns:5000}
 SPI_DEV=${SPI_DEV-0}

--- a/TemplateBicep/create_device.sh
+++ b/TemplateBicep/create_device.sh
@@ -1,13 +1,3 @@
-resolve_lora_region() {
-    local inputRegion=$1
-    local result="EU863"
-    if [ "$inputRegion" = "us" ]; then
-        $result="US902"
-    fi
-
-    echo "$result"
-}
-
 create_devices_with_lora_cli() {
     echo "Downloading lora-cli from $LORA_CLI_URL..."
     curl -SsL "$LORA_CLI_URL" -o lora-cli.tar.gz
@@ -16,7 +6,6 @@ create_devices_with_lora_cli() {
     cd lora-cli
     chmod +x ./loradeviceprovisioning
 
-    local regionName=$(resolve_lora_region $REGION)
     local monitoringEnabled="false"
     if [ "${MONITORING_ENABLED}" = "1" ]; then
         monitoringEnabled="true"
@@ -25,8 +14,8 @@ create_devices_with_lora_cli() {
     echo "Creating gateway $EDGE_GATEWAY_NAME..."
     ./loradeviceprovisioning add-gateway --reset-pin "$RESET_PIN" --device-id "$EDGE_GATEWAY_NAME" --spi-dev "$SPI_DEV" --spi-speed "$SPI_SPEED" --api-url "$FACADE_SERVER_URL" --api-key "$FACADE_AUTH_CODE" --lns-host-address "$LNS_HOST_ADDRESS" --network "$NETWORK" --monitoring "$monitoringEnabled" --iothub-resource-id "$IOTHUB_RESOURCE_ID" --log-analytics-workspace-id "$LOG_ANALYTICS_WORKSPACE_ID" --log-analytics-shared-key "$LOG_ANALYTICS_SHARED_KEY" --lora-version "$LORA_VERSION"
 
-    echo "Creating concentrator $STATION_DEVICE_NAME for region $regionName..."
-    ./loradeviceprovisioning add --type concentrator --region "$regionName" --stationeui "$STATION_DEVICE_NAME" --no-cups --network "$NETWORK"
+    echo "Creating concentrator $STATION_DEVICE_NAME for region $REGION..."
+    ./loradeviceprovisioning add --type concentrator --region "$REGION" --stationeui "$STATION_DEVICE_NAME" --no-cups --network "$NETWORK"
 
     # add leaf devices
     if [ "${DEPLOY_DEVICE}" = "1" ]; then

--- a/TemplateBicep/main.bicep
+++ b/TemplateBicep/main.bicep
@@ -13,8 +13,8 @@ param deployDevice bool
 param resetPin int 
 
 @description('In what region is your gateway deployed?')
-@allowed(['EU','US'])
-param region string = 'EU'
+@allowed(['EU863', 'US902', 'AS923-1', 'AS923-2', 'AS923-3', 'CN470RP1', 'CN470RP2', 'AU915'])
+param region string = 'EU863'
 
 @description('The StationEUI of the sample concentrator device')
 param stationEui string = 'AA555A0000000101'


### PR DESCRIPTION
# PR for issue #1042 

## What is being addressed

Allowing the user to select all support regions when provisioning devices.

## How is this addressed

- Changed Bicep script to accept full region names