### PR TITLE
Remove PR creation from release job.

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -65,7 +65,7 @@ jobs:
     env:
       DOCKERHUB_ORGANISATION: ${{ secrets.DOCKER_REPOSITORY }}
 
-  CreatePRToUpdateDoc:
+  CreateBranchToUpdateDoc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -87,14 +87,10 @@ jobs:
           git add docs/quickstart.md
           git commit -m "$DESCRIPTION"
           git push --set-upstream origin $BRANCH_NAME
-      - name: Create pull request
-        run: |
-          gh pr create --repo ${{ github.repository }} --head $BRANCH_NAME --base "docs/main" --title "$DESCRIPTION" \
-          --body "$DESCRIPTION"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  CreatePRToUpdateBicep:
+  CreateBranchToUpdateBicep:
     runs-on: ubuntu-latest
     env:
       ARM_FILE: Template/azuredeploy.json
@@ -124,10 +120,6 @@ jobs:
           git add $ARM_FILE
           git commit -m "$DESCRIPTION"
           git push --set-upstream origin $BRANCH_NAME
-      - name: Create pull request
-        run: |
-          gh pr create --repo ${{ github.repository }} --head $BRANCH_NAME --base dev --title "$DESCRIPTION" \
-          --body "$DESCRIPTION"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -173,4 +165,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     needs:
-      [BuildAndPushDockerImages, CreateManifests, CreatePRToUpdateDoc, CreatePRToUpdateBicep]
+      [BuildAndPushDockerImages, CreateManifests, CreateBranchToUpdateDoc, CreateBranchToUpdateBicep]

--- a/README.md
+++ b/README.md
@@ -130,9 +130,16 @@ Write release notes to the [release notes documentation](https://github.com/Azur
 
 Go to the [Create draft release workflow](https://github.com/Azure/iotedge-lorawan-starterkit/actions/workflows/create_release.yaml) and specify the release version before running the workflow.
 
-### Merge 2 PRs
+### Create and merge 2 PRs
 
-The Prerelease workflow will create 2 PRs, one PR to update the Starter Kit version in Bicep and one PR to update the Button URL. Merge these 2 PRs.
+The release workflow will create 2 branches:
+- `docs/release-${RELEASE_VERSION}-${GITHUB_RUN_ID}`
+This branch updates the Button URL.
+
+- `feature/update-version-${RELEASE_VERSION}-${GITHUB_RUN_ID}`
+This branch updates the Starter Kit version in Bicep.
+
+Created 2 PRs from these branches, verify the PRs look good and merge them.
 
 ### Update master
 


### PR DESCRIPTION
## What is being addressed

We are not allowed anymore to have PR creation done from Github action:

<img width="653" alt="MicrosoftTeams-image (5)" src="https://github.com/Azure/iotedge-lorawan-starterkit/assets/17216799/d016627c-29df-494d-a9b0-5ea4ae1caff0">

Because of that the release job fails when trying to create the PR:

![Screenshot 2023-11-01 at 10 18 40](https://github.com/Azure/iotedge-lorawan-starterkit/assets/17216799/cc504127-60f3-4d86-8672-d7a0d207b81e)



## How is this addressed

Change the release process:

- The release job will be creating branches instead and the developer taking care of the release has to create the PRs.

