### PR TITLE
Make adddevice idempotent

### DIFF
--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/AddOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/AddOptions.cs
@@ -6,6 +6,7 @@ namespace LoRaWan.Tools.CLI.Options
     using System;
     using System.Collections.Generic;
     using CommandLine;
+    using Riok.Mapperly.Abstractions;
 
     [Verb("add", HelpText = "Add a new device to IoT Hub.")]
     public class AddOptions
@@ -228,5 +229,11 @@ namespace LoRaWan.Tools.CLI.Options
             HelpText = "Network identifier for LNS Discovery purposes"
             )]
         public string Network { get; set; }
+    }
+
+    [Mapper]
+    public static partial class AddOptionsMapper
+    {
+        public static partial UpdateOptions ToUpdateOptions(this AddOptions opts);
     }
 }

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/AddOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/AddOptions.cs
@@ -10,7 +10,7 @@ namespace LoRaWan.Tools.CLI.Options
     [Verb("add", HelpText = "Add a new device to IoT Hub.")]
     public class AddOptions
     {
-        private const string ConcentratorSetName = "Contentrator";
+        private const string ConcentratorSetName = "Concentrator";
         private const string LoRaDeviceSetName = "LoRaDevice";
 
         [Option(

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/UpdateOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/UpdateOptions.cs
@@ -3,40 +3,11 @@
 
 namespace LoRaWan.Tools.CLI.Options
 {
-    using System;
     using CommandLine;
 
     [Verb("update", HelpText = "Update an existing device in IoT Hub.")]
     public class UpdateOptions
     {
-        public UpdateOptions(AddOptions opts)
-        {
-            if (opts == null) throw new ArgumentNullException(nameof(opts));
-            Rx1DrOffset = opts.Rx1DrOffset;
-            AppEui = opts.AppEui;
-            AppSKey = opts.AppSKey;
-            AppKey = opts.AppKey;
-            NwkSKey = opts.NwkSKey;
-            DevEui = opts.DevEui;
-            ABPRelaxMode = opts.ABPRelaxMode;
-            ClassType = opts.ClassType;
-            Deduplication = opts.Deduplication;
-            DownlinkEnabled = opts.DownlinkEnabled;
-            DevAddr = opts.DevAddr;
-            FCntDownStart = opts.FCntDownStart;
-            FCntResetCounter = opts.FCntResetCounter;
-            FCntUpStart = opts.FCntUpStart;
-            KeepAliveTimeout = opts.KeepAliveTimeout;
-            NetId = opts.NetId;
-            NwkSKey = opts.NwkSKey;
-            PreferredWindow = opts.PreferredWindow;
-            Rx1DrOffset = opts.Rx1DrOffset;
-            Rx2DataRate = opts.Rx2DataRate;
-            RxDelay = opts.RxDelay;
-            SensorDecoder = opts.SensorDecoder;
-            Supports32BitFCnt = opts.Supports32BitFCnt;
-        }
-
         [Option(
             "deveui",
             Required = true,

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/UpdateOptions.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/CommandLineOptions/UpdateOptions.cs
@@ -3,11 +3,40 @@
 
 namespace LoRaWan.Tools.CLI.Options
 {
+    using System;
     using CommandLine;
 
     [Verb("update", HelpText = "Update an existing device in IoT Hub.")]
     public class UpdateOptions
     {
+        public UpdateOptions(AddOptions opts)
+        {
+            if (opts == null) throw new ArgumentNullException(nameof(opts));
+            Rx1DrOffset = opts.Rx1DrOffset;
+            AppEui = opts.AppEui;
+            AppSKey = opts.AppSKey;
+            AppKey = opts.AppKey;
+            NwkSKey = opts.NwkSKey;
+            DevEui = opts.DevEui;
+            ABPRelaxMode = opts.ABPRelaxMode;
+            ClassType = opts.ClassType;
+            Deduplication = opts.Deduplication;
+            DownlinkEnabled = opts.DownlinkEnabled;
+            DevAddr = opts.DevAddr;
+            FCntDownStart = opts.FCntDownStart;
+            FCntResetCounter = opts.FCntResetCounter;
+            FCntUpStart = opts.FCntUpStart;
+            KeepAliveTimeout = opts.KeepAliveTimeout;
+            NetId = opts.NetId;
+            NwkSKey = opts.NwkSKey;
+            PreferredWindow = opts.PreferredWindow;
+            Rx1DrOffset = opts.Rx1DrOffset;
+            Rx2DataRate = opts.Rx2DataRate;
+            RxDelay = opts.RxDelay;
+            SensorDecoder = opts.SensorDecoder;
+            Supports32BitFCnt = opts.Supports32BitFCnt;
+        }
+
         [Option(
             "deveui",
             Required = true,

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/LoRaWan.Tools.CLI.csproj
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/LoRaWan.Tools.CLI.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Riok.Mapperly" Version="2.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Program.cs
@@ -191,7 +191,7 @@ namespace LoRaWan.Tools.CLI
                 }
                 else
                 {
-                    var updateOptions = new UpdateOptions(opts);
+                    var updateOptions = opts.ToUpdateOptions();
                     var newTwins = IoTDeviceHelper.UpdateDeviceTwin(existingDeviceTwins, updateOptions);
                     newTwins.DeviceId = opts.DevEui;
                     isSuccess = await IoTDeviceHelper.WriteDeviceTwin(newTwins, opts.DevEui, configurationHelper, false);

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Program.cs
@@ -182,7 +182,19 @@ namespace LoRaWan.Tools.CLI
             if (IoTDeviceHelper.VerifyDevice(opts, null, null, null, configurationHelper, true))
             {
                 var twin = IoTDeviceHelper.CreateDeviceTwin(opts);
-                isSuccess = await IoTDeviceHelper.WriteDeviceTwin(twin, opts.DevEui, configurationHelper, true);
+
+                // Check if the device already exists.
+                var existingDeviceTwins = await IoTDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);
+                if (existingDeviceTwins is null)
+                {
+                    isSuccess = await IoTDeviceHelper.WriteDeviceTwin(twin, opts.DevEui, configurationHelper, true);
+                }
+                else
+                {
+                    var updateOptions = new UpdateOptions(opts);
+                    var newTwins = IoTDeviceHelper.UpdateDeviceTwin(existingDeviceTwins, updateOptions);
+                    isSuccess = await IoTDeviceHelper.WriteDeviceTwin(newTwins, opts.DevEui, configurationHelper, false);
+                }
             }
             else
             {

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Program.cs
@@ -193,6 +193,7 @@ namespace LoRaWan.Tools.CLI
                 {
                     var updateOptions = new UpdateOptions(opts);
                     var newTwins = IoTDeviceHelper.UpdateDeviceTwin(existingDeviceTwins, updateOptions);
+                    newTwins.DeviceId = opts.DevEui;
                     isSuccess = await IoTDeviceHelper.WriteDeviceTwin(newTwins, opts.DevEui, configurationHelper, false);
                 }
             }

--- a/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Program.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/LoRaWan.Tools.CLI/Program.cs
@@ -187,6 +187,7 @@ namespace LoRaWan.Tools.CLI
                 var existingDeviceTwins = await IoTDeviceHelper.QueryDeviceTwin(opts.DevEui, configurationHelper);
                 if (existingDeviceTwins is null)
                 {
+                    WriteToConsole($"Device {opts.DevEui} already exists, updating the twins.", ConsoleColor.Yellow);
                     isSuccess = await IoTDeviceHelper.WriteDeviceTwin(twin, opts.DevEui, configurationHelper, true);
                 }
                 else

--- a/Tools/Cli-LoRa-Device-Provisioning/Tests/LoRaWan.Tools.CLI.Tests.Unit/DeviceProvisioningTest.cs
+++ b/Tools/Cli-LoRa-Device-Provisioning/Tests/LoRaWan.Tools.CLI.Tests.Unit/DeviceProvisioningTest.cs
@@ -107,6 +107,9 @@ namespace LoRaWan.Tools.CLI.Tests.Unit
                         DevEUI.ToString(),
                         It.IsNotNull<Twin>(),
                         It.IsAny<string>()), Times.Once());
+                this.registryManager.Verify(c => c.AddDeviceWithTwinAsync(
+                        It.IsAny<Device>(),
+                        It.IsAny<Twin>()), Times.Never());
             }
             else
             {
@@ -166,6 +169,9 @@ namespace LoRaWan.Tools.CLI.Tests.Unit
                         DevEUI.ToString(),
                         It.IsNotNull<Twin>(),
                         It.IsAny<string>()), Times.Once());
+                this.registryManager.Verify(c => c.AddDeviceWithTwinAsync(
+                        It.IsAny<Device>(),
+                        It.IsAny<Twin>()), Times.Never());
             }
             else
             {


### PR DESCRIPTION
# PR for issue #2061

## What is being addressed

Make device addition idempotent in the provisioning CLIs. This would cause the Bicep template to be able to be rerun multiple times when provisionDevices is set to true instead of failing after the first run.
closes #2061 

## How is this addressed

Check if the device exists first, update it if it does and add it if it doesnt.