### PR TITLE
Fixed bicep build and manifest creation in the release job

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -34,12 +34,6 @@ jobs:
         run: |
           docker buildx build -f "./LoRaEngine/modules/LoRaWanNetworkSrvModule/Dockerfile.${{ matrix.image }}" -t $DOCKERHUB_ORGANISATION/lorawannetworksrvmodule:$VERSION-${{ matrix.image }} --output type=image,push=true "."
           docker buildx build -f "./LoRaEngine/modules/LoRaBasicsStationModule/Dockerfile.${{ matrix.image }}" -t $DOCKERHUB_ORGANISATION/lorabasicsstationmodule:$VERSION-${{ matrix.image }} --build-arg CONTAINER_REGISTRY_ADDRESS=docker.io --output type=image,push=true "."
-      - name: Create manifests
-        run: |
-          docker manifest create $DOCKERHUB_ORGANISATION/lorawannetworksrvmodule:$VERSION $DOCKERHUB_ORGANISATION/lorawannetworksrvmodule:$VERSION-${{ matrix.image }} --amend
-          docker manifest create $DOCKERHUB_ORGANISATION/lorabasicsstationmodule:$VERSION $DOCKERHUB_ORGANISATION/lorabasicsstationmodule:$VERSION-${{ matrix.image }} --amend
-          docker manifest push $DOCKERHUB_ORGANISATION/lorabasicsstationmodule:$VERSION
-          docker manifest push $DOCKERHUB_ORGANISATION/lorawannetworksrvmodule:$VERSION
     env:
       DOCKERHUB_ORGANISATION: ${{ secrets.DOCKER_REPOSITORY }}
   

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -84,7 +84,9 @@ jobs:
         run: |
           sed -r -i "s/param version string = '[0-9/.]+'/param version string = '${VERSION}'/g" TemplateBicep/main.bicep
       - name: Generate ARM file
-        run: az bicep build --file TemplateBicep/main.bicep --outfile $ARM_FILE
+        run: |
+          mkdir Template
+          az bicep build --file TemplateBicep/main.bicep --outfile $ARM_FILE
       - name: Set up git user using the built-in token
         run: |
           git config user.name github-actions

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -42,6 +42,32 @@ jobs:
           docker manifest push $DOCKERHUB_ORGANISATION/lorawannetworksrvmodule:$VERSION
     env:
       DOCKERHUB_ORGANISATION: ${{ secrets.DOCKER_REPOSITORY }}
+  
+  CreateManifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v3
+        id: buildx
+        with:
+          install: true
+      - name: Login to docker hub
+        run: |
+          docker login -u ${{ secrets.DOCKER_LOGIN }} -p ${{ secrets.DOCKER_PASSWORD }}
+      - name: Create manifests
+        run: |
+          docker buildx imagetools create -t $DOCKERHUB_ORGANISATION/lorawannetworksrvmodule:$VERSION \
+            $DOCKERHUB_ORGANISATION/lorawannetworksrvmodule:$VERSION-amd64 \
+            $DOCKERHUB_ORGANISATION/lorawannetworksrvmodule:$VERSION-arm32v7 \
+            $DOCKERHUB_ORGANISATION/lorawannetworksrvmodule:$VERSION-arm64v8
+          
+          docker buildx imagetools create -t $DOCKERHUB_ORGANISATION/lorabasicsstationmodule:$VERSION \
+            $DOCKERHUB_ORGANISATION/lorabasicsstationmodule:$VERSION-amd64 \
+            $DOCKERHUB_ORGANISATION/lorabasicsstationmodule:$VERSION-arm32v7 \
+            $DOCKERHUB_ORGANISATION/lorabasicsstationmodule:$VERSION-arm64v8
+    env:
+      DOCKERHUB_ORGANISATION: ${{ secrets.DOCKER_REPOSITORY }}
 
   CreatePRToUpdateDoc:
     runs-on: ubuntu-latest

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -43,7 +43,7 @@ jobs:
     env:
       DOCKERHUB_ORGANISATION: ${{ secrets.DOCKER_REPOSITORY }}
   
-  CreateManifest:
+  CreateManifests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -66,6 +66,8 @@ jobs:
             $DOCKERHUB_ORGANISATION/lorabasicsstationmodule:$VERSION-amd64 \
             $DOCKERHUB_ORGANISATION/lorabasicsstationmodule:$VERSION-arm32v7 \
             $DOCKERHUB_ORGANISATION/lorabasicsstationmodule:$VERSION-arm64v8
+    needs:
+      [BuildAndPushDockerImages]
     env:
       DOCKERHUB_ORGANISATION: ${{ secrets.DOCKER_REPOSITORY }}
 
@@ -177,4 +179,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     needs:
-      [BuildAndPushDockerImages, CreatePRToUpdateDoc, CreatePRToUpdateBicep]
+      [BuildAndPushDockerImages, CreateManifests, CreatePRToUpdateDoc, CreatePRToUpdateBicep]


### PR DESCRIPTION
## What is being addressed

Release job is broken because:
- Bicep build is broken
- Manifest creation is broken

## How is this addressed

- Fixed bicep build
- Fixed manifest creation

The [release job fixed was tested here](https://github.com/ouphi/iotedge-lorawan-starterkit/actions/runs/6711932899/job/18240498408)

When testing it I get the following manifest published:

<img width="1303" alt="Screenshot 2023-10-31 at 21 20 07" src="https://github.com/Azure/iotedge-lorawan-starterkit/assets/17216799/f853263e-ca28-45a5-9c0f-cb6fb2b673f2">
