### PR TITLE
Fix test device provisioning

### DIFF
--- a/Tests/Common/TestDeviceInfo.cs
+++ b/Tests/Common/TestDeviceInfo.cs
@@ -115,7 +115,7 @@ namespace LoRaWan.Tests.Common
             desiredProperties[TwinProperty.KeepAliveTimeout] = KeepAliveTimeout;
 
             if (Deduplication is not DeduplicationMode.Drop)
-                desiredProperties[TwinProperty.Deduplication] = Deduplication;
+                desiredProperties[TwinProperty.Deduplication] = Deduplication.ToString();
 
             return desiredProperties;
         }


### PR DESCRIPTION
# PR fixing wrong device provisioning

As we migrated IoT Hub the test devices as part of the recent E2E CI migration, the test devices needed to be recreated. It happens that the deduplication was wrongly serialized in these tests causing some of them to fail, this PR aims to fix this particular issue.

Example of issue: https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/4531734855/jobs/7982471685#step:11:93