### PR TITLE
Correct VM shutdown

### DIFF
--- a/.github/actions/power-azure-vm/action.yml
+++ b/.github/actions/power-azure-vm/action.yml
@@ -18,12 +18,12 @@ runs:
   steps:
     - name: "Deallocate VM"
       shell: bash
-      if: ${{ !inputs.POWER_SWITCH }}
+      if: inputs.POWER_SWITCH == 'false'
       run: | 
         az vm deallocate --name ${{ inputs.AZURE_VM_NAME }} --resource-group ${{ inputs.AZURE_RG_NAME }} --no-wait 
 
     - name: "Start VM"
       shell: bash
-      if: ${{ inputs.POWER_SWITCH }}
+      if: inputs.POWER_SWITCH == 'true'
       run: | 
         az vm start --name ${{ inputs.AZURE_VM_NAME }} --resource-group ${{ inputs.AZURE_RG_NAME }} --no-wait 


### PR DESCRIPTION
The current VM deallocate is not executing correctly as it seems the condition doesn't work, it execute VM start instead of VM deallocate. This results in additional costs on the subscription as the VM is not properly deallocated after a run.

example: https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/4720922669/jobs/8375148406#step:5:32

The current PR aims at fixing the condition and using string comparison instead of bool. Successfull run:
https://github.com/Azure/iotedge-lorawan-starterkit/actions/runs/4732528603/jobs/8399118099#step:5:32