### PR TITLE
Remove tag creation for docs

### DIFF
--- a/.github/workflows/publish-docs-new-version.yml
+++ b/.github/workflows/publish-docs-new-version.yml
@@ -1,16 +1,16 @@
 # This workflow needs to be triggered manually to create a 
-# new version of the documentation
+# new version of the documentation.
 # 
-# this workflow needs to live in default branch to be able
+# This workflow needs to live in default branch to be able
 # to be triggered manually due to a limitation of github actions.
 
-# make sure to select the branch `docs/main` when triggering this action
+# Make sure to select the branch `docs/main` when triggering this action
 name: publish-docs-new-version
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The version that needs to be deployed'
+        description: 'Input the version that needs to be deployed. For example 2.0.0. (And make sure you select the branch docs/main when triggering this action.)'
         required: true
 
 jobs:
@@ -32,5 +32,3 @@ jobs:
       - run: | 
           mike deploy --push --update-aliases ${{ github.event.inputs.version }} latest
           mike list
-      # tag the repository
-      - run: git tag docs@${{ github.event.inputs.version }}

--- a/.github/workflows/publish-docs-new-version.yml
+++ b/.github/workflows/publish-docs-new-version.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Input the version that needs to be deployed. For example 2.0.0. (And make sure you select the branch docs/main when triggering this action.)'
+        description: 'Input the version that needs to be deployed. For example 2.0.0 (and make sure you select the branch docs/main when triggering this action.)'
         required: true
 
 jobs:


### PR DESCRIPTION
## What is being addressed

We create a tag for the doc called `docs@<release-version>` but the tag does not get pushed so was never created in the repo.

## How is this addressed

- Delete the tag creation
- Another solution would have been to push the tag, but these docs tags were never used so I can assume we don't need it.
