### PR TITLE
Fix ARM URL to point to release

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,7 +46,7 @@ The template will deploy in your Azure subscription the Following resources:
 
 1. Press on the button here below to start your Azure Deployment.
     <!-- markdownlint-disable MD033 -->
-    <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fiotedge-lorawan-starterkit%2Fv2.2.1%2FTemplate%2Fazuredeploy.json" target="_blank">
+    <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fgithub.com%2FAzure%2Fiotedge-lorawan-starterkit%2Freleases%2Fdownload%2Fv2.2.1%2Fazuredeploy.json" target="_blank">
         <img src="https://aka.ms/deploytoazurebutton"/>
     </a>
     <!-- markdownlint-enable MD033 -->


### PR DESCRIPTION
The Docs QuickStart page mistakenly still pointed to the arm version and not to the generated bicep file. This pr aims to fix this.