### PR TITLE
Correct the syntax for custom run

### DIFF
--- a/.github/actions/rune2etest/action.yml
+++ b/.github/actions/rune2etest/action.yml
@@ -1,27 +1,26 @@
-name: 'Run E2E test'
-description: 'run an E2E test'
+name: "Run E2E test"
+description: "run an E2E test"
 inputs:
   test_name:
-    description: 'the test name to run'
+    description: "the test name to run"
     required: true
 
 runs:
   using: "composite"
   steps:
-  - name: Runs ${{ inputs.test_name }} E2E tests
-    id: run_e2e_tests
-    shell: bash
-    run: |
-      dotnet test --logger trx --no-build --configuration ${{ env.BUILD_CONFIGURATION }} \
-      -p:ParallelizeTestCollections=false -r ${{ env.TESTS_RESULTS_FOLDER }}/E2E/ --filter "${{ inputs.test_name }}" \
-      ${{ env.TESTS_FOLDER }}/E2E/LoRaWan.Tests.E2E.csproj
+    - name: Runs ${{ inputs.test_name }} E2E tests
+      id: run_e2e_tests
+      shell: bash
+      run: |
+        dotnet test --logger trx --no-build --configuration ${{ env.BUILD_CONFIGURATION }} \
+        -p:ParallelizeTestCollections=false -r ${{ env.TESTS_RESULTS_FOLDER }}/E2E/ --filter "${{ inputs.test_name }}" \
+        ${{ env.TESTS_FOLDER }}/E2E/LoRaWan.Tests.E2E.csproj
 
-  - run: |
-      gh pr edit ${{ github.event.pull_request.number }} --add-label ${{ inputs.test_name }}
-    name: Add ${{ inputs.test_name }} Test Label
-    shell: bash
-    if: ${{ github.event_name }} == 'pull_request'
-    id: edit_pr_label
-    env:
-      GITHUB_TOKEN: ${{ github.token }}
-
+    - run: |
+        gh pr edit ${{ github.event.pull_request.number }} --add-label ${{ inputs.test_name }}
+      name: Add ${{ inputs.test_name }} Test Label
+      shell: bash
+      if: github.event_name == 'pull_request'
+      id: edit_pr_label
+      env:
+        GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# PR for issue #1983

Correct a syntax issue that prevented the condition for correctly applying

Proof that the status is now correctly reflected and run PR is not updated when not running from a pr event: https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/4476798528/jobs/7867739888