### PR TITLE
Fix the GetStationTwinAsync to be handle non existing twins

### DIFF
--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubRegistryManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubRegistryManager.cs
@@ -4,19 +4,13 @@
 namespace LoRaTools.IoTHubImpl
 {
     using System;
-    using System.Collections.Generic;
     using System.Globalization;
     using System.Net.Http;
-    using System.Runtime.CompilerServices;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using LoRaWan;
     using Microsoft.Azure.Devices;
-    using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Logging;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
 
     public sealed class IoTHubRegistryManager : IDeviceRegistryManager, IDisposable
     {
@@ -84,7 +78,12 @@ namespace LoRaTools.IoTHubImpl
         }
 
         public async Task<IStationTwin> GetStationTwinAsync(StationEui stationEui, CancellationToken? cancellationToken = null)
-             => new IoTHubStationTwin(await this.instance.GetTwinAsync(stationEui.ToString(), cancellationToken ?? CancellationToken.None));
+        {
+            var twin = await this.instance.GetTwinAsync(stationEui.ToString(), cancellationToken ?? CancellationToken.None);
+            if (twin is null)
+                return null;
+            return new IoTHubStationTwin(twin);
+        }
 
         public IRegistryPageResult<ILoRaDeviceTwin> GetLastUpdatedLoRaDevices(DateTime lastUpdateDateTime)
         {

--- a/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubRegistryManager.cs
+++ b/LoRaEngine/modules/LoRaWanNetworkSrvModule/LoraTools/IoTHubImpl/IoTHubRegistryManager.cs
@@ -77,14 +77,6 @@ namespace LoRaTools.IoTHubImpl
             return new IoTHubLoRaDeviceTwinPageResult(q);
         }
 
-        public async Task<IStationTwin> GetStationTwinAsync(StationEui stationEui, CancellationToken? cancellationToken = null)
-        {
-            var twin = await this.instance.GetTwinAsync(stationEui.ToString(), cancellationToken ?? CancellationToken.None);
-            if (twin is null)
-                return null;
-            return new IoTHubStationTwin(twin);
-        }
-
         public IRegistryPageResult<ILoRaDeviceTwin> GetLastUpdatedLoRaDevices(DateTime lastUpdateDateTime)
         {
             var formattedDateTime = lastUpdateDateTime.ToString(Constants.RoundTripDateTimeStringFormat, CultureInfo.InvariantCulture);
@@ -115,5 +107,7 @@ namespace LoRaTools.IoTHubImpl
 
         public async Task<IDeviceTwin> GetTwinAsync(string deviceId, CancellationToken? cancellationToken = null)
              => await this.instance.GetTwinAsync(deviceId, cancellationToken ?? CancellationToken.None) is { } twin ? new IoTHubDeviceTwin(twin) : null;
+        public async Task<IStationTwin> GetStationTwinAsync(StationEui stationEui, CancellationToken? cancellationToken = null)
+            => await this.instance.GetTwinAsync(stationEui.ToString(), cancellationToken ?? CancellationToken.None) is { } twin ? new IoTHubStationTwin(twin) : null;
     }
 }


### PR DESCRIPTION
Since the PR #1822, the result of the call to GetStationTwinAsync was improperly wrapped and the null case was improperly handled which caused the discovery test to fail ([example](https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/4596429155/jobs/8119000342#step:19:101)). This fix now resolves the issue ([GetStationTwinAsync](https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/4659558596/jobs/8246693837#step:19:2))

close #1866