### PR TITLE
Release workflow creates pull requests to update versions in files.

### DIFF
--- a/.github/workflows/create_prerelease.yaml
+++ b/.github/workflows/create_prerelease.yaml
@@ -125,6 +125,8 @@ jobs:
           zip -r $DISCOVERY_SERVICE_ZIP $PUBLISH_FOLDER
           # Define DISCOVERY_SERVICE_ZIP env var for next steps.
           echo "DISCOVERY_SERVICE_ZIP=$DISCOVERY_SERVICE_ZIP" >> $GITHUB_ENV
+      - name: Update the default LoRaWAN Starter Kit version to use in Bicep. 
+          run: sed -i "s/param version string = '[0-9/.]*'/param version string = '${VERSION}'/g" TemplateBicep/main.bicep
       - name: Generate ARM file
         working-directory: TemplateBicep
         run: |

--- a/.github/workflows/create_prerelease.yaml
+++ b/.github/workflows/create_prerelease.yaml
@@ -58,17 +58,17 @@ jobs:
       - name: Create branch
         run: |
           BRANCH_NAME="docs/release-${VERSION}-${{ github.run_id }}"
-          DESCRIPTION="Update the default LoRaWAN Starter Kit version to use in Bicep with version $VERSION."
+          DESCRIPTION="Update button URL with version $VERSION."
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           echo "DESCRIPTION=$DESCRIPTION" >> $GITHUB_ENV
           git checkout -b $BRANCH_NAME
           git add docs/quickstart.md
-          git commit -m $DESCRIPTION
+          git commit -m "$DESCRIPTION"
           git push --set-upstream origin $BRANCH_NAME
       - name: Create pull request
         run: |
-          gh pr create --repo ${{ github.repository }} --head $BRANCH_NAME --base "docs/main" \
-          --title "Update button URL with version $VERSION." --body "Update button URL with version $VERSION."
+          gh pr create --repo ${{ github.repository }} --head $BRANCH_NAME --base "docs/main" --title "$DESCRIPTION" \
+          --body "$DESCRIPTION"
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create_prerelease.yaml
+++ b/.github/workflows/create_prerelease.yaml
@@ -67,7 +67,8 @@ jobs:
           git push --set-upstream origin $BRANCH_NAME
       - name: Create pull request
         run: |
-          gh pr create --repo ${{ github.repository }} --head $BRANCH_NAME --base "docs/main" --title "Update button URL with version $VERSION." --body "Update button URL with version $VERSION."
+          gh pr create --repo ${{ github.repository }} --head $BRANCH_NAME --base "docs/main" \
+          --title "Update button URL with version $VERSION." --body "Update button URL with version $VERSION."
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -95,7 +96,8 @@ jobs:
           git push --set-upstream origin $BRANCH_NAME
       - name: Create pull request
         run: |
-          gh pr create --repo ${{ github.repository }} --head $BRANCH_NAME --base dev --title "$DESCRIPTION" --body "$DESCRIPTION"
+          gh pr create --repo ${{ github.repository }} --head $BRANCH_NAME --base dev --title "$DESCRIPTION" \
+          --body "$DESCRIPTION"
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create_prerelease.yaml
+++ b/.github/workflows/create_prerelease.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           ref: docs/main
       - name: Update doc URL with new version
-        run: sed -i "s/iotedge-lorawan-starterkit%2Fv[0-9\.]*/iotedge-lorawan-starterkit%2Fv${VERSION}/g" docs/quickstart.md
+        run: sed -r -i "s/iotedge-lorawan-starterkit%2Fv[0-9\.]+/iotedge-lorawan-starterkit%2Fv${VERSION}/g" docs/quickstart.md
       - name: Set up git user using the built-in token
         run: |
           git config user.name github-actions
@@ -79,7 +79,7 @@ jobs:
         with:
           ref: dev
       - name: Update the default LoRaWAN Starter Kit version to use in Bicep.
-        run: sed -i "s/param version string = '[0-9/.]*'/param version string = '${VERSION}'/g" TemplateBicep/main.bicep
+        run: sed -r -i "s/param version string = '[0-9/.]+'/param version string = '${VERSION}'/g" TemplateBicep/main.bicep
       - name: Set up git user using the built-in token
         run: |
           git config user.name github-actions
@@ -126,7 +126,7 @@ jobs:
           # Define DISCOVERY_SERVICE_ZIP env var for next steps.
           echo "DISCOVERY_SERVICE_ZIP=$DISCOVERY_SERVICE_ZIP" >> $GITHUB_ENV
       - name: Update the default LoRaWAN Starter Kit version to use in Bicep. 
-        run: sed -i "s/param version string = '[0-9/.]*'/param version string = '${VERSION}'/g" TemplateBicep/main.bicep
+        run: sed -r -i "s/param version string = '[0-9/.]+'/param version string = '${VERSION}'/g" TemplateBicep/main.bicep
       - name: Generate ARM file
         working-directory: TemplateBicep
         run: az bicep build --file main.bicep --outfile $ARM_FILE

--- a/.github/workflows/create_prerelease.yaml
+++ b/.github/workflows/create_prerelease.yaml
@@ -96,7 +96,8 @@ jobs:
       - name: Create pull request
         run: |
           gh pr create --repo ${{ github.repository }} --head $BRANCH_NAME --base dev --title "$DESCRIPTION" --body "$DESCRIPTION"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   CreateRelease:
     permissions:

--- a/.github/workflows/create_prerelease.yaml
+++ b/.github/workflows/create_prerelease.yaml
@@ -41,7 +41,62 @@ jobs:
           docker manifest push $DOCKERHUB_ORGANISATION/lorabasicsstationmodule:$VERSION
           docker manifest push $DOCKERHUB_ORGANISATION/lorawannetworksrvmodule:$VERSION
     env:
-      DOCKERHUB_ORGANISATION: ${{ secrets.DOCKER_REPOSITORY }}  
+      DOCKERHUB_ORGANISATION: ${{ secrets.DOCKER_REPOSITORY }}
+      
+  CreatePRToUpdateDoc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: docs/main
+      - name: Update doc URL with new version
+        run: sed -i "s/iotedge-lorawan-starterkit%2Fv[0-9\.]*/iotedge-lorawan-starterkit%2Fv${VERSION}/g" docs/quickstart.md
+      - name: Set up git user using the built-in token
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Create branch
+        run: |
+          BRANCH_NAME="docs/release-${VERSION}-${{ github.run_id }}"
+          DESCRIPTION="Update the default LoRaWAN Starter Kit version to use in Bicep with version $VERSION."
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "DESCRIPTION=$DESCRIPTION" >> $GITHUB_ENV
+          git checkout -b $BRANCH_NAME
+          git add docs/quickstart.md
+          git commit -m $DESCRIPTION
+          git push --set-upstream origin $BRANCH_NAME
+      - name: Create pull request
+        run: |
+          gh pr create --repo ${{ github.repository }} --head $BRANCH_NAME --base "docs/main" --title "Update button URL with version $VERSION." --body "Update button URL with version $VERSION."
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  CreatePRToUpdateBicep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: dev
+      - name: Update the default LoRaWAN Starter Kit version to use in Bicep.
+        run: sed -i "s/param version string = '[0-9/.]*'/param version string = '${VERSION}'/g" TemplateBicep/main.bicep
+      - name: Set up git user using the built-in token
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Create branch
+        run: |
+          BRANCH_NAME="feature/update-version-${VERSION}-${{ github.run_id }}"
+          DESCRIPTION="Update the default LoRaWAN Starter Kit version to use in Bicep with version $VERSION."
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "DESCRIPTION=$DESCRIPTION" >> $GITHUB_ENV
+          git checkout -b $BRANCH_NAME
+          git add TemplateBicep/main.bicep
+          git commit -m "$DESCRIPTION"
+          git push --set-upstream origin $BRANCH_NAME
+      - name: Create pull request
+        run: |
+          gh pr create --repo ${{ github.repository }} --head $BRANCH_NAME --base dev --title "$DESCRIPTION" --body "$DESCRIPTION"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   CreateRelease:
     permissions:
@@ -86,6 +141,6 @@ jobs:
             --title "Release v$VERSION" --prerelease --repo ${{ github.repository }} --notes ""
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    needs: BuildAndPushDockerImages
+    needs: [BuildAndPushDockerImages, CreatePRToUpdateDoc, CreatePRToUpdateBicep]
     env:
       ARM_FILE: azuredeploy.json

--- a/.github/workflows/create_prerelease.yaml
+++ b/.github/workflows/create_prerelease.yaml
@@ -126,11 +126,10 @@ jobs:
           # Define DISCOVERY_SERVICE_ZIP env var for next steps.
           echo "DISCOVERY_SERVICE_ZIP=$DISCOVERY_SERVICE_ZIP" >> $GITHUB_ENV
       - name: Update the default LoRaWAN Starter Kit version to use in Bicep. 
-          run: sed -i "s/param version string = '[0-9/.]*'/param version string = '${VERSION}'/g" TemplateBicep/main.bicep
+        run: sed -i "s/param version string = '[0-9/.]*'/param version string = '${VERSION}'/g" TemplateBicep/main.bicep
       - name: Generate ARM file
         working-directory: TemplateBicep
-        run: |
-          az bicep build --file main.bicep --outfile $ARM_FILE
+        run: az bicep build --file main.bicep --outfile $ARM_FILE
       - name: Compile provisioning CLI for different platform
         working-directory: Tools/Cli-LoRa-Device-Provisioning
         shell: pwsh 


### PR DESCRIPTION
# PR for issue #1950 

## What is being addressed

- Automated the following release steps:
  - Create a PR updating the URL button version in the doc, on the target branch docs/main.
  - Create a PR updating the default starter kit version in bicep, on the target branch dev

- Make sure the ARM release artefact has the correct default started kit version.

I considered creating a custom action to reduce the code duplication. I didn't implement this solution because of the following overhead:
- State: The custom action would depend on a state: the current checked out branch. This can be confusing IMO.
- A custom action can only be used it the action file is present in the branch. The custom action is not present in the `docs/main` branch. We could consider committing it to this branch, but it would mean maintaining this action twice.

## How it was tested

It was tested on a fork to avoid creating PR on this repository.
You can find [here a successful run](https://github.com/ouphi/iotedge-lorawan-starterkit/actions/runs/3363155234).
You can find [here the release created by the run](https://github.com/ouphi/iotedge-lorawan-starterkit/releases/tag/v3.3.3).

You can see the following 2 PRs have been created by the workflow:
- [Update bicep button PR](https://github.com/ouphi/iotedge-lorawan-starterkit/pull/14)
- [Update default version in bicep](https://github.com/ouphi/iotedge-lorawan-starterkit/pull/15)
