### PR TITLE
Remove tag creation for docs.

### DIFF
--- a/.github/workflows/publish-docs-new-version.yml
+++ b/.github/workflows/publish-docs-new-version.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          #set excplicitly to 0 to get full history (see https://github.com/actions/checkout#usage)
+          # Set explicitly to 0 to get full history (see https://github.com/actions/checkout#usage)
           fetch-depth: '0'
       - uses: actions/setup-python@v2
         with:
@@ -25,4 +25,3 @@ jobs:
       - run: | 
           mike deploy --push --update-aliases ${{ github.event.inputs.version }} latest
           mike list
-      - run: git tag docs@${{ github.event.inputs.version }}


### PR DESCRIPTION
## What is being addressed

We create a tag for the doc called docs@<release-version> but the tag does not get pushed so was never created in the repo.

## How is this addressed

- Delete the tag creation
- Another solution would have been to push the tag, but these docs tags were never used so I can assume we don't need it.
